### PR TITLE
feat(ci): enforce merge queue workflow for dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  merge_group:
+    branches: [dev]
   workflow_dispatch:
 
 jobs:
@@ -64,10 +66,10 @@ jobs:
 
   # Cross-platform/version compatibility
   # NOTE: macOS runners cost 10x Linux minutes - minimal matrix
-  # Only run on main branch and PRs (skip direct dev pushes)
+  # Run on: main branch, PRs, and merge queue (skip direct dev pushes)
   install-matrix:
     needs: check
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-push hook: Block direct pushes to main + manual version tags
+# Pre-push hook: Block direct pushes to main/dev + enforce PR workflow
 
 set -e
 
@@ -9,7 +9,7 @@ if [ -n "$CI" ]; then
 fi
 
 # ============================================================================
-# PART 1: Block direct pushes to main branch
+# PART 1: Block direct pushes to main and dev branches
 # ============================================================================
 
 # Read push details from stdin
@@ -28,16 +28,35 @@ while read local_ref local_sha remote_ref remote_sha; do
     echo ""
     echo "❌ ERROR: You cannot push directly to 'main' branch"
     echo ""
-    echo "Required workflow:"
-    echo "  1. Switch to 'dev': git switch dev"
-    echo "  2. Push to 'dev': git push origin dev"
-    echo "  3. Open PR: dev → main"
-    echo "  4. Merge after CI passes"
+    echo "Releases flow:  dev → PR → main → semantic-release"
     echo ""
-    echo "This enforces:"
-    echo "  • All changes reviewed via PR"
-    echo "  • CI validation before production"
-    echo "  • semantic-release manages versions"
+    echo "To release:"
+    echo "  gh pr create --base main --head dev --title \"Release\""
+    echo ""
+    exit 1
+  fi
+
+  # Block pushes to dev
+  if [ "$remote_branch" = "dev" ]; then
+    echo ""
+    echo "╔═══════════════════════════════════════════════════════════════════╗"
+    echo "║                                                                   ║"
+    echo "║  ❌ BLOCKED: Direct push to 'dev' branch                          ║"
+    echo "║                                                                   ║"
+    echo "╚═══════════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "❌ ERROR: You cannot push directly to 'dev' branch"
+    echo ""
+    echo "Required workflow:"
+    echo "  1. Create feature branch: git switch -c feat/my-feature"
+    echo "  2. Push feature branch:   git push -u origin feat/my-feature"
+    echo "  3. Create PR:             gh pr create --base dev"
+    echo "  4. Enable auto-merge:     gh pr merge --auto --squash"
+    echo ""
+    echo "Merge queue will:"
+    echo "  • Rebase your PR on latest dev"
+    echo "  • Re-run CI on rebased code"
+    echo "  • Merge only if CI passes"
     echo ""
     exit 1
   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,48 @@ const maxValidators = cluster.config.complexity === 'CRITICAL' ? 5 : 3;
 
 ## 🔴 BEHAVIORAL RULES
 
-### Git Workflow (Multi-Agent Context)
+### Git Workflow (Contributing to Zeroshot)
+
+**Merge queue enforces CI on rebased code before merge.**
+
+```
+feature-branch (local)
+↓
+pre-push hook → lint + typecheck (~5s)
+↓
+push to origin/feature-branch
+↓
+gh pr create --base dev
+↓
+CI runs tests on PR branch
+↓
+gh pr merge --auto --squash → enters merge queue
+↓
+Queue rebases PR on latest dev + runs CI again
+↓
+Merge to dev (only if CI passes on rebased code)
+```
+
+**Pre-push hook blocks:** Direct pushes to `main` or `dev`. Must use PR workflow.
+
+**Commands:**
+
+```bash
+# Feature work
+git switch -c feat/my-feature
+# ... make changes ...
+git push -u origin feat/my-feature
+gh pr create --base dev
+gh pr merge --auto --squash
+
+# Release (dev → main)
+gh pr create --base main --head dev --title "Release"
+# → CI passes → merge → semantic-release publishes
+```
+
+**Setup merge queue (admin):** `./scripts/setup-merge-queue.sh`
+
+### Git Safety (Multi-Agent Context)
 
 **CRITICAL: Use WIP commits instead of stashing:**
 
@@ -454,14 +495,16 @@ npm run typecheck         # TypeScript (if applicable)
 
 ## Mechanical Enforcement
 
-| Antipattern               | Enforcement               |
-| ------------------------- | ------------------------- |
-| Dangerous fallbacks       | ESLint ERROR              |
-| Manual git tags           | Pre-push hook             |
-| Git in validator prompts  | Config validator          |
-| Multiple impl files (-v2) | Pre-commit hook           |
-| Spawn without permission  | Runtime check (CLI)       |
-| Git stash usage           | Pre-commit hook (planned) |
+| Antipattern               | Enforcement                              |
+| ------------------------- | ---------------------------------------- |
+| Dangerous fallbacks       | ESLint ERROR                             |
+| Manual git tags           | Pre-push hook                            |
+| Direct push to main/dev   | Pre-push hook (blocks with instructions) |
+| Git in validator prompts  | Config validator                         |
+| Multiple impl files (-v2) | Pre-commit hook                          |
+| Spawn without permission  | Runtime check (CLI)                      |
+| Git stash usage           | Pre-commit hook (planned)                |
+| Merge without CI rebase   | GitHub merge queue                       |
 
 ## 🔴 NODE.JS PATTERNS (Zeroshot-Specific)
 

--- a/scripts/setup-merge-queue.sh
+++ b/scripts/setup-merge-queue.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Setup GitHub merge queue and branch protection for zeroshot
+# Run once after creating the repo or to update settings
+
+set -e
+
+REPO="covibes/zeroshot"
+
+echo "╔═══════════════════════════════════════════════════════════════════╗"
+echo "║  Setting up merge queue for $REPO                         ║"
+echo "╚═══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Check gh is authenticated
+if ! gh auth status &>/dev/null; then
+  echo "❌ ERROR: Not authenticated with GitHub CLI"
+  echo "   Run: gh auth login"
+  exit 1
+fi
+
+# Check we have admin access
+if ! gh api "repos/$REPO" --jq '.permissions.admin' | grep -q true; then
+  echo "❌ ERROR: You need admin access to $REPO"
+  exit 1
+fi
+
+echo "✓ Authenticated with admin access"
+echo ""
+
+# ============================================================================
+# Configure 'dev' branch protection (merge target)
+# ============================================================================
+
+echo "→ Configuring 'dev' branch protection..."
+
+gh api --method PUT "repos/$REPO/branches/dev/protection" \
+  --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["check", "install-matrix (ubuntu-latest, 20)", "install-matrix (macos-latest, 20)"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true,
+  "required_conversation_resolution": false
+}
+EOF
+
+echo "✓ 'dev' branch protection configured"
+
+# Enable merge queue for dev branch
+echo "→ Enabling merge queue for 'dev' branch..."
+
+# Note: Merge queue requires GitHub Enterprise or public repos with Actions
+# Using the ruleset API which supports merge queue
+gh api --method POST "repos/$REPO/rulesets" \
+  --input - <<EOF 2>/dev/null || echo "   (ruleset may already exist)"
+{
+  "name": "dev-merge-queue",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/dev"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 30,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 1
+      }
+    }
+  ]
+}
+EOF
+
+echo "✓ Merge queue enabled for 'dev'"
+
+# ============================================================================
+# Configure 'main' branch protection (release branch)
+# ============================================================================
+
+echo "→ Configuring 'main' branch protection..."
+
+gh api --method PUT "repos/$REPO/branches/main/protection" \
+  --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["check", "install-matrix (ubuntu-latest, 20)", "install-matrix (macos-latest, 20)"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true,
+  "required_conversation_resolution": false
+}
+EOF
+
+echo "✓ 'main' branch protection configured"
+
+# ============================================================================
+# Configure repository settings
+# ============================================================================
+
+echo "→ Configuring repository settings..."
+
+gh api --method PATCH "repos/$REPO" \
+  --input - <<EOF
+{
+  "allow_squash_merge": true,
+  "allow_merge_commit": false,
+  "allow_rebase_merge": false,
+  "squash_merge_commit_title": "PR_TITLE",
+  "squash_merge_commit_message": "PR_BODY",
+  "delete_branch_on_merge": true,
+  "allow_auto_merge": true
+}
+EOF
+
+echo "✓ Repository settings configured"
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "╔═══════════════════════════════════════════════════════════════════╗"
+echo "║  ✓ Merge queue setup complete!                                    ║"
+echo "╚═══════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Workflow:"
+echo "  feature-branch (local)"
+echo "  ↓"
+echo "  pre-push hook → lint + typecheck (~5s)"
+echo "  ↓"
+echo "  push to origin/feature-branch"
+echo "  ↓"
+echo "  gh pr create --base dev"
+echo "  ↓"
+echo "  CI runs tests on PR branch"
+echo "  ↓"
+echo "  gh pr merge --auto --squash → enters merge queue"
+echo "  ↓"
+echo "  Queue rebases PR on latest dev + runs CI again"
+echo "  ↓"
+echo "  Merge to dev (only if CI passes on rebased code)"
+echo ""
+echo "Release workflow:"
+echo "  gh pr create --base main --head dev --title \"Release\""
+echo "  → CI passes → merge → semantic-release publishes"
+echo ""


### PR DESCRIPTION
## Summary
- CI workflow now triggers on `merge_group` events for dev branch
- Pre-push hook blocks direct pushes to BOTH main AND dev
- Added `setup-merge-queue.sh` script to configure GitHub settings
- Updated CLAUDE.md with workflow documentation

## Workflow After This PR

```
feature-branch (local)
↓
pre-push hook → lint + typecheck (~5s)
↓
push to origin/feature-branch
↓
gh pr create --base dev
↓
CI runs tests on PR branch
↓
gh pr merge --auto --squash → enters merge queue
↓
Queue rebases PR on latest dev + runs CI again
↓
Merge to dev (only if CI passes on rebased code)
```

## Test plan
- [x] Pre-push hook blocks direct push to dev (tested locally)
- [x] Pre-push hook blocks direct push to main (tested locally)
- [x] Pre-push hook allows feature branches (tested locally)
- [ ] CI runs on this PR
- [ ] Merge queue rebases and re-runs CI before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)