### PR TITLE
feat: TUI v2 3.1: start-cluster helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,30 +20,32 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 
 ## Where to Look
 
-| Concept                  | File                                |
-| ------------------------ | ----------------------------------- |
-| Conductor classification | `src/conductor-bootstrap.js`        |
-| Base templates           | `cluster-templates/base-templates/` |
-| Message bus              | `src/message-bus.js`                |
-| Ledger (SQLite)          | `src/ledger.js`                     |
-| Trigger evaluation       | `src/logic-engine.js`               |
-| Agent wrapper            | `src/agent-wrapper.js`              |
-| Providers registry       | `src/providers/index.js`            |
-| Provider implementations | `src/providers/`                    |
-| Provider detection       | `lib/provider-detection.js`         |
-| Provider capabilities    | `src/providers/capabilities.js`     |
-| Ink TUI entrypoint       | `src/tui/index.tsx`                 |
-| Ink TUI app              | `src/tui/app.tsx`                   |
-| Ink TUI router           | `src/tui/router.tsx`                |
-| Ink TUI view stack       | `src/tui/view-stack.ts`             |
-| Ink TUI commands         | `src/tui/commands/`                 |
-| TUI command registry     | `src/tui/commands/registry.ts`      |
-| TUI CLI compat wrapper   | `src/tui/commands/cli-compat.ts`    |
-| Ink TUI views            | `src/tui/views/`                    |
-| Ink TUI build output     | `lib/tui/`                          |
-| Docker mounts/env        | `lib/docker-config.js`              |
-| Container lifecycle      | `src/isolation-manager.js`          |
-| Settings                 | `lib/settings.js`                   |
+| Concept                   | File                                |
+| ------------------------- | ----------------------------------- |
+| Conductor classification  | `src/conductor-bootstrap.js`        |
+| Base templates            | `cluster-templates/base-templates/` |
+| Message bus               | `src/message-bus.js`                |
+| Ledger (SQLite)           | `src/ledger.js`                     |
+| Trigger evaluation        | `src/logic-engine.js`               |
+| Agent wrapper             | `src/agent-wrapper.js`              |
+| Providers registry        | `src/providers/index.js`            |
+| Provider implementations  | `src/providers/`                    |
+| Provider detection        | `lib/provider-detection.js`         |
+| Provider capabilities     | `src/providers/capabilities.js`     |
+| Ink TUI entrypoint        | `src/tui/index.tsx`                 |
+| Ink TUI app               | `src/tui/app.tsx`                   |
+| Ink TUI router            | `src/tui/router.tsx`                |
+| Ink TUI view stack        | `src/tui/view-stack.ts`             |
+| Ink TUI commands          | `src/tui/commands/`                 |
+| TUI command registry      | `src/tui/commands/registry.ts`      |
+| TUI CLI compat wrapper    | `src/tui/commands/cli-compat.ts`    |
+| Ink TUI views             | `src/tui/views/`                    |
+| Ink TUI build output      | `lib/tui/`                          |
+| TUI start-cluster helper  | `lib/start-cluster.js`              |
+| TUI start-cluster service | `src/tui/services/start-cluster.ts` |
+| Docker mounts/env         | `lib/docker-config.js`              |
+| Container lifecycle       | `src/isolation-manager.js`          |
+| Settings                  | `lib/settings.js`                   |
 
 TUI navigation convention: view stack with `launcher` as root; Esc pops the stack to the previous view. Global command box is always available and slash commands live under `src/tui/commands/`.
 TUI command convention: register slash commands in `src/tui/commands/dispatcher.ts` via `createCommandRegistry()`; use `src/tui/commands/cli-compat.ts` to reuse task-lib CLI helpers and return condensed output for the status bar.

--- a/cli/index.js
+++ b/cli/index.js
@@ -49,6 +49,16 @@ const {
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider, parseProviderChunk } = require('../src/providers');
 const { MOUNT_PRESETS, resolveEnvs } = require('../lib/docker-config');
+const {
+  detectGitRepoRoot,
+  detectRunInput,
+  loadClusterConfig,
+  resolveConfigPath,
+  resolveProviderOverride,
+  startClusterFromFile,
+  startClusterFromIssue,
+  startClusterFromText,
+} = require('../lib/start-cluster');
 const { requirePreflight } = require('../src/preflight');
 const { providersCommand, setDefaultCommand, setupCommand } = require('./commands/providers');
 // Setup wizard removed - use: zeroshot settings set <key> <value>
@@ -152,43 +162,6 @@ process.on('unhandledRejection', (reason) => {
 // Package root directory (for resolving default config paths)
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
-/**
- * Detect git repository root from current directory
- * Critical for CWD propagation - agents must work in the target repo, not where CLI was invoked
- * @returns {string} Git repo root, or process.cwd() if not in a git repo
- */
-function detectGitRepoRoot() {
-  const { execSync } = require('child_process');
-  try {
-    const root = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    return root;
-  } catch {
-    // Not in a git repo - use current directory
-    return process.cwd();
-  }
-}
-
-/**
- * Parse CLI mount specs (host:container[:ro]) into mount config objects
- * @param {string[]} specs - Array of mount specs from CLI
- * @returns {Array<{host: string, container: string, readonly: boolean}>}
- */
-function parseMountSpecs(specs) {
-  return specs.map((spec) => {
-    const parts = spec.split(':');
-    if (parts.length < 2) {
-      throw new Error(`Invalid mount spec: "${spec}". Format: host:container[:ro]`);
-    }
-    const host = parts[0];
-    const container = parts[1];
-    const readonly = parts[2] === 'ro';
-    return { host, container, readonly };
-  });
-}
-
 function normalizeRunOptions(options) {
   if (options.ship) {
     options.pr = true;
@@ -202,47 +175,6 @@ function normalizeRunOptions(options) {
   if (options.docker) {
     options.worktree = false;
   }
-}
-
-function detectRunInput(inputArg) {
-  const input = {};
-
-  // Check if it looks like an issue URL or key
-  const isGitHubUrl = /^https?:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/.test(inputArg);
-  const isGitLabUrl = /gitlab\.(com|[\w.-]+)\/[\w-]+\/[\w-]+\/-\/issues\/\d+/.test(inputArg);
-  const isJiraUrl = /(atlassian\.net|jira\.[\w.-]+)\/browse\/[A-Z][A-Z0-9]+-\d+/.test(inputArg);
-  const isAzureUrl =
-    /dev\.azure\.com\/.*\/_workitems\/edit\/\d+/.test(inputArg) ||
-    /visualstudio\.com\/.*\/_workitems\/edit\/\d+/.test(inputArg);
-  const isJiraKey = /^[A-Z][A-Z0-9]+-\d+$/.test(inputArg);
-  const isIssueNumber = /^\d+$/.test(inputArg);
-  const isRepoIssue = /^[\w-]+\/[\w-]+#\d+$/.test(inputArg);
-  const isMarkdownFile = /\.(md|markdown)$/i.test(inputArg);
-
-  if (
-    isGitHubUrl ||
-    isGitLabUrl ||
-    isJiraUrl ||
-    isAzureUrl ||
-    isJiraKey ||
-    isIssueNumber ||
-    isRepoIssue
-  ) {
-    input.issue = inputArg;
-  } else if (isMarkdownFile) {
-    input.file = inputArg;
-  } else {
-    input.text = inputArg;
-  }
-  return input;
-}
-
-function resolveProviderOverride(options) {
-  const override = options.provider || process.env.ZEROSHOT_PROVIDER;
-  if (!override || (typeof override === 'string' && !override.trim())) {
-    return null;
-  }
-  return normalizeProviderName(override);
 }
 
 function resolveTuiProviderOverride(options = {}) {
@@ -360,42 +292,6 @@ function resolveConfigName(options, settings) {
   return options.config || settings.defaultConfig;
 }
 
-function resolveConfigPath(configName) {
-  if (path.isAbsolute(configName) || configName.startsWith('./') || configName.startsWith('../')) {
-    return path.resolve(process.cwd(), configName);
-  }
-  if (configName.endsWith('.json')) {
-    return path.join(PACKAGE_ROOT, 'cluster-templates', configName);
-  }
-  return path.join(PACKAGE_ROOT, 'cluster-templates', `${configName}.json`);
-}
-
-function ensureConfigProviderDefaults(config, settings) {
-  if (!config.defaultProvider) {
-    config.defaultProvider = settings.defaultProvider || 'claude';
-  }
-  config.defaultProvider = normalizeProviderName(config.defaultProvider) || 'claude';
-}
-
-function applyProviderOverrideToConfig(config, providerOverride, settings) {
-  const provider = getProvider(providerOverride);
-  const providerSettings = settings.providerSettings?.[providerOverride] || {};
-  config.forceProvider = providerOverride;
-  config.defaultProvider = providerOverride;
-  config.forceLevel = providerSettings.defaultLevel || provider.getDefaultLevel();
-  config.defaultLevel = config.forceLevel;
-  console.log(chalk.dim(`Provider override: ${providerOverride} (all agents)`));
-}
-
-function loadClusterConfig(orchestrator, configPath, settings, providerOverride) {
-  const config = orchestrator.loadConfig(configPath);
-  ensureConfigProviderDefaults(config, settings);
-  if (providerOverride) {
-    applyProviderOverrideToConfig(config, providerOverride, settings);
-  }
-  return config;
-}
-
 function trackActiveCluster(clusterId, orchestrator) {
   activeClusterId = clusterId;
   orchestratorInstance = orchestrator;
@@ -471,34 +367,6 @@ function applyModelOverrideToConfig(config, modelOverride, providerOverride, set
     }
   }
   console.log(chalk.dim(`Model override: ${modelOverride} (all agents)`));
-}
-
-function buildStartOptions({
-  clusterId,
-  options,
-  settings,
-  providerOverride,
-  modelOverride,
-  forceProvider,
-}) {
-  const targetCwd = process.env.ZEROSHOT_CWD || detectGitRepoRoot();
-  return {
-    clusterId,
-    cwd: targetCwd,
-    isolation: options.docker || process.env.ZEROSHOT_DOCKER === '1' || settings.defaultDocker,
-    isolationImage: options.dockerImage || process.env.ZEROSHOT_DOCKER_IMAGE || undefined,
-    worktree: options.worktree || process.env.ZEROSHOT_WORKTREE === '1',
-    autoPr: options.pr || process.env.ZEROSHOT_PR === '1',
-    autoMerge: process.env.ZEROSHOT_MERGE === '1',
-    autoPush: process.env.ZEROSHOT_PUSH === '1',
-    modelOverride: modelOverride || undefined,
-    providerOverride: providerOverride || undefined,
-    noMounts: options.noMounts || false,
-    mounts: options.mount ? parseMountSpecs(options.mount) : undefined,
-    containerHome: options.containerHome || undefined,
-    forceProvider: forceProvider || undefined,
-    settings, // Pass settings for provider detection
-  };
 }
 
 function createStatusFooter(clusterId, messageBus) {
@@ -2488,17 +2356,46 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps)
       const modelOverride = resolveModelOverride(options);
       applyModelOverrideToConfig(config, modelOverride, providerOverride, settings);
 
-      const startOptions = buildStartOptions({
-        clusterId,
-        options,
-        settings,
-        providerOverride,
-        modelOverride,
-        forceProvider,
-      });
-
-      // Start cluster
-      const cluster = await orchestrator.start(config, input, startOptions);
+      let cluster = null;
+      if (input.text) {
+        cluster = await startClusterFromText({
+          orchestrator,
+          text: input.text,
+          config,
+          settings,
+          providerOverride,
+          modelOverride,
+          forceProvider,
+          clusterId,
+          options,
+        });
+      } else if (input.issue) {
+        cluster = await startClusterFromIssue({
+          orchestrator,
+          issue: input.issue,
+          config,
+          settings,
+          providerOverride,
+          modelOverride,
+          forceProvider,
+          clusterId,
+          options,
+        });
+      } else if (input.file) {
+        cluster = await startClusterFromFile({
+          orchestrator,
+          file: input.file,
+          config,
+          settings,
+          providerOverride,
+          modelOverride,
+          forceProvider,
+          clusterId,
+          options,
+        });
+      } else {
+        throw new Error('Invalid run input: expected text, issue, or file');
+      }
 
       if (!process.env.ZEROSHOT_DAEMON) {
         await streamClusterInForeground(cluster, orchestrator, clusterId);

--- a/lib/start-cluster.js
+++ b/lib/start-cluster.js
@@ -1,0 +1,296 @@
+const path = require('path');
+const { execSync } = require('child_process');
+const chalk = require('chalk');
+const { normalizeProviderName } = require('./provider-names');
+const { getProvider } = require('../src/providers');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Detect git repository root from current directory.
+ * @returns {string} Git repo root, or process.cwd() if not in a git repo.
+ */
+function detectGitRepoRoot() {
+  try {
+    const root = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return root;
+  } catch {
+    return process.cwd();
+  }
+}
+
+/**
+ * Parse CLI mount specs (host:container[:ro]) into mount config objects.
+ * @param {string[]} specs - Array of mount specs from CLI.
+ * @returns {Array<{host: string, container: string, readonly: boolean}>}
+ */
+function parseMountSpecs(specs) {
+  return specs.map((spec) => {
+    const parts = spec.split(':');
+    if (parts.length < 2) {
+      throw new Error(`Invalid mount spec: "${spec}". Format: host:container[:ro]`);
+    }
+    const host = parts[0];
+    const container = parts[1];
+    const readonly = parts[2] === 'ro';
+    return { host, container, readonly };
+  });
+}
+
+function buildTextInput(text) {
+  return { text };
+}
+
+function buildIssueInput(issue) {
+  return { issue };
+}
+
+function buildFileInput(file) {
+  return { file };
+}
+
+function detectRunInput(inputArg) {
+  const isGitHubUrl = /^https?:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/.test(inputArg);
+  const isGitLabUrl = /gitlab\.(com|[\w.-]+)\/[\w-]+\/[\w-]+\/-\/issues\/\d+/.test(inputArg);
+  const isJiraUrl = /(atlassian\.net|jira\.[\w.-]+)\/browse\/[A-Z][A-Z0-9]+-\d+/.test(inputArg);
+  const isAzureUrl =
+    /dev\.azure\.com\/.*\/_workitems\/edit\/\d+/.test(inputArg) ||
+    /visualstudio\.com\/.*\/_workitems\/edit\/\d+/.test(inputArg);
+  const isJiraKey = /^[A-Z][A-Z0-9]+-\d+$/.test(inputArg);
+  const isIssueNumber = /^\d+$/.test(inputArg);
+  const isRepoIssue = /^[\w-]+\/[\w-]+#\d+$/.test(inputArg);
+  const isMarkdownFile = /\.(md|markdown)$/i.test(inputArg);
+
+  if (
+    isGitHubUrl ||
+    isGitLabUrl ||
+    isJiraUrl ||
+    isAzureUrl ||
+    isJiraKey ||
+    isIssueNumber ||
+    isRepoIssue
+  ) {
+    return buildIssueInput(inputArg);
+  }
+  if (isMarkdownFile) {
+    return buildFileInput(inputArg);
+  }
+  return buildTextInput(inputArg);
+}
+
+function resolveProviderOverride(options = {}) {
+  const override = options.provider || options.envProvider || process.env.ZEROSHOT_PROVIDER;
+  if (!override || (typeof override === 'string' && !override.trim())) {
+    return null;
+  }
+  const normalized = normalizeProviderName(override);
+  if (options.validateProvider) {
+    getProvider(normalized);
+  }
+  return normalized;
+}
+
+function resolveConfigPath(configName) {
+  if (path.isAbsolute(configName) || configName.startsWith('./') || configName.startsWith('../')) {
+    return path.resolve(process.cwd(), configName);
+  }
+  if (configName.endsWith('.json')) {
+    return path.join(PACKAGE_ROOT, 'cluster-templates', configName);
+  }
+  return path.join(PACKAGE_ROOT, 'cluster-templates', `${configName}.json`);
+}
+
+function ensureConfigProviderDefaults(config, settings) {
+  if (!config.defaultProvider) {
+    config.defaultProvider = settings.defaultProvider || 'claude';
+  }
+  config.defaultProvider = normalizeProviderName(config.defaultProvider) || 'claude';
+}
+
+function applyProviderOverrideToConfig(config, providerOverride, settings) {
+  const provider = getProvider(providerOverride);
+  const providerSettings = settings.providerSettings?.[providerOverride] || {};
+  config.forceProvider = providerOverride;
+  config.defaultProvider = providerOverride;
+  config.forceLevel = providerSettings.defaultLevel || provider.getDefaultLevel();
+  config.defaultLevel = config.forceLevel;
+  console.log(chalk.dim(`Provider override: ${providerOverride} (all agents)`));
+}
+
+function loadClusterConfig(orchestrator, configPath, settings = {}, providerOverride) {
+  const config = orchestrator.loadConfig(configPath);
+  ensureConfigProviderDefaults(config, settings);
+  if (providerOverride) {
+    applyProviderOverrideToConfig(config, providerOverride, settings);
+  }
+  return config;
+}
+
+function buildStartOptions({
+  clusterId,
+  options = {},
+  settings = {},
+  providerOverride,
+  modelOverride,
+  forceProvider,
+}) {
+  const targetCwd = process.env.ZEROSHOT_CWD || detectGitRepoRoot();
+  return {
+    clusterId,
+    cwd: targetCwd,
+    isolation: options.docker || process.env.ZEROSHOT_DOCKER === '1' || settings.defaultDocker,
+    isolationImage: options.dockerImage || process.env.ZEROSHOT_DOCKER_IMAGE || undefined,
+    worktree: options.worktree || process.env.ZEROSHOT_WORKTREE === '1',
+    autoPr: options.pr || process.env.ZEROSHOT_PR === '1',
+    autoMerge: process.env.ZEROSHOT_MERGE === '1',
+    autoPush: process.env.ZEROSHOT_PUSH === '1',
+    modelOverride: modelOverride || undefined,
+    providerOverride: providerOverride || undefined,
+    noMounts: options.mounts === false || options.noMounts === true,
+    mounts: options.mount ? parseMountSpecs(options.mount) : undefined,
+    containerHome: options.containerHome || undefined,
+    forceProvider: forceProvider || undefined,
+    settings,
+  };
+}
+
+function resolveConfigOrThrow({
+  orchestrator,
+  config,
+  configPath,
+  configName,
+  settings,
+  providerOverride,
+}) {
+  if (config) {
+    return config;
+  }
+  const resolvedPath = configPath || (configName ? resolveConfigPath(configName) : null);
+  if (!resolvedPath) {
+    throw new Error('configPath or configName is required when config is not provided');
+  }
+  return loadClusterConfig(orchestrator, resolvedPath, settings, providerOverride);
+}
+
+function startClusterFromText({
+  orchestrator,
+  text,
+  config,
+  configPath,
+  configName,
+  settings,
+  providerOverride,
+  modelOverride,
+  forceProvider,
+  clusterId,
+  options = {},
+}) {
+  if (!orchestrator) {
+    throw new Error('orchestrator is required');
+  }
+  const resolvedConfig = resolveConfigOrThrow({
+    orchestrator,
+    config,
+    configPath,
+    configName,
+    settings,
+    providerOverride,
+  });
+  const startOptions = buildStartOptions({
+    clusterId,
+    options,
+    settings,
+    providerOverride,
+    modelOverride,
+    forceProvider,
+  });
+  return orchestrator.start(resolvedConfig, buildTextInput(text), startOptions);
+}
+
+function startClusterFromIssue({
+  orchestrator,
+  issue,
+  config,
+  configPath,
+  configName,
+  settings,
+  providerOverride,
+  modelOverride,
+  forceProvider,
+  clusterId,
+  options = {},
+}) {
+  if (!orchestrator) {
+    throw new Error('orchestrator is required');
+  }
+  const resolvedConfig = resolveConfigOrThrow({
+    orchestrator,
+    config,
+    configPath,
+    configName,
+    settings,
+    providerOverride,
+  });
+  const startOptions = buildStartOptions({
+    clusterId,
+    options,
+    settings,
+    providerOverride,
+    modelOverride,
+    forceProvider,
+  });
+  return orchestrator.start(resolvedConfig, buildIssueInput(issue), startOptions);
+}
+
+function startClusterFromFile({
+  orchestrator,
+  file,
+  config,
+  configPath,
+  configName,
+  settings,
+  providerOverride,
+  modelOverride,
+  forceProvider,
+  clusterId,
+  options = {},
+}) {
+  if (!orchestrator) {
+    throw new Error('orchestrator is required');
+  }
+  const resolvedConfig = resolveConfigOrThrow({
+    orchestrator,
+    config,
+    configPath,
+    configName,
+    settings,
+    providerOverride,
+  });
+  const startOptions = buildStartOptions({
+    clusterId,
+    options,
+    settings,
+    providerOverride,
+    modelOverride,
+    forceProvider,
+  });
+  return orchestrator.start(resolvedConfig, buildFileInput(file), startOptions);
+}
+
+module.exports = {
+  buildTextInput,
+  buildIssueInput,
+  buildFileInput,
+  detectRunInput,
+  resolveProviderOverride,
+  resolveConfigPath,
+  loadClusterConfig,
+  buildStartOptions,
+  startClusterFromText,
+  startClusterFromIssue,
+  startClusterFromFile,
+  detectGitRepoRoot,
+};

--- a/src/tui/services/start-cluster.ts
+++ b/src/tui/services/start-cluster.ts
@@ -1,0 +1,1 @@
+export { startClusterFromText, startClusterFromIssue } from "../../../lib/start-cluster";

--- a/tests/unit/tui-start-cluster.test.js
+++ b/tests/unit/tui-start-cluster.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+
+const { startClusterFromText, startClusterFromIssue } = require('../../lib/start-cluster');
+
+function createOrchestrator() {
+  const calls = { loadConfig: [], start: [] };
+  return {
+    calls,
+    loadConfig(configPath) {
+      calls.loadConfig.push(configPath);
+      return { agents: [] };
+    },
+    start(config, input, options) {
+      calls.start.push({ config, input, options });
+      return { id: 'cluster-test' };
+    },
+  };
+}
+
+describe('TUI start cluster helper', function () {
+  const originalCwd = process.env.ZEROSHOT_CWD;
+
+  afterEach(function () {
+    if (originalCwd === undefined) {
+      delete process.env.ZEROSHOT_CWD;
+    } else {
+      process.env.ZEROSHOT_CWD = originalCwd;
+    }
+  });
+
+  it('startClusterFromText builds text input and forwards providerOverride', async function () {
+    process.env.ZEROSHOT_CWD = '/tmp';
+    const orchestrator = createOrchestrator();
+    const settings = { defaultProvider: 'claude', providerSettings: {} };
+    const configPath = '/tmp/config.json';
+
+    const result = await startClusterFromText({
+      orchestrator,
+      text: 'Launch cluster',
+      configPath,
+      settings,
+      providerOverride: 'codex',
+      modelOverride: 'gpt-4o',
+      forceProvider: 'github',
+      clusterId: 'cluster-123',
+      options: { docker: false, worktree: false, pr: false, mounts: false },
+    });
+
+    assert.strictEqual(orchestrator.calls.loadConfig[0], configPath);
+    assert.strictEqual(orchestrator.calls.start.length, 1);
+    const call = orchestrator.calls.start[0];
+    assert.deepStrictEqual(call.input, { text: 'Launch cluster' });
+    assert.strictEqual(call.options.providerOverride, 'codex');
+    assert.strictEqual(call.options.clusterId, 'cluster-123');
+    assert.strictEqual(call.options.noMounts, true);
+    assert.strictEqual(result.id, 'cluster-test');
+  });
+
+  it('startClusterFromIssue builds issue input and forwards providerOverride', async function () {
+    process.env.ZEROSHOT_CWD = '/tmp';
+    const orchestrator = createOrchestrator();
+    const settings = { defaultProvider: 'claude', providerSettings: {} };
+    const configPath = '/tmp/config.json';
+
+    await startClusterFromIssue({
+      orchestrator,
+      issue: '123',
+      configPath,
+      settings,
+      providerOverride: 'codex',
+      clusterId: 'cluster-456',
+      options: { docker: false, worktree: false, pr: false },
+    });
+
+    assert.strictEqual(orchestrator.calls.loadConfig[0], configPath);
+    assert.strictEqual(orchestrator.calls.start.length, 1);
+    const call = orchestrator.calls.start[0];
+    assert.deepStrictEqual(call.input, { issue: '123' });
+    assert.strictEqual(call.options.providerOverride, 'codex');
+    assert.strictEqual(call.options.clusterId, 'cluster-456');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable start-cluster helper for TUI (text/issue/file)
- add TUI service wrapper for starting clusters
- add unit tests for helper

## Testing
- npm test (via pre-commit)
- npm run lint (warnings only)

Fixes #187