### PR TITLE
fix(auth): support macOS Keychain credentials for preflight and Docker mode

### DIFF
--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -865,10 +865,65 @@ class IsolationManager {
     const projectsDir = path.join(configDir, 'projects');
     fs.mkdirSync(projectsDir, { recursive: true });
 
-    // Copy only credentials file (essential for auth)
+    // Copy credentials for container auth
+    // Priority: 1) .credentials.json file, 2) macOS Keychain, 3) ANTHROPIC_API_KEY env var
     const credentialsFile = path.join(sourceDir, '.credentials.json');
+    const destCredentialsFile = path.join(configDir, '.credentials.json');
+    let hasCredentials = false;
+
+    // Try 1: File-based credentials (Linux default)
     if (fs.existsSync(credentialsFile)) {
-      fs.copyFileSync(credentialsFile, path.join(configDir, '.credentials.json'));
+      try {
+        const content = fs.readFileSync(credentialsFile, 'utf8');
+        const creds = JSON.parse(content);
+        // Only copy if file has actual credentials (not empty/placeholder)
+        if (creds.claudeAiOauth?.accessToken || creds.apiKey) {
+          fs.copyFileSync(credentialsFile, destCredentialsFile);
+          hasCredentials = true;
+        }
+      } catch {
+        // File exists but can't be parsed - try next method
+      }
+    }
+
+    // Try 2: macOS Keychain (where Claude CLI stores OAuth on macOS)
+    if (!hasCredentials && os.platform() === 'darwin') {
+      try {
+        // Claude CLI stores OAuth in Keychain under "Claude Code-credentials"
+        // See: https://github.com/anthropics/claude-code/issues/10039
+        const keychainCreds = execSync(
+          'security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null',
+          { encoding: 'utf8', stdio: 'pipe' }
+        ).trim();
+
+        if (keychainCreds) {
+          // Keychain stores the full JSON object as the password
+          const parsed = JSON.parse(keychainCreds);
+          if (parsed.claudeAiOauth?.accessToken || parsed.apiKey) {
+            fs.writeFileSync(destCredentialsFile, JSON.stringify(parsed, null, 2));
+            console.log('[IsolationManager] Extracted credentials from macOS Keychain');
+            hasCredentials = true;
+          }
+        }
+      } catch {
+        // Keychain access failed - try next method
+      }
+    }
+
+    // Try 3: ANTHROPIC_API_KEY environment variable
+    if (!hasCredentials && process.env.ANTHROPIC_API_KEY) {
+      const apiKeyCreds = { apiKey: process.env.ANTHROPIC_API_KEY };
+      fs.writeFileSync(destCredentialsFile, JSON.stringify(apiKeyCreds, null, 2));
+      console.log('[IsolationManager] Using ANTHROPIC_API_KEY for container authentication');
+      hasCredentials = true;
+    }
+
+    if (!hasCredentials) {
+      console.warn(
+        '[IsolationManager] ⚠️ No credentials available for container.\n' +
+        '  Tried: .credentials.json, macOS Keychain, ANTHROPIC_API_KEY env var\n' +
+        '  Run: claude login (or set ANTHROPIC_API_KEY)'
+      );
     }
 
     // Copy hook script to block AskUserQuestion (CRITICAL for autonomous execution)

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -86,65 +86,122 @@ function getClaudeVersion() {
 
 /**
  * Check Claude CLI authentication status
+ * Supports both file-based credentials (Linux) and Keychain (macOS)
  * @returns {{ authenticated: boolean, error: string | null, configDir: string }}
  */
 function checkClaudeAuth() {
   const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
   const credentialsPath = path.join(configDir, '.credentials.json');
 
-  // Check if credentials file exists
-  if (!fs.existsSync(credentialsPath)) {
-    return {
-      authenticated: false,
-      error: 'No credentials file found',
-      configDir,
-    };
-  }
+  // Track what we've checked for appropriate error messages
+  let credentialsFileChecked = false;
 
-  // Check if credentials file has content
-  try {
-    const content = fs.readFileSync(credentialsPath, 'utf8');
-    const creds = JSON.parse(content);
+  // Try 1: File-based credentials (Linux, or explicit file auth)
+  if (fs.existsSync(credentialsPath)) {
+    credentialsFileChecked = true;
+    try {
+      const content = fs.readFileSync(credentialsPath, 'utf8');
+      const creds = JSON.parse(content);
 
-    // Check for OAuth token (primary auth method)
-    if (creds.claudeAiOauth?.accessToken) {
-      // Check if token is expired
-      const expiresAt = creds.claudeAiOauth.expiresAt;
-      if (expiresAt && new Date(expiresAt) < new Date()) {
+      // Check for OAuth token (primary auth method)
+      if (creds.claudeAiOauth?.accessToken) {
+        // Check if token is expired
+        const expiresAt = creds.claudeAiOauth.expiresAt;
+        if (expiresAt && new Date(expiresAt) < new Date()) {
+          return {
+            authenticated: false,
+            error: 'OAuth token expired',
+            configDir,
+          };
+        }
         return {
-          authenticated: false,
-          error: 'OAuth token expired',
+          authenticated: true,
+          error: null,
           configDir,
         };
       }
+
+      // Check for API key auth
+      if (creds.apiKey) {
+        return {
+          authenticated: true,
+          error: null,
+          configDir,
+        };
+      }
+
+      // File exists but no valid credentials in it
       return {
-        authenticated: true,
-        error: null,
+        authenticated: false,
+        error: 'No valid authentication in credentials file',
+        configDir,
+      };
+    } catch {
+      // File exists but can't be parsed
+      return {
+        authenticated: false,
+        error: 'Credentials file is invalid',
         configDir,
       };
     }
+  }
 
-    // Check for API key auth
-    if (creds.apiKey) {
-      return {
-        authenticated: true,
-        error: null,
-        configDir,
-      };
+  // Try 2: macOS Keychain (Claude CLI stores OAuth here on macOS)
+  if (os.platform() === 'darwin') {
+    try {
+      // Claude CLI stores credentials under "Claude Code-credentials"
+      // See: https://github.com/anthropics/claude-code/issues/10039
+      const keychainCreds = execSync(
+        'security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null',
+        { encoding: 'utf8', stdio: 'pipe' }
+      ).trim();
+
+      if (keychainCreds) {
+        const parsed = JSON.parse(keychainCreds);
+        if (parsed.claudeAiOauth?.accessToken) {
+          // Check if token is expired
+          const expiresAt = parsed.claudeAiOauth.expiresAt;
+          if (expiresAt && new Date(expiresAt) < new Date()) {
+            return {
+              authenticated: false,
+              error: 'OAuth token expired (run: claude login)',
+              configDir,
+            };
+          }
+          return {
+            authenticated: true,
+            error: null,
+            configDir,
+          };
+        }
+        if (parsed.apiKey) {
+          return {
+            authenticated: true,
+            error: null,
+            configDir,
+          };
+        }
+      }
+    } catch {
+      // Keychain access failed - continue to next check
     }
+  }
 
+  // Try 3: ANTHROPIC_API_KEY environment variable
+  if (process.env.ANTHROPIC_API_KEY) {
     return {
-      authenticated: false,
-      error: 'No valid authentication found in credentials',
-      configDir,
-    };
-  } catch (err) {
-    return {
-      authenticated: false,
-      error: `Failed to parse credentials: ${err.message}`,
+      authenticated: true,
+      error: null,
       configDir,
     };
   }
+
+  // No credentials found anywhere
+  return {
+    authenticated: false,
+    error: credentialsFileChecked ? 'No valid authentication in credentials file' : 'No credentials file found',
+    configDir,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

On macOS, Claude CLI stores OAuth credentials in the system Keychain under `"Claude Code-credentials"` instead of `~/.claude/.credentials.json`. This PR adds support for reading credentials from both locations.

## Changes

- **`src/preflight.js`**: Add Keychain lookup after file-based check, remove problematic CLI test
- **`src/isolation-manager.js`**: Extract Keychain credentials for Docker container mounting

## How It Works

1. Check `~/.claude/.credentials.json` (Linux, explicit file auth)
2. Check macOS Keychain `"Claude Code-credentials"` (darwin only)
3. Check `ANTHROPIC_API_KEY` environment variable
4. Return appropriate error if nothing found

## Test Plan

- [x] CI passes
- [x] File-based auth still works (Linux)
- [x] Keychain auth works (macOS)
- [x] Docker mode correctly extracts credentials

Fixes #30