### PR TITLE
fix(ci): use Node.js 22 for semantic-release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
semantic-release 25.x requires Node.js >=22.14.0

The release workflow was failing with:
```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.
```

This updates both the test and release jobs to use Node 22.