### PR TITLE
feat: TUI v2 3.2: launcher starts cluster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,32 +20,34 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 
 ## Where to Look
 
-| Concept                   | File                                |
-| ------------------------- | ----------------------------------- |
-| Conductor classification  | `src/conductor-bootstrap.js`        |
-| Base templates            | `cluster-templates/base-templates/` |
-| Message bus               | `src/message-bus.js`                |
-| Ledger (SQLite)           | `src/ledger.js`                     |
-| Trigger evaluation        | `src/logic-engine.js`               |
-| Agent wrapper             | `src/agent-wrapper.js`              |
-| Providers registry        | `src/providers/index.js`            |
-| Provider implementations  | `src/providers/`                    |
-| Provider detection        | `lib/provider-detection.js`         |
-| Provider capabilities     | `src/providers/capabilities.js`     |
-| Ink TUI entrypoint        | `src/tui/index.tsx`                 |
-| Ink TUI app               | `src/tui/app.tsx`                   |
-| Ink TUI router            | `src/tui/router.tsx`                |
-| Ink TUI view stack        | `src/tui/view-stack.ts`             |
-| Ink TUI commands          | `src/tui/commands/`                 |
-| TUI command registry      | `src/tui/commands/registry.ts`      |
-| TUI CLI compat wrapper    | `src/tui/commands/cli-compat.ts`    |
-| Ink TUI views             | `src/tui/views/`                    |
-| Ink TUI build output      | `lib/tui/`                          |
-| TUI start-cluster helper  | `lib/start-cluster.js`              |
-| TUI start-cluster service | `src/tui/services/start-cluster.ts` |
-| Docker mounts/env         | `lib/docker-config.js`              |
-| Container lifecycle       | `src/isolation-manager.js`          |
-| Settings                  | `lib/settings.js`                   |
+| Concept                   | File                                   |
+| ------------------------- | -------------------------------------- |
+| Conductor classification  | `src/conductor-bootstrap.js`           |
+| Base templates            | `cluster-templates/base-templates/`    |
+| Message bus               | `src/message-bus.js`                   |
+| Ledger (SQLite)           | `src/ledger.js`                        |
+| Trigger evaluation        | `src/logic-engine.js`                  |
+| Agent wrapper             | `src/agent-wrapper.js`                 |
+| Providers registry        | `src/providers/index.js`               |
+| Provider implementations  | `src/providers/`                       |
+| Provider detection        | `lib/provider-detection.js`            |
+| Provider capabilities     | `src/providers/capabilities.js`        |
+| Ink TUI entrypoint        | `src/tui/index.tsx`                    |
+| Ink TUI app               | `src/tui/app.tsx`                      |
+| Ink TUI router            | `src/tui/router.tsx`                   |
+| Ink TUI view stack        | `src/tui/view-stack.ts`                |
+| Ink TUI commands          | `src/tui/commands/`                    |
+| TUI command registry      | `src/tui/commands/registry.ts`         |
+| TUI CLI compat wrapper    | `src/tui/commands/cli-compat.ts`       |
+| Ink TUI views             | `src/tui/views/`                       |
+| Ink TUI build output      | `lib/tui/`                             |
+| TUI start-cluster helper  | `lib/start-cluster.js`                 |
+| TUI start-cluster service | `src/tui/services/start-cluster.ts`    |
+| TUI launcher actions      | `src/tui/launcher-actions.ts`          |
+| TUI cluster launcher      | `src/tui/services/cluster-launcher.ts` |
+| Docker mounts/env         | `lib/docker-config.js`                 |
+| Container lifecycle       | `src/isolation-manager.js`             |
+| Settings                  | `lib/settings.js`                      |
 
 TUI navigation convention: view stack with `launcher` as root; Esc pops the stack to the previous view. Global command box is always available and slash commands live under `src/tui/commands/`.
 TUI command convention: register slash commands in `src/tui/commands/dispatcher.ts` via `createCommandRegistry()`; use `src/tui/commands/cli-compat.ts` to reuse task-lib CLI helpers and return condensed output for the status bar.

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -6,6 +6,7 @@ import StatusBar from "./components/StatusBar";
 import { dispatchCommand } from "./commands/dispatcher";
 import { parseInput } from "./commands/parser";
 import { CommandResult } from "./commands/types";
+import { submitLauncherText } from "./launcher-actions";
 import {
   activeView,
   createViewStack,
@@ -40,6 +41,7 @@ export default function App({
   const [provider, setProvider] = useState<string | null>(
     providerOverride ?? null
   );
+  const [activeClusterId, setActiveClusterId] = useState<string | null>(null);
   const [isDispatching, setIsDispatching] = useState(false);
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
@@ -55,17 +57,21 @@ export default function App({
       return;
     }
 
-    if (parsed.type === "text") {
-      setStatus({
-        tone: "info",
-        message: "Plain-text tasks are not wired up yet.",
-      });
-      setInputValue("");
-      return;
-    }
-
     setIsDispatching(true);
     try {
+      if (parsed.type === "text") {
+        await submitLauncherText({
+          text: parsed.text,
+          providerOverride: provider,
+          activeView: active,
+          setStatus,
+          setClusterId: setActiveClusterId,
+          navigate: (view) =>
+            setViewStack((stack) => pushIfDifferent(stack, view)),
+        });
+        return;
+      }
+
       const result = await dispatchCommand(parsed, {
         navigate: (view) =>
           setViewStack((stack) => pushIfDifferent(stack, view)),
@@ -121,7 +127,7 @@ export default function App({
   return (
     <Box flexDirection="column">
       <Box flexGrow={1} flexDirection="column">
-        <Router view={active} provider={provider} />
+        <Router view={active} provider={provider} clusterId={activeClusterId} />
       </Box>
       <StatusBar status={status} provider={provider} />
       <CommandInput value={inputValue} />

--- a/src/tui/launcher-actions.ts
+++ b/src/tui/launcher-actions.ts
@@ -1,0 +1,73 @@
+import { CommandResult } from "./commands/types";
+import { generateClusterId, launchClusterFromText } from "./services/cluster-launcher";
+import { ViewId } from "./view-stack";
+
+type LauncherActionDeps = {
+  generateClusterId?: () => string;
+  launchClusterFromText?: typeof launchClusterFromText;
+};
+
+type SubmitLauncherTextArgs = {
+  text: string;
+  providerOverride?: string | null;
+  activeView: ViewId;
+  setStatus: (status: CommandResult) => void;
+  setClusterId: (clusterId: string | null) => void;
+  navigate: (view: ViewId) => void;
+  deps?: LauncherActionDeps;
+};
+
+export async function submitLauncherText({
+  text,
+  providerOverride = null,
+  activeView,
+  setStatus,
+  setClusterId,
+  navigate,
+  deps = {},
+}: SubmitLauncherTextArgs): Promise<void> {
+  if (activeView !== "launcher") {
+    setStatus({
+      tone: "info",
+      message: "Text launch only works from the Launcher view.",
+    });
+    return;
+  }
+
+  if (text.trim().startsWith("/")) {
+    setStatus({
+      tone: "info",
+      message: "Use slash commands for /help, /monitor, and /provider.",
+    });
+    return;
+  }
+
+  const generateClusterIdImpl = deps.generateClusterId ?? generateClusterId;
+  const launchClusterFromTextImpl =
+    deps.launchClusterFromText ?? launchClusterFromText;
+
+  const clusterId = generateClusterIdImpl();
+  setClusterId(clusterId);
+  setStatus({
+    tone: "info",
+    message: `Starting cluster ${clusterId}...`,
+  });
+
+  try {
+    await launchClusterFromTextImpl({
+      text,
+      providerOverride,
+      clusterId,
+    });
+    navigate("cluster");
+    setStatus({
+      tone: "success",
+      message: `Cluster ${clusterId} started.`,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Cluster start failed.";
+    setStatus({ tone: "error", message });
+    setClusterId(null);
+  }
+}

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -8,16 +8,17 @@ import AgentView from "./views/AgentView";
 type RouterProps = {
   view: ViewId;
   provider: string | null;
+  clusterId?: string | null;
 };
 
-export default function Router({ view, provider }: RouterProps) {
+export default function Router({ view, provider, clusterId }: RouterProps) {
   switch (view) {
     case "launcher":
       return <LauncherView provider={provider} />;
     case "monitor":
       return <MonitorView provider={provider} />;
     case "cluster":
-      return <ClusterView provider={provider} />;
+      return <ClusterView provider={provider} clusterId={clusterId} />;
     case "agent":
       return <AgentView provider={provider} />;
     default:

--- a/src/tui/services/cluster-launcher.ts
+++ b/src/tui/services/cluster-launcher.ts
@@ -1,0 +1,75 @@
+import { loadSettings } from "../../../lib/settings";
+import {
+  loadClusterConfig,
+  resolveConfigPath,
+  startClusterFromText,
+} from "../../../lib/start-cluster";
+
+const { generateName } = require("../../../src/name-generator");
+
+type ClusterLauncherDeps = {
+  getOrchestrator?: () => Promise<any>;
+  loadSettings?: typeof loadSettings;
+  resolveConfigPath?: typeof resolveConfigPath;
+  loadClusterConfig?: typeof loadClusterConfig;
+  startClusterFromText?: typeof startClusterFromText;
+  generateClusterId?: () => string;
+};
+
+let orchestratorPromise: Promise<any> | null = null;
+
+async function getOrchestrator() {
+  if (!orchestratorPromise) {
+    const Orchestrator = require("../../../src/orchestrator");
+    orchestratorPromise = Orchestrator.create({ quiet: true });
+  }
+  return orchestratorPromise;
+}
+
+export function generateClusterId(): string {
+  return generateName("cluster");
+}
+
+type LaunchClusterFromTextArgs = {
+  text: string;
+  providerOverride?: string | null;
+  clusterId?: string;
+  deps?: ClusterLauncherDeps;
+};
+
+export async function launchClusterFromText({
+  text,
+  providerOverride = null,
+  clusterId,
+  deps = {},
+}: LaunchClusterFromTextArgs): Promise<{ clusterId: string }> {
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const loadSettingsImpl = deps.loadSettings ?? loadSettings;
+  const resolveConfigPathImpl = deps.resolveConfigPath ?? resolveConfigPath;
+  const loadClusterConfigImpl = deps.loadClusterConfig ?? loadClusterConfig;
+  const startClusterFromTextImpl = deps.startClusterFromText ?? startClusterFromText;
+  const generateClusterIdImpl = deps.generateClusterId ?? generateClusterId;
+
+  const orchestrator = await getOrchestratorImpl();
+  const settings = loadSettingsImpl();
+  const configName = settings.defaultConfig || "conductor-bootstrap";
+  const configPath = resolveConfigPathImpl(configName);
+  const config = loadClusterConfigImpl(
+    orchestrator,
+    configPath,
+    settings,
+    providerOverride
+  );
+  const resolvedClusterId = clusterId || generateClusterIdImpl();
+
+  await startClusterFromTextImpl({
+    orchestrator,
+    text,
+    config,
+    settings,
+    providerOverride,
+    clusterId: resolvedClusterId,
+  });
+
+  return { clusterId: resolvedClusterId };
+}

--- a/src/tui/views/ClusterView.tsx
+++ b/src/tui/views/ClusterView.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Box, Text } from "ink";
 
-export default function ClusterView({ provider }: { provider: string | null }) {
+type ClusterViewProps = {
+  provider: string | null;
+  clusterId?: string | null;
+};
+
+export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
   return (
     <Box flexDirection="column">
       <Text color="cyan">Cluster</Text>
+      <Text color="gray">Id: {clusterId || "pending"}</Text>
       <Text color="gray">Provider: {provider || "auto"}</Text>
       <Text color="gray">Stub view</Text>
       <Text color="gray">Type /help for commands</Text>

--- a/tests/unit/tui-launcher-actions.test.js
+++ b/tests/unit/tui-launcher-actions.test.js
@@ -1,0 +1,115 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(__dirname, '..', '..', 'lib', 'tui', 'launcher-actions.js');
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const { submitLauncherText } = require('../../lib/tui/launcher-actions');
+
+function createHarness() {
+  const calls = {
+    status: [],
+    clusterIds: [],
+    navigate: [],
+  };
+
+  return {
+    calls,
+    setStatus: (status) => calls.status.push(status),
+    setClusterId: (clusterId) => calls.clusterIds.push(clusterId),
+    navigate: (view) => calls.navigate.push(view),
+  };
+}
+
+describe('TUI launcher actions', function () {
+  it('starts a cluster from text and navigates', async function () {
+    const { calls, setStatus, setClusterId, navigate } = createHarness();
+    const launchCalls = [];
+    const deps = {
+      generateClusterId: () => 'cluster-test-1',
+      launchClusterFromText: (options) => {
+        launchCalls.push(options);
+      },
+    };
+
+    await submitLauncherText({
+      text: 'Implement X',
+      providerOverride: 'codex',
+      activeView: 'launcher',
+      setStatus,
+      setClusterId,
+      navigate,
+      deps,
+    });
+
+    assert.strictEqual(launchCalls.length, 1);
+    assert.strictEqual(launchCalls[0].text, 'Implement X');
+    assert.strictEqual(launchCalls[0].providerOverride, 'codex');
+    assert.strictEqual(launchCalls[0].clusterId, 'cluster-test-1');
+    assert.deepStrictEqual(calls.navigate, ['cluster']);
+    assert.ok(calls.status.some((status) => status.message.includes('cluster-test-1')));
+    assert.strictEqual(calls.clusterIds[0], 'cluster-test-1');
+  });
+
+  it('treats numeric input as plain text', async function () {
+    const { calls, setStatus, setClusterId, navigate } = createHarness();
+    const launchCalls = [];
+    const deps = {
+      generateClusterId: () => 'cluster-test-2',
+      launchClusterFromText: (options) => {
+        launchCalls.push(options);
+      },
+    };
+
+    await submitLauncherText({
+      text: '123',
+      providerOverride: null,
+      activeView: 'launcher',
+      setStatus,
+      setClusterId,
+      navigate,
+      deps,
+    });
+
+    assert.strictEqual(launchCalls.length, 1);
+    assert.strictEqual(launchCalls[0].text, '123');
+    assert.strictEqual(launchCalls[0].clusterId, 'cluster-test-2');
+    assert.deepStrictEqual(calls.navigate, ['cluster']);
+  });
+
+  it('shows error and stays on launcher when start fails', async function () {
+    const { calls, setStatus, setClusterId, navigate } = createHarness();
+    const deps = {
+      generateClusterId: () => 'cluster-fail',
+      launchClusterFromText: () => {
+        throw new Error('boom');
+      },
+    };
+
+    await submitLauncherText({
+      text: 'Fail me',
+      providerOverride: null,
+      activeView: 'launcher',
+      setStatus,
+      setClusterId,
+      navigate,
+      deps,
+    });
+
+    assert.deepStrictEqual(calls.navigate, []);
+    assert.strictEqual(calls.clusterIds[0], 'cluster-fail');
+    assert.strictEqual(calls.clusterIds[calls.clusterIds.length - 1], null);
+    const lastStatus = calls.status[calls.status.length - 1];
+    assert.strictEqual(lastStatus.tone, 'error');
+    assert.ok(lastStatus.message.includes('boom'));
+  });
+});


### PR DESCRIPTION
## Summary
- wire Launcher submit to start cluster from text
- treat numeric input as plain text
- optimistic cluster id + navigate to Cluster view
- tests for launcher behavior

## Testing
- npm test (via pre-commit)
- npm run lint (warnings only)

Fixes #189