### PR TITLE
Add monitor metrics to TUI monitor view

### DIFF
--- a/src/tui/services/cluster-registry.ts
+++ b/src/tui/services/cluster-registry.ts
@@ -1,5 +1,12 @@
+const pidusage = require("pidusage");
+
+type PidusageStats = Record<string, { cpu?: number; memory?: number }>;
+type PidusageFn = (pids: number[]) => Promise<PidusageStats>;
+
 type ClusterRegistryDeps = {
   getOrchestrator?: () => Promise<any>;
+  pidusage?: PidusageFn;
+  platform?: string;
 };
 
 export type ClusterSummary = {
@@ -9,6 +16,13 @@ export type ClusterSummary = {
   agentCount: number;
   messageCount: number;
   cwd: string | null;
+};
+
+export type ClusterMetrics = {
+  id: string;
+  supported: boolean;
+  cpuPercent: number | null;
+  memoryMB: number | null;
 };
 
 let orchestratorPromise: Promise<any> | null = null;
@@ -32,6 +46,39 @@ function resolveClusterCwd(cluster: any): string | null {
     return cluster.isolation.workDir;
   }
   return null;
+}
+
+function resolveAgentPid(agent: any): number | null {
+  if (!agent || typeof agent !== "object") {
+    return null;
+  }
+  const pid = agent.processPid ?? agent.pid ?? null;
+  if (Number.isFinite(pid) && pid > 0) {
+    return pid;
+  }
+  if (typeof agent.getState === "function") {
+    const state = agent.getState();
+    const statePid = state?.pid ?? null;
+    if (Number.isFinite(statePid) && statePid > 0) {
+      return statePid;
+    }
+  }
+  return null;
+}
+
+function collectAgentPids(cluster: any): number[] {
+  if (!cluster || typeof cluster !== "object") {
+    return [];
+  }
+  const agents = Array.isArray(cluster.agents) ? cluster.agents : [];
+  const pids = new Set<number>();
+  for (const agent of agents) {
+    const pid = resolveAgentPid(agent);
+    if (pid) {
+      pids.add(pid);
+    }
+  }
+  return Array.from(pids);
 }
 
 function normalizeSummary(summary: any, orchestrator: any): ClusterSummary {
@@ -66,6 +113,13 @@ type ListClustersArgs = {
   deps?: ClusterRegistryDeps;
 };
 
+type ListClusterMetricsArgs = {
+  deps?: ClusterRegistryDeps;
+};
+
+const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
+const BYTES_PER_MB = 1024 * 1024;
+
 export async function listClusters(
   { deps = {} }: ListClustersArgs = {}
 ): Promise<ClusterSummary[]> {
@@ -84,3 +138,80 @@ export async function listClusters(
   return results;
 }
 
+export async function listClusterMetrics(
+  { deps = {} }: ListClusterMetricsArgs = {}
+): Promise<Record<string, ClusterMetrics>> {
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const pidusageImpl = deps.pidusage ?? pidusage;
+  const platform = deps.platform ?? process.platform;
+  const orchestrator = await getOrchestratorImpl();
+  const summaries = orchestrator.listClusters();
+  const clusterIds = summaries.map((summary: any) => summary.id);
+
+  if (!SUPPORTED_PLATFORMS.has(platform)) {
+    return Object.fromEntries(
+      clusterIds.map((id) => [
+        id,
+        {
+          id,
+          supported: false,
+          cpuPercent: null,
+          memoryMB: null,
+        },
+      ])
+    );
+  }
+
+  const pidsByCluster = new Map<string, number[]>();
+  const allPids = new Set<number>();
+  for (const clusterId of clusterIds) {
+    const cluster = orchestrator.getCluster(clusterId);
+    const pids = collectAgentPids(cluster);
+    pidsByCluster.set(clusterId, pids);
+    for (const pid of pids) {
+      allPids.add(pid);
+    }
+  }
+
+  let statsByPid: PidusageStats = {};
+  if (allPids.size > 0) {
+    try {
+      statsByPid = await pidusageImpl(Array.from(allPids));
+    } catch {
+      statsByPid = {};
+    }
+  }
+
+  const results: Record<string, ClusterMetrics> = {};
+  for (const clusterId of clusterIds) {
+    const pids = pidsByCluster.get(clusterId) ?? [];
+    let cpuTotal = 0;
+    let memoryTotalBytes = 0;
+    let hasCpu = false;
+    let hasMemory = false;
+    for (const pid of pids) {
+      const stats = statsByPid[String(pid)] ?? statsByPid[pid as any];
+      if (!stats) {
+        continue;
+      }
+      const cpu = Number(stats.cpu);
+      const memory = Number(stats.memory);
+      if (Number.isFinite(cpu)) {
+        cpuTotal += cpu;
+        hasCpu = true;
+      }
+      if (Number.isFinite(memory)) {
+        memoryTotalBytes += memory;
+        hasMemory = true;
+      }
+    }
+    results[clusterId] = {
+      id: clusterId,
+      supported: true,
+      cpuPercent: hasCpu ? cpuTotal : null,
+      memoryMB: hasMemory ? memoryTotalBytes / BYTES_PER_MB : null,
+    };
+  }
+
+  return results;
+}

--- a/src/tui/views/MonitorView.tsx
+++ b/src/tui/views/MonitorView.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import {
   ClusterSummary,
+  ClusterMetrics,
+  listClusterMetrics,
   listClusters,
 } from "../services/cluster-registry";
 
@@ -12,6 +14,7 @@ type MonitorViewProps = {
 };
 
 const REFRESH_INTERVAL_MS = 3000;
+const METRICS_REFRESH_INTERVAL_MS = 2000;
 
 function formatAge(createdAt: number, now: number): string {
   const diffSeconds = Math.max(0, Math.floor((now - createdAt) / 1000));
@@ -51,6 +54,20 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+function formatCpu(cpuPercent: number | null | undefined): string {
+  if (!Number.isFinite(cpuPercent)) {
+    return "-";
+  }
+  return `${Number(cpuPercent).toFixed(1)}%`;
+}
+
+function formatMemory(memoryMB: number | null | undefined): string {
+  if (!Number.isFinite(memoryMB)) {
+    return "-";
+  }
+  return `${Math.round(Number(memoryMB))}MB`;
+}
+
 export default function MonitorView({
   provider,
   onOpenCluster,
@@ -58,6 +75,9 @@ export default function MonitorView({
 }: MonitorViewProps) {
   const [clusters, setClusters] = useState<ClusterSummary[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [metricsById, setMetricsById] = useState<
+    Record<string, ClusterMetrics>
+  >({});
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -103,14 +123,47 @@ export default function MonitorView({
     };
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+
+    async function refreshMetrics() {
+      if (inFlight) {
+        return;
+      }
+      inFlight = true;
+      try {
+        const result = await listClusterMetrics();
+        if (!cancelled) {
+          setMetricsById(result);
+        }
+      } catch {
+        if (!cancelled) {
+          setMetricsById({});
+        }
+      } finally {
+        inFlight = false;
+      }
+    }
+
+    void refreshMetrics();
+    const interval = setInterval(refreshMetrics, METRICS_REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
   const rows = useMemo(() => {
     const now = Date.now();
     return clusters.map((cluster) => ({
       ...cluster,
       age: formatAge(cluster.createdAt, now),
       cwdDisplay: cluster.cwd ?? "-",
+      cpuDisplay: formatCpu(metricsById[cluster.id]?.cpuPercent),
+      memoryDisplay: formatMemory(metricsById[cluster.id]?.memoryMB),
     }));
-  }, [clusters]);
+  }, [clusters, metricsById]);
 
   const columnWidths = useMemo(() => {
     const idWidth = clamp(
@@ -128,7 +181,17 @@ export default function MonitorView({
       3,
       6
     );
-    return { idWidth, statusWidth, ageWidth };
+    const cpuWidth = clamp(
+      rows.reduce((max, row) => Math.max(max, row.cpuDisplay.length), 4),
+      4,
+      8
+    );
+    const memWidth = clamp(
+      rows.reduce((max, row) => Math.max(max, row.memoryDisplay.length), 3),
+      3,
+      10
+    );
+    return { idWidth, statusWidth, ageWidth, cpuWidth, memWidth };
   }, [rows]);
 
   useInput((_input, key) => {
@@ -176,7 +239,9 @@ export default function MonitorView({
           <Text color="gray">
             {padRight("ID", columnWidths.idWidth)}{" "}
             {padRight("Status", columnWidths.statusWidth)}{" "}
-            {padRight("Age", columnWidths.ageWidth)} CWD
+            {padRight("Age", columnWidths.ageWidth)}{" "}
+            {padRight("CPU%", columnWidths.cpuWidth)}{" "}
+            {padRight("Mem", columnWidths.memWidth)} CWD
           </Text>
           {rows.map((row) => {
             const isSelected = row.id === selectedId;
@@ -184,6 +249,8 @@ export default function MonitorView({
               padRight(row.id, columnWidths.idWidth),
               padRight(row.state, columnWidths.statusWidth),
               padRight(row.age, columnWidths.ageWidth),
+              padRight(row.cpuDisplay, columnWidths.cpuWidth),
+              padRight(row.memoryDisplay, columnWidths.memWidth),
               truncate(row.cwdDisplay, 80),
             ].join(" ");
             return (

--- a/tests/unit/tui-cluster-registry.test.js
+++ b/tests/unit/tui-cluster-registry.test.js
@@ -21,7 +21,7 @@ function ensureTuiBuild() {
 
 ensureTuiBuild();
 
-const { listClusters } = require('../../lib/tui/services/cluster-registry');
+const { listClusters, listClusterMetrics } = require('../../lib/tui/services/cluster-registry');
 
 function createOrchestrator(summaries, clustersById) {
   return {
@@ -79,5 +79,63 @@ describe('TUI cluster registry', function () {
     assert.strictEqual(cwdById['cluster-1'], '/worktree/path');
     assert.strictEqual(cwdById['cluster-2'], '/isolation/path');
     assert.strictEqual(cwdById['cluster-3'], null);
+  });
+
+  it('aggregates CPU and memory metrics across agent pids', async function () {
+    const summaries = [
+      { id: 'cluster-a', state: 'running', createdAt: 100, agentCount: 2, messageCount: 3 },
+      { id: 'cluster-b', state: 'running', createdAt: 200, agentCount: 3, messageCount: 4 },
+    ];
+    const clustersById = {
+      'cluster-a': { agents: [{ processPid: 11 }, { processPid: 12 }] },
+      'cluster-b': { agents: [{ processPid: 21 }, { pid: 22 }, { processPid: null }] },
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+    const MB = 1024 * 1024;
+    const pidusage = (pids) => {
+      const stats = {
+        11: { cpu: 10, memory: 100 * MB },
+        12: { cpu: 5, memory: 200 * MB },
+        21: { cpu: 1, memory: 50 * MB },
+        22: { cpu: 2, memory: 60 * MB },
+      };
+      return Object.fromEntries(pids.map((pid) => [String(pid), stats[pid]]));
+    };
+
+    const result = await listClusterMetrics({
+      deps: {
+        getOrchestrator: () => Promise.resolve(orchestrator),
+        pidusage,
+        platform: 'darwin',
+      },
+    });
+
+    assert.strictEqual(result['cluster-a'].supported, true);
+    assert.strictEqual(result['cluster-a'].cpuPercent, 15);
+    assert.strictEqual(result['cluster-a'].memoryMB, 300);
+    assert.strictEqual(result['cluster-b'].cpuPercent, 3);
+    assert.strictEqual(result['cluster-b'].memoryMB, 110);
+  });
+
+  it('returns unsupported metrics on unsupported platforms', async function () {
+    const summaries = [
+      { id: 'cluster-a', state: 'running', createdAt: 100, agentCount: 2, messageCount: 3 },
+    ];
+    const clustersById = {
+      'cluster-a': { agents: [{ processPid: 11 }] },
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+
+    const result = await listClusterMetrics({
+      deps: {
+        getOrchestrator: () => Promise.resolve(orchestrator),
+        pidusage: () => ({}),
+        platform: 'win32',
+      },
+    });
+
+    assert.strictEqual(result['cluster-a'].supported, false);
+    assert.strictEqual(result['cluster-a'].cpuPercent, null);
+    assert.strictEqual(result['cluster-a'].memoryMB, null);
   });
 });


### PR DESCRIPTION
## Summary
- add cluster metrics aggregation using pidusage
- render CPU/memory columns in Monitor view
- extend cluster registry tests for metrics handling

## Testing
- npx mocha tests/unit/tui-cluster-registry.test.js

Closes #198