### PR TITLE
feat: context metrics instrumentation

### DIFF
--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -12,6 +12,12 @@
 // Defensive limit: 500,000 chars ≈ 125k tokens (safe buffer below 200k limit)
 // Prevents "Prompt is too long" errors that kill tasks
 const MAX_CONTEXT_CHARS = 500000;
+const {
+  buildContextMetrics,
+  emitContextMetrics,
+  resolveLegacyMaxTokens,
+  updateTotalMetrics,
+} = require('./context-metrics');
 
 /**
  * Generate an example object from a JSON schema
@@ -377,7 +383,7 @@ function truncateContextIfNeeded(context) {
 }
 
 function applyLegacyMaxTokens(context, strategy) {
-  const maxTokens = strategy.maxTokens || 100000;
+  const maxTokens = resolveLegacyMaxTokens(strategy);
   const maxChars = maxTokens * 4;
   if (context.length > maxChars) {
     return context.slice(0, maxChars) + '\n\n[Context truncated...]';
@@ -419,22 +425,72 @@ function buildContext({
   const strategy = config.contextStrategy || { sources: [] };
   const isIsolated = !!(worktree?.enabled || isolation?.enabled);
 
-  let context = buildHeaderContext({ id, role, iteration, isIsolated });
-  context += buildInstructionsSection({ config, selectedPrompt, id });
-  context += buildLegacyOutputSchemaSection(config);
-  context += buildJsonSchemaSection(config);
-  context += buildSourcesSection({
+  const header = buildHeaderContext({ id, role, iteration, isIsolated });
+  const instructions = buildInstructionsSection({ config, selectedPrompt, id });
+  const legacyOutputSchema = buildLegacyOutputSchemaSection(config);
+  const jsonSchema = buildJsonSchemaSection(config);
+  const sources = buildSourcesSection({
     strategy,
     messageBus,
     cluster,
     lastTaskEndTime,
     lastAgentStartTime,
   });
-  context += buildValidatorSkipSection({ role, messageBus, cluster });
-  context += buildTriggeringMessageSection(triggeringMessage);
+  const validatorSkip = buildValidatorSkipSection({ role, messageBus, cluster });
+  const triggeringMessageSection = buildTriggeringMessageSection(triggeringMessage);
 
+  const sections = {
+    header,
+    instructions,
+    legacyOutputSchema,
+    jsonSchema,
+    sources,
+    validatorSkip,
+    triggeringMessage: triggeringMessageSection,
+  };
+
+  let context =
+    header +
+    instructions +
+    legacyOutputSchema +
+    jsonSchema +
+    sources +
+    validatorSkip +
+    triggeringMessageSection;
+
+  const metrics = buildContextMetrics({
+    clusterId: cluster.id,
+    agentId: id,
+    role,
+    iteration,
+    triggeringMessage,
+    strategy,
+    sections,
+  });
+
+  const maxContextBeforeChars = context.length;
   context = truncateContextIfNeeded(context);
+  const maxContextAfterChars = context.length;
+
+  const legacyMaxTokens = resolveLegacyMaxTokens(strategy);
+  const legacyMaxBeforeChars = context.length;
   context = applyLegacyMaxTokens(context, strategy);
+  const legacyMaxAfterChars = context.length;
+
+  metrics.truncation.maxContextChars = {
+    applied: maxContextBeforeChars > MAX_CONTEXT_CHARS,
+    beforeChars: maxContextBeforeChars,
+    afterChars: maxContextAfterChars,
+  };
+  metrics.truncation.legacyMaxTokens = {
+    applied: legacyMaxBeforeChars > legacyMaxTokens * 4,
+    beforeChars: legacyMaxBeforeChars,
+    afterChars: legacyMaxAfterChars,
+    maxTokens: legacyMaxTokens,
+  };
+
+  updateTotalMetrics(metrics, legacyMaxAfterChars);
+  emitContextMetrics(metrics, { messageBus, clusterId: cluster.id, agentId: id });
 
   return context;
 }

--- a/src/agent/context-metrics.js
+++ b/src/agent/context-metrics.js
@@ -1,0 +1,114 @@
+const TOKENS_PER_CHAR_ESTIMATE = 4;
+
+function estimateTokensFromChars(chars) {
+  if (!Number.isFinite(chars) || chars <= 0) {
+    return 0;
+  }
+
+  return Math.ceil(chars / TOKENS_PER_CHAR_ESTIMATE);
+}
+
+function buildSectionMetrics(sections) {
+  const sectionMetrics = {};
+  let totalChars = 0;
+
+  for (const [sectionName, text] of Object.entries(sections)) {
+    const safeText = typeof text === 'string' ? text : '';
+    const chars = safeText.length;
+    const estimatedTokens = estimateTokensFromChars(chars);
+    sectionMetrics[sectionName] = { chars, estimatedTokens };
+    totalChars += chars;
+  }
+
+  return { sectionMetrics, totalChars };
+}
+
+function resolveLegacyMaxTokens(strategy) {
+  if (!strategy) {
+    return 100000;
+  }
+
+  return strategy.maxTokens || 100000;
+}
+
+function buildContextMetrics({
+  clusterId,
+  agentId,
+  role,
+  iteration,
+  triggeringMessage,
+  strategy,
+  sections,
+}) {
+  const { sectionMetrics, totalChars } = buildSectionMetrics(sections);
+  const maxTokens = resolveLegacyMaxTokens(strategy);
+  const sourcesCount = Array.isArray(strategy?.sources) ? strategy.sources.length : 0;
+
+  return {
+    clusterId,
+    agentId,
+    role,
+    iteration,
+    triggeredBy: triggeringMessage?.topic || null,
+    triggerFrom: triggeringMessage?.sender || null,
+    strategy: {
+      maxTokens,
+      sourcesCount,
+    },
+    sections: sectionMetrics,
+    total: {
+      chars: totalChars,
+      estimatedTokens: estimateTokensFromChars(totalChars),
+    },
+    truncation: {
+      maxContextChars: {
+        applied: false,
+        beforeChars: totalChars,
+        afterChars: totalChars,
+      },
+      legacyMaxTokens: {
+        applied: false,
+        beforeChars: totalChars,
+        afterChars: totalChars,
+        maxTokens,
+      },
+    },
+  };
+}
+
+function updateTotalMetrics(metrics, chars) {
+  if (!metrics || !Number.isFinite(chars)) {
+    return;
+  }
+
+  metrics.total = {
+    chars,
+    estimatedTokens: estimateTokensFromChars(chars),
+  };
+}
+
+function emitContextMetrics(metrics, { messageBus, clusterId, agentId }) {
+  if (process.env.ZEROSHOT_CONTEXT_METRICS === '1') {
+    console.log('[ContextMetrics]', JSON.stringify(metrics));
+  }
+
+  if (process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER === '1' && messageBus?.publish) {
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'CONTEXT_METRICS',
+      sender: agentId,
+      receiver: 'system',
+      content: {
+        data: metrics,
+      },
+    });
+  }
+}
+
+module.exports = {
+  estimateTokensFromChars,
+  resolveLegacyMaxTokens,
+  buildContextMetrics,
+  updateTotalMetrics,
+  emitContextMetrics,
+};

--- a/tests/integration/context-metrics.test.js
+++ b/tests/integration/context-metrics.test.js
@@ -1,0 +1,123 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Ledger = require('../../src/ledger');
+const MessageBus = require('../../src/message-bus');
+const { buildContext } = require('../../src/agent/agent-context-builder');
+
+const MAX_CONTEXT_CHARS = 500000;
+
+describe('Context Metrics Integration', function () {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let originalMetricsEnv;
+  let originalLedgerEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-context-metrics-'));
+    const dbPath = path.join(tempDir, 'test-ledger.db');
+    ledger = new Ledger(dbPath);
+    messageBus = new MessageBus(ledger);
+
+    originalMetricsEnv = process.env.ZEROSHOT_CONTEXT_METRICS;
+    originalLedgerEnv = process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER;
+    process.env.ZEROSHOT_CONTEXT_METRICS = '0';
+    process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER = '1';
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    if (originalMetricsEnv === undefined) {
+      delete process.env.ZEROSHOT_CONTEXT_METRICS;
+    } else {
+      process.env.ZEROSHOT_CONTEXT_METRICS = originalMetricsEnv;
+    }
+
+    if (originalLedgerEnv === undefined) {
+      delete process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER;
+    } else {
+      process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER = originalLedgerEnv;
+    }
+  });
+
+  it('publishes metrics to the ledger and records truncation stages', function () {
+    const clusterId = 'cluster-metrics-1';
+    const createdAt = Date.now() - 60000;
+    const secretMarker = 'SECRET_CONTEXT_PAYLOAD';
+    const hugeText = `${secretMarker}${'x'.repeat(MAX_CONTEXT_CHARS + 200000)}`;
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'user',
+      content: { text: 'Test issue' },
+    });
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'HUGE_TOPIC',
+      sender: 'tester',
+      content: { text: hugeText },
+    });
+
+    const context = buildContext({
+      id: 'worker',
+      role: 'implementation',
+      iteration: 1,
+      config: {
+        contextStrategy: {
+          sources: [
+            { topic: 'ISSUE_OPENED', since: 'cluster_start', limit: 1 },
+            { topic: 'HUGE_TOPIC', since: 'cluster_start', limit: 1 },
+          ],
+          maxTokens: 1,
+        },
+      },
+      messageBus,
+      cluster: { id: clusterId, createdAt },
+      triggeringMessage: {
+        topic: 'TASK_READY',
+        sender: 'planner',
+        content: { text: 'go' },
+      },
+    });
+
+    assert.ok(context.length > 0, 'Context should be generated');
+
+    const metricsMessages = ledger.query({ cluster_id: clusterId, topic: 'CONTEXT_METRICS' });
+    assert.strictEqual(metricsMessages.length, 1, 'Should publish one CONTEXT_METRICS message');
+
+    const metrics = metricsMessages[0].content.data;
+    assert.strictEqual(metrics.clusterId, clusterId);
+    assert.strictEqual(metrics.agentId, 'worker');
+    assert.strictEqual(metrics.role, 'implementation');
+    assert.strictEqual(metrics.iteration, 1);
+    assert.strictEqual(metrics.strategy.maxTokens, 1);
+    assert.strictEqual(metrics.strategy.sourcesCount, 2);
+
+    assert.strictEqual(metrics.truncation.maxContextChars.applied, true);
+    assert.strictEqual(metrics.truncation.legacyMaxTokens.applied, true);
+    assert.ok(
+      metrics.truncation.maxContextChars.beforeChars >
+        metrics.truncation.maxContextChars.afterChars,
+      'Max context truncation should reduce size'
+    );
+    assert.ok(
+      metrics.truncation.legacyMaxTokens.beforeChars >
+        metrics.truncation.legacyMaxTokens.afterChars,
+      'Legacy max tokens truncation should reduce size'
+    );
+    assert.strictEqual(metrics.truncation.legacyMaxTokens.maxTokens, 1);
+    assert.strictEqual(metrics.total.chars, metrics.truncation.legacyMaxTokens.afterChars);
+
+    const metricsJson = JSON.stringify(metrics);
+    assert.ok(!metricsJson.includes(secretMarker), 'Metrics should not include raw context');
+    assert.ok(metrics.sections.sources.chars > 0, 'Sources section should be counted');
+  });
+});

--- a/tests/unit/context-metrics.test.js
+++ b/tests/unit/context-metrics.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const { buildContextMetrics, estimateTokensFromChars } = require('../../src/agent/context-metrics');
+
+describe('Context Metrics', function () {
+  it('estimates tokens using ceil(chars / 4)', function () {
+    assert.strictEqual(estimateTokensFromChars(0), 0);
+    assert.strictEqual(estimateTokensFromChars(1), 1);
+    assert.strictEqual(estimateTokensFromChars(4), 1);
+    assert.strictEqual(estimateTokensFromChars(5), 2);
+  });
+
+  it('builds section breakdown with totals', function () {
+    const metrics = buildContextMetrics({
+      clusterId: 'cluster-1',
+      agentId: 'agent-1',
+      role: 'worker',
+      iteration: 2,
+      triggeringMessage: { topic: 'TASK', sender: 'user' },
+      strategy: { sources: [{ topic: 'A' }, { topic: 'B' }], maxTokens: 10 },
+      sections: {
+        header: 'abcd',
+        instructions: '12345',
+        legacyOutputSchema: '',
+        jsonSchema: 'xy',
+        sources: '',
+        validatorSkip: 'z',
+        triggeringMessage: 'q',
+      },
+    });
+
+    assert.strictEqual(metrics.sections.header.chars, 4);
+    assert.strictEqual(metrics.sections.header.estimatedTokens, 1);
+    assert.strictEqual(metrics.sections.instructions.chars, 5);
+    assert.strictEqual(metrics.sections.instructions.estimatedTokens, 2);
+    assert.strictEqual(metrics.sections.jsonSchema.chars, 2);
+    assert.strictEqual(metrics.sections.validatorSkip.chars, 1);
+    assert.strictEqual(metrics.sections.triggeringMessage.chars, 1);
+    assert.strictEqual(metrics.total.chars, 4 + 5 + 0 + 2 + 0 + 1 + 1);
+    assert.strictEqual(metrics.total.estimatedTokens, Math.ceil(metrics.total.chars / 4));
+
+    assert.strictEqual(metrics.strategy.maxTokens, 10);
+    assert.strictEqual(metrics.strategy.sourcesCount, 2);
+    assert.strictEqual(metrics.triggeredBy, 'TASK');
+    assert.strictEqual(metrics.triggerFrom, 'user');
+    assert.strictEqual(metrics.truncation.maxContextChars.beforeChars, metrics.total.chars);
+    assert.strictEqual(metrics.truncation.legacyMaxTokens.maxTokens, 10);
+  });
+
+  it('defaults maxTokens when not provided', function () {
+    const metrics = buildContextMetrics({
+      clusterId: 'cluster-1',
+      agentId: 'agent-1',
+      role: 'worker',
+      iteration: 1,
+      triggeringMessage: { topic: 'TASK', sender: 'user' },
+      strategy: { sources: [] },
+      sections: { header: 'a' },
+    });
+
+    assert.strictEqual(metrics.strategy.maxTokens, 100000);
+  });
+});


### PR DESCRIPTION
## Summary
- add context metrics helper and emit JSON metrics with truncation tracking
- refactor context builder to compute section breakdowns without changing prompt output
- add unit + integration tests for context metrics and ledger emission

## Testing
- npm run lint (warnings only, existing)
- npm run typecheck
- npm run test:all (fails in this environment: existing suite failures + env issues; ran before fixing the new integration test)
- npx mocha --no-config tests/integration/context-metrics.test.js --timeout 180000