### PR TITLE
feat(output-extraction): extract CLI errors from all providers

### DIFF
--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1699,7 +1699,17 @@ async function parseResultOutput(agent, output) {
   }
 
   const providerName = agent._resolveProvider ? agent._resolveProvider() : 'claude';
-  const { extractJsonFromOutput, hasFatalStandaloneOutput } = require('./output-extraction');
+  const {
+    extractJsonFromOutput,
+    extractCliError,
+    hasFatalStandaloneOutput,
+  } = require('./output-extraction');
+
+  // Check for CLI errors FIRST - surface the actual error message
+  const cliError = extractCliError(output);
+  if (cliError) {
+    throw new Error(`CLI error (${cliError.provider}): ${cliError.error}`);
+  }
 
   // Use clean extraction pipeline
   let parsed = extractJsonFromOutput(output, providerName);

--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -236,6 +236,71 @@ function extractDirectJson(text) {
 }
 
 /**
+ * Extract CLI error from provider output (all providers).
+ * Returns the error message if the CLI reported an error, null otherwise.
+ *
+ * Provider error formats:
+ * - Claude: {type:"result", is_error:true, errors:["msg"]} or {type:"result", subtype:"error"}
+ * - Codex:  {type:"turn.failed", error:{message:"msg"}}
+ * - Gemini: {type:"result", success:false, error:"msg"}
+ * - Opencode: {type:"session.error", error:{message:"msg"}}
+ *
+ * @param {string} output - Raw CLI output
+ * @returns {{error: string, provider: string}|null} Error info or null
+ */
+function extractCliError(output) {
+  if (!output || typeof output !== 'string') return null;
+
+  const lines = output.split('\n');
+
+  for (const line of lines) {
+    const content = stripTimestamp(line);
+    if (!content.startsWith('{')) continue;
+
+    let obj;
+    try {
+      obj = JSON.parse(content);
+    } catch {
+      continue;
+    }
+
+    // Claude: {type:"result", is_error:true, errors:[...]}
+    if (obj.type === 'result' && obj.is_error === true) {
+      const errorMsg = Array.isArray(obj.errors)
+        ? obj.errors.join('; ')
+        : obj.error || obj.result || 'Unknown CLI error';
+      return { error: errorMsg, provider: 'claude' };
+    }
+
+    // Claude: {type:"result", subtype:"error"}
+    if (obj.type === 'result' && obj.subtype === 'error') {
+      const errorMsg = obj.error || obj.result || 'CLI returned error';
+      return { error: errorMsg, provider: 'claude' };
+    }
+
+    // Codex: {type:"turn.failed", error:{message:"..."}}
+    if (obj.type === 'turn.failed') {
+      const errorMsg = obj.error?.message || obj.error || 'Turn failed';
+      return { error: errorMsg, provider: 'codex' };
+    }
+
+    // Gemini: {type:"result", success:false, error:"..."}
+    if (obj.type === 'result' && obj.success === false && obj.error) {
+      return { error: obj.error, provider: 'gemini' };
+    }
+
+    // Opencode: {type:"session.error", error:{...}}
+    if (obj.type === 'session.error') {
+      const errorMsg =
+        obj.error?.data?.message || obj.error?.message || obj.error?.name || 'Session error';
+      return { error: errorMsg, provider: 'opencode' };
+    }
+  }
+
+  return null;
+}
+
+/**
  * Detects fatal standalone output lines that indicate no task output was produced.
  * Only matches when the line itself is the fatal message (not when it appears inside JSON).
  *
@@ -293,6 +358,7 @@ function extractJsonFromOutput(output, providerName = 'claude') {
 
 module.exports = {
   extractJsonFromOutput,
+  extractCliError,
   extractFromResultWrapper,
   extractFromTextEvents,
   extractFromMarkdown,

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -9,6 +9,7 @@
 const assert = require('assert');
 const {
   extractJsonFromOutput,
+  extractCliError,
   extractFromResultWrapper,
   extractFromTextEvents,
   extractFromMarkdown,
@@ -22,6 +23,7 @@ describe('Output Extraction Module', function () {
   defineTextEventExtractionTests();
   defineMarkdownExtractionTests();
   defineDirectJsonExtractionTests();
+  defineCliErrorExtractionTests();
   defineFullPipelineTests();
   defineRegressionTests();
 });
@@ -310,6 +312,131 @@ function defineDirectJsonExtractionTests() {
       const text = '{"summary":"Fixed bugs","errors":[]}';
       const result = extractDirectJson(text);
       assert.deepStrictEqual(result, { summary: 'Fixed bugs', errors: [] });
+    });
+  });
+}
+
+function defineCliErrorExtractionTests() {
+  // ============================================================================
+  // CLI ERROR EXTRACTION (ALL PROVIDERS)
+  // ============================================================================
+  describe('extractCliError', function () {
+    // Claude errors
+    it('should extract Claude error with is_error:true', function () {
+      const output = '{"type":"result","is_error":true,"errors":["Permission denied for tool X"]}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Permission denied for tool X',
+        provider: 'claude',
+      });
+    });
+
+    it('should extract Claude error with multiple errors', function () {
+      const output = '{"type":"result","is_error":true,"errors":["Error 1","Error 2"]}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Error 1; Error 2',
+        provider: 'claude',
+      });
+    });
+
+    it('should extract Claude error with subtype:error', function () {
+      const output = '{"type":"result","subtype":"error","error":"Token limit exceeded"}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Token limit exceeded',
+        provider: 'claude',
+      });
+    });
+
+    // Codex errors
+    it('should extract Codex turn.failed error', function () {
+      const output = '{"type":"turn.failed","error":{"message":"API rate limit exceeded"}}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'API rate limit exceeded',
+        provider: 'codex',
+      });
+    });
+
+    it('should extract Codex turn.failed with string error', function () {
+      const output = '{"type":"turn.failed","error":"Something went wrong"}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Something went wrong',
+        provider: 'codex',
+      });
+    });
+
+    // Gemini errors
+    it('should extract Gemini error with success:false', function () {
+      const output = '{"type":"result","success":false,"error":"Model unavailable"}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Model unavailable',
+        provider: 'gemini',
+      });
+    });
+
+    // Opencode errors
+    it('should extract Opencode session.error', function () {
+      const output = '{"type":"session.error","error":{"message":"Connection timeout"}}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Connection timeout',
+        provider: 'opencode',
+      });
+    });
+
+    it('should extract Opencode session.error with nested data', function () {
+      const output =
+        '{"type":"session.error","error":{"data":{"message":"Auth failed"},"name":"AuthError"}}';
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Auth failed',
+        provider: 'opencode',
+      });
+    });
+
+    // No error cases
+    it('should return null for successful Claude output', function () {
+      const output = '{"type":"result","subtype":"success","result":{"foo":"bar"}}';
+      const result = extractCliError(output);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return null for successful Codex output', function () {
+      const output = '{"type":"turn.completed","usage":{"input_tokens":100}}';
+      const result = extractCliError(output);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return null for successful Gemini output', function () {
+      const output = '{"type":"result","success":true}';
+      const result = extractCliError(output);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return null for empty output', function () {
+      assert.strictEqual(extractCliError(''), null);
+      assert.strictEqual(extractCliError(null), null);
+    });
+
+    it('should return null for non-error JSON', function () {
+      const output = '{"foo":"bar","baz":123}';
+      const result = extractCliError(output);
+      assert.strictEqual(result, null);
+    });
+
+    it('should find error in multi-line NDJSON output', function () {
+      const output = `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{}}
+{"type":"result","is_error":true,"errors":["Task failed"]}`;
+      const result = extractCliError(output);
+      assert.deepStrictEqual(result, {
+        error: 'Task failed',
+        provider: 'claude',
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add `extractCliError()` for Claude, Codex, Gemini, Opencode error formats
- Check CLI errors FIRST before JSON extraction in `parseResultOutput()`
- Surface real error messages instead of useless schema validation errors

## Before/After

**Before:**
```
Agent worker output failed JSON schema validation: must have required property 'summary'
```

**After:**
```
CLI error (claude): Permission denied for tool Write
```

## Provider Error Formats

| Provider | Error Event Format |
|----------|-------------------|
| Claude | `{type:"result", is_error:true, errors:[...]}` |
| Codex | `{type:"turn.failed", error:{message:...}}` |
| Gemini | `{type:"result", success:false, error:...}` |
| Opencode | `{type:"session.error", error:{...}}` |

## Test Coverage

14 tests covering all providers, error variants, and edge cases.

🤖 Generated with [Claude Code](https://claude.ai/code)