### PR TITLE
Fail fast on Windows and document deferral

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and surface conflicts with details. Handle the ABA problem where version goes A-
 
 ## Install and Requirements
 
-**Platforms**: Linux, macOS (Windows WSL not yet supported)
+**Platforms**: Linux, macOS. Windows (native/WSL) is deferred while we harden reliability and multi-provider correctness.
 
 ```bash
 npm install -g @covibes/zeroshot

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -473,6 +473,24 @@ function runPreflight(options = {}) {
   const warnings = [];
 
   const settings = loadSettings();
+
+  if (process.platform === 'win32') {
+    return {
+      valid: false,
+      errors: [
+        formatError(
+          'Windows not supported',
+          'Zeroshot currently supports Linux and macOS only; Windows (native or WSL) is deferred.',
+          [
+            'Use Linux or macOS to run Zeroshot',
+            'Or run inside a Linux VM/container on Windows',
+            'Check README for supported platforms and updates',
+          ]
+        ),
+      ],
+      warnings: [],
+    };
+  }
   const providerName = normalizeProviderName(
     options.provider || settings.defaultProvider || 'claude'
   );


### PR DESCRIPTION
## Summary
- fail fast on Windows in preflight with clear guidance
- document Windows deferral rationale in README

## Testing
- npm run typecheck
- npm run validate:templates
- npm run lint (warnings only)