### PR TITLE
Add provider TUI entrypoints

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -3288,6 +3288,27 @@ program
     }
   });
 
+function registerTuiEntrypoint(commandName, providerName) {
+  program
+    .command(commandName)
+    .description(`Interactive TUI to monitor clusters (provider: ${providerName})`)
+    .allowExcessArguments(true)
+    .allowUnknownOption(true)
+    .action(() => {
+      try {
+        startTuiSession({ provider: providerName });
+      } catch (error) {
+        console.error('Error starting TUI:', error.message);
+        process.exit(1);
+      }
+    });
+}
+
+registerTuiEntrypoint('codex', 'codex');
+registerTuiEntrypoint('claude', 'claude');
+registerTuiEntrypoint('gemini', 'gemini');
+registerTuiEntrypoint('opencode', 'opencode');
+
 // Settings management
 const settingsCmd = program.command('settings').description('Manage zeroshot settings');
 

--- a/tests/unit/cli-invalid-command.test.js
+++ b/tests/unit/cli-invalid-command.test.js
@@ -38,6 +38,10 @@ describe('CLI Invalid Command Handling', function () {
       'export',
       'watch',
       'tui',
+      'codex',
+      'claude',
+      'gemini',
+      'opencode',
       'attach',
       'agents',
       'config',
@@ -101,6 +105,22 @@ describe('CLI Invalid Command Handling', function () {
 
     it('should not prepend run for "settings" command', function () {
       assert.strictEqual(shouldPrependRun(['settings']), false);
+    });
+
+    it('should not prepend run for "codex" command', function () {
+      assert.strictEqual(shouldPrependRun(['codex']), false);
+    });
+
+    it('should not prepend run for "claude" command', function () {
+      assert.strictEqual(shouldPrependRun(['claude']), false);
+    });
+
+    it('should not prepend run for "gemini" command', function () {
+      assert.strictEqual(shouldPrependRun(['gemini']), false);
+    });
+
+    it('should not prepend run for "opencode" command', function () {
+      assert.strictEqual(shouldPrependRun(['opencode']), false);
     });
   });
 

--- a/tests/unit/cli-tui-entrypoints.test.js
+++ b/tests/unit/cli-tui-entrypoints.test.js
@@ -1,0 +1,45 @@
+/**
+ * Test: CLI TUI Entrypoints
+ *
+ * Verifies provider-specific entrypoints map to TUI provider override.
+ */
+
+const assert = require('assert');
+const { normalizeProviderName, VALID_PROVIDERS } = require('../../lib/provider-names');
+
+// Mirrors resolveTuiProviderOverride in cli/index.js
+function resolveTuiProviderOverride(options = {}) {
+  const override = options.provider;
+  if (!override || (typeof override === 'string' && !override.trim())) {
+    return null;
+  }
+  const normalized = normalizeProviderName(override);
+  if (!VALID_PROVIDERS.includes(normalized)) {
+    throw new Error(`Unknown provider: ${normalized}. Valid: ${VALID_PROVIDERS.join(', ')}`);
+  }
+  return normalized;
+}
+
+// Mirrors the TUI bootstrap call options in cli/index.js
+function buildTuiStartOptions(options = {}) {
+  return {
+    autoExit: false,
+    providerOverride: resolveTuiProviderOverride(options),
+    initialView: options.initialView,
+  };
+}
+
+function buildEntrypointOptions(providerName) {
+  return buildTuiStartOptions({ provider: providerName });
+}
+
+describe('CLI TUI Entrypoints', function () {
+  const entrypoints = ['codex', 'claude', 'gemini', 'opencode'];
+
+  for (const provider of entrypoints) {
+    it(`sets providerOverride for ${provider}`, function () {
+      const result = buildEntrypointOptions(provider);
+      assert.strictEqual(result.providerOverride, provider);
+    });
+  }
+});


### PR DESCRIPTION
## Summary\n- add CLI entrypoints for codex/claude/gemini/opencode that launch the TUI\n- keep invalid-command handling aware of new entrypoints\n- add unit coverage for entrypoint provider overrides\n\n## Testing\n- npm test -- tests/unit/cli-invalid-command.test.js\n- npm test -- tests/unit/cli-tui-entrypoints.test.js\n\nCloses #227