### PR TITLE
fix: orchestrator cluster_id and Codex git repo check

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -989,7 +989,11 @@ class Orchestrator {
         );
 
         watchdogTimer = setTimeout(() => {
-          const clusterOps = messageBus.query({ topic: 'CLUSTER_OPERATIONS', limit: 1 });
+          const clusterOps = messageBus.query({
+            cluster_id: clusterId,
+            topic: 'CLUSTER_OPERATIONS',
+            limit: 1,
+          });
           if (clusterOps.length === 0) {
             console.error(`\n${'='.repeat(80)}`);
             console.error(`🔴 CONDUCTOR WATCHDOG TRIGGERED - CLUSTER_OPERATIONS NEVER RECEIVED`);

--- a/src/providers/openai/cli-builder.js
+++ b/src/providers/openai/cli-builder.js
@@ -78,6 +78,11 @@ function buildCommand(context, options = {}) {
     args.push('--dangerously-bypass-approvals-and-sandbox');
   }
 
+  // Always skip git repo check - zeroshot runs non-interactively and may run in any directory
+  if (cliFeatures.supportsSkipGitRepoCheck !== false) {
+    args.push('--skip-git-repo-check');
+  }
+
   // Augment context with schema if CLI doesn't support native --output-schema
   let finalContext = context;
   if (jsonSchema && cliFeatures.supportsOutputSchema) {

--- a/src/providers/openai/index.js
+++ b/src/providers/openai/index.js
@@ -54,6 +54,7 @@ class OpenAIProvider extends BaseProvider {
       supportsCwd: unknown ? true : /\s-C\b/.test(help) || /--cwd\b/.test(help),
       supportsConfigOverride: unknown ? true : /--config\b/.test(help),
       supportsModel: unknown ? true : /\s-m\b/.test(help) || /--model\b/.test(help),
+      supportsSkipGitRepoCheck: unknown ? true : /--skip-git-repo-check\b/.test(help),
       unknown,
     };
 


### PR DESCRIPTION
## Summary
- Fix orchestrator.js:992 missing cluster_id in query (caused crash during conductor watchdog)
- Add --skip-git-repo-check to Codex CLI invocation (allows running in non-git directories)

## Test plan
- [x] Tested all 4 providers with dummy tasks:
  - Claude: ✅ Created file successfully
  - Codex: ✅ Created file successfully (after fix)
  - Gemini: ✅ Created file successfully
  - Opencode: ✅ Created file successfully
- [x] Unit tests pass (exit code 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)