### PR TITLE
fix(status-footer): use decimal display for interpolated metrics

### DIFF
--- a/src/status-footer.js
+++ b/src/status-footer.js
@@ -681,8 +681,8 @@ class StatusFooter {
       let metricsStr = '';
       if (metrics && data.exists) {
         const cpuColor = metrics.cpuPercent > 50 ? COLORS.yellow : COLORS.green;
-        const cpuVal = `${Math.round(metrics.cpuPercent)}%`.padStart(4);
-        const ramVal = `${Math.round(metrics.memoryMB)}MB`.padStart(6);
+        const cpuVal = `${metrics.cpuPercent.toFixed(1)}%`.padStart(6);
+        const ramVal = `${metrics.memoryMB.toFixed(1)}MB`.padStart(8);
 
         metricsStr += `${COLORS.dim}CPU:${COLORS.reset}${cpuColor}${cpuVal}${COLORS.reset}`;
         metricsStr += `  ${COLORS.dim}RAM:${COLORS.reset}${COLORS.gray}${ramVal}${COLORS.reset}`;
@@ -781,8 +781,8 @@ class StatusFooter {
     if (totalCpu > 0 || totalMem > 0) {
       parts.push(` ${COLORS.gray}│${COLORS.reset}`);
       let aggregateStr = ` ${COLORS.cyan}Σ${COLORS.reset} `;
-      aggregateStr += `${COLORS.dim}CPU:${COLORS.reset}${totalCpu.toFixed(0)}%`;
-      aggregateStr += ` ${COLORS.dim}RAM:${COLORS.reset}${totalMem.toFixed(0)}MB`;
+      aggregateStr += `${COLORS.dim}CPU:${COLORS.reset}${totalCpu.toFixed(1)}%`;
+      aggregateStr += ` ${COLORS.dim}RAM:${COLORS.reset}${totalMem.toFixed(1)}MB`;
       if (totalBytesSent > 0 || totalBytesReceived > 0) {
         aggregateStr += ` ${COLORS.dim}NET:${COLORS.reset}${COLORS.cyan}↑${this.formatBytes(totalBytesSent)} ↓${this.formatBytes(totalBytesReceived)}${COLORS.reset}`;
       }


### PR DESCRIPTION
## Summary
- Show 1 decimal place for CPU/RAM to make interpolation visually apparent
- `45.3%` → `45.7%` → `46.0%` (visible smooth motion)
- Previously: `45%` → `45%` → `46%` (sudden jumps)
- Adjusted padding to accommodate extra characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)