### PR TITLE
Add agent selection and agent log view

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -42,10 +42,16 @@ export default function App({
     providerOverride ?? null
   );
   const [activeClusterId, setActiveClusterId] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [isDispatching, setIsDispatching] = useState(false);
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
   const isCommandInputEmpty = inputValue.length === 0;
+
+  const setClusterId = (clusterId: string | null) => {
+    setActiveClusterId(clusterId);
+    setSelectedAgentId(null);
+  };
 
   async function handleSubmit() {
     if (isDispatching) {
@@ -66,7 +72,7 @@ export default function App({
           providerOverride: provider,
           activeView: active,
           setStatus,
-          setClusterId: setActiveClusterId,
+          setClusterId,
           navigate: (view) =>
             setViewStack((stack) => pushIfDifferent(stack, view)),
         });
@@ -77,7 +83,7 @@ export default function App({
         navigate: (view) =>
           setViewStack((stack) => pushIfDifferent(stack, view)),
         setProvider: (next) => setProvider(next),
-        setClusterId: (clusterId) => setActiveClusterId(clusterId),
+        setClusterId,
         provider,
         exit,
       });
@@ -128,8 +134,13 @@ export default function App({
   }, [autoExit, exit, exitDelayMs]);
 
   function handleOpenCluster(clusterId: string) {
-    setActiveClusterId(clusterId);
+    setClusterId(clusterId);
     setViewStack((stack) => pushIfDifferent(stack, "cluster"));
+  }
+
+  function handleOpenAgent(agentId: string) {
+    setSelectedAgentId(agentId);
+    setViewStack((stack) => pushIfDifferent(stack, "agent"));
   }
 
   return (
@@ -139,7 +150,10 @@ export default function App({
           view={active}
           provider={provider}
           clusterId={activeClusterId}
+          agentId={selectedAgentId}
           onOpenCluster={handleOpenCluster}
+          onSelectAgent={setSelectedAgentId}
+          onOpenAgent={handleOpenAgent}
           isCommandInputEmpty={isCommandInputEmpty}
         />
       </Box>

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -9,7 +9,10 @@ type RouterProps = {
   view: ViewId;
   provider: string | null;
   clusterId?: string | null;
+  agentId?: string | null;
   onOpenCluster?: (clusterId: string) => void;
+  onSelectAgent?: (agentId: string | null) => void;
+  onOpenAgent?: (agentId: string) => void;
   isCommandInputEmpty?: boolean;
 };
 
@@ -17,7 +20,10 @@ export default function Router({
   view,
   provider,
   clusterId,
+  agentId,
   onOpenCluster,
+  onSelectAgent,
+  onOpenAgent,
   isCommandInputEmpty,
 }: RouterProps) {
   switch (view) {
@@ -32,9 +38,20 @@ export default function Router({
         />
       );
     case "cluster":
-      return <ClusterView provider={provider} clusterId={clusterId} />;
+      return (
+        <ClusterView
+          provider={provider}
+          clusterId={clusterId}
+          selectedAgentId={agentId}
+          onSelectAgent={onSelectAgent}
+          onOpenAgent={onOpenAgent}
+          isCommandInputEmpty={isCommandInputEmpty}
+        />
+      );
     case "agent":
-      return <AgentView provider={provider} />;
+      return (
+        <AgentView provider={provider} clusterId={clusterId} agentId={agentId} />
+      );
     default:
       return <LauncherView provider={provider} />;
   }

--- a/src/tui/services/cluster-logs.ts
+++ b/src/tui/services/cluster-logs.ts
@@ -25,6 +25,7 @@ export type ClusterLogLine = {
 
 type ClusterLogStreamOptions = {
   clusterId?: string | null;
+  agentId?: string | null;
   onLines: (lines: ClusterLogLine[]) => void;
   onStatus?: (status: ClusterLogStatus) => void;
   pollIntervalMs?: number;
@@ -94,6 +95,7 @@ export function normalizeAgentOutput(message: any): ClusterLogLine | null {
 
 export function createClusterLogStream({
   clusterId,
+  agentId,
   onLines,
   onStatus,
   pollIntervalMs = LOG_POLL_INTERVAL_MS,
@@ -105,6 +107,18 @@ export function createClusterLogStream({
   let initialized = false;
   let closed = false;
   let lastStatus: ClusterLogStatus | null = null;
+  const normalizedAgentId =
+    typeof agentId === "string" && agentId.trim() ? agentId.trim() : null;
+
+  const filterLines = (lines: ClusterLogLine[]) => {
+    if (!normalizedAgentId) {
+      return lines;
+    }
+    return lines.filter(
+      (line) =>
+        line.agent === normalizedAgentId || line.sender === normalizedAgentId
+    );
+  };
 
   const emitStatus = (status: ClusterLogStatus) => {
     if (!onStatus) return;
@@ -192,9 +206,11 @@ export function createClusterLogStream({
     }
 
     const messages = rows.slice().reverse();
-    const lines = messages
-      .map((message: any) => normalizeAgentOutput(message))
-      .filter(Boolean) as ClusterLogLine[];
+    const lines = filterLines(
+      messages
+        .map((message: any) => normalizeAgentOutput(message))
+        .filter(Boolean) as ClusterLogLine[]
+    );
 
     if (lines.length > 0) {
       onLines(lines);
@@ -243,9 +259,11 @@ export function createClusterLogStream({
       return;
     }
 
-    const lines = rows
-      .map((message: any) => normalizeAgentOutput(message))
-      .filter(Boolean) as ClusterLogLine[];
+    const lines = filterLines(
+      rows
+        .map((message: any) => normalizeAgentOutput(message))
+        .filter(Boolean) as ClusterLogLine[]
+    );
 
     if (lines.length > 0) {
       onLines(lines);

--- a/src/tui/views/AgentView.tsx
+++ b/src/tui/views/AgentView.tsx
@@ -1,12 +1,122 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text } from "ink";
+import {
+  ClusterLogLine,
+  ClusterLogStatus,
+  createClusterLogStream,
+  MAX_LOG_LINES,
+} from "../services/cluster-logs";
 
-export default function AgentView({ provider }: { provider: string | null }) {
+type AgentViewProps = {
+  provider: string | null;
+  clusterId?: string | null;
+  agentId?: string | null;
+};
+
+type ClusterLogStreamHandle = ReturnType<typeof createClusterLogStream>;
+const EMPTY_STATUS: ClusterLogStatus = { state: "idle" };
+
+function padTime(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${padTime(date.getHours())}:${padTime(date.getMinutes())}:${padTime(
+    date.getSeconds()
+  )}`;
+}
+
+function formatLogLine(line: ClusterLogLine): string {
+  const agent = line.agent || line.sender || "agent";
+  const roleSuffix = line.role ? `/${line.role}` : "";
+  return `[${formatTimestamp(line.timestamp)}] ${agent}${roleSuffix}: ${line.text}`;
+}
+
+export default function AgentView({
+  provider,
+  clusterId,
+  agentId,
+}: AgentViewProps) {
+  const [logLines, setLogLines] = useState<ClusterLogLine[]>([]);
+  const [logStatus, setLogStatus] = useState<ClusterLogStatus>(EMPTY_STATUS);
+  const streamRef = useRef<ClusterLogStreamHandle | null>(null);
+
+  useEffect(() => {
+    setLogLines([]);
+    if (clusterId && agentId) {
+      setLogStatus({ state: "waiting" });
+    } else {
+      setLogStatus(EMPTY_STATUS);
+    }
+
+    if (streamRef.current) {
+      streamRef.current.close();
+      streamRef.current = null;
+    }
+
+    if (!clusterId || !agentId) {
+      return;
+    }
+
+    const stream = createClusterLogStream({
+      clusterId,
+      agentId,
+      onLines: (lines) => {
+        setLogLines((prev) => {
+          const next = prev.concat(lines);
+          if (next.length <= MAX_LOG_LINES) {
+            return next;
+          }
+          return next.slice(next.length - MAX_LOG_LINES);
+        });
+      },
+      onStatus: setLogStatus,
+    });
+
+    stream.start();
+    streamRef.current = stream;
+
+    return () => {
+      stream.close();
+      streamRef.current = null;
+    };
+  }, [agentId, clusterId]);
+
+  const emptyMessage = useMemo(() => {
+    if (!clusterId) {
+      return "No cluster selected.";
+    }
+    if (!agentId) {
+      return "No agent selected.";
+    }
+    if (logStatus.state === "waiting") {
+      return "Waiting for agent logs...";
+    }
+    if (logStatus.state === "error") {
+      return logStatus.message
+        ? `Log error: ${logStatus.message}`
+        : "Log error.";
+    }
+    return "No logs yet.";
+  }, [agentId, clusterId, logStatus]);
+
   return (
     <Box flexDirection="column">
       <Text color="cyan">Agent</Text>
+      <Text color="gray">Cluster: {clusterId || "pending"}</Text>
+      <Text color="gray">Agent: {agentId || "pending"}</Text>
       <Text color="gray">Provider: {provider || "auto"}</Text>
-      <Text color="gray">Stub view</Text>
+      <Box flexDirection="column" marginTop={1} flexGrow={1}>
+        <Text color="yellow">Live logs</Text>
+        {logLines.length === 0 ? (
+          <Text color="gray">{emptyMessage}</Text>
+        ) : (
+          logLines.map((line) => (
+            <Text key={line.id}>{formatLogLine(line)}</Text>
+          ))
+        )}
+      </Box>
       <Text color="gray">Type /help for commands</Text>
       <Text color="gray">Esc back, Ctrl+C exit</Text>
     </Box>

--- a/src/tui/views/ClusterView.tsx
+++ b/src/tui/views/ClusterView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useInput } from "ink";
 import {
   ClusterLogLine,
   ClusterLogStatus,
@@ -21,6 +21,10 @@ import {
 type ClusterViewProps = {
   provider: string | null;
   clusterId?: string | null;
+  selectedAgentId?: string | null;
+  onSelectAgent?: (agentId: string | null) => void;
+  onOpenAgent?: (agentId: string) => void;
+  isCommandInputEmpty?: boolean;
 };
 
 type ClusterLogStreamHandle = ReturnType<typeof createClusterLogStream>;
@@ -51,7 +55,14 @@ function formatTimelineEvent(event: TimelineEvent): string {
   return `[${formatTimestamp(event.timestamp)}] ${event.label}`;
 }
 
-export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
+export default function ClusterView({
+  provider,
+  clusterId,
+  selectedAgentId,
+  onSelectAgent,
+  onOpenAgent,
+  isCommandInputEmpty = false,
+}: ClusterViewProps) {
   const [logLines, setLogLines] = useState<ClusterLogLine[]>([]);
   const [logStatus, setLogStatus] = useState<ClusterLogStatus>(EMPTY_STATUS);
   const streamRef = useRef<ClusterLogStreamHandle | null>(null);
@@ -62,6 +73,33 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
   const [topology, setTopology] = useState<ClusterTopology | null>(null);
   const [topologyError, setTopologyError] = useState<string | null>(null);
   const [topologyLoading, setTopologyLoading] = useState(false);
+  const agents = topology?.agents ?? [];
+
+  useEffect(() => {
+    if (!onSelectAgent) {
+      return;
+    }
+    if (!agents.length) {
+      if (selectedAgentId) {
+        onSelectAgent(null);
+      }
+      return;
+    }
+    const hasSelection = Boolean(
+      selectedAgentId && agents.some((agent) => agent.id === selectedAgentId)
+    );
+    if (!hasSelection) {
+      onSelectAgent(agents[0].id);
+    }
+  }, [agents, onSelectAgent, selectedAgentId]);
+
+  const selectedIndex = useMemo(() => {
+    if (agents.length === 0) {
+      return -1;
+    }
+    const index = agents.findIndex((agent) => agent.id === selectedAgentId);
+    return index >= 0 ? index : 0;
+  }, [agents, selectedAgentId]);
 
   useEffect(() => {
     setLogLines([]);
@@ -251,6 +289,36 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
     return null;
   }, [clusterId, topologyError, topologyLoading, topology]);
 
+  useInput((_input, key) => {
+    if (!agents.length) {
+      return;
+    }
+    const currentIndex = selectedIndex >= 0 ? selectedIndex : 0;
+
+    if (key.upArrow) {
+      const nextIndex = Math.max(0, currentIndex - 1);
+      const nextAgent = agents[nextIndex];
+      if (nextAgent && nextAgent.id !== selectedAgentId) {
+        onSelectAgent?.(nextAgent.id);
+      }
+      return;
+    }
+    if (key.downArrow) {
+      const nextIndex = Math.min(agents.length - 1, currentIndex + 1);
+      const nextAgent = agents[nextIndex];
+      if (nextAgent && nextAgent.id !== selectedAgentId) {
+        onSelectAgent?.(nextAgent.id);
+      }
+      return;
+    }
+    if (key.return && isCommandInputEmpty) {
+      const agent = agents[currentIndex];
+      if (agent && onOpenAgent) {
+        onOpenAgent(agent.id);
+      }
+    }
+  });
+
   return (
     <Box flexDirection="column">
       <Box flexDirection="column" marginBottom={1}>
@@ -266,11 +334,13 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
         ) : (
           <Box flexDirection="column">
             <Text color="gray">Agents</Text>
-            {topology?.agents.map((agent) => {
+            {agents.map((agent, index) => {
               const suffix = agent.role ? ` (${agent.role})` : "";
+              const isSelected = index === selectedIndex;
+              const prefix = isSelected ? "›" : " ";
               return (
-                <Text key={agent.id}>
-                  - {agent.id}
+                <Text key={agent.id} inverse={isSelected}>
+                  {prefix} {agent.id}
                   {suffix}
                 </Text>
               );
@@ -309,7 +379,9 @@ export default function ClusterView({ provider, clusterId }: ClusterViewProps) {
 
       <Box flexDirection="column" marginTop={1}>
         <Text color="gray">Type /help for commands</Text>
-        <Text color="gray">Esc back, Ctrl+C exit</Text>
+        <Text color="gray">
+          Keys: Up/Down select, Enter open (empty input), Esc back
+        </Text>
       </Box>
     </Box>
   );

--- a/tests/unit/tui-cluster-logs.test.js
+++ b/tests/unit/tui-cluster-logs.test.js
@@ -140,4 +140,108 @@ describe('TUI cluster logs service', function () {
     assert.ok(seen.some((line) => line.text.includes('first log')));
     assert.ok(seen.some((line) => line.text.includes('second log')));
   });
+
+  it('filters log lines by agent id', async function () {
+    const clusterId = 'cluster-test-3';
+    const zeroshotDir = path.join(tempHome, '.zeroshot');
+    fs.mkdirSync(zeroshotDir, { recursive: true });
+
+    const dbPath = path.join(zeroshotDir, `${clusterId}.db`);
+    const clustersFile = path.join(zeroshotDir, 'clusters.json');
+    fs.writeFileSync(
+      clustersFile,
+      JSON.stringify(
+        {
+          [clusterId]: {
+            config: {
+              dbPath,
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const writer = new Ledger(dbPath);
+    writer.append({
+      cluster_id: clusterId,
+      topic: 'AGENT_OUTPUT',
+      sender: 'alpha',
+      content: {
+        text: 'alpha one',
+        data: {
+          agent: 'alpha',
+          role: 'implementation',
+          line: 'alpha one',
+        },
+      },
+    });
+    writer.append({
+      cluster_id: clusterId,
+      topic: 'AGENT_OUTPUT',
+      sender: 'bravo',
+      content: {
+        text: 'bravo one',
+        data: {
+          agent: 'bravo',
+          role: 'review',
+          line: 'bravo one',
+        },
+      },
+    });
+    writer.close();
+
+    const seen = [];
+
+    const stream = createClusterLogStream({
+      clusterId,
+      agentId: 'alpha',
+      pollIntervalMs: 25,
+      onLines: (lines) => {
+        seen.push(...lines);
+      },
+    });
+
+    stream.start();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    const writer2 = new Ledger(dbPath);
+    writer2.append({
+      cluster_id: clusterId,
+      topic: 'AGENT_OUTPUT',
+      sender: 'bravo',
+      content: {
+        text: 'bravo two',
+        data: {
+          agent: 'bravo',
+          role: 'review',
+          line: 'bravo two',
+        },
+      },
+    });
+    writer2.append({
+      cluster_id: clusterId,
+      topic: 'AGENT_OUTPUT',
+      sender: 'alpha',
+      content: {
+        text: 'alpha two',
+        data: {
+          agent: 'alpha',
+          role: 'implementation',
+          line: 'alpha two',
+        },
+      },
+    });
+    writer2.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    stream.close();
+
+    assert.ok(seen.some((line) => line.text.includes('alpha one')));
+    assert.ok(seen.some((line) => line.text.includes('alpha two')));
+    assert.ok(!seen.some((line) => line.text.includes('bravo')));
+  });
 });


### PR DESCRIPTION
## Summary
- add agent selection in Cluster view with Enter to open Agent view
- tail logs for a specific agent using filtered cluster log stream
- add agent log filtering coverage

## Testing
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/tsc -p tsconfig.tui.json
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/mocha tests/unit/tui-cluster-logs.test.js

Closes #207