### PR TITLE
Add agent message queue UI

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -8,6 +8,11 @@ import { parseInput } from "./commands/parser";
 import { CommandResult } from "./commands/types";
 import { submitLauncherText } from "./launcher-actions";
 import {
+  PendingAgentMessage,
+  agentMessageKey,
+  createPendingAgentMessage,
+} from "./services/agent-messages";
+import {
   activeView,
   createViewStack,
   popView,
@@ -44,9 +49,23 @@ export default function App({
   const [activeClusterId, setActiveClusterId] = useState<string | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [isDispatching, setIsDispatching] = useState(false);
+  const [pendingMessages, setPendingMessages] = useState<
+    Record<string, PendingAgentMessage[]>
+  >({});
   const active = useMemo(() => activeView(viewStack), [viewStack]);
   const isInputActive = Boolean(process.stdin.isTTY);
   const isCommandInputEmpty = inputValue.length === 0;
+  const trimmedInput = inputValue.trim();
+  const isAgentView = active === "agent";
+  const isAgentCommand = isAgentView && trimmedInput.startsWith("/");
+  const agentInputMode = isAgentView
+    ? isAgentCommand
+      ? "command"
+      : "message"
+    : "command";
+  const commandPlaceholder = isAgentView
+    ? "Type a message or /command"
+    : "Type /help for commands";
 
   const setClusterId = (clusterId: string | null) => {
     setActiveClusterId(clusterId);
@@ -67,6 +86,32 @@ export default function App({
     setIsDispatching(true);
     try {
       if (parsed.type === "text") {
+        if (active === "agent") {
+          if (!activeClusterId || !selectedAgentId) {
+            setStatus({
+              tone: "info",
+              message: "Select an agent to queue messages.",
+            });
+            return;
+          }
+          const message = createPendingAgentMessage({
+            clusterId: activeClusterId,
+            agentId: selectedAgentId,
+            text: parsed.text,
+          });
+          const key = agentMessageKey(activeClusterId, selectedAgentId);
+          setPendingMessages((prev) => {
+            const nextForAgent = prev[key]
+              ? [...prev[key], message]
+              : [message];
+            return { ...prev, [key]: nextForAgent };
+          });
+          setStatus({
+            tone: "success",
+            message: `Queued message for ${selectedAgentId}.`,
+          });
+          return;
+        }
         await submitLauncherText({
           text: parsed.text,
           providerOverride: provider,
@@ -143,6 +188,14 @@ export default function App({
     setViewStack((stack) => pushIfDifferent(stack, "agent"));
   }
 
+  const pendingForActiveAgent = useMemo(() => {
+    if (!activeClusterId || !selectedAgentId) {
+      return [];
+    }
+    const key = agentMessageKey(activeClusterId, selectedAgentId);
+    return pendingMessages[key] ?? [];
+  }, [activeClusterId, pendingMessages, selectedAgentId]);
+
   return (
     <Box flexDirection="column">
       <Box flexGrow={1} flexDirection="column">
@@ -151,6 +204,9 @@ export default function App({
           provider={provider}
           clusterId={activeClusterId}
           agentId={selectedAgentId}
+          agentPendingMessages={pendingForActiveAgent}
+          agentMessageDraft={inputValue}
+          agentInputMode={agentInputMode}
           onOpenCluster={handleOpenCluster}
           onSelectAgent={setSelectedAgentId}
           onOpenAgent={handleOpenAgent}
@@ -158,7 +214,7 @@ export default function App({
         />
       </Box>
       <StatusBar status={status} provider={provider} />
-      <CommandInput value={inputValue} />
+      <CommandInput value={inputValue} placeholder={commandPlaceholder} />
     </Box>
   );
 }

--- a/src/tui/router.tsx
+++ b/src/tui/router.tsx
@@ -4,12 +4,16 @@ import LauncherView from "./views/LauncherView";
 import MonitorView from "./views/MonitorView";
 import ClusterView from "./views/ClusterView";
 import AgentView from "./views/AgentView";
+import { PendingAgentMessage } from "./services/agent-messages";
 
 type RouterProps = {
   view: ViewId;
   provider: string | null;
   clusterId?: string | null;
   agentId?: string | null;
+  agentPendingMessages?: PendingAgentMessage[];
+  agentMessageDraft?: string;
+  agentInputMode?: "command" | "message";
   onOpenCluster?: (clusterId: string) => void;
   onSelectAgent?: (agentId: string | null) => void;
   onOpenAgent?: (agentId: string) => void;
@@ -21,6 +25,9 @@ export default function Router({
   provider,
   clusterId,
   agentId,
+  agentPendingMessages,
+  agentMessageDraft,
+  agentInputMode,
   onOpenCluster,
   onSelectAgent,
   onOpenAgent,
@@ -50,7 +57,14 @@ export default function Router({
       );
     case "agent":
       return (
-        <AgentView provider={provider} clusterId={clusterId} agentId={agentId} />
+        <AgentView
+          provider={provider}
+          clusterId={clusterId}
+          agentId={agentId}
+          pendingMessages={agentPendingMessages}
+          messageDraft={agentMessageDraft}
+          inputMode={agentInputMode}
+        />
       );
     default:
       return <LauncherView provider={provider} />;

--- a/src/tui/services/agent-messages.ts
+++ b/src/tui/services/agent-messages.ts
@@ -1,0 +1,40 @@
+export type PendingAgentMessage = {
+  id: string;
+  clusterId: string;
+  agentId: string;
+  text: string;
+  createdAt: number;
+  status: "pending";
+};
+
+type CreatePendingAgentMessageArgs = {
+  clusterId: string;
+  agentId: string;
+  text: string;
+  now?: number;
+  id?: string;
+};
+
+export function agentMessageKey(clusterId: string, agentId: string): string {
+  return `${clusterId}:${agentId}`;
+}
+
+export function createPendingAgentMessage({
+  clusterId,
+  agentId,
+  text,
+  now = Date.now(),
+  id,
+}: CreatePendingAgentMessageArgs): PendingAgentMessage {
+  const createdAt = now;
+  const messageId =
+    id ?? `${createdAt}-${Math.random().toString(16).slice(2)}`;
+  return {
+    id: messageId,
+    clusterId,
+    agentId,
+    text,
+    createdAt,
+    status: "pending",
+  };
+}

--- a/src/tui/views/AgentView.tsx
+++ b/src/tui/views/AgentView.tsx
@@ -6,11 +6,15 @@ import {
   createClusterLogStream,
   MAX_LOG_LINES,
 } from "../services/cluster-logs";
+import { PendingAgentMessage } from "../services/agent-messages";
 
 type AgentViewProps = {
   provider: string | null;
   clusterId?: string | null;
   agentId?: string | null;
+  pendingMessages?: PendingAgentMessage[];
+  messageDraft?: string;
+  inputMode?: "command" | "message";
 };
 
 type ClusterLogStreamHandle = ReturnType<typeof createClusterLogStream>;
@@ -33,14 +37,29 @@ function formatLogLine(line: ClusterLogLine): string {
   return `[${formatTimestamp(line.timestamp)}] ${agent}${roleSuffix}: ${line.text}`;
 }
 
+function formatPendingMessage(message: PendingAgentMessage): string {
+  return `[${formatTimestamp(message.createdAt)}] pending: ${message.text}`;
+}
+
 export default function AgentView({
   provider,
   clusterId,
   agentId,
+  pendingMessages,
+  messageDraft,
+  inputMode = "message",
 }: AgentViewProps) {
   const [logLines, setLogLines] = useState<ClusterLogLine[]>([]);
   const [logStatus, setLogStatus] = useState<ClusterLogStatus>(EMPTY_STATUS);
   const streamRef = useRef<ClusterLogStreamHandle | null>(null);
+  const pending = pendingMessages ?? [];
+  const draft = messageDraft ?? "";
+  const messagePlaceholder =
+    inputMode === "command" ? "Type a command (/help)" : "Type a message";
+  const modeLabel =
+    inputMode === "command"
+      ? "Command mode (starts with /)"
+      : "Message mode (Enter queues)";
 
   useEffect(() => {
     setLogLines([]);
@@ -107,6 +126,31 @@ export default function AgentView({
       <Text color="gray">Cluster: {clusterId || "pending"}</Text>
       <Text color="gray">Agent: {agentId || "pending"}</Text>
       <Text color="gray">Provider: {provider || "auto"}</Text>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color="yellow">Message</Text>
+        <Box>
+          <Text color="cyan">{"> "}</Text>
+          {draft ? (
+            <Text>{draft}</Text>
+          ) : (
+            <Text color="gray">{messagePlaceholder}</Text>
+          )}
+        </Box>
+        <Text color="gray">{modeLabel}</Text>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color="yellow">Queued messages</Text>
+        {pending.length === 0 ? (
+          <Text color="gray">No queued messages.</Text>
+        ) : (
+          pending.map((message) => (
+            <Text key={message.id}>{formatPendingMessage(message)}</Text>
+          ))
+        )}
+      </Box>
+
       <Box flexDirection="column" marginTop={1} flexGrow={1}>
         <Text color="yellow">Live logs</Text>
         {logLines.length === 0 ? (

--- a/tests/unit/tui-agent-messages.test.js
+++ b/tests/unit/tui-agent-messages.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(__dirname, '..', '..', 'lib', 'tui', 'services', 'agent-messages.js');
+
+function ensureTuiBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui', { stdio: 'inherit' });
+  }
+}
+
+ensureTuiBuild();
+
+const {
+  agentMessageKey,
+  createPendingAgentMessage,
+} = require('../../lib/tui/services/agent-messages');
+
+describe('TUI agent messages', function () {
+  it('builds a stable key for cluster and agent', function () {
+    assert.strictEqual(agentMessageKey('cluster-1', 'agent-a'), 'cluster-1:agent-a');
+  });
+
+  it('creates a pending message payload', function () {
+    const message = createPendingAgentMessage({
+      clusterId: 'cluster-1',
+      agentId: 'agent-a',
+      text: 'hello',
+      now: 1700000000000,
+      id: 'msg-1',
+    });
+
+    assert.deepStrictEqual(message, {
+      id: 'msg-1',
+      clusterId: 'cluster-1',
+      agentId: 'agent-a',
+      text: 'hello',
+      createdAt: 1700000000000,
+      status: 'pending',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add agent message queue helper utilities
- render message input + queued list in Agent view
- queue pending messages in app state for Agent view

## Testing
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/tsc -p tsconfig.tui.json
- NODE_PATH=/Users/tom/code/covibes/external/zeroshot/node_modules /Users/tom/code/covibes/external/zeroshot/node_modules/.bin/mocha tests/unit/tui-agent-messages.test.js

Closes #209