### PR TITLE
Add validator docker fallback for platform mismatch

### DIFF
--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -299,13 +299,17 @@ function buildSourcePack({
   };
 }
 
-function collectCannotValidateCriteria(prevValidations) {
+const { isPlatformMismatchReason } = require('./validation-platform');
+
+function collectCannotValidateCriteria(prevValidations, options = {}) {
   const cannotValidateCriteria = [];
+  const ignoreReason = options.ignoreReason;
   for (const msg of prevValidations) {
     const criteriaResults = msg.content?.data?.criteriaResults;
     if (!Array.isArray(criteriaResults)) continue;
     for (const cr of criteriaResults) {
       if (cr.status !== 'CANNOT_VALIDATE' || !cr.id) continue;
+      if (ignoreReason && ignoreReason(cr.reason)) continue;
       if (cannotValidateCriteria.find((c) => c.id === cr.id)) continue;
       cannotValidateCriteria.push({
         id: cr.id,
@@ -330,7 +334,7 @@ function buildCannotValidateSection(cannotValidateCriteria) {
   return context;
 }
 
-function buildValidatorSkipSection({ role, messageBus, cluster }) {
+function buildValidatorSkipSection({ role, messageBus, cluster, isolation }) {
   if (role !== 'validator') return '';
 
   const prevValidations = messageBus.query({
@@ -340,7 +344,8 @@ function buildValidatorSkipSection({ role, messageBus, cluster }) {
     limit: 50,
   });
 
-  const cannotValidateCriteria = collectCannotValidateCriteria(prevValidations);
+  const ignoreReason = isolation?.enabled ? isPlatformMismatchReason : null;
+  const cannotValidateCriteria = collectCannotValidateCriteria(prevValidations, { ignoreReason });
   return buildCannotValidateSection(cannotValidateCriteria);
 }
 
@@ -392,7 +397,7 @@ function buildContext({
   const instructions = buildInstructionsSection({ config, selectedPrompt, id });
   const legacyOutputSchema = buildLegacyOutputSchemaSection(config);
   const jsonSchema = buildJsonSchemaSection(config);
-  const validatorSkip = buildValidatorSkipSection({ role, messageBus, cluster });
+  const validatorSkip = buildValidatorSkipSection({ role, messageBus, cluster, isolation });
   const triggeringMessageSection = buildTriggeringMessageSection(triggeringMessage);
 
   const packs = [];

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -14,11 +14,135 @@
 
 const { findMatchingTrigger, evaluateTrigger } = require('./agent-trigger-evaluator');
 const { executeHook } = require('./agent-hook-executor');
+const IsolationManager = require('../isolation-manager');
 const {
   analyzeProcessHealth,
   isPlatformSupported,
   STUCK_THRESHOLD,
 } = require('./agent-stuck-detector');
+const { normalizeProviderName } = require('../../lib/provider-names');
+const { loadSettings } = require('../../lib/settings');
+const { findPlatformMismatchReason } = require('./validation-platform');
+
+const DEFAULT_VALIDATOR_IMAGE = 'zeroshot-cluster-base';
+
+function resolveValidatorIsolationConfig(agent) {
+  const config = agent.config?.isolation || {};
+  if (config.type && config.type !== 'docker') {
+    return null;
+  }
+
+  return {
+    image: config.image || DEFAULT_VALIDATOR_IMAGE,
+    mounts: config.mounts,
+    noMounts: config.noMounts,
+    containerHome: config.containerHome,
+  };
+}
+
+async function createValidatorIsolation(agent, isolationConfig) {
+  if (!IsolationManager.isDockerAvailable()) {
+    agent._log(`[${agent.id}] Docker not available - cannot retry validator in isolation`);
+    return null;
+  }
+
+  const cluster = agent.cluster || {};
+  const workDir = agent.config?.cwd || cluster.worktree?.path || cluster.cwd || process.cwd();
+  const image = isolationConfig.image;
+  await IsolationManager.ensureImage(image);
+
+  const manager = new IsolationManager({ image });
+  const providerName = normalizeProviderName(
+    (agent._resolveProvider && agent._resolveProvider()) ||
+      cluster.config?.forceProvider ||
+      cluster.config?.defaultProvider ||
+      loadSettings().defaultProvider ||
+      'claude'
+  );
+
+  const isolationClusterId = `${cluster.id}-validators`;
+  const containerId = await manager.createContainer(isolationClusterId, {
+    workDir,
+    image,
+    noMounts: isolationConfig.noMounts,
+    mounts: isolationConfig.mounts,
+    containerHome: isolationConfig.containerHome,
+    provider: providerName,
+    reuseExistingWorkspace: true,
+  });
+
+  const validatorIsolation = {
+    enabled: true,
+    manager,
+    clusterId: isolationClusterId,
+    containerId,
+    image,
+    workDir,
+  };
+
+  cluster.validatorIsolation = validatorIsolation;
+  return validatorIsolation;
+}
+
+async function ensureValidatorIsolation(agent) {
+  const cluster = agent.cluster || {};
+
+  if (agent.isolation?.enabled) {
+    return agent.isolation;
+  }
+
+  if (cluster.validatorIsolation?.enabled) {
+    agent.isolation = cluster.validatorIsolation;
+    return agent.isolation;
+  }
+
+  if (cluster.validatorIsolationPromise) {
+    const isolation = await cluster.validatorIsolationPromise;
+    if (isolation?.enabled) {
+      agent.isolation = isolation;
+    }
+    return agent.isolation || null;
+  }
+
+  const isolationConfig = resolveValidatorIsolationConfig(agent);
+  if (!isolationConfig) {
+    agent._log(`[${agent.id}] Validator isolation config is not docker - skipping fallback`);
+    return null;
+  }
+
+  cluster.validatorIsolationPromise = createValidatorIsolation(agent, isolationConfig);
+
+  try {
+    const isolation = await cluster.validatorIsolationPromise;
+    if (isolation?.enabled) {
+      agent.isolation = isolation;
+      return agent.isolation;
+    }
+    return null;
+  } finally {
+    cluster.validatorIsolationPromise = null;
+  }
+}
+
+async function maybeRetryValidatorInDocker(agent, result) {
+  if (agent.role !== 'validator') return null;
+  if (agent.isolation?.enabled) return null;
+  if (agent._validatorIsolationAttemptedIteration === agent.iteration) {
+    return null;
+  }
+
+  const reason = findPlatformMismatchReason(result?.result || {});
+  if (!reason) return null;
+
+  const isolation = await ensureValidatorIsolation(agent);
+  if (!isolation) {
+    return null;
+  }
+
+  agent._validatorIsolationAttemptedIteration = agent.iteration;
+  agent._log(`[${agent.id}] Platform mismatch detected - retrying validator in Docker isolation`);
+  return reason;
+}
 
 /**
  * Start the agent (begin listening for triggers)
@@ -399,6 +523,13 @@ async function runTaskAttempt(agent, triggeringMessage) {
   // Check if task execution failed
   if (!result.success) {
     throw new Error(result.error || 'Task execution failed');
+  }
+
+  const fallbackReason = await maybeRetryValidatorInDocker(agent, result);
+  if (fallbackReason) {
+    throw new Error(
+      `Validator platform mismatch detected (${fallbackReason}). Retrying in Docker isolation.`
+    );
   }
 
   // Set state to idle BEFORE publishing lifecycle event

--- a/src/agent/validation-platform.js
+++ b/src/agent/validation-platform.js
@@ -1,0 +1,35 @@
+const PLATFORM_MISMATCH_REGEX =
+  /EBADPLATFORM|Unsupported platform|darwin-arm64|linux-x64|@esbuild\/linux-x64/i;
+
+function isPlatformMismatchReason(reason) {
+  if (!reason) return false;
+  return PLATFORM_MISMATCH_REGEX.test(String(reason));
+}
+
+function findPlatformMismatchReason(result = {}) {
+  const criteriaResults = result.criteriaResults;
+  if (Array.isArray(criteriaResults)) {
+    for (const criteria of criteriaResults) {
+      if (criteria?.status !== 'CANNOT_VALIDATE') continue;
+      if (isPlatformMismatchReason(criteria.reason)) {
+        return String(criteria.reason);
+      }
+    }
+  }
+
+  const errors = result.errors;
+  if (Array.isArray(errors)) {
+    for (const error of errors) {
+      if (isPlatformMismatchReason(error)) {
+        return String(error);
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  isPlatformMismatchReason,
+  findPlatformMismatchReason,
+};

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1440,6 +1440,14 @@ class Orchestrator {
       this._log(`[Orchestrator] Container stopped, workspace preserved`);
     }
 
+    if (cluster.validatorIsolation?.manager) {
+      this._log(`[Orchestrator] Cleaning up validator isolation container for ${clusterId}...`);
+      await cluster.validatorIsolation.manager.cleanup(cluster.validatorIsolation.clusterId, {
+        preserveWorkspace: false,
+      });
+      cluster.validatorIsolation = null;
+    }
+
     // Worktree cleanup on stop: preserve for resume capability
     // Branch stays, worktree stays - can resume work later
     if (cluster.worktree?.manager) {
@@ -1484,6 +1492,14 @@ class Orchestrator {
       );
       await cluster.isolation.manager.cleanup(clusterId, { preserveWorkspace: false });
       this._log(`[Orchestrator] Container and workspace removed`);
+    }
+
+    if (cluster.validatorIsolation?.manager) {
+      this._log(`[Orchestrator] Force removing validator isolation container for ${clusterId}...`);
+      await cluster.validatorIsolation.manager.cleanup(cluster.validatorIsolation.clusterId, {
+        preserveWorkspace: false,
+      });
+      cluster.validatorIsolation = null;
     }
 
     // Force remove worktree (full cleanup, no resume)

--- a/tests/validation-platform.test.js
+++ b/tests/validation-platform.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const {
+  isPlatformMismatchReason,
+  findPlatformMismatchReason,
+} = require('../src/agent/validation-platform');
+
+describe('Validation platform mismatch detection', function () {
+  it('detects platform mismatch from reason strings', function () {
+    assert.ok(isPlatformMismatchReason('EBADPLATFORM @esbuild/linux-x64'));
+    assert.ok(isPlatformMismatchReason('Unsupported platform for @esbuild/linux-x64'));
+    assert.ok(isPlatformMismatchReason('darwin-arm64 vs linux-x64'));
+    assert.ok(!isPlatformMismatchReason('kubectl not installed'));
+  });
+
+  it('finds platform mismatch in criteriaResults', function () {
+    const result = {
+      criteriaResults: [
+        { id: 'AC1', status: 'PASS' },
+        {
+          id: 'AC2',
+          status: 'CANNOT_VALIDATE',
+          reason: 'npm install fails on darwin-arm64 (EBADPLATFORM for @esbuild/linux-x64)',
+        },
+      ],
+    };
+
+    const reason = findPlatformMismatchReason(result);
+    assert.ok(reason, 'Should return a platform mismatch reason');
+    assert.ok(reason.includes('EBADPLATFORM'), 'Should keep original reason');
+  });
+
+  it('finds platform mismatch in errors array', function () {
+    const result = {
+      errors: ['EBADPLATFORM for @esbuild/linux-x64'],
+    };
+
+    const reason = findPlatformMismatchReason(result);
+    assert.ok(reason, 'Should return a platform mismatch reason');
+  });
+
+  it('returns null when no mismatch found', function () {
+    const result = {
+      criteriaResults: [{ id: 'AC1', status: 'CANNOT_VALIDATE', reason: 'kubectl not installed' }],
+      errors: ['No SSH access'],
+    };
+
+    assert.strictEqual(findPlatformMismatchReason(result), null);
+  });
+});


### PR DESCRIPTION
## Summary
- detect platform-mismatch CANNOT_VALIDATE results and retry validators in docker isolation
- skip platform-mismatch reasons when validator runs in docker
- add platform mismatch detection tests

## Testing
- npm run lint
- npm run test

Fixes #142