### PR TITLE
TUI v2: monitor view cluster list

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -45,6 +45,7 @@ export default function App({
   const [isDispatching, setIsDispatching] = useState(false);
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
+  const isCommandInputEmpty = inputValue.length === 0;
 
   async function handleSubmit() {
     if (isDispatching) {
@@ -126,10 +127,21 @@ export default function App({
     return undefined;
   }, [autoExit, exit, exitDelayMs]);
 
+  function handleOpenCluster(clusterId: string) {
+    setActiveClusterId(clusterId);
+    setViewStack((stack) => pushIfDifferent(stack, "cluster"));
+  }
+
   return (
     <Box flexDirection="column">
       <Box flexGrow={1} flexDirection="column">
-        <Router view={active} provider={provider} clusterId={activeClusterId} />
+        <Router
+          view={active}
+          provider={provider}
+          clusterId={activeClusterId}
+          onOpenCluster={handleOpenCluster}
+          isCommandInputEmpty={isCommandInputEmpty}
+        />
       </Box>
       <StatusBar status={status} provider={provider} />
       <CommandInput value={inputValue} />

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -9,14 +9,28 @@ type RouterProps = {
   view: ViewId;
   provider: string | null;
   clusterId?: string | null;
+  onOpenCluster?: (clusterId: string) => void;
+  isCommandInputEmpty?: boolean;
 };
 
-export default function Router({ view, provider, clusterId }: RouterProps) {
+export default function Router({
+  view,
+  provider,
+  clusterId,
+  onOpenCluster,
+  isCommandInputEmpty,
+}: RouterProps) {
   switch (view) {
     case "launcher":
       return <LauncherView provider={provider} />;
     case "monitor":
-      return <MonitorView provider={provider} />;
+      return (
+        <MonitorView
+          provider={provider}
+          onOpenCluster={onOpenCluster}
+          isCommandInputEmpty={isCommandInputEmpty ?? false}
+        />
+      );
     case "cluster":
       return <ClusterView provider={provider} clusterId={clusterId} />;
     case "agent":

--- a/src/tui/services/cluster-registry.ts
+++ b/src/tui/services/cluster-registry.ts
@@ -1,0 +1,86 @@
+type ClusterRegistryDeps = {
+  getOrchestrator?: () => Promise<any>;
+};
+
+export type ClusterSummary = {
+  id: string;
+  state: string;
+  createdAt: number;
+  agentCount: number;
+  messageCount: number;
+  cwd: string | null;
+};
+
+let orchestratorPromise: Promise<any> | null = null;
+
+async function getOrchestrator() {
+  if (!orchestratorPromise) {
+    const Orchestrator = require("../../../src/orchestrator");
+    orchestratorPromise = Orchestrator.create({ quiet: true });
+  }
+  return orchestratorPromise;
+}
+
+function resolveClusterCwd(cluster: any): string | null {
+  if (!cluster || typeof cluster !== "object") {
+    return null;
+  }
+  if (cluster.worktree?.path) {
+    return cluster.worktree.path;
+  }
+  if (cluster.isolation?.workDir) {
+    return cluster.isolation.workDir;
+  }
+  return null;
+}
+
+function normalizeSummary(summary: any, orchestrator: any): ClusterSummary {
+  if (!summary || typeof summary !== "object") {
+    throw new Error("Invalid cluster summary.");
+  }
+  if (typeof summary.id !== "string" || summary.id.length === 0) {
+    throw new Error("Invalid cluster id.");
+  }
+  if (!Number.isFinite(summary.createdAt)) {
+    throw new Error(`Invalid createdAt for cluster ${summary.id}.`);
+  }
+  if (!Number.isFinite(summary.agentCount)) {
+    throw new Error(`Invalid agentCount for cluster ${summary.id}.`);
+  }
+  if (!Number.isFinite(summary.messageCount)) {
+    throw new Error(`Invalid messageCount for cluster ${summary.id}.`);
+  }
+  const cluster = orchestrator.getCluster(summary.id);
+  const cwd = resolveClusterCwd(cluster);
+  return {
+    id: summary.id,
+    state: String(summary.state ?? "unknown"),
+    createdAt: summary.createdAt,
+    agentCount: summary.agentCount,
+    messageCount: summary.messageCount,
+    cwd,
+  };
+}
+
+type ListClustersArgs = {
+  deps?: ClusterRegistryDeps;
+};
+
+export async function listClusters(
+  { deps = {} }: ListClustersArgs = {}
+): Promise<ClusterSummary[]> {
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const orchestrator = await getOrchestratorImpl();
+  const summaries = orchestrator.listClusters();
+  const results = summaries.map((summary: any) =>
+    normalizeSummary(summary, orchestrator)
+  );
+  results.sort((left, right) => {
+    if (left.createdAt !== right.createdAt) {
+      return left.createdAt - right.createdAt;
+    }
+    return left.id.localeCompare(right.id);
+  });
+  return results;
+}
+

--- a/src/tui/views/MonitorView.tsx
+++ b/src/tui/views/MonitorView.tsx
@@ -1,14 +1,202 @@
-import React from "react";
-import { Box, Text } from "ink";
+import React, { useEffect, useMemo, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import {
+  ClusterSummary,
+  listClusters,
+} from "../services/cluster-registry";
 
-export default function MonitorView({ provider }: { provider: string | null }) {
+type MonitorViewProps = {
+  provider: string | null;
+  onOpenCluster?: (clusterId: string) => void;
+  isCommandInputEmpty?: boolean;
+};
+
+const REFRESH_INTERVAL_MS = 3000;
+
+function formatAge(createdAt: number, now: number): string {
+  const diffSeconds = Math.max(0, Math.floor((now - createdAt) / 1000));
+  if (diffSeconds < 60) {
+    return `${diffSeconds}s`;
+  }
+  const minutes = Math.floor(diffSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function padRight(text: string, width: number): string {
+  if (text.length >= width) {
+    return text.slice(0, width);
+  }
+  return text.padEnd(width, " ");
+}
+
+function truncate(text: string, width: number): string {
+  if (text.length <= width) {
+    return text;
+  }
+  if (width <= 3) {
+    return text.slice(0, width);
+  }
+  return `${text.slice(0, width - 3)}...`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export default function MonitorView({
+  provider,
+  onOpenCluster,
+  isCommandInputEmpty = false,
+}: MonitorViewProps) {
+  const [clusters, setClusters] = useState<ClusterSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      setIsLoading(true);
+      try {
+        const result = await listClusters();
+        if (cancelled) {
+          return;
+        }
+        setClusters(result);
+        setSelectedId((current) => {
+          if (result.length === 0) {
+            return null;
+          }
+          if (current && result.some((cluster) => cluster.id === current)) {
+            return current;
+          }
+          return result[0].id;
+        });
+        setError(null);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Failed to load clusters.";
+        setError(message);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void refresh();
+    const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const rows = useMemo(() => {
+    const now = Date.now();
+    return clusters.map((cluster) => ({
+      ...cluster,
+      age: formatAge(cluster.createdAt, now),
+      cwdDisplay: cluster.cwd ?? "-",
+    }));
+  }, [clusters]);
+
+  const columnWidths = useMemo(() => {
+    const idWidth = clamp(
+      rows.reduce((max, row) => Math.max(max, row.id.length), 2),
+      8,
+      24
+    );
+    const statusWidth = clamp(
+      rows.reduce((max, row) => Math.max(max, row.state.length), 6),
+      6,
+      14
+    );
+    const ageWidth = clamp(
+      rows.reduce((max, row) => Math.max(max, row.age.length), 3),
+      3,
+      6
+    );
+    return { idWidth, statusWidth, ageWidth };
+  }, [rows]);
+
+  useInput((_input, key) => {
+    if (clusters.length === 0) {
+      return;
+    }
+    const currentIndex = Math.max(
+      0,
+      clusters.findIndex((cluster) => cluster.id === selectedId)
+    );
+
+    if (key.upArrow) {
+      const nextIndex = Math.max(0, currentIndex - 1);
+      setSelectedId(clusters[nextIndex].id);
+      return;
+    }
+    if (key.downArrow) {
+      const nextIndex = Math.min(clusters.length - 1, currentIndex + 1);
+      setSelectedId(clusters[nextIndex].id);
+      return;
+    }
+    if (key.return && isCommandInputEmpty) {
+      const cluster = clusters[currentIndex];
+      if (cluster && onOpenCluster) {
+        onOpenCluster(cluster.id);
+      }
+    }
+  });
+
   return (
     <Box flexDirection="column">
       <Text color="cyan">Monitor</Text>
       <Text color="gray">Provider: {provider || "auto"}</Text>
-      <Text color="gray">Stub view</Text>
-      <Text color="gray">Type /help for commands</Text>
-      <Text color="gray">Esc back, Ctrl+C exit</Text>
+      {error ? (
+        <Text color="red">Error: {error}</Text>
+      ) : null}
+      {isLoading && clusters.length === 0 ? (
+        <Text color="gray">Loading clusters...</Text>
+      ) : null}
+      {!isLoading && clusters.length === 0 && !error ? (
+        <Text color="gray">No clusters found.</Text>
+      ) : null}
+      {clusters.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="gray">
+            {padRight("ID", columnWidths.idWidth)}{" "}
+            {padRight("Status", columnWidths.statusWidth)}{" "}
+            {padRight("Age", columnWidths.ageWidth)} CWD
+          </Text>
+          {rows.map((row) => {
+            const isSelected = row.id === selectedId;
+            const line = [
+              padRight(row.id, columnWidths.idWidth),
+              padRight(row.state, columnWidths.statusWidth),
+              padRight(row.age, columnWidths.ageWidth),
+              truncate(row.cwdDisplay, 80),
+            ].join(" ");
+            return (
+              <Text key={row.id} inverse={isSelected}>
+                {line}
+              </Text>
+            );
+          })}
+        </Box>
+      ) : null}
+      <Text color="gray">
+        Keys: Up/Down select, Enter open (empty input), Esc back
+      </Text>
     </Box>
   );
 }

--- a/tests/unit/tui-cluster-registry.test.js
+++ b/tests/unit/tui-cluster-registry.test.js
@@ -1,0 +1,83 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(
+  __dirname,
+  '..',
+  '..',
+  'lib',
+  'tui',
+  'services',
+  'cluster-registry.js'
+);
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const { listClusters } = require('../../lib/tui/services/cluster-registry');
+
+function createOrchestrator(summaries, clustersById) {
+  return {
+    listClusters() {
+      return summaries;
+    },
+    getCluster(id) {
+      return clustersById[id];
+    },
+  };
+}
+
+describe('TUI cluster registry', function () {
+  it('sorts clusters by createdAt ascending and then id', async function () {
+    const summaries = [
+      { id: 'cluster-b', state: 'running', createdAt: 200, agentCount: 1, messageCount: 2 },
+      { id: 'cluster-a', state: 'completed', createdAt: 100, agentCount: 2, messageCount: 5 },
+      { id: 'cluster-c', state: 'running', createdAt: 100, agentCount: 1, messageCount: 1 },
+    ];
+    const clustersById = {
+      'cluster-a': { worktree: { path: '/tmp/a' } },
+      'cluster-b': { isolation: { workDir: '/tmp/b' } },
+      'cluster-c': {},
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+
+    const result = await listClusters({
+      deps: { getOrchestrator: () => Promise.resolve(orchestrator) },
+    });
+
+    assert.deepStrictEqual(
+      result.map((cluster) => cluster.id),
+      ['cluster-a', 'cluster-c', 'cluster-b']
+    );
+  });
+
+  it('derives cwd from worktree then isolation workDir', async function () {
+    const summaries = [
+      { id: 'cluster-1', state: 'running', createdAt: 1, agentCount: 1, messageCount: 1 },
+      { id: 'cluster-2', state: 'running', createdAt: 2, agentCount: 1, messageCount: 1 },
+      { id: 'cluster-3', state: 'running', createdAt: 3, agentCount: 1, messageCount: 1 },
+    ];
+    const clustersById = {
+      'cluster-1': { worktree: { path: '/worktree/path' }, isolation: { workDir: '/iso' } },
+      'cluster-2': { isolation: { workDir: '/isolation/path' } },
+      'cluster-3': {},
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+
+    const result = await listClusters({
+      deps: { getOrchestrator: () => Promise.resolve(orchestrator) },
+    });
+
+    const cwdById = Object.fromEntries(result.map((cluster) => [cluster.id, cluster.cwd]));
+    assert.strictEqual(cwdById['cluster-1'], '/worktree/path');
+    assert.strictEqual(cwdById['cluster-2'], '/isolation/path');
+    assert.strictEqual(cwdById['cluster-3'], null);
+  });
+});


### PR DESCRIPTION
## Summary
- add a cluster registry helper to read orchestrator cluster summaries
- render a selectable Monitor view list with refresh + keyboard navigation
- wire Monitor view into app/router and open selected cluster
- add unit coverage for cluster sorting and cwd resolution

## Testing
- `npx mocha tests/unit/tui-cluster-registry.test.js`

Closes #196.
