### PR TITLE
chore: ignore generated tui output in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -264,7 +264,14 @@ export default [
     },
   },
   {
-    ignores: ['node_modules/**', 'dist/**', 'coverage/**', 'cluster-hooks/**', 'hooks/**'],
+    ignores: [
+      'node_modules/**',
+      'dist/**',
+      'coverage/**',
+      'cluster-hooks/**',
+      'hooks/**',
+      'lib/tui/**',
+    ],
   },
   prettierConfig,
 ];


### PR DESCRIPTION
## Summary
- exclude generated lib/tui output from linting

## Testing
- npm run lint (warnings only)
- tsc --noEmit (pre-push)