### PR TITLE
feat(cli): change default model ceiling to opus

### DIFF
--- a/cli/lib/first-run.js
+++ b/cli/lib/first-run.js
@@ -50,8 +50,8 @@ function promptModel(rl) {
     console.log('  2) opus    - Agents can use opus, sonnet, or haiku');
     console.log('  3) haiku   - Agents can only use haiku (lowest cost)\n');
 
-    rl.question('Enter 1, 2, or 3 [1]: ', (answer) => {
-      const choice = answer.trim() || '1';
+    rl.question('Enter 1, 2, or 3 [2]: ', (answer) => {
+      const choice = answer.trim() || '2';
       switch (choice) {
         case '2':
           resolve('opus');


### PR DESCRIPTION
## Summary

Changes the default model ceiling from sonnet to opus in the first-run setup wizard.

Users now get opus as the default when setting up Zeroshot for the first time. This allows agents to use opus, sonnet, or haiku based on their configuration.

## Changes

- Modified `cli/lib/first-run.js` to default to option 2 (opus) instead of option 1 (sonnet)
- Users can still choose a lower ceiling during setup if desired

## Testing

Verified the wizard prompt now shows `[2]` as the default and resolves to `'opus'` when user presses Enter.