### PR TITLE
feat: TUI v2 2.3: Command registry + /status & /list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Ink TUI router           | `src/tui/router.tsx`                |
 | Ink TUI view stack       | `src/tui/view-stack.ts`             |
 | Ink TUI commands         | `src/tui/commands/`                 |
+| TUI command registry     | `src/tui/commands/registry.ts`      |
+| TUI CLI compat wrapper   | `src/tui/commands/cli-compat.ts`    |
 | Ink TUI views            | `src/tui/views/`                    |
 | Ink TUI build output     | `lib/tui/`                          |
 | Docker mounts/env        | `lib/docker-config.js`              |
@@ -44,6 +46,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Settings                 | `lib/settings.js`                   |
 
 TUI navigation convention: view stack with `launcher` as root; Esc pops the stack to the previous view. Global command box is always available and slash commands live under `src/tui/commands/`.
+TUI command convention: register slash commands in `src/tui/commands/dispatcher.ts` via `createCommandRegistry()`; use `src/tui/commands/cli-compat.ts` to reuse task-lib CLI helpers and return condensed output for the status bar.
 
 ## CLI Quick Reference
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -40,10 +40,15 @@ export default function App({
   const [provider, setProvider] = useState<string | null>(
     providerOverride ?? null
   );
+  const [isDispatching, setIsDispatching] = useState(false);
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
 
-  function handleSubmit() {
+  async function handleSubmit() {
+    if (isDispatching) {
+      return;
+    }
+
     const parsed = parseInput(inputValue);
     if (parsed.type === "empty") {
       setInputValue("");
@@ -59,14 +64,22 @@ export default function App({
       return;
     }
 
-    const result = dispatchCommand(parsed, {
-      navigate: (view) =>
-        setViewStack((stack) => pushIfDifferent(stack, view)),
-      setProvider: (next) => setProvider(next),
-      exit,
-    });
-    setStatus(result);
-    setInputValue("");
+    setIsDispatching(true);
+    try {
+      const result = await dispatchCommand(parsed, {
+        navigate: (view) =>
+          setViewStack((stack) => pushIfDifferent(stack, view)),
+        setProvider: (next) => setProvider(next),
+        exit,
+      });
+      setStatus(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Command failed.";
+      setStatus({ tone: "error", message });
+    } finally {
+      setInputValue("");
+      setIsDispatching(false);
+    }
   }
 
   useInput(
@@ -80,7 +93,7 @@ export default function App({
         return;
       }
       if (key.return) {
-        handleSubmit();
+        void handleSubmit();
         return;
       }
       if (key.backspace || key.delete) {

--- a/src/tui/commands/cli-compat.ts
+++ b/src/tui/commands/cli-compat.ts
@@ -1,0 +1,120 @@
+import { format } from "node:util";
+
+export type CliCompatResult = {
+  output: string;
+  exitCode: number;
+};
+
+class CliCompatExit extends Error {
+  code: number;
+
+  constructor(code: number) {
+    super("CLI_COMPAT_EXIT");
+    this.code = code;
+  }
+}
+
+function stripAnsi(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+function condenseOutput(value: string): string {
+  const cleaned = stripAnsi(value).replace(/\r/g, "");
+  const lines = cleaned
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.join(" | ");
+}
+
+function normalizeChunk(chunk: unknown): string {
+  if (typeof chunk === "string") return chunk;
+  if (Buffer.isBuffer(chunk)) return chunk.toString("utf-8");
+  return String(chunk);
+}
+
+async function runWithOutput(
+  runner: () => void | Promise<void>
+): Promise<CliCompatResult> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode = 0;
+
+  const originalConsoleLog = console.log;
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalExit = process.exit;
+
+  console.log = (...args: unknown[]) => {
+    stdout.push(format(...args));
+  };
+  console.error = (...args: unknown[]) => {
+    stderr.push(format(...args));
+  };
+  console.warn = (...args: unknown[]) => {
+    stderr.push(format(...args));
+  };
+
+  process.stdout.write = ((chunk: unknown, encoding?: unknown, callback?: unknown) => {
+    stdout.push(normalizeChunk(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: unknown, encoding?: unknown, callback?: unknown) => {
+    stderr.push(normalizeChunk(chunk));
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+
+  process.exit = ((code?: number) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new CliCompatExit(exitCode);
+  }) as typeof process.exit;
+
+  try {
+    await runner();
+  } catch (error) {
+    if (!(error instanceof CliCompatExit)) {
+      throw error;
+    }
+  } finally {
+    console.log = originalConsoleLog;
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exit = originalExit;
+  }
+
+  const combined = [...stdout, ...stderr].join("\n");
+  return {
+    output: condenseOutput(combined),
+    exitCode,
+  };
+}
+
+export async function runListTasks(options: {
+  status?: string;
+  limit?: number;
+  verbose?: boolean;
+}): Promise<CliCompatResult> {
+  const { listTasks } = await import("../../../task-lib/commands/list.js");
+  return runWithOutput(() => listTasks(options));
+}
+
+export async function runShowStatus(taskId: string): Promise<CliCompatResult> {
+  const { showStatus } = await import("../../../task-lib/commands/status.js");
+  return runWithOutput(() => showStatus(taskId));
+}

--- a/src/tui/commands/dispatcher.ts
+++ b/src/tui/commands/dispatcher.ts
@@ -1,42 +1,196 @@
 import { CommandContext, CommandResult, ParsedCommand } from "./types";
 import {
+  CommandDefinition,
+  CommandRegistry,
+  createCommandRegistry,
+} from "./registry";
+import { runListTasks, runShowStatus } from "./cli-compat";
+import {
   normalizeProviderName,
   VALID_PROVIDERS,
 } from "../../../lib/provider-names";
 
-function formatHelp(): string {
-  return [
-    "Commands:",
-    "/help - show commands",
-    "/monitor - open Monitor view",
-    "/issue <ref> - start from issue (stub)",
-    "/provider <name> - switch provider",
-    "/quit - exit the TUI",
-    "Keys: Esc back, Ctrl+C exit",
-  ].join(" ");
+const { detectIdType } = require("../../../lib/id-detector");
+
+type ListOptions = {
+  status?: string;
+  limit?: number;
+  verbose?: boolean;
+};
+
+const LIST_USAGE =
+  "Usage: /list [--status <status>] [--limit <n>] [--verbose]";
+
+function formatHelp(definitions: CommandDefinition[]): string {
+  const lines = definitions.map((definition) => {
+    const usage = definition.usage ? ` ${definition.usage}` : "";
+    return `/${definition.name}${usage} - ${definition.description}`;
+  });
+
+  return ["Commands:", ...lines, "Keys: Esc back, Ctrl+C exit"].join(" ");
 }
 
-export function dispatchCommand(
-  command: ParsedCommand,
-  context: CommandContext
-): CommandResult {
-  const { name, args } = command;
+function parseListOptions(args: string[]):
+  | { options: ListOptions }
+  | { error: string } {
+  const options: ListOptions = {};
 
-  switch (name) {
-    case "help":
-      return { tone: "info", message: formatHelp() };
-    case "monitor":
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--status" || arg === "-s") {
+      const value = args[index + 1];
+      if (!value) {
+        return { error: LIST_USAGE };
+      }
+      options.status = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--limit" || arg === "-n") {
+      const value = args[index + 1];
+      if (!value) {
+        return { error: LIST_USAGE };
+      }
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return { error: LIST_USAGE };
+      }
+      options.limit = parsed;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--verbose" || arg === "-v") {
+      options.verbose = true;
+      continue;
+    }
+
+    return { error: LIST_USAGE };
+  }
+
+  return { options };
+}
+
+async function handleList(args: string[]): Promise<CommandResult> {
+  const parsed = parseListOptions(args);
+  if ("error" in parsed) {
+    return { tone: "error", message: parsed.error };
+  }
+
+  try {
+    const result = await runListTasks(parsed.options);
+    const message = result.output || "No tasks found.";
+
+    if (result.exitCode !== 0) {
+      return { tone: "error", message };
+    }
+
+    return { tone: "info", message };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { tone: "error", message: `Error listing tasks: ${message}` };
+  }
+}
+
+async function handleClusterStatus(clusterId: string): Promise<CommandResult> {
+  try {
+    const Orchestrator = require("../../../src/orchestrator");
+    const orchestrator = await Orchestrator.create({ quiet: true });
+    const status = orchestrator.getStatus(clusterId);
+    const state = status.isZombie ? "zombie" : status.state;
+    const message = `Cluster ${status.id}: ${state}. Agents: ${status.agents.length}. Messages: ${status.messageCount}. Created: ${new Date(
+      status.createdAt
+    ).toLocaleString()}.`;
+    return { tone: "info", message };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { tone: "error", message: `Error getting cluster status: ${message}` };
+  }
+}
+
+async function handleStatus(args: string[]): Promise<CommandResult> {
+  if (args.length === 0) {
+    return { tone: "error", message: "Usage: /status <id>" };
+  }
+
+  const id = args[0];
+  let type: "cluster" | "task" | null = null;
+
+  try {
+    type = detectIdType(id);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { tone: "error", message: `Error checking id: ${message}` };
+  }
+
+  if (!type) {
+    return { tone: "error", message: `Unknown id: ${id}.` };
+  }
+
+  if (type === "cluster") {
+    return handleClusterStatus(id);
+  }
+
+  try {
+    const result = await runShowStatus(id);
+    const message = result.output || `No status output for ${id}.`;
+
+    if (result.exitCode !== 0) {
+      return { tone: "error", message };
+    }
+
+    return { tone: "info", message };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { tone: "error", message: `Error getting status: ${message}` };
+  }
+}
+
+function createBuiltInRegistry(): CommandRegistry {
+  const registry = createCommandRegistry();
+
+  registry.register({
+    name: "help",
+    description: "show commands",
+    handler: () => ({
+      tone: "info",
+      message: formatHelp(registry.list()),
+    }),
+  });
+
+  registry.register({
+    name: "monitor",
+    description: "open Monitor view",
+    handler: (_args, context) => {
       context.navigate("monitor");
       return { tone: "success", message: "Opened Monitor view." };
-    case "issue":
+    },
+  });
+
+  registry.register({
+    name: "issue",
+    description: "start from issue (stub)",
+    usage: "<ref>",
+    handler: (args) => {
       if (args.length === 0) {
         return { tone: "error", message: "Usage: /issue <ref>" };
       }
       return {
         tone: "info",
-        message: `Issue launch is not implemented yet. Placeholder for: ${args.join(" ")}.`,
+        message: `Issue launch is not implemented yet. Placeholder for: ${args.join(
+          " "
+        )}.`,
       };
-    case "provider":
+    },
+  });
+
+  registry.register({
+    name: "provider",
+    description: "switch provider",
+    usage: "<name>",
+    handler: (args, context) => {
       if (args.length === 0) {
         return { tone: "error", message: "Usage: /provider <name>" };
       }
@@ -51,13 +205,47 @@ export function dispatchCommand(
       }
       context.setProvider(normalized);
       return { tone: "success", message: `Provider set to ${normalized}.` };
-    case "quit":
+    },
+  });
+
+  registry.register({
+    name: "list",
+    description: "list tasks",
+    usage: "[--status <status>] [--limit <n>] [--verbose]",
+    handler: (args) => handleList(args),
+  });
+
+  registry.register({
+    name: "status",
+    description: "show task or cluster status",
+    usage: "<id>",
+    handler: (args) => handleStatus(args),
+  });
+
+  registry.register({
+    name: "quit",
+    description: "exit the TUI",
+    handler: (_args, context) => {
       context.exit();
       return { tone: "info", message: "Exiting..." };
-    default:
-      return {
-        tone: "error",
-        message: `Unknown command: /${name || ""}. Type /help for commands.`,
-      };
+    },
+  });
+
+  return registry;
+}
+
+let registry: CommandRegistry | null = null;
+
+function getRegistry(): CommandRegistry {
+  if (!registry) {
+    registry = createBuiltInRegistry();
   }
+  return registry;
+}
+
+export async function dispatchCommand(
+  command: ParsedCommand,
+  context: CommandContext
+): Promise<CommandResult> {
+  return getRegistry().dispatch(command, context);
 }

--- a/src/tui/commands/registry.ts
+++ b/src/tui/commands/registry.ts
@@ -1,0 +1,61 @@
+import { CommandContext, CommandResult, ParsedCommand } from "./types";
+
+export type CommandHandler = (
+  args: string[],
+  context: CommandContext
+) => Promise<CommandResult> | CommandResult;
+
+export type CommandDefinition = {
+  name: string;
+  description: string;
+  usage?: string;
+  handler: CommandHandler;
+};
+
+export type CommandRegistry = {
+  register: (definition: CommandDefinition) => void;
+  list: () => CommandDefinition[];
+  dispatch: (
+    command: ParsedCommand,
+    context: CommandContext
+  ) => Promise<CommandResult>;
+};
+
+export function createCommandRegistry(): CommandRegistry {
+  const commands = new Map<string, CommandDefinition>();
+
+  function register(definition: CommandDefinition): void {
+    const key = definition.name.toLowerCase();
+    if (!key) {
+      throw new Error("Command name is required.");
+    }
+    if (commands.has(key)) {
+      throw new Error(`Command already registered: ${key}`);
+    }
+    commands.set(key, { ...definition, name: key });
+  }
+
+  function list(): CommandDefinition[] {
+    return Array.from(commands.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }
+
+  async function dispatch(
+    command: ParsedCommand,
+    context: CommandContext
+  ): Promise<CommandResult> {
+    const key = command.name.toLowerCase();
+    const definition = commands.get(key);
+    if (!definition) {
+      return {
+        tone: "error",
+        message: `Unknown command: /${command.name || ""}. Type /help for commands.`,
+      };
+    }
+
+    return await definition.handler(command.args, context);
+  }
+
+  return { register, list, dispatch };
+}

--- a/src/tui/commands/types.ts
+++ b/src/tui/commands/types.ts
@@ -27,6 +27,16 @@ export type CommandResult = {
   message: string;
 };
 
+export type CommandHandler = (
+  args: string[],
+  context: CommandContext
+) => Promise<CommandResult> | CommandResult;
+
+export type CommandDispatcher = (
+  command: ParsedCommand,
+  context: CommandContext
+) => Promise<CommandResult>;
+
 export type CommandContext = {
   navigate: (view: ViewId) => void;
   setProvider: (provider: string | null) => void;

--- a/tests/unit/tui-command-dispatcher.test.js
+++ b/tests/unit/tui-command-dispatcher.test.js
@@ -1,9 +1,15 @@
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execSync } = require('child_process');
+const { pathToFileURL } = require('url');
 
 const buildOutput = path.join(__dirname, '..', '..', 'lib', 'tui', 'commands', 'dispatcher.js');
+
+const originalHome = process.env.HOME;
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-tui-'));
+process.env.HOME = tempHome;
 
 function ensureTuiBuild() {
   if (!fs.existsSync(buildOutput)) {
@@ -14,6 +20,37 @@ function ensureTuiBuild() {
 ensureTuiBuild();
 
 const { dispatchCommand } = require('../../lib/tui/commands/dispatcher');
+
+let seeded = false;
+
+async function seedTasks() {
+  if (seeded) return;
+  const storeUrl = pathToFileURL(path.join(__dirname, '..', '..', 'task-lib', 'store.js')).href;
+  const { saveTasks } = await import(storeUrl);
+  const now = new Date().toISOString();
+  saveTasks({
+    'task-123': {
+      id: 'task-123',
+      prompt: 'Example prompt',
+      fullPrompt: 'Example prompt',
+      cwd: tempHome,
+      status: 'completed',
+      pid: null,
+      sessionId: null,
+      logFile: path.join(tempHome, 'task-123.log'),
+      createdAt: now,
+      updatedAt: now,
+      exitCode: 0,
+      error: null,
+      provider: 'codex',
+      model: 'test-model',
+      scheduleId: null,
+      socketPath: null,
+      attachable: false,
+    },
+  });
+  seeded = true;
+}
 
 function createContext() {
   const calls = {
@@ -37,9 +74,9 @@ function createContext() {
 }
 
 describe('TUI command dispatcher', function () {
-  it('handles /help', function () {
+  it('handles /help', async function () {
     const { context } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       { type: 'command', name: 'help', args: [], raw: '/help' },
       context
     );
@@ -47,9 +84,9 @@ describe('TUI command dispatcher', function () {
     assert.ok(result.message.includes('/help'));
   });
 
-  it('navigates on /monitor', function () {
+  it('navigates on /monitor', async function () {
     const { context, calls } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       { type: 'command', name: 'monitor', args: [], raw: '/monitor' },
       context
     );
@@ -57,18 +94,18 @@ describe('TUI command dispatcher', function () {
     assert.deepStrictEqual(calls.navigate, ['monitor']);
   });
 
-  it('stubs /issue', function () {
+  it('stubs /issue', async function () {
     const { context } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       { type: 'command', name: 'issue', args: ['123'], raw: '/issue 123' },
       context
     );
     assert.ok(result.message.toLowerCase().includes('not implemented'));
   });
 
-  it('sets provider on /provider', function () {
+  it('sets provider on /provider', async function () {
     const { context, calls } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       { type: 'command', name: 'provider', args: ['codex'], raw: '/provider codex' },
       context
     );
@@ -76,9 +113,9 @@ describe('TUI command dispatcher', function () {
     assert.strictEqual(calls.provider, 'codex');
   });
 
-  it('rejects invalid providers', function () {
+  it('rejects invalid providers', async function () {
     const { context } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       {
         type: 'command',
         name: 'provider',
@@ -90,13 +127,49 @@ describe('TUI command dispatcher', function () {
     assert.strictEqual(result.tone, 'error');
   });
 
-  it('exits on /quit', function () {
+  it('exits on /quit', async function () {
     const { context, calls } = createContext();
-    const result = dispatchCommand(
+    const result = await dispatchCommand(
       { type: 'command', name: 'quit', args: [], raw: '/quit' },
       context
     );
     assert.strictEqual(result.tone, 'info');
     assert.strictEqual(calls.exit, 1);
   });
+
+  it('handles /list', async function () {
+    await seedTasks();
+    const { context } = createContext();
+    const result = await dispatchCommand(
+      { type: 'command', name: 'list', args: [], raw: '/list' },
+      context
+    );
+    assert.strictEqual(result.tone, 'info');
+    assert.ok(result.message.includes('task-123'));
+  });
+
+  it('handles /status <id>', async function () {
+    await seedTasks();
+    const { context } = createContext();
+    const result = await dispatchCommand(
+      { type: 'command', name: 'status', args: ['task-123'], raw: '/status task-123' },
+      context
+    );
+    assert.strictEqual(result.tone, 'info');
+    assert.ok(result.message.includes('task-123'));
+  });
+
+  it('rejects /status without id', async function () {
+    const { context } = createContext();
+    const result = await dispatchCommand(
+      { type: 'command', name: 'status', args: [], raw: '/status' },
+      context
+    );
+    assert.strictEqual(result.tone, 'error');
+    assert.ok(result.message.includes('Usage: /status <id>'));
+  });
+});
+
+after(function () {
+  process.env.HOME = originalHome;
 });

--- a/tests/unit/tui-command-registry.test.js
+++ b/tests/unit/tui-command-registry.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(__dirname, '..', '..', 'lib', 'tui', 'commands', 'registry.js');
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const { createCommandRegistry } = require('../../lib/tui/commands/registry');
+
+function createContext() {
+  return {
+    navigate: () => {},
+    setProvider: () => {},
+    exit: () => {},
+  };
+}
+
+describe('TUI command registry', function () {
+  it('registers and dispatches commands', async function () {
+    const registry = createCommandRegistry();
+    registry.register({
+      name: 'ping',
+      description: 'ping',
+      handler: () => ({ tone: 'success', message: 'pong' }),
+    });
+
+    const result = await registry.dispatch(
+      { type: 'command', name: 'ping', args: [], raw: '/ping' },
+      createContext()
+    );
+
+    assert.strictEqual(result.tone, 'success');
+    assert.strictEqual(result.message, 'pong');
+  });
+
+  it('lists registered commands', function () {
+    const registry = createCommandRegistry();
+    registry.register({
+      name: 'alpha',
+      description: 'alpha',
+      handler: () => ({ tone: 'info', message: 'alpha' }),
+    });
+    registry.register({
+      name: 'beta',
+      description: 'beta',
+      handler: () => ({ tone: 'info', message: 'beta' }),
+    });
+
+    const names = registry.list().map((command) => command.name);
+    assert.deepStrictEqual(names, ['alpha', 'beta']);
+  });
+
+  it('returns unknown command error', async function () {
+    const registry = createCommandRegistry();
+    const result = await registry.dispatch(
+      { type: 'command', name: 'missing', args: [], raw: '/missing' },
+      createContext()
+    );
+
+    assert.strictEqual(result.tone, 'error');
+    assert.ok(result.message.includes('/missing'));
+  });
+});


### PR DESCRIPTION
## Summary
- add typed command registry + dispatch wiring for TUI slash commands
- add CLI compatibility helpers for list/status output
- add tests for registry and dispatcher updates

## Testing
- npm test (via pre-commit)
- npm run lint (warnings only)

Fixes #185