### PR TITLE
Add topology model and view in Cluster view

### DIFF
--- a/src/tui/services/cluster-topology.ts
+++ b/src/tui/services/cluster-topology.ts
@@ -1,0 +1,145 @@
+type ClusterTopologyDeps = {
+  getOrchestrator?: () => Promise<any>;
+};
+
+export type TopologyAgent = {
+  id: string;
+  role: string | null;
+};
+
+export type TopologyEdge = {
+  from: string;
+  to: string;
+  topic: string;
+  kind: "trigger" | "publish" | "source";
+  dynamic?: boolean;
+};
+
+export type ClusterTopology = {
+  agents: TopologyAgent[];
+  edges: TopologyEdge[];
+  topics: string[];
+};
+
+let orchestratorPromise: Promise<any> | null = null;
+
+async function getOrchestrator() {
+  if (!orchestratorPromise) {
+    const Orchestrator = require("../../../src/orchestrator");
+    orchestratorPromise = Orchestrator.create({ quiet: true });
+  }
+  return orchestratorPromise;
+}
+
+function normalizeTopic(value: any): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const topic = value.trim();
+  return topic ? topic : null;
+}
+
+function extractTopicsFromScript(script: any): string[] {
+  if (typeof script !== "string") {
+    return [];
+  }
+  const topics = new Set<string>();
+  const regex = /topic\s*:\s*['"`]([A-Za-z0-9_:-]+)['"`]/g;
+  let match: RegExpExecArray | null = null;
+  while ((match = regex.exec(script)) !== null) {
+    if (match[1]) {
+      topics.add(match[1]);
+    }
+  }
+  return Array.from(topics);
+}
+
+export function buildTopologyModel(config: any): ClusterTopology {
+  const agents: TopologyAgent[] = [];
+  const edges: TopologyEdge[] = [];
+  const topics = new Set<string>();
+  const edgeKeys = new Set<string>();
+
+  const addEdge = (
+    from: string,
+    to: string,
+    topic: string,
+    kind: TopologyEdge["kind"],
+    dynamic?: boolean
+  ) => {
+    if (!from || !to || !topic) {
+      return;
+    }
+    const key = `${from}::${to}`;
+    if (edgeKeys.has(key)) {
+      return;
+    }
+    edgeKeys.add(key);
+    edges.push({ from, to, topic, kind, dynamic });
+  };
+
+  topics.add("ISSUE_OPENED");
+  addEdge("system", "ISSUE_OPENED", "ISSUE_OPENED", "source");
+
+  const agentConfigs = Array.isArray(config?.agents) ? config.agents : [];
+  for (const agent of agentConfigs) {
+    const id = typeof agent?.id === "string" ? agent.id : null;
+    if (!id) {
+      continue;
+    }
+    agents.push({
+      id,
+      role: typeof agent.role === "string" ? agent.role : null,
+    });
+
+    const triggers = Array.isArray(agent.triggers) ? agent.triggers : [];
+    for (const trigger of triggers) {
+      const topic = normalizeTopic(trigger?.topic);
+      if (!topic) {
+        continue;
+      }
+      topics.add(topic);
+      addEdge(topic, id, topic, "trigger");
+    }
+
+    const outputTopic = normalizeTopic(agent?.hooks?.onComplete?.config?.topic);
+    if (outputTopic) {
+      topics.add(outputTopic);
+      addEdge(id, outputTopic, outputTopic, "publish");
+    }
+
+    const hookLogicScript = agent?.hooks?.onComplete?.logic?.script;
+    for (const topic of extractTopicsFromScript(hookLogicScript)) {
+      topics.add(topic);
+      addEdge(id, topic, topic, "publish", true);
+    }
+
+    const hookTransformScript = agent?.hooks?.onComplete?.transform?.script;
+    for (const topic of extractTopicsFromScript(hookTransformScript)) {
+      topics.add(topic);
+      addEdge(id, topic, topic, "publish", true);
+    }
+  }
+
+  return {
+    agents,
+    edges,
+    topics: Array.from(topics),
+  };
+}
+
+export async function getClusterTopology(
+  clusterId: string | null | undefined,
+  { deps = {} }: { deps?: ClusterTopologyDeps } = {}
+): Promise<ClusterTopology> {
+  if (!clusterId) {
+    return { agents: [], edges: [], topics: [] };
+  }
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const orchestrator = await getOrchestratorImpl();
+  const cluster = orchestrator.getCluster(clusterId);
+  if (!cluster?.config) {
+    throw new Error(`Cluster ${clusterId} not found.`);
+  }
+  return buildTopologyModel(cluster.config);
+}

--- a/src/tui/views/ClusterView.tsx
+++ b/src/tui/views/ClusterView.tsx
@@ -6,6 +6,11 @@ import {
   createClusterLogStream,
   MAX_LOG_LINES,
 } from "../services/cluster-logs";
+import {
+  ClusterTopology,
+  getClusterTopology,
+  TopologyEdge,
+} from "../services/cluster-topology";
 
 type ClusterViewProps = {
   provider: string | null;
@@ -15,6 +20,7 @@ type ClusterViewProps = {
 type ClusterLogStreamHandle = ReturnType<typeof createClusterLogStream>;
 
 const EMPTY_STATUS: ClusterLogStatus = { state: "idle" };
+const TOPOLOGY_REFRESH_INTERVAL_MS = 1500;
 
 function padTime(value: number): string {
   return value.toString().padStart(2, "0");
@@ -37,6 +43,9 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
   const [logLines, setLogLines] = useState<ClusterLogLine[]>([]);
   const [logStatus, setLogStatus] = useState<ClusterLogStatus>(EMPTY_STATUS);
   const streamRef = useRef<ClusterLogStreamHandle | null>(null);
+  const [topology, setTopology] = useState<ClusterTopology | null>(null);
+  const [topologyError, setTopologyError] = useState<string | null>(null);
+  const [topologyLoading, setTopologyLoading] = useState(false);
 
   useEffect(() => {
     setLogLines([]);
@@ -70,6 +79,52 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
     };
   }, [clusterId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    let inFlight = false;
+
+    async function refresh() {
+      if (!clusterId) {
+        setTopology(null);
+        setTopologyError(null);
+        setTopologyLoading(false);
+        return;
+      }
+      if (inFlight) {
+        return;
+      }
+      inFlight = true;
+      setTopologyLoading(true);
+      try {
+        const result = await getClusterTopology(clusterId);
+        if (cancelled) {
+          return;
+        }
+        setTopology(result);
+        setTopologyError(null);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Failed to load topology.";
+        setTopologyError(message);
+        setTopology(null);
+      } finally {
+        if (!cancelled) {
+          setTopologyLoading(false);
+        }
+        inFlight = false;
+      }
+    }
+
+    void refresh();
+    const interval = setInterval(refresh, TOPOLOGY_REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [clusterId]);
+
   const emptyMessage = useMemo(() => {
     if (!clusterId) {
       return "No cluster selected.";
@@ -85,12 +140,77 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
     return "No logs yet.";
   }, [clusterId, logStatus]);
 
+  const topologyLines = useMemo(() => {
+    if (!topology) {
+      return [] as string[];
+    }
+    const adjacency = new Map<string, string[]>();
+
+    const addEdge = (edge: TopologyEdge) => {
+      const list = adjacency.get(edge.from) ?? [];
+      if (!list.includes(edge.to)) {
+        list.push(edge.to);
+      }
+      adjacency.set(edge.from, list);
+    };
+
+    for (const edge of topology.edges) {
+      addEdge(edge);
+    }
+
+    return Array.from(adjacency.entries()).map(
+      ([from, tos]) => `${from} -> ${tos.join(", ")}`
+    );
+  }, [topology]);
+
+  const topologyMessage = useMemo(() => {
+    if (!clusterId) {
+      return "No cluster selected.";
+    }
+    if (topologyError) {
+      return `Topology error: ${topologyError}`;
+    }
+    if (topologyLoading && !topology) {
+      return "Loading topology...";
+    }
+    if (!topology || topology.agents.length === 0) {
+      return "No topology data.";
+    }
+    return null;
+  }, [clusterId, topologyError, topologyLoading, topology]);
+
   return (
     <Box flexDirection="column">
       <Box flexDirection="column" marginBottom={1}>
         <Text color="cyan">Cluster</Text>
         <Text color="gray">Id: {clusterId || "pending"}</Text>
         <Text color="gray">Provider: {provider || "auto"}</Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color="yellow">Topology</Text>
+        {topologyMessage ? (
+          <Text color="gray">{topologyMessage}</Text>
+        ) : (
+          <Box flexDirection="column">
+            <Text color="gray">Agents</Text>
+            {topology?.agents.map((agent) => {
+              const suffix = agent.role ? ` (${agent.role})` : "";
+              return (
+                <Text key={agent.id}>
+                  - {agent.id}
+                  {suffix}
+                </Text>
+              );
+            })}
+            <Text color="gray">Wiring</Text>
+            {topologyLines.length === 0 ? (
+              <Text color="gray">No wiring detected.</Text>
+            ) : (
+              topologyLines.map((line) => <Text key={line}>{line}</Text>)
+            )}
+          </Box>
+        )}
       </Box>
 
       <Box flexDirection="column" flexGrow={1}>

--- a/tests/unit/tui-cluster-topology.test.js
+++ b/tests/unit/tui-cluster-topology.test.js
@@ -1,0 +1,99 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(
+  __dirname,
+  '..',
+  '..',
+  'lib',
+  'tui',
+  'services',
+  'cluster-topology.js'
+);
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const { buildTopologyModel } = require('../../lib/tui/services/cluster-topology');
+
+function edgeKey(edge) {
+  return `${edge.from}=>${edge.to}::${edge.topic}`;
+}
+
+describe('TUI cluster topology', function () {
+  it('builds agents and edges including dynamic topics', function () {
+    const config = {
+      agents: [
+        {
+          id: 'planner',
+          role: 'planning',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              config: { topic: 'PLAN_READY' },
+              logic: {
+                engine: 'javascript',
+                script: "if (ok) { return { topic: 'PLANNER_PROGRESS' }; }",
+              },
+            },
+          },
+        },
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'PLAN_READY', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              config: { topic: 'IMPLEMENTATION_READY' },
+              transform: {
+                engine: 'javascript',
+                script: "return { topic: 'WORKER_PROGRESS' };",
+              },
+            },
+          },
+        },
+        {
+          id: 'validator',
+          role: 'validator',
+          triggers: [{ topic: 'IMPLEMENTATION_READY', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              config: { topic: 'VALIDATION_RESULT' },
+            },
+          },
+        },
+        {
+          id: 'newcomer',
+          role: 'observer',
+          triggers: [],
+          hooks: {},
+        },
+      ],
+    };
+
+    const topology = buildTopologyModel(config);
+    assert.deepStrictEqual(
+      topology.agents.map((agent) => agent.id),
+      ['planner', 'worker', 'validator', 'newcomer']
+    );
+
+    const edges = new Set(topology.edges.map(edgeKey));
+
+    assert.ok(edges.has('system=>ISSUE_OPENED::ISSUE_OPENED'));
+    assert.ok(edges.has('ISSUE_OPENED=>planner::ISSUE_OPENED'));
+    assert.ok(edges.has('planner=>PLAN_READY::PLAN_READY'));
+    assert.ok(edges.has('planner=>PLANNER_PROGRESS::PLANNER_PROGRESS'));
+    assert.ok(edges.has('PLAN_READY=>worker::PLAN_READY'));
+    assert.ok(edges.has('worker=>IMPLEMENTATION_READY::IMPLEMENTATION_READY'));
+    assert.ok(edges.has('worker=>WORKER_PROGRESS::WORKER_PROGRESS'));
+    assert.ok(edges.has('IMPLEMENTATION_READY=>validator::IMPLEMENTATION_READY'));
+    assert.ok(edges.has('validator=>VALIDATION_RESULT::VALIDATION_RESULT'));
+  });
+});


### PR DESCRIPTION
## Summary
- add cluster topology model from config (agents + topic wiring)
- render topology section in Cluster view (agents + adjacency list)
- add unit coverage for topology model parsing

## Testing
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/tsc -p tsconfig.tui.json
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/mocha tests/unit/tui-cluster-topology.test.js

Closes #203