### PR TITLE
fix: unblock git-pusher after validator approval

### DIFF
--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -22,13 +22,25 @@ const results = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.times
 if (results.length < validators.length) return false;
 const allApproved = results.every(r => r.content?.data?.approved === 'true' || r.content?.data?.approved === true);
 if (!allApproved) return false;
-const hasRealEvidence = results.every(r => {
-  const criteria = r.content?.data?.criteriaResults || [];
+const hasSufficientEvidence = results.every(r => {
+  const criteria = r.content?.data?.criteriaResults;
+  if (!Array.isArray(criteria) || criteria.length === 0) return true;
   return criteria.every(c => {
-    return c.evidence?.command && typeof c.evidence?.exitCode === 'number' && c.evidence?.output?.length > 10;
+    const status = String(c.status || '').toUpperCase();
+    if (status === 'CANNOT_VALIDATE') return true;
+    if (status === 'SKIPPED') return true;
+    if (status === 'CANNOT_VALIDATE_YET') return false;
+    const evidence = c.evidence || {};
+    const hasCommand = typeof evidence.command === 'string' && evidence.command.trim().length > 0;
+    const exitCode = evidence.exitCode;
+    const hasExitCode =
+      typeof exitCode === 'number' ||
+      (typeof exitCode === 'string' && exitCode.trim() !== '' && Number.isFinite(Number(exitCode)));
+    const hasOutput = evidence.output === undefined || typeof evidence.output === 'string';
+    return hasCommand && hasExitCode && hasOutput;
   });
 });
-return hasRealEvidence;`;
+return hasSufficientEvidence;`;
 
 /**
  * Platform-specific CLI commands and terminology

--- a/tests/integration/trigger-evaluation.test.js
+++ b/tests/integration/trigger-evaluation.test.js
@@ -13,6 +13,7 @@ const os = require('os');
 const LogicEngine = require('../../src/logic-engine');
 const MessageBus = require('../../src/message-bus');
 const Ledger = require('../../src/ledger');
+const { SHARED_TRIGGER_SCRIPT } = require('../../src/agents/git-pusher-template');
 
 let tempDir;
 let ledger;
@@ -61,6 +62,7 @@ describe('Trigger Evaluation Integration', function () {
   defineErrorHandlingTests();
   defineScriptValidationTests();
   defineComplexConsensusTests();
+  defineGitPusherTriggerTests();
 });
 
 function defineBasicLedgerQueryTests() {
@@ -469,6 +471,61 @@ function defineComplexConsensusTests() {
           id: 'completion-detector',
           cluster_id: cluster.id,
         },
+        { topic: 'VALIDATION_RESULT' }
+      );
+
+      assert.strictEqual(result, true);
+    });
+  });
+}
+
+function defineGitPusherTriggerTests() {
+  describe('Git-pusher Trigger Evidence', () => {
+    it('should allow approvals with CANNOT_VALIDATE and empty output evidence', () => {
+      messageBus.publish({
+        cluster_id: cluster.id,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        timestamp: Date.now(),
+      });
+
+      const implTime = Date.now();
+
+      messageBus.publish({
+        cluster_id: cluster.id,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-1',
+        timestamp: implTime + 100,
+        content: {
+          data: {
+            approved: true,
+            criteriaResults: [
+              {
+                id: 'AC1',
+                status: 'PASS',
+                evidence: { command: 'npm test', exitCode: 0, output: '' },
+              },
+              {
+                id: 'AC2',
+                status: 'CANNOT_VALIDATE',
+                reason: 'Docker not available',
+              },
+            ],
+          },
+        },
+      });
+
+      messageBus.publish({
+        cluster_id: cluster.id,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-2',
+        timestamp: implTime + 200,
+        content: { data: { approved: true } },
+      });
+
+      const result = logicEngine.evaluate(
+        SHARED_TRIGGER_SCRIPT,
+        { id: 'git-pusher', cluster_id: cluster.id },
         { topic: 'VALIDATION_RESULT' }
       );
 


### PR DESCRIPTION
Fixes #176.

- relax git-pusher evidence gating to allow CANNOT_VALIDATE/empty outputs
- add regression test for trigger evaluation