### PR TITLE
feat: implement #213 - TUI v2 7.2 guidance live injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Ledger (SQLite)           | `src/ledger.js`                        |
 | Guidance topics           | `src/guidance-topics.js`               |
 | Guidance mailbox helper   | `src/ledger.js`                        |
+| Guidance live injection   | `src/orchestrator.js`                  |
 | Trigger evaluation        | `src/logic-engine.js`                  |
 | Agent wrapper             | `src/agent-wrapper.js`                 |
 | Providers registry        | `src/providers/index.js`               |
@@ -112,6 +113,7 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 
 - Topics: `USER_GUIDANCE_CLUSTER`, `USER_GUIDANCE_AGENT` (see `src/guidance-topics.js`).
 - Mailbox helper: `ledger.queryGuidanceMailbox()` with `messageBus.queryGuidanceMailbox()` passthrough.
+- Live injection: `Orchestrator.sendGuidanceToAgent()` uses `agent.injectInput()` to attempt PTY stdin; always persists `USER_GUIDANCE_AGENT` with `metadata.delivery` (`status: injected|unsupported`, `method: pty`, `taskId`, `reason`).
 
 ### Agent Configuration (Minimal)
 

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -18,6 +18,7 @@ const { getProvider } = require('./providers');
 const { buildContext } = require('./agent/agent-context-builder');
 const { findMatchingTrigger, evaluateTrigger } = require('./agent/agent-trigger-evaluator');
 const { executeHook } = require('./agent/agent-hook-executor');
+const { injectInput: injectAgentInput } = require('./agent/agent-input-injector');
 const {
   spawnClaudeTask,
   followClaudeTaskLogs,
@@ -540,6 +541,16 @@ class AgentWrapper {
 
     // Execute the task with resume context
     await this._executeTask(triggeringMessage);
+  }
+
+  /**
+   * Inject live input into a running agent task when possible
+   * @param {string} text
+   * @param {object} [options]
+   * @returns {Promise<{status: string, reason?: string|null, method?: string|null, taskId?: string|null}>}
+   */
+  injectInput(text, options = {}) {
+    return injectAgentInput(this, text, options);
   }
 
   /**

--- a/src/agent/agent-input-injector.js
+++ b/src/agent/agent-input-injector.js
@@ -1,0 +1,141 @@
+/**
+ * AgentInputInjector - Live guidance injection for running agents
+ *
+ * Resolves the current task, validates attachable socket availability,
+ * and sends input via attach STDIN when possible.
+ */
+
+const { getTask } = require('../../task-lib/store.js');
+const { sendInput } = require('../attach/send-input');
+const { isSocketAlive } = require('../attach/socket-discovery');
+
+const DEFAULT_TIMEOUT_MS = 1500;
+
+function buildResult({ status, reason = null, method = null, taskId = null }) {
+  return {
+    status,
+    reason,
+    method,
+    taskId,
+  };
+}
+
+function ensureValidInputs(agent, text) {
+  if (!agent) {
+    throw new Error('AgentInputInjector: agent is required');
+  }
+  if (typeof text !== 'string') {
+    throw new Error('AgentInputInjector: text must be a string');
+  }
+  if (!text.trim()) {
+    throw new Error('AgentInputInjector: text cannot be empty');
+  }
+}
+
+function buildUnsupported(reason, taskId) {
+  return buildResult({
+    status: 'unsupported',
+    reason,
+    taskId,
+  });
+}
+
+function getTaskId(agent) {
+  return agent.currentTaskId || null;
+}
+
+function checkIsolation(agent, taskId) {
+  if (agent.isolation?.enabled) {
+    return buildUnsupported('isolation-enabled', taskId);
+  }
+  return null;
+}
+
+function checkTaskId(taskId) {
+  if (!taskId) {
+    return buildUnsupported('no-current-task', null);
+  }
+  return null;
+}
+
+function checkTaskInfo(taskInfo, taskId) {
+  if (!taskInfo) {
+    return buildUnsupported('task-not-found', taskId);
+  }
+  if (!taskInfo.socketPath) {
+    return buildUnsupported('no-socket', taskId);
+  }
+  if (!taskInfo.attachable) {
+    return buildUnsupported('task-not-attachable', taskId);
+  }
+  return null;
+}
+
+async function checkSocketAlive(socketPath, taskId) {
+  const socketAlive = await isSocketAlive(socketPath);
+  if (!socketAlive) {
+    return buildUnsupported('socket-not-alive', taskId);
+  }
+  return null;
+}
+
+function normalizePayload(text) {
+  return text.endsWith('\n') ? text : `${text}\n`;
+}
+
+function resolveTimeout(options) {
+  return options.timeoutMs || DEFAULT_TIMEOUT_MS;
+}
+
+function buildInjected(taskId) {
+  return buildResult({
+    status: 'injected',
+    method: 'pty',
+    taskId,
+  });
+}
+
+function buildSendFailure(reason, taskId) {
+  return buildResult({
+    status: 'unsupported',
+    reason: reason || 'send-failed',
+    method: 'pty',
+    taskId,
+  });
+}
+
+async function injectInput(agent, text, options = {}) {
+  ensureValidInputs(agent, text);
+
+  const taskId = getTaskId(agent);
+  const isolationResult = checkIsolation(agent, taskId);
+  if (isolationResult) return isolationResult;
+
+  const taskIdResult = checkTaskId(taskId);
+  if (taskIdResult) return taskIdResult;
+
+  const taskInfo = getTask(taskId);
+  const taskInfoResult = checkTaskInfo(taskInfo, taskId);
+  if (taskInfoResult) return taskInfoResult;
+
+  const socketResult = await checkSocketAlive(taskInfo.socketPath, taskId);
+  if (socketResult) return socketResult;
+
+  const payload = normalizePayload(text);
+  const timeoutMs = resolveTimeout(options);
+  const result = await sendInput({
+    socketPath: taskInfo.socketPath,
+    data: payload,
+    timeoutMs,
+  });
+
+  if (!result.ok) {
+    return buildSendFailure(result.error, taskId);
+  }
+
+  return buildInjected(taskId);
+}
+
+module.exports = {
+  injectInput,
+};

--- a/src/attach/index.js
+++ b/src/attach/index.js
@@ -25,6 +25,7 @@ const AttachClient = require('./attach-client');
 const RingBuffer = require('./ring-buffer');
 const protocol = require('./protocol');
 const socketDiscovery = require('./socket-discovery');
+const { sendInput } = require('./send-input');
 
 module.exports = {
   AttachServer,
@@ -32,4 +33,5 @@ module.exports = {
   RingBuffer,
   protocol,
   socketDiscovery,
+  sendInput,
 };

--- a/src/attach/send-input.js
+++ b/src/attach/send-input.js
@@ -1,0 +1,88 @@
+/**
+ * sendInput - write stdin data to a live attach socket
+ *
+ * Uses the attach protocol's STDIN message to forward input to the PTY.
+ * Returns { ok, error } instead of throwing on transport failures.
+ */
+
+const net = require('net');
+const fs = require('fs');
+const protocol = require('./protocol');
+
+const DEFAULT_TIMEOUT_MS = 1500;
+
+/**
+ * Send input to an attach socket via STDIN message.
+ * @param {object} options
+ * @param {string} options.socketPath - Unix socket path
+ * @param {Buffer|string} options.data - Data to send
+ * @param {number} [options.timeoutMs=1500] - Timeout in ms
+ * @returns {Promise<{ok: boolean, error: string|null}>}
+ */
+function sendInput(options = {}) {
+  const { socketPath, data, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+
+  if (!socketPath) {
+    throw new Error('sendInput: socketPath is required');
+  }
+
+  if (data === undefined || data === null) {
+    throw new Error('sendInput: data is required');
+  }
+
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`sendInput: timeoutMs must be positive (got ${timeoutMs})`);
+  }
+
+  if (!fs.existsSync(socketPath)) {
+    return { ok: false, error: `Socket not found: ${socketPath}` };
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timeout;
+    const socket = net.createConnection(socketPath);
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      try {
+        socket.end();
+        socket.destroy();
+      } catch (cleanupError) {
+        console.warn('[sendInput] socket cleanup failed:', cleanupError);
+      }
+      resolve(result);
+    };
+
+    timeout = setTimeout(() => {
+      finish({ ok: false, error: 'Timeout waiting for socket connection' });
+    }, timeoutMs);
+
+    socket.on('connect', () => {
+      try {
+        const encoded = protocol.encode(protocol.createStdinMessage(data));
+        socket.write(encoded, (err) => {
+          if (err) {
+            finish({ ok: false, error: err.message });
+          } else {
+            finish({ ok: true, error: null });
+          }
+        });
+      } catch (err) {
+        finish({ ok: false, error: err.message });
+      }
+    });
+
+    socket.on('error', (err) => {
+      finish({ ok: false, error: err.message });
+    });
+  });
+}
+
+module.exports = {
+  sendInput,
+};

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -38,6 +38,7 @@ const SubClusterWrapper = require('./sub-cluster-wrapper');
 const MessageBus = require('./message-bus');
 const Ledger = require('./ledger');
 const InputHelpers = require('./input-helpers');
+const { USER_GUIDANCE_AGENT } = require('./guidance-topics');
 const { detectProvider } = require('./issue-providers');
 const IsolationManager = require('./isolation-manager');
 const { generateName } = require('./name-generator');
@@ -1608,6 +1609,113 @@ class Orchestrator {
     }
 
     return this._resumeCleanCluster(clusterId, cluster, recentMessages, prompt);
+  }
+
+  _validateGuidanceArgs(clusterId, agentId, text) {
+    if (!clusterId) {
+      throw new Error('sendGuidanceToAgent: clusterId is required');
+    }
+    if (!agentId) {
+      throw new Error('sendGuidanceToAgent: agentId is required');
+    }
+    if (typeof text !== 'string' || !text.trim()) {
+      throw new Error('sendGuidanceToAgent: text must be a non-empty string');
+    }
+  }
+
+  _getClusterOrThrow(clusterId) {
+    const cluster = this.clusters.get(clusterId);
+    if (!cluster) {
+      throw new Error(`sendGuidanceToAgent: cluster not found: ${clusterId}`);
+    }
+    return cluster;
+  }
+
+  _getAgentOrThrow(cluster, agentId) {
+    const agent = cluster.agents.find((candidate) => candidate.id === agentId);
+    if (!agent) {
+      throw new Error(`sendGuidanceToAgent: agent not found: ${agentId}`);
+    }
+    return agent;
+  }
+
+  _buildDefaultDelivery(agent) {
+    return {
+      status: 'unsupported',
+      reason: 'unknown',
+      method: null,
+      taskId: agent.currentTaskId || null,
+    };
+  }
+
+  async _attemptGuidanceInjection(agent, text, timeoutMs) {
+    try {
+      const result = await agent.injectInput(text, { timeoutMs });
+      return {
+        status: result.status === 'injected' ? 'injected' : 'unsupported',
+        reason: result.status === 'injected' ? null : result.reason || 'unsupported',
+        method: result.status === 'injected' ? result.method || 'pty' : result.method || null,
+        taskId: result.taskId || agent.currentTaskId || null,
+      };
+    } catch (error) {
+      return {
+        status: 'unsupported',
+        reason: error.message,
+        method: null,
+        taskId: agent.currentTaskId || null,
+      };
+    }
+  }
+
+  _buildGuidanceMetadata(options, delivery) {
+    return {
+      ...(options.metadata || {}),
+      delivery: {
+        status: delivery.status,
+        reason: delivery.reason,
+        method: delivery.method,
+        taskId: delivery.taskId,
+        timestamp: Date.now(),
+      },
+    };
+  }
+
+  _publishGuidance(cluster, clusterId, agentId, text, metadata, sender) {
+    cluster.messageBus.publish({
+      cluster_id: clusterId,
+      topic: USER_GUIDANCE_AGENT,
+      sender,
+      target_agent_id: agentId,
+      content: { text },
+      metadata,
+    });
+  }
+
+  /**
+   * Send guidance to a specific agent with optional live injection.
+   * Always persists USER_GUIDANCE_AGENT in the ledger with delivery metadata.
+   * @param {string} clusterId
+   * @param {string} agentId
+   * @param {string} text
+   * @param {object} [options]
+   * @param {string} [options.sender='user']
+   * @param {object} [options.metadata]
+   * @param {number} [options.timeoutMs]
+   * @returns {Promise<{status: string, reason: string|null, method: string|null, taskId: string|null}>}
+   */
+  async sendGuidanceToAgent(clusterId, agentId, text, options = {}) {
+    this._validateGuidanceArgs(clusterId, agentId, text);
+
+    const cluster = this._getClusterOrThrow(clusterId);
+    const agent = this._getAgentOrThrow(cluster, agentId);
+    const defaultDelivery = this._buildDefaultDelivery(agent);
+    const delivery =
+      (await this._attemptGuidanceInjection(agent, text, options.timeoutMs)) || defaultDelivery;
+    const metadata = this._buildGuidanceMetadata(options, delivery);
+
+    this._publishGuidance(cluster, clusterId, agentId, text, metadata, options.sender || 'user');
+
+    return delivery;
   }
 
   _resolveFailureInfo(cluster, clusterId) {

--- a/tests/unit/attach-stdin.test.js
+++ b/tests/unit/attach-stdin.test.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { AttachServer } = require('../../src/attach');
+const { sendInput } = require('../../src/attach/send-input');
+
+describe('Attach stdin', function () {
+  this.timeout(10000);
+
+  it('sendInput writes to a live PTY', async function () {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-attach-'));
+    const socketPath = path.join(tmpDir, 'attach.sock');
+
+    const server = new AttachServer({
+      id: 'attach-stdin-test',
+      socketPath,
+      command: 'cat',
+      args: [],
+      cwd: process.cwd(),
+      env: process.env,
+      cols: 80,
+      rows: 24,
+    });
+
+    let output = '';
+    let resolved = false;
+
+    const outputPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          reject(new Error('Timed out waiting for PTY output'));
+        }
+      }, 2000);
+
+      const onOutput = (data) => {
+        output += data.toString();
+        if (output.includes('hello-attach')) {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(timeout);
+          server.off('output', onOutput);
+          resolve();
+        }
+      };
+
+      server.on('output', onOutput);
+    });
+
+    let testError;
+    let stopError;
+    try {
+      await server.start();
+      const result = await sendInput({
+        socketPath,
+        data: 'hello-attach\n',
+        timeoutMs: 1000,
+      });
+
+      assert.strictEqual(result.ok, true);
+      await outputPromise;
+      assert.ok(output.includes('hello-attach'));
+    } catch (error) {
+      testError = error;
+    } finally {
+      try {
+        await server.stop('SIGTERM');
+      } catch (error) {
+        console.warn('AttachServer.stop failed in attach-stdin test', error);
+        stopError = error;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    if (stopError && !testError) {
+      throw stopError;
+    }
+    if (testError) {
+      throw testError;
+    }
+  });
+});

--- a/tests/unit/guidance-delivery.test.js
+++ b/tests/unit/guidance-delivery.test.js
@@ -1,0 +1,166 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-guidance-'));
+process.env.ZEROSHOT_HOME = tempHome;
+
+const assert = require('assert');
+
+const Orchestrator = require('../../src/orchestrator');
+const AgentWrapper = require('../../src/agent-wrapper');
+const MessageBus = require('../../src/message-bus');
+const Ledger = require('../../src/ledger');
+const { USER_GUIDANCE_AGENT } = require('../../src/guidance-topics');
+const { AttachServer } = require('../../src/attach');
+
+describe('Guidance delivery', function () {
+  this.timeout(10000);
+
+  let orchestrator;
+  let cluster;
+  let agent;
+  let ledger;
+
+  beforeEach(() => {
+    ledger = new Ledger(':memory:');
+    const messageBus = new MessageBus(ledger);
+    cluster = {
+      id: 'guidance-cluster',
+      messageBus,
+      ledger,
+      agents: [],
+      config: {},
+    };
+
+    orchestrator = new Orchestrator({
+      quiet: true,
+      skipLoad: true,
+      storageDir: path.join(tempHome, 'clusters'),
+    });
+
+    agent = new AgentWrapper(
+      {
+        id: 'agent-1',
+        role: 'implementation',
+        modelLevel: 'level1',
+        prompt: 'noop',
+        triggers: [],
+      },
+      messageBus,
+      cluster,
+      { testMode: true }
+    );
+
+    cluster.agents.push(agent);
+    orchestrator.clusters.set(cluster.id, cluster);
+  });
+
+  afterEach(() => {
+    ledger.close();
+    orchestrator.close();
+    orchestrator.clusters.clear();
+  });
+
+  after(() => {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('publishes unsupported delivery metadata when no live socket is available', async () => {
+    const result = await orchestrator.sendGuidanceToAgent(cluster.id, agent.id, 'Use approach A');
+
+    assert.strictEqual(result.status, 'unsupported');
+
+    const messages = cluster.messageBus.query({
+      cluster_id: cluster.id,
+      topic: USER_GUIDANCE_AGENT,
+    });
+
+    assert.strictEqual(messages.length, 1);
+    assert.strictEqual(messages[0].metadata.delivery.status, 'unsupported');
+  });
+
+  it('publishes injected delivery metadata when attach socket is live', async () => {
+    const { addTask, ensureDirs, removeTask } = await import('../../task-lib/store.js');
+    ensureDirs();
+
+    const taskId = 'task-guidance-1';
+    const socketDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-guidance-sock-'));
+    const socketPath = path.join(socketDir, 'attach.sock');
+
+    const server = new AttachServer({
+      id: taskId,
+      socketPath,
+      command: 'cat',
+      args: [],
+      cwd: process.cwd(),
+      env: process.env,
+      cols: 80,
+      rows: 24,
+    });
+
+    let testError;
+    let stopError;
+    try {
+      await server.start();
+
+      addTask({
+        id: taskId,
+        prompt: 'test',
+        fullPrompt: 'test',
+        cwd: process.cwd(),
+        status: 'running',
+        pid: server.pid,
+        sessionId: null,
+        logFile: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        exitCode: null,
+        error: null,
+        provider: 'claude',
+        model: null,
+        scheduleId: null,
+        socketPath,
+        attachable: true,
+      });
+
+      agent.currentTaskId = taskId;
+
+      const result = await orchestrator.sendGuidanceToAgent(
+        cluster.id,
+        agent.id,
+        'Injected guidance'
+      );
+
+      assert.strictEqual(result.status, 'injected');
+
+      const messages = cluster.messageBus.query({
+        cluster_id: cluster.id,
+        topic: USER_GUIDANCE_AGENT,
+      });
+
+      assert.strictEqual(messages.length, 1);
+      assert.strictEqual(messages[0].metadata.delivery.status, 'injected');
+      assert.strictEqual(messages[0].metadata.delivery.method, 'pty');
+      assert.strictEqual(messages[0].metadata.delivery.taskId, taskId);
+    } catch (error) {
+      testError = error;
+    } finally {
+      removeTask(taskId);
+      try {
+        await server.stop('SIGTERM');
+      } catch (error) {
+        console.warn('AttachServer.stop failed in guidance-delivery test', error);
+        stopError = error;
+      }
+      fs.rmSync(socketDir, { recursive: true, force: true });
+    }
+
+    if (stopError && !testError) {
+      throw stopError;
+    }
+    if (testError) {
+      throw testError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add live guidance injection via attach stdin
- persist guidance delivery metadata on guidance messages
- add tests for attach stdin + guidance delivery

## Testing
- npm test -- tests/unit/attach-stdin.test.js tests/unit/guidance-delivery.test.js
- npm run lint
- npm run typecheck
