### PR TITLE
Add monitor metrics to TUI monitor view

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -45,6 +45,12 @@ export default function App({
   const [isDispatching, setIsDispatching] = useState(false);
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
+  const isCommandInputEmpty = inputValue.length === 0;
+
+  const handleOpenCluster = (clusterId: string) => {
+    setActiveClusterId(clusterId);
+    setViewStack((stack) => pushIfDifferent(stack, "cluster"));
+  };
 
   async function handleSubmit() {
     if (isDispatching) {
@@ -129,7 +135,13 @@ export default function App({
   return (
     <Box flexDirection="column">
       <Box flexGrow={1} flexDirection="column">
-        <Router view={active} provider={provider} clusterId={activeClusterId} />
+        <Router
+          view={active}
+          provider={provider}
+          clusterId={activeClusterId}
+          onOpenCluster={handleOpenCluster}
+          isCommandInputEmpty={isCommandInputEmpty}
+        />
       </Box>
       <StatusBar status={status} provider={provider} />
       <CommandInput value={inputValue} />

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -9,14 +9,28 @@ type RouterProps = {
   view: ViewId;
   provider: string | null;
   clusterId?: string | null;
+  onOpenCluster?: (clusterId: string) => void;
+  isCommandInputEmpty?: boolean;
 };
 
-export default function Router({ view, provider, clusterId }: RouterProps) {
+export default function Router({
+  view,
+  provider,
+  clusterId,
+  onOpenCluster,
+  isCommandInputEmpty,
+}: RouterProps) {
   switch (view) {
     case "launcher":
       return <LauncherView provider={provider} />;
     case "monitor":
-      return <MonitorView provider={provider} />;
+      return (
+        <MonitorView
+          provider={provider}
+          onOpenCluster={onOpenCluster}
+          isCommandInputEmpty={isCommandInputEmpty}
+        />
+      );
     case "cluster":
       return <ClusterView provider={provider} clusterId={clusterId} />;
     case "agent":

--- a/src/tui/services/monitor-metrics.ts
+++ b/src/tui/services/monitor-metrics.ts
@@ -1,0 +1,240 @@
+type ClusterSummary = {
+  id: string;
+  state: string;
+  createdAt: number;
+  agentCount: number;
+  messageCount: number;
+  cwd?: string | null;
+};
+
+type AgentState = {
+  pid?: number | null;
+};
+
+type ClusterStatus = {
+  agents: AgentState[];
+};
+
+type PidusageStat = {
+  cpu?: number;
+  memory?: number;
+};
+
+type PidusageResult = Record<string, PidusageStat> | PidusageStat;
+type PidusageFn = (pids: number[] | number) => Promise<PidusageResult>;
+
+type MonitorMetricsDeps = {
+  getOrchestrator?: () => Promise<any>;
+  pidusage?: PidusageFn;
+  platform?: string;
+};
+
+export type MonitorClusterRow = ClusterSummary & {
+  cpu: number | null;
+  memory: number | null;
+};
+
+export type MonitorMetricsResult = {
+  rows: MonitorClusterRow[];
+  error: string | null;
+};
+
+const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
+let orchestratorPromise: Promise<any> | null = null;
+
+async function getOrchestrator() {
+  if (!orchestratorPromise) {
+    const Orchestrator = require("../../../src/orchestrator");
+    orchestratorPromise = Orchestrator.create({ quiet: true });
+  }
+  return orchestratorPromise;
+}
+
+function extractAgentPids(agents: AgentState[] | null | undefined): number[] {
+  if (!agents || agents.length === 0) return [];
+  const pids = new Set<number>();
+  for (const agent of agents) {
+    const pid = agent?.pid;
+    if (typeof pid === "number" && Number.isFinite(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+  return Array.from(pids);
+}
+
+function normalizePidusageResult(
+  result: PidusageResult | null | undefined,
+  pids: number[]
+): Map<number, PidusageStat> {
+  const map = new Map<number, PidusageStat>();
+  if (!result || pids.length === 0) return map;
+
+  const isSingle =
+    typeof (result as PidusageStat).cpu === "number" ||
+    typeof (result as PidusageStat).memory === "number";
+
+  if (isSingle && pids.length === 1) {
+    map.set(pids[0], result as PidusageStat);
+    return map;
+  }
+
+  const record = result as Record<string, PidusageStat>;
+  for (const pid of pids) {
+    const stat = record[String(pid)];
+    if (stat) {
+      map.set(pid, stat);
+    }
+  }
+
+  return map;
+}
+
+function aggregateStats(stats: Iterable<PidusageStat>): {
+  cpu: number | null;
+  memory: number | null;
+} {
+  let cpuTotal = 0;
+  let memTotal = 0;
+  let hasCpu = false;
+  let hasMem = false;
+
+  for (const stat of stats) {
+    if (typeof stat.cpu === "number" && Number.isFinite(stat.cpu)) {
+      cpuTotal += stat.cpu;
+      hasCpu = true;
+    }
+    if (typeof stat.memory === "number" && Number.isFinite(stat.memory)) {
+      memTotal += stat.memory;
+      hasMem = true;
+    }
+  }
+
+  return {
+    cpu: hasCpu ? cpuTotal : null,
+    memory: hasMem ? memTotal : null,
+  };
+}
+
+function buildRows(clusters: ClusterSummary[]): MonitorClusterRow[] {
+  return clusters.map((cluster) => ({
+    ...cluster,
+    cpu: null,
+    memory: null,
+  }));
+}
+
+type MetricsErrorState = {
+  message: string | null;
+};
+
+function getPlatformError(platform: string): string | null {
+  if (SUPPORTED_PLATFORMS.has(platform)) return null;
+  return `Metrics unsupported on ${platform}.`;
+}
+
+async function loadPidusageImpl(
+  pidusage?: PidusageFn
+): Promise<{ pidusage: PidusageFn | null; error: string | null }> {
+  if (pidusage) {
+    return { pidusage, error: null };
+  }
+  try {
+    const loaded = require("pidusage") as PidusageFn;
+    return { pidusage: loaded, error: null };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to load pidusage.";
+    return { pidusage: null, error: `Metrics unavailable: ${message}` };
+  }
+}
+
+function buildRowIndex(rows: MonitorClusterRow[]): Map<string, MonitorClusterRow> {
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+function recordMetricsError(
+  state: MetricsErrorState,
+  error: unknown,
+  fallback: string
+) {
+  if (state.message) return;
+  const message = error instanceof Error ? error.message : fallback;
+  state.message = `Metrics unavailable: ${message}`;
+}
+
+async function updateClusterRow(params: {
+  cluster: ClusterSummary;
+  rowById: Map<string, MonitorClusterRow>;
+  orchestrator: any;
+  pidusage: PidusageFn;
+  errorState: MetricsErrorState;
+}) {
+  const { cluster, rowById, orchestrator, pidusage, errorState } = params;
+  const row = rowById.get(cluster.id);
+  if (!row) return;
+
+  let status: ClusterStatus | null = null;
+  try {
+    status = orchestrator.getStatus(cluster.id) as ClusterStatus;
+  } catch (error) {
+    recordMetricsError(errorState, error, "Status error.");
+    return;
+  }
+
+  const pids = extractAgentPids(status?.agents);
+  if (pids.length === 0) return;
+
+  try {
+    const raw = await pidusage(pids);
+    const normalized = normalizePidusageResult(raw, pids);
+    const aggregate = aggregateStats(normalized.values());
+    row.cpu = aggregate.cpu;
+    row.memory = aggregate.memory;
+  } catch (error) {
+    recordMetricsError(errorState, error, "pidusage error.");
+  }
+}
+
+async function applyClusterMetrics(params: {
+  clusters: ClusterSummary[];
+  rows: MonitorClusterRow[];
+  orchestrator: any;
+  pidusage: PidusageFn;
+  errorState: MetricsErrorState;
+}) {
+  const { clusters, rows, orchestrator, pidusage, errorState } = params;
+  const rowById = buildRowIndex(rows);
+  const runningClusters = clusters.filter((cluster) => cluster.state === "running");
+  await Promise.all(
+    runningClusters.map((cluster) =>
+      updateClusterRow({ cluster, rowById, orchestrator, pidusage, errorState })
+    )
+  );
+}
+
+export async function fetchMonitorMetrics(
+  deps: MonitorMetricsDeps & { clusters?: ClusterSummary[] } = {}
+): Promise<MonitorMetricsResult> {
+  const platform = deps.platform ?? process.platform;
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const orchestrator = await getOrchestratorImpl();
+  const clusters =
+    deps.clusters ?? (orchestrator.listClusters() as ClusterSummary[]);
+  const rows = buildRows(clusters);
+  const platformError = getPlatformError(platform);
+  if (platformError) return { rows, error: platformError };
+
+  const { pidusage, error } = await loadPidusageImpl(deps.pidusage);
+  if (!pidusage || error) return { rows, error };
+
+  const errorState: MetricsErrorState = { message: null };
+  await applyClusterMetrics({
+    clusters,
+    rows,
+    orchestrator,
+    pidusage,
+    errorState,
+  });
+
+  return { rows, error: errorState.message };
+}

--- a/src/tui/views/MonitorView.tsx
+++ b/src/tui/views/MonitorView.tsx
@@ -1,14 +1,251 @@
-import React from "react";
-import { Box, Text } from "ink";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { listClusters } from "../services/cluster-registry";
+import {
+  fetchMonitorMetrics,
+  MonitorClusterRow,
+} from "../services/monitor-metrics";
 
-export default function MonitorView({ provider }: { provider: string | null }) {
+type MonitorViewProps = {
+  provider: string | null;
+  onOpenCluster?: (clusterId: string) => void;
+  isCommandInputEmpty?: boolean;
+};
+
+const REFRESH_INTERVAL_MS = 2000;
+
+function formatAge(createdAt: number, now: number): string {
+  const diffSeconds = Math.max(0, Math.floor((now - createdAt) / 1000));
+  if (diffSeconds < 60) {
+    return `${diffSeconds}s`;
+  }
+  const minutes = Math.floor(diffSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function padRight(text: string, width: number): string {
+  if (text.length >= width) {
+    return text.slice(0, width);
+  }
+  return text.padEnd(width, " ");
+}
+
+function truncate(text: string, width: number): string {
+  if (text.length <= width) {
+    return text;
+  }
+  if (width <= 3) {
+    return text.slice(0, width);
+  }
+  return `${text.slice(0, width - 3)}...`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatCpu(cpu: number | null): string {
+  if (cpu === null) return "--";
+  return `${cpu.toFixed(1)}%`;
+}
+
+function formatMemory(bytes: number | null): string {
+  if (bytes === null) return "--";
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
+  const kb = 1024;
+  const mb = kb * 1024;
+  const gb = mb * 1024;
+  if (bytes < kb) return `${Math.round(bytes)}B`;
+  if (bytes < mb) return `${(bytes / kb).toFixed(1)}KB`;
+  if (bytes < gb) return `${(bytes / mb).toFixed(1)}MB`;
+  return `${(bytes / gb).toFixed(1)}GB`;
+}
+
+export default function MonitorView({
+  provider,
+  onOpenCluster,
+  isCommandInputEmpty = false,
+}: MonitorViewProps) {
+  const [rows, setRows] = useState<MonitorClusterRow[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const refresh = async () => {
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setIsLoading(true);
+
+      try {
+        const clusters = await listClusters();
+        let metricsResult = await fetchMonitorMetrics({ clusters });
+        if (!metricsResult.rows.length) {
+          metricsResult = {
+            rows: clusters.map((cluster) => ({
+              ...cluster,
+              cpu: null,
+              memory: null,
+            })),
+            error: metricsResult.error,
+          };
+        }
+
+        if (!cancelled) {
+          setRows(metricsResult.rows);
+          setSelectedId((current) => {
+            if (metricsResult.rows.length === 0) {
+              return null;
+            }
+            if (current && metricsResult.rows.some((row) => row.id === current)) {
+              return current;
+            }
+            return metricsResult.rows[0].id;
+          });
+          setError(metricsResult.error);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message =
+            err instanceof Error ? err.message : "Failed to load clusters.";
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+        inFlightRef.current = false;
+      }
+    };
+
+    void refresh();
+    const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const displayRows = useMemo(() => {
+    const now = Date.now();
+    return rows.map((row) => ({
+      ...row,
+      age: formatAge(row.createdAt, now),
+      cwdDisplay: row.cwd ?? "-",
+      cpuDisplay: formatCpu(row.cpu),
+      memoryDisplay: formatMemory(row.memory),
+    }));
+  }, [rows]);
+
+  const columnWidths = useMemo(() => {
+    const idWidth = clamp(
+      displayRows.reduce((max, row) => Math.max(max, row.id.length), 2),
+      8,
+      24
+    );
+    const statusWidth = clamp(
+      displayRows.reduce((max, row) => Math.max(max, row.state.length), 6),
+      6,
+      14
+    );
+    const ageWidth = clamp(
+      displayRows.reduce((max, row) => Math.max(max, row.age.length), 3),
+      3,
+      6
+    );
+    const cpuWidth = clamp(
+      displayRows.reduce((max, row) => Math.max(max, row.cpuDisplay.length), 3),
+      4,
+      8
+    );
+    const memWidth = clamp(
+      displayRows.reduce((max, row) => Math.max(max, row.memoryDisplay.length), 3),
+      5,
+      10
+    );
+    return { idWidth, statusWidth, ageWidth, cpuWidth, memWidth };
+  }, [displayRows]);
+
+  useInput((_input, key) => {
+    if (rows.length === 0) {
+      return;
+    }
+    const currentIndex = Math.max(
+      0,
+      rows.findIndex((row) => row.id === selectedId)
+    );
+
+    if (key.upArrow) {
+      const nextIndex = Math.max(0, currentIndex - 1);
+      setSelectedId(rows[nextIndex].id);
+      return;
+    }
+    if (key.downArrow) {
+      const nextIndex = Math.min(rows.length - 1, currentIndex + 1);
+      setSelectedId(rows[nextIndex].id);
+      return;
+    }
+    if (key.return && isCommandInputEmpty) {
+      const row = rows[currentIndex];
+      if (row && onOpenCluster) {
+        onOpenCluster(row.id);
+      }
+    }
+  });
+
   return (
     <Box flexDirection="column">
       <Text color="cyan">Monitor</Text>
       <Text color="gray">Provider: {provider || "auto"}</Text>
-      <Text color="gray">Stub view</Text>
-      <Text color="gray">Type /help for commands</Text>
-      <Text color="gray">Esc back, Ctrl+C exit</Text>
+      <Text color="gray">Refresh: {REFRESH_INTERVAL_MS / 1000}s</Text>
+      {error ? <Text color="yellow">{error}</Text> : null}
+      {isLoading && rows.length === 0 ? (
+        <Text color="gray">Loading clusters...</Text>
+      ) : null}
+      {!isLoading && rows.length === 0 && !error ? (
+        <Text color="gray">No clusters found.</Text>
+      ) : null}
+      {rows.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color="gray">
+            {padRight("ID", columnWidths.idWidth)}{" "}
+            {padRight("Status", columnWidths.statusWidth)}{" "}
+            {padRight("Age", columnWidths.ageWidth)}{" "}
+            {padRight("CPU", columnWidths.cpuWidth)}{" "}
+            {padRight("Mem", columnWidths.memWidth)} CWD
+          </Text>
+          {displayRows.map((row) => {
+            const isSelected = row.id === selectedId;
+            const line = [
+              padRight(row.id, columnWidths.idWidth),
+              padRight(row.state, columnWidths.statusWidth),
+              padRight(row.age, columnWidths.ageWidth),
+              padRight(row.cpuDisplay, columnWidths.cpuWidth),
+              padRight(row.memoryDisplay, columnWidths.memWidth),
+              truncate(row.cwdDisplay, 80),
+            ].join(" ");
+            return (
+              <Text key={row.id} inverse={isSelected}>
+                {line}
+              </Text>
+            );
+          })}
+        </Box>
+      ) : null}
+      <Text color="gray">
+        Keys: Up/Down select, Enter open (empty input), Esc back
+      </Text>
     </Box>
   );
 }

--- a/tests/unit/tui-monitor-metrics.test.js
+++ b/tests/unit/tui-monitor-metrics.test.js
@@ -1,0 +1,142 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(
+  __dirname,
+  '..',
+  '..',
+  'lib',
+  'tui',
+  'services',
+  'monitor-metrics.js'
+);
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const { fetchMonitorMetrics } = require('../../lib/tui/services/monitor-metrics');
+
+describe('TUI monitor metrics', function () {
+  it('aggregates cpu and memory for running clusters', async function () {
+    const orchestrator = {
+      listClusters: () => [
+        {
+          id: 'cluster-a',
+          state: 'running',
+          createdAt: 100,
+          agentCount: 2,
+          messageCount: 12,
+        },
+        {
+          id: 'cluster-b',
+          state: 'completed',
+          createdAt: 200,
+          agentCount: 1,
+          messageCount: 4,
+        },
+      ],
+      getStatus: (id) => {
+        if (id === 'cluster-a') {
+          return { agents: [{ pid: 101 }, { pid: 202 }] };
+        }
+        return { agents: [] };
+      },
+    };
+
+    const pidusage = (pids) => {
+      if (Array.isArray(pids)) {
+        return {
+          101: { cpu: 12.5, memory: 2560 },
+          202: { cpu: 7.5, memory: 1024 },
+        };
+      }
+      return { cpu: 0, memory: 0 };
+    };
+
+    const result = await fetchMonitorMetrics({
+      getOrchestrator: () => Promise.resolve(orchestrator),
+      pidusage,
+      platform: 'darwin',
+    });
+
+    assert.strictEqual(result.error, null);
+    const rowA = result.rows.find((row) => row.id === 'cluster-a');
+    const rowB = result.rows.find((row) => row.id === 'cluster-b');
+    assert.ok(rowA);
+    assert.ok(rowB);
+    assert.strictEqual(rowA.cpu, 20);
+    assert.strictEqual(rowA.memory, 3584);
+    assert.strictEqual(rowB.cpu, null);
+    assert.strictEqual(rowB.memory, null);
+  });
+
+  it('returns placeholders when pidusage fails', async function () {
+    const orchestrator = {
+      listClusters: () => [
+        {
+          id: 'cluster-error',
+          state: 'running',
+          createdAt: 300,
+          agentCount: 1,
+          messageCount: 1,
+        },
+      ],
+      getStatus: () => ({ agents: [{ pid: 999 }] }),
+    };
+
+    const pidusage = () => {
+      throw new Error('pidusage failed');
+    };
+
+    const result = await fetchMonitorMetrics({
+      getOrchestrator: () => Promise.resolve(orchestrator),
+      pidusage,
+      platform: 'linux',
+    });
+
+    assert.ok(result.error);
+    assert.ok(result.error.includes('pidusage failed'));
+    assert.strictEqual(result.rows[0].cpu, null);
+    assert.strictEqual(result.rows[0].memory, null);
+  });
+
+  it('skips metrics on unsupported platforms', async function () {
+    let called = false;
+    const orchestrator = {
+      listClusters: () => [
+        {
+          id: 'cluster-win',
+          state: 'running',
+          createdAt: 400,
+          agentCount: 1,
+          messageCount: 2,
+        },
+      ],
+      getStatus: () => ({ agents: [{ pid: 111 }] }),
+    };
+
+    const pidusage = () => {
+      called = true;
+      return {};
+    };
+
+    const result = await fetchMonitorMetrics({
+      getOrchestrator: () => Promise.resolve(orchestrator),
+      pidusage,
+      platform: 'win32',
+    });
+
+    assert.strictEqual(called, false);
+    assert.ok(result.error);
+    assert.ok(result.error.includes('win32'));
+    assert.strictEqual(result.rows[0].cpu, null);
+    assert.strictEqual(result.rows[0].memory, null);
+  });
+});


### PR DESCRIPTION
## Summary
- add monitor metrics service using pidusage
- show CPU/memory columns in Monitor view with selection preserved
- add unit coverage for metrics aggregation and platform handling

## Testing
- npx mocha tests/unit/tui-monitor-metrics.test.js

Closes #198