### PR TITLE
docs: fix misleading provider claim in announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zeroshot CLI
 
-> **🎉 New in v5.4:** Now supports **OpenCode** CLI! Use Claude, Codex, Gemini, or OpenCode - mix providers in multi-agent workflows. Also supports **GitHub, GitLab, Jira, and Azure DevOps** as issue backends. See [Providers](#providers) and [Multi-Platform Issue Support](#multi-platform-issue-support).
+> **🎉 New in v5.4:** Now supports **OpenCode** CLI! Use Claude, Codex, Gemini, or OpenCode as your AI provider. Also supports **GitHub, GitLab, Jira, and Azure DevOps** as issue backends. See [Providers](#providers) and [Multi-Platform Issue Support](#multi-platform-issue-support).
 
 <!-- install-placeholder -->
 <p align="center">


### PR DESCRIPTION
Removes 'mix providers in multi-agent workflows' claim - technically supported but not practically used or tested.