### PR TITLE
fix(output-extraction): reject CLI metadata in extractDirectJson

### DIFF
--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -168,8 +168,47 @@ function extractFromMarkdown(text) {
 }
 
 /**
+ * CLI metadata fields that indicate raw provider output (not agent content).
+ * These objects should be rejected - they're wrapper metadata, not actual output.
+ */
+const CLI_METADATA_FIELDS = new Set([
+  'duration_ms',
+  'duration_api_ms',
+  'total_cost_usd',
+  'session_id',
+  'num_turns',
+  'permission_denials',
+  'modelUsage',
+]);
+
+/**
+ * Check if an object looks like CLI metadata rather than agent output.
+ * CLI metadata has specific fields like duration_ms, session_id, etc.
+ *
+ * @param {object} obj - Parsed JSON object
+ * @returns {boolean} True if this looks like CLI metadata
+ */
+function isCliMetadata(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+
+  // If it has type:result, it's definitely CLI wrapper (should have been handled by extractFromResultWrapper)
+  if (obj.type === 'result') return true;
+
+  // Check for CLI-specific metadata fields
+  const keys = Object.keys(obj);
+  const metadataFieldCount = keys.filter((k) => CLI_METADATA_FIELDS.has(k)).length;
+
+  // If 2+ CLI metadata fields present, reject as CLI output
+  return metadataFieldCount >= 2;
+}
+
+/**
  * Strategy 4: Direct JSON parse
  * Handles raw JSON output (single-line or multi-line)
+ *
+ * IMPORTANT: Rejects CLI metadata objects to prevent schema validation
+ * against wrong data structure (e.g., validating {duration_ms, session_id}
+ * against agent schema expecting {summary, completionStatus}).
  *
  * @param {string} text - Text to parse
  * @returns {object|null} Parsed JSON or null
@@ -183,6 +222,10 @@ function extractDirectJson(text) {
   try {
     const parsed = JSON.parse(trimmed);
     if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      // Reject CLI metadata - this is wrapper output, not agent content
+      if (isCliMetadata(parsed)) {
+        return null;
+      }
       return parsed;
     }
   } catch {

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -274,6 +274,43 @@ function defineDirectJsonExtractionTests() {
       assert.strictEqual(extractDirectJson('   '), null);
       assert.strictEqual(extractDirectJson(null), null);
     });
+
+    // CLI metadata rejection tests - prevent schema validation against wrong structure
+    it('should reject type:result objects (CLI wrapper)', function () {
+      const text = '{"type":"result","subtype":"success","duration_ms":1234}';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
+
+    it('should reject CLI metadata with duration_ms and session_id', function () {
+      const text =
+        '{"duration_ms":5000,"session_id":"abc123","total_cost_usd":0.05,"usage":{"input_tokens":100}}';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
+
+    it('should reject CLI metadata with multiple metadata fields', function () {
+      const text =
+        '{"type":"result","subtype":"error","is_error":true,"duration_ms":123,"num_turns":5,"total_cost_usd":0.1,"permission_denials":[],"errors":["some error"]}';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
+
+    it('should accept normal agent output (not CLI metadata)', function () {
+      const text = '{"summary":"Task completed","completionStatus":{"canValidate":true}}';
+      const result = extractDirectJson(text);
+      assert.deepStrictEqual(result, {
+        summary: 'Task completed',
+        completionStatus: { canValidate: true },
+      });
+    });
+
+    it('should accept agent output that has one CLI-like field by coincidence', function () {
+      // If agent happens to output a field named "errors", that's fine (< 2 CLI fields)
+      const text = '{"summary":"Fixed bugs","errors":[]}';
+      const result = extractDirectJson(text);
+      assert.deepStrictEqual(result, { summary: 'Fixed bugs', errors: [] });
+    });
   });
 }
 
@@ -492,6 +529,16 @@ Done.`;
       const result = extractJsonFromOutput(output, 'claude');
       assert.strictEqual(result.complexity, 'TRIVIAL');
       assert.strictEqual(result.taskType, 'TASK');
+    });
+
+    it('REGRESSION: Claude CLI error result without actual output', function () {
+      // When Claude has an error, it returns CLI metadata without result field.
+      // This MUST return null (not the CLI metadata object), so schema validation
+      // doesn't run against wrong structure ({duration_ms, session_id} vs {summary, completionStatus})
+      const output =
+        '{"type":"result","subtype":"error","is_error":true,"duration_ms":1234,"duration_api_ms":1200,"num_turns":0,"session_id":"abc123","total_cost_usd":0.0,"usage":{},"modelUsage":null,"permission_denials":[],"uuid":"xyz","errors":["Permission denied"]}';
+      const result = extractJsonFromOutput(output, 'claude');
+      assert.strictEqual(result, null);
     });
   });
 }


### PR DESCRIPTION
## Summary

When Claude CLI returns an error result without actual agent output, the extraction pipeline was falling through to `extractDirectJson` which blindly accepted any JSON object - including raw CLI metadata like:
```json
{"type":"result","subtype":"error","duration_ms":1234,"session_id":"abc",...}
```

This caused schema validation to run against the wrong data structure, generating confusing warnings:
```
Agent worker output failed JSON schema validation: #/required must have required property 'summary'; 
#/required must have required property 'completionStatus'
```

## Fix

Add `isCliMetadata()` check to reject objects that have:
- `type:result` (CLI wrapper format)
- 2+ CLI-specific metadata fields (duration_ms, session_id, total_cost_usd, etc.)

This ensures `parseResultOutput` returns `null` for error cases, triggering proper error handling rather than schema validation against wrong data.

## Test plan

- [x] Added unit tests for CLI metadata rejection
- [x] Added regression test for error result scenario
- [x] All 70 output extraction tests pass