### PR TITLE
fix: allow parsing when fatal strings appear in logs

### DIFF
--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1673,13 +1673,13 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
  * @returns {Promise<Object>} Parsed result data
  */
 async function parseResultOutput(agent, output) {
-  // Empty or error outputs = FAIL
-  if (!output || output.includes('Task not found') || output.includes('Process terminated')) {
+  // Empty outputs = FAIL
+  if (!output || !output.trim()) {
     throw new Error('Task execution failed - no output');
   }
 
   const providerName = agent._resolveProvider ? agent._resolveProvider() : 'claude';
-  const { extractJsonFromOutput } = require('./output-extraction');
+  const { extractJsonFromOutput, hasFatalStandaloneOutput } = require('./output-extraction');
 
   // Use clean extraction pipeline
   let parsed = extractJsonFromOutput(output, providerName);
@@ -1710,6 +1710,9 @@ async function parseResultOutput(agent, output) {
   }
 
   if (!parsed) {
+    if (hasFatalStandaloneOutput(output)) {
+      throw new Error('Task execution failed - no output');
+    }
     const trimmedOutput = output.trim();
     console.error(`\n${'='.repeat(80)}`);
     console.error(`🔴 AGENT OUTPUT MISSING REQUIRED JSON BLOCK`);

--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -178,6 +178,26 @@ function extractDirectJson(text) {
 }
 
 /**
+ * Detects fatal standalone output lines that indicate no task output was produced.
+ * Only matches when the line itself is the fatal message (not when it appears inside JSON).
+ *
+ * @param {string} output - Raw output text
+ * @returns {boolean} True if a standalone fatal line is present
+ */
+function hasFatalStandaloneOutput(output) {
+  if (!output || typeof output !== 'string') return false;
+  const lines = output.split('\n');
+  for (const line of lines) {
+    const stripped = stripTimestamp(line).trim();
+    if (!stripped) continue;
+    if (/^(task not found|process terminated)\b/i.test(stripped)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Main extraction function - tries all strategies in priority order
  *
  * @param {string} output - Raw output from AI provider CLI
@@ -189,11 +209,6 @@ function extractJsonFromOutput(output, providerName = 'claude') {
 
   const trimmedOutput = output.trim();
   if (!trimmedOutput) return null;
-
-  // Check for fatal error indicators
-  if (trimmedOutput.includes('Task not found') || trimmedOutput.includes('Process terminated')) {
-    return null;
-  }
 
   // Strategy 1: Result wrapper (Claude format)
   const fromWrapper = extractFromResultWrapper(trimmedOutput);
@@ -211,6 +226,10 @@ function extractJsonFromOutput(output, providerName = 'claude') {
   const fromDirect = extractDirectJson(trimmedOutput);
   if (fromDirect) return fromDirect;
 
+  if (hasFatalStandaloneOutput(trimmedOutput)) {
+    return null;
+  }
+
   return null;
 }
 
@@ -221,4 +240,5 @@ module.exports = {
   extractFromMarkdown,
   extractDirectJson,
   stripTimestamp,
+  hasFatalStandaloneOutput,
 };

--- a/tests/unit/output-extraction-fatal-strings.test.js
+++ b/tests/unit/output-extraction-fatal-strings.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const {
+  extractJsonFromOutput,
+  hasFatalStandaloneOutput,
+} = require('../../src/agent/output-extraction');
+
+describe('Output Extraction - fatal strings handling', () => {
+  it('extracts JSON when fatal substrings appear inside JSON events', () => {
+    const output = [
+      '{"type":"item.completed","item":{"id":"item_1","type":"command_execution","aggregated_output":"Task not found"}}',
+      '{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"{\\"summary\\":\\"ok\\",\\"completionStatus\\":{\\"canValidate\\":true,\\"percentComplete\\":100}}"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}',
+    ].join('\n');
+
+    const parsed = extractJsonFromOutput(output, 'codex');
+
+    assert.deepStrictEqual(parsed, {
+      summary: 'ok',
+      completionStatus: {
+        canValidate: true,
+        percentComplete: 100,
+      },
+    });
+  });
+
+  it('detects standalone fatal output lines', () => {
+    const output = 'Task not found\n';
+    assert.strictEqual(hasFatalStandaloneOutput(output), true);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid treating "Task not found"/"Process terminated" substrings inside JSON logs as fatal
- only treat standalone fatal lines as no-output
- add output-extraction unit tests for fatal-string handling

## Testing
- npm test

Fixes #165