### PR TITLE
fix(daemon): exit process when cluster completes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -574,21 +574,33 @@ See `src/logic-engine.js` for sandbox implementation.
 
 ### Context Building
 
-Agents build context from ledger messages before executing:
+Agents build context from ledger messages before executing. Use explicit selection semantics:
 
-```javascript
+```json
 {
   "contextStrategy": {
     "sources": [
-      { "topic": "ISSUE_OPENED", "limit": 1 },
-      { "topic": "VALIDATION_RESULT", "since": "last_task_end", "limit": 10 }
+      { "topic": "ISSUE_OPENED", "priority": "required", "strategy": "latest", "amount": 1 },
+      { "topic": "STATE_SNAPSHOT", "priority": "required", "strategy": "latest", "amount": 1 },
+      {
+        "topic": "VALIDATION_RESULT",
+        "priority": "high",
+        "since": "last_task_end",
+        "strategy": "latest",
+        "amount": 10,
+        "compactAmount": 3
+      }
     ],
     "maxTokens": 100000
   }
 }
 ```
 
-See `src/agent/agent-context-builder.js` for implementation.
+Notes: `limit` is a deprecated alias for `amount`. If `amount` is set and `strategy` is omitted,
+the default is `latest`; otherwise defaults to `all`.
+
+See `docs/context-management.md` for the full reference and diagrams. Implementation lives in
+`src/agent/agent-context-builder.js`.
 
 ### Template Resolution
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and surface conflicts with details. Handle the ABA problem where version goes A-
 
 ## Install and Requirements
 
-**Platforms**: Linux, macOS (Windows WSL not yet supported)
+**Platforms**: Linux, macOS. Windows (native/WSL) is deferred while we harden reliability and multi-provider correctness.
 
 ```bash
 npm install -g @covibes/zeroshot
@@ -439,6 +439,7 @@ zeroshot settings set dockerEnvPassthrough '["MY_API_KEY", "TF_VAR_*"]'
 
 - [CLAUDE.md](./CLAUDE.md) - Architecture, cluster config schema, agent primitives
 - `docs/providers.md` - Provider setup, model levels, and Docker mounts
+- `docs/context-management.md` - Context selection, context packs, and state snapshots
 - [Discord](https://discord.gg/PdZ3UEXB) - Support and community
 - `zeroshot export <id>` - Export conversation to markdown
 - `sqlite3 ~/.zeroshot/*.db` - Direct ledger access for debugging

--- a/cli/index.js
+++ b/cli/index.js
@@ -237,10 +237,12 @@ function detectRunInput(inputArg) {
   return input;
 }
 
-function resolveProviderOverride(options, settings) {
-  return normalizeProviderName(
-    options.provider || process.env.ZEROSHOT_PROVIDER || settings.defaultProvider
-  );
+function resolveProviderOverride(options) {
+  const override = options.provider || process.env.ZEROSHOT_PROVIDER;
+  if (!override || (typeof override === 'string' && !override.trim())) {
+    return null;
+  }
+  return normalizeProviderName(override);
 }
 
 function runClusterPreflight({ input, options, providerOverride, settings, forceProvider }) {
@@ -2440,7 +2442,7 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps)
       // Auto-detect input type
       const input = detectRunInput(inputArg);
       const settings = loadSettings();
-      const providerOverride = resolveProviderOverride(options, settings);
+      const providerOverride = resolveProviderOverride(options);
 
       // Preflight checks
       runClusterPreflight({ input, options, providerOverride, settings, forceProvider });
@@ -3006,7 +3008,7 @@ program
     try {
       // Try cluster first, then task (both use same ID format: "adjective-noun-number")
       const OrchestratorModule = require('../src/orchestrator');
-      const orchestrator = new OrchestratorModule();
+      const orchestrator = await OrchestratorModule.create();
 
       // Check if cluster exists
       const cluster = orchestrator.getCluster(id);

--- a/cli/index.js
+++ b/cli/index.js
@@ -722,6 +722,24 @@ function setupDaemonCleanup(orchestrator, clusterId) {
 
   process.on('SIGTERM', () => cleanup('SIGTERM'));
   process.on('SIGINT', () => cleanup('SIGINT'));
+
+  // CRITICAL: Monitor cluster state for completion
+  // When CLUSTER_COMPLETE triggers orchestrator.stop(), the cluster state
+  // changes to 'stopped' but no signal is sent. Poll for this state change.
+  const checkInterval = setInterval(() => {
+    try {
+      const status = orchestrator.getStatus(clusterId);
+      if (status.state === 'stopped' || status.state === 'completed') {
+        clearInterval(checkInterval);
+        console.log(`\n[DAEMON] Cluster ${clusterId} completed, exiting.`);
+        process.exit(0);
+      }
+    } catch {
+      // Cluster no longer exists, exit gracefully
+      clearInterval(checkInterval);
+      process.exit(0);
+    }
+  }, 1000);
 }
 
 function readClusterTokenTotals(orchestrator, clusterId) {

--- a/cluster-templates/base-templates/debug-workflow.json
+++ b/cluster-templates/base-templates/debug-workflow.json
@@ -120,7 +120,15 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",
@@ -164,16 +172,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "INVESTIGATION_COMPLETE",
-            "limit": 1
+            "priority": "high",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "VALIDATION_RESULT",
+            "priority": "high",
             "since": "last_task_end",
-            "limit": 5
+            "strategy": "latest",
+            "amount": 5
           }
         ],
         "format": "chronological",
@@ -333,16 +353,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "INVESTIGATION_COMPLETE",
-            "limit": 1
+            "priority": "high",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "FIX_APPLIED",
+            "priority": "medium",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",

--- a/cluster-templates/base-templates/full-workflow.json
+++ b/cluster-templates/base-templates/full-workflow.json
@@ -114,7 +114,15 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "medium",
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",
@@ -193,21 +201,35 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "PLAN_READY",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "WORKER_PROGRESS",
+            "priority": "medium",
             "since": "last_task_end",
-            "limit": 3
+            "strategy": "latest",
+            "amount": 3
           },
           {
             "topic": "VALIDATION_RESULT",
+            "priority": "high",
             "since": "last_task_end",
-            "limit": 10
+            "strategy": "latest",
+            "amount": 10
           }
         ],
         "format": "chronological",
@@ -256,11 +278,83 @@
       "maxIterations": "{{max_iterations}}"
     },
     {
+      "id": "meta-coordinator",
+      "role": "coordinator",
+      "modelLevel": "level1",
+      "timeout": "{{timeout}}",
+      "condition": "{{complexity}} == 'CRITICAL' && {{validator_count}} == 0",
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["load_quick", "load_heavy", "skip"]
+          }
+        },
+        "required": ["action"]
+      },
+      "prompt": {
+        "system": "Coordinate two-stage validation. On IMPLEMENTATION_READY: output {\"action\":\"load_quick\"}. On QUICK_VALIDATION_PASSED: output {\"action\":\"load_heavy\"}. On VALIDATION_RESULT from Stage 1 (rejection): output {\"action\":\"skip\"}"
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "IMPLEMENTATION_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "QUICK_VALIDATION_PASSED",
+            "priority": "medium",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "VALIDATION_RESULT",
+            "priority": "medium",
+            "strategy": "latest",
+            "amount": 1
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "IMPLEMENTATION_READY",
+          "action": "execute_task"
+        },
+        {
+          "topic": "QUICK_VALIDATION_PASSED",
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "CLUSTER_OPERATIONS"
+          },
+          "transform": {
+            "engine": "javascript",
+            "script": "const template = result.action === 'load_quick' ? 'quick-validation' : 'heavy-validation'; return { topic: 'CLUSTER_OPERATIONS', content: { text: result.action === 'load_quick' ? 'Stage 1 (quick)' : 'Stage 2 (heavy)', data: { operations: [{ operation: 'load_config', config: { base: template, params: { validator_level: '{{validator_level}}', max_tokens: {{max_tokens}}, timeout: {{timeout}} } } }] } } };"
+          },
+          "logic": {
+            "engine": "javascript",
+            "script": "return result.action !== 'skip';"
+          }
+        }
+      }
+    },
+    {
       "id": "validator-requirements",
       "role": "validator",
       "modelLevel": "{{validator_level}}",
       "timeout": "{{timeout}}",
       "maxRetries": 3,
+      "condition": "{{validator_count}} >= 1 && {{validator_count}} < 4",
       "outputFormat": "json",
       "jsonSchema": {
         "type": "object",
@@ -316,7 +410,7 @@
             }
           }
         },
-        "required": ["approved", "summary", "criteriaResults"]
+        "required": ["approved", "summary"]
       },
       "prompt": {
         "system": "# REQUIREMENTS VALIDATOR\n\nVerify implementation meets ALL requirements from issue. Hold a HIGH BAR.\n\n## WORKFLOW\n1. Read context files (CLAUDE.md, AGENTS.md, README) for repo-specific validation\n2. Parse acceptanceCriteria from PLAN_READY\n3. For EACH criterion: run verification, record evidence\n4. If repo has validation script (e.g. `./scripts/check-all.sh`), RUN IT\n\n## VERIFICATION\n- SEARCH before claiming 'missing' (Glob, Grep, Read)\n- RUN commands, capture output as evidence\n- CANNOT_VALIDATE only for: tool not installed, no network, permission denied\n\n## INSTANT REJECT\n- TODO/FIXME/placeholder = REJECT\n- Silent error swallowing = REJECT\n- 'Phase 2 deferred' = REJECT\n- 'Will add tests later' = REJECT\n- ANY priority=MUST criterion fails = REJECT\n\n## APPROVAL\n- approved:true = ALL MUST criteria pass + no blocking issues\n- approved:false = any MUST fails OR incomplete implementation\n\n🚫 NO questions. Make safe choice and proceed.\n\n## 🔴 OUTPUT FORMAT (CRITICAL)\n\nYou MUST return valid JSON with these REQUIRED fields:\n```json\n{\n  \"approved\": boolean,\n  \"summary\": \"<100 chars max>\",\n  \"errors\": [\"blocking issue 1\", \"blocking issue 2\"],\n  \"criteriaResults\": [{\"id\": \"AC1\", \"status\": \"PASS|FAIL|CANNOT_VALIDATE\", \"evidence\": {\"command\": \"...\", \"exitCode\": 0, \"output\": \"<200 chars>\"}, \"reason\": \"for CANNOT_VALIDATE only\"}]\n}\n```\nNo preamble. JSON only."
@@ -325,16 +419,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "PLAN_READY",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",
@@ -369,7 +475,7 @@
       "modelLevel": "{{validator_level}}",
       "timeout": "{{timeout}}",
       "maxRetries": 3,
-      "condition": "{{validator_count}} >= 2",
+      "condition": "{{validator_count}} >= 2 && {{validator_count}} < 4",
       "outputFormat": "json",
       "jsonSchema": {
         "type": "object",
@@ -396,16 +502,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "PLAN_READY",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",
@@ -439,7 +557,7 @@
       "modelLevel": "{{validator_level}}",
       "timeout": "{{timeout}}",
       "maxRetries": 3,
-      "condition": "{{validator_count}} >= 3",
+      "condition": "{{validator_count}} == 3",
       "outputFormat": "json",
       "jsonSchema": {
         "type": "object",
@@ -466,16 +584,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "PLAN_READY",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",
@@ -509,7 +639,7 @@
       "modelLevel": "{{validator_level}}",
       "timeout": "{{timeout}}",
       "maxRetries": 3,
-      "condition": "{{validator_count}} >= 4",
+      "condition": "{{validator_count}} == 3",
       "outputFormat": "json",
       "jsonSchema": {
         "type": "object",
@@ -539,16 +669,28 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "PLAN_READY",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",

--- a/cluster-templates/base-templates/heavy-validation.json
+++ b/cluster-templates/base-templates/heavy-validation.json
@@ -1,0 +1,253 @@
+{
+  "name": "Heavy Validation",
+  "description": "Stage 2: Security + Adversarial testing. Expensive (120-180s). Only runs after Stage 1 passes.",
+  "params": {
+    "validator_level": {
+      "type": "string",
+      "enum": ["level1", "level2", "level3"],
+      "default": "level2"
+    },
+    "max_tokens": {
+      "type": "number",
+      "default": 100000
+    },
+    "timeout": {
+      "type": "number",
+      "default": 0,
+      "description": "Task timeout in milliseconds (0 = no timeout)"
+    }
+  },
+  "agents": [
+    {
+      "id": "validator-security",
+      "role": "validator",
+      "modelLevel": "{{validator_level}}",
+      "timeout": "{{timeout}}",
+      "maxRetries": 3,
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "approved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["approved", "summary"]
+      },
+      "prompt": {
+        "system": "## 🔴 OUTPUT FORMAT (CRITICAL - READ FIRST)\n\nYour output MUST be MINIMAL and STRUCTURED:\n- Output ONLY the required JSON schema fields\n- NO preambles (\"Here is my analysis...\", \"Let me explain...\")\n- NO verbose summaries - be CONCISE (max 100 chars per string field)\n- NO redundant information\n- NO explanations before or after the JSON\n\n## 🚫 YOU CANNOT ASK QUESTIONS\n\nYou are running non-interactively. There is NO USER to answer.\n- NEVER use AskUserQuestion tool\n- NEVER say \"Should I...\" or \"Would you like...\"\n- When unsure: Make the SAFER choice and proceed.\n\n## 🔴 READ CONTEXT FILES FOR REPO-SPECIFIC VALIDATION\n\n**BEFORE approving any implementation:**\n1. Read the repo's context files (CLAUDE.md, AGENTS.md, README if they exist)\n2. Look for validation instructions, scripts, or commands the repo specifies\n3. If context files say to run a validation script (e.g., `./scripts/check-all.sh`), RUN IT\n4. If the validation script fails, the implementation is NOT complete - REJECT\n\nThis ensures you validate according to THIS repo's standards, not generic rules.\n\n## 🔴 VERIFICATION PROTOCOL (REQUIRED - PREVENTS FALSE CLAIMS)\n\nBefore making ANY claim about security vulnerabilities or missing protections:\n\n1. **SEARCH FIRST** - Use Glob to find ALL relevant files\n2. **READ THE CODE** - Use Read to inspect actual implementation\n3. **GREP FOR PATTERNS** - Use Grep to search for specific code (auth checks, validation, etc.)\n\n**NEVER claim a vulnerability exists without FIRST searching for the relevant code.**\n\nThe worker may have implemented security features in different files than originally planned. If you claim 'missing input validation' without searching, you may miss that validation exists in 'server/middleware/validator.ts' instead of the controller.\n\n### Example Verification Flow:\n```\n1. Claim: 'Missing SQL injection protection'\n2. BEFORE claiming → Grep for 'parameterized', 'prepared', 'escape' in relevant files\n3. BEFORE claiming → Read the actual database query code\n4. ONLY IF NOT FOUND → Add to errors array\n```\n\nYou are a security auditor for a CRITICAL task.\n\n## Security Review Checklist\n1. Input validation (injection attacks)\n2. Authentication/authorization checks\n3. Sensitive data handling\n4. OWASP Top 10 vulnerabilities\n5. Secrets management\n6. Error messages don't leak info\n\n## Output\n- approved: true if no security issues\n- summary: Security assessment\n- errors: Security vulnerabilities found\n\n## 🔴 DEBUGGING METHODOLOGY CHECK\n\nBefore approving, verify the worker didn't take shortcuts:\n\n### Ad Hoc Fix Detection\n- Did worker fix ONE instance? → Grep for similar patterns. If N > 1 exists, REJECT.\n- Example: Fixed null check in `auth.ts:42`? → `grep -r \"similar pattern\" .` - are there others?\n\n### Root Cause vs Symptom\n- Did worker add a workaround? → Find the ACTUAL bug. If workaround hides real issue, REJECT.\n- Example: Added `|| []` fallback? → WHY is it undefined? Fix THAT.\n\n### Lazy Debugging Red Flags (INSTANT REJECT)\n- Worker suggests \"restart the service\" → REJECT (hides the bug)\n- Worker suggests \"clear the cache\" → REJECT (hides the bug)\n- Worker says \"works on my machine\" → REJECT (not a fix)\n- Worker blames the test → REJECT unless they PROVE test is wrong with evidence"
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "ISSUE_OPENED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "PLAN_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "IMPLEMENTATION_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "QUICK_VALIDATION_PASSED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "QUICK_VALIDATION_PASSED",
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "HEAVY_VALIDATION_RESULT",
+            "content": {
+              "text": "{{result.summary}}",
+              "data": {
+                "approved": "{{result.approved}}",
+                "errors": "{{result.errors}}",
+                "validatorId": "validator-security"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "validator-tester",
+      "role": "validator",
+      "modelLevel": "{{validator_level}}",
+      "timeout": "{{timeout}}",
+      "maxRetries": 3,
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "approved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "testResults": {
+            "type": "string"
+          }
+        },
+        "required": ["approved", "summary"]
+      },
+      "prompt": {
+        "system": "## 🔴 OUTPUT FORMAT (CRITICAL - READ FIRST)\n\nYour output MUST be MINIMAL and STRUCTURED:\n- Output ONLY the required JSON schema fields\n- NO preambles (\"Here is my analysis...\", \"Let me explain...\")\n- NO verbose summaries - be CONCISE (max 100 chars per string field)\n- NO redundant information\n- NO explanations before or after the JSON\n- testResults field: ONLY include pass/fail counts and key errors, NOT full test output\n\n## 🚫 YOU CANNOT ASK QUESTIONS\n\nYou are running non-interactively. There is NO USER to answer.\n- NEVER use AskUserQuestion tool\n- NEVER say \"Should I...\" or \"Would you like...\"\n- When unsure: Make the SAFER choice and proceed.\n\nYou are a TEST EXECUTOR. Your job is to RUN TESTS, not read them.\n\n## 🔴 CORE PRINCIPLE: RUN THE TESTS, DON'T JUST READ THEM\n\n**Reading test code is NOT verification. You must EXECUTE tests.**\n\n- 'Tests look correct' = NOT ACCEPTABLE\n- 'Test output shows 15/15 passing' = ACTUAL VERIFICATION\n\n## 🔴 STEP 1: FIND AND RUN THE TEST SUITE (MANDATORY)\n\n1. Read context files (CLAUDE.md, AGENTS.md, README) for repo-specific test commands\n2. Find the test runner: `npm test`, `pytest`, `go test`, `cargo test`, etc.\n3. **RUN THE TESTS** using Bash tool\n4. Record FULL output in testResults field\n5. If ANY tests fail → REJECT immediately\n\n**This is not optional. You MUST run tests, not just search for them.**\n\n## 🔴 STEP 2: RUN REPO-SPECIFIC VALIDATION\n\nIf context files specify validation commands (e.g., `./scripts/check-all.sh`):\n1. RUN THEM\n2. Record output\n3. If they fail → REJECT\n\n## 🔴 STEP 3: VERIFY TEST QUALITY BY RUNNING\n\n**DO NOT assess quality by reading code. Assess by execution:**\n\n1. Run tests with verbose output: `npm test -- --verbose`\n2. Check coverage: `npm test -- --coverage`\n3. Record actual numbers in testResults\n\n**Quality indicators from EXECUTION:**\n- Coverage percentage (from actual run)\n- Number of test cases (from actual output)\n- Test duration (from actual output)\n\n## FORBIDDEN PATTERNS\n\n- ❌ 'Tests appear to have good coverage' without running them\n- ❌ 'Test assertions look correct' without executing them\n- ❌ 'The test file exists' as evidence of testing\n- ❌ Approving without testResults containing actual test output\n\n## APPROVAL CRITERIA\n\nONLY approve if:\n1. You RAN the test suite (actual output in testResults)\n2. All tests pass (verified by execution)\n3. Repo-specific validation commands pass (if specified)\n4. Coverage is acceptable for the repo (from actual coverage report)\n\n## Output\n- **approved**: true if tests RAN and PASSED\n- **summary**: Assessment based on ACTUAL test execution results\n- **errors**: Issues found (from running tests, not reading code)\n- **testResults**: ACTUAL OUTPUT from running test commands (REQUIRED)\n\n## 🔴 DEBUGGING METHODOLOGY CHECK\n\nBefore approving, verify the worker didn't take shortcuts:\n\n### Ad Hoc Fix Detection\n- Did worker fix ONE instance? → Grep for similar patterns. If N > 1 exists, REJECT.\n- Example: Fixed null check in `auth.ts:42`? → `grep -r \"similar pattern\" .` - are there others?\n\n### Root Cause vs Symptom\n- Did worker add a workaround? → Find the ACTUAL bug. If workaround hides real issue, REJECT.\n- Example: Added `|| []` fallback? → WHY is it undefined? Fix THAT.\n\n### Lazy Debugging Red Flags (INSTANT REJECT)\n- Worker suggests \"restart the service\" → REJECT (hides the bug)\n- Worker suggests \"clear the cache\" → REJECT (hides the bug)\n- Worker says \"works on my machine\" → REJECT (not a fix)\n- Worker blames the test → REJECT unless they PROVE test is wrong with evidence"
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "ISSUE_OPENED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "PLAN_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "IMPLEMENTATION_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "QUICK_VALIDATION_PASSED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "QUICK_VALIDATION_PASSED",
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "HEAVY_VALIDATION_RESULT",
+            "content": {
+              "text": "{{result.summary}}",
+              "data": {
+                "approved": "{{result.approved}}",
+                "errors": "{{result.errors}}",
+                "testResults": "{{result.testResults}}",
+                "validatorId": "validator-tester"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "consensus-coordinator",
+      "role": "coordinator",
+      "modelLevel": "level1",
+      "timeout": "{{timeout}}",
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "allApproved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": ["allApproved", "summary"]
+      },
+      "prompt": {
+        "system": "Check if both validators approved. Output: {\"allApproved\": boolean, \"summary\": \"<50 chars>\"}"
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "HEAVY_VALIDATION_RESULT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 2
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "HEAVY_VALIDATION_RESULT",
+          "logic": {
+            "engine": "javascript",
+            "script": "const results = ledger.query({ topic: 'HEAVY_VALIDATION_RESULT', since: ledger.findLast({ topic: 'QUICK_VALIDATION_PASSED' })?.timestamp || 0 }); return results.length === 2;"
+          },
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "transform": {
+            "engine": "javascript",
+            "script": "return { topic: 'VALIDATION_RESULT', content: { text: result.allApproved ? 'All validations passed' : 'Stage 2 rejected', data: { approved: result.allApproved, stage: 'heavy', summary: result.summary, errors: ledger.query({ topic: 'HEAVY_VALIDATION_RESULT' }).flatMap(r => r.content?.data?.errors || []) } } };"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cluster-templates/base-templates/quick-validation.json
+++ b/cluster-templates/base-templates/quick-validation.json
@@ -1,0 +1,285 @@
+{
+  "name": "Quick Validation",
+  "description": "Stage 1: Requirements + Code validation. Fast feedback (30-60s).",
+  "params": {
+    "validator_level": {
+      "type": "string",
+      "enum": ["level1", "level2", "level3"],
+      "default": "level2"
+    },
+    "max_tokens": {
+      "type": "number",
+      "default": 100000
+    },
+    "timeout": {
+      "type": "number",
+      "default": 0,
+      "description": "Task timeout in milliseconds (0 = no timeout)"
+    }
+  },
+  "agents": [
+    {
+      "id": "validator-requirements",
+      "role": "validator",
+      "modelLevel": "{{validator_level}}",
+      "timeout": "{{timeout}}",
+      "maxRetries": 3,
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "approved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "criteriaResults": {
+            "type": "array",
+            "description": "Status for each acceptance criterion. PASS/FAIL require evidence. CANNOT_VALIDATE requires reason.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "AC1, AC2, etc. from plan"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["PASS", "FAIL", "SKIPPED", "CANNOT_VALIDATE"],
+                  "description": "CANNOT_VALIDATE = verification impossible (missing tools, permissions, etc). Treated as PASS with warning."
+                },
+                "evidence": {
+                  "type": "object",
+                  "description": "REQUIRED for PASS/FAIL. Proof of verification - actual command output.",
+                  "properties": {
+                    "command": {
+                      "type": "string"
+                    },
+                    "exitCode": {
+                      "type": "integer"
+                    },
+                    "output": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "reason": {
+                  "type": "string",
+                  "description": "REQUIRED for CANNOT_VALIDATE. WHY verification is impossible (e.g., 'kubectl not installed', 'no SSH access')."
+                }
+              },
+              "required": ["id", "status"]
+            }
+          }
+        },
+        "required": ["approved", "summary"]
+      },
+      "prompt": {
+        "system": "# REQUIREMENTS VALIDATOR\n\nVerify implementation meets ALL requirements from issue. Hold a HIGH BAR.\n\n## WORKFLOW\n1. Read context files (CLAUDE.md, AGENTS.md, README) for repo-specific validation\n2. Parse acceptanceCriteria from PLAN_READY\n3. For EACH criterion: run verification, record evidence\n4. If repo has validation script (e.g. `./scripts/check-all.sh`), RUN IT\n\n## VERIFICATION\n- SEARCH before claiming 'missing' (Glob, Grep, Read)\n- RUN commands, capture output as evidence\n- CANNOT_VALIDATE only for: tool not installed, no network, permission denied\n\n## INSTANT REJECT\n- TODO/FIXME/placeholder = REJECT\n- Silent error swallowing = REJECT\n- 'Phase 2 deferred' = REJECT\n- 'Will add tests later' = REJECT\n- ANY priority=MUST criterion fails = REJECT\n\n## APPROVAL\n- approved:true = ALL MUST criteria pass + no blocking issues\n- approved:false = any MUST fails OR incomplete implementation\n\n🚫 NO questions. Make safe choice and proceed.\n\n## 🔴 OUTPUT FORMAT (CRITICAL)\n\nYou MUST return valid JSON with these REQUIRED fields:\n```json\n{\n  \"approved\": boolean,\n  \"summary\": \"<100 chars max>\",\n  \"errors\": [\"blocking issue 1\", \"blocking issue 2\"],\n  \"criteriaResults\": [{\"id\": \"AC1\", \"status\": \"PASS|FAIL|CANNOT_VALIDATE\", \"evidence\": {\"command\": \"...\", \"exitCode\": 0, \"output\": \"<200 chars>\"}, \"reason\": \"for CANNOT_VALIDATE only\"}]\n}\n```\nNo preamble. JSON only."
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "ISSUE_OPENED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "PLAN_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
+            "since": "last_agent_start",
+            "strategy": "latest",
+            "amount": 1
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "IMPLEMENTATION_READY",
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "QUICK_VALIDATION_RESULT",
+            "content": {
+              "text": "{{result.summary}}",
+              "data": {
+                "approved": "{{result.approved}}",
+                "errors": "{{result.errors}}",
+                "criteriaResults": "{{result.criteriaResults}}",
+                "validatorId": "validator-requirements"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "validator-code",
+      "role": "validator",
+      "modelLevel": "{{validator_level}}",
+      "timeout": "{{timeout}}",
+      "maxRetries": 3,
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "approved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["approved", "summary"]
+      },
+      "prompt": {
+        "system": "# CODE VALIDATOR\n\nSenior engineer code review. Catch REAL bugs, not style preferences.\n\n## WORKFLOW\n1. Read context files (CLAUDE.md, AGENTS.md, README) for repo-specific validation\n2. SEARCH before claiming 'missing' (Glob, Grep, Read)\n3. RUN validation scripts if specified\n\n## INSTANT REJECT\n- TODO/FIXME/placeholder = REJECT\n- Silent error swallowing = REJECT\n- Dangerous fallbacks hiding failures = REJECT\n\n## 🔴 GENERALIZATION CHECK (CRITICAL)\nWorker fixed a bug? Verify they fixed ALL instances:\n1. Identify the PATTERN (not just the line)\n2. `grep -rn \"pattern\" .` - search codebase\n3. If N > 1 exists → Did worker fix ALL? If NO → REJECT\n\nExamples: null check in one handler? Check ALL. SQL injection in one query? Check ALL. A fix that leaves identical bugs elsewhere is NOT a fix.\n\n## BLOCKING (reject with WHAT/HOW/WHY)\n- Logic/off-by-one bugs\n- Race conditions\n- Security holes (injection, auth bypass)\n- Resource leaks (timers, connections)\n- God functions (>50 lines) - SPLIT\n- DRY violation (same logic 2+ places)\n- Missing error handling\n- Hardcoded values that should be config\n\n## NOT BLOCKING (summary only)\n- Style/naming preferences\n- 'Could theoretically...' without proof\n\n🚫 NO questions. Make safe choice and proceed.\n\n## 🔴 OUTPUT FORMAT (CRITICAL)\n\nYou MUST return valid JSON:\n```json\n{\n  \"approved\": boolean,\n  \"summary\": \"<100 chars max>\",\n  \"errors\": [\"WHAT: X. HOW: Y. WHY: Z\"]\n}\n```\nNo preamble. JSON only."
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "ISSUE_OPENED",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "PLAN_READY",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "IMPLEMENTATION_READY",
+            "priority": "high",
+            "since": "last_agent_start",
+            "strategy": "latest",
+            "amount": 1
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "IMPLEMENTATION_READY",
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "QUICK_VALIDATION_RESULT",
+            "content": {
+              "text": "{{result.summary}}",
+              "data": {
+                "approved": "{{result.approved}}",
+                "errors": "{{result.errors}}",
+                "validatorId": "validator-code"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "consensus-coordinator",
+      "role": "coordinator",
+      "modelLevel": "level1",
+      "timeout": "{{timeout}}",
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "allApproved": {
+            "type": "boolean"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": ["allApproved", "summary"]
+      },
+      "prompt": {
+        "system": "Check if both validators approved. Output: {\"allApproved\": boolean, \"summary\": \"<50 chars>\"}"
+      },
+      "contextStrategy": {
+        "sources": [
+          {
+            "topic": "QUICK_VALIDATION_RESULT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 2
+          }
+        ],
+        "format": "chronological",
+        "maxTokens": "{{max_tokens}}"
+      },
+      "triggers": [
+        {
+          "topic": "QUICK_VALIDATION_RESULT",
+          "logic": {
+            "engine": "javascript",
+            "script": "const results = ledger.query({ topic: 'QUICK_VALIDATION_RESULT', since: ledger.findLast({ topic: 'IMPLEMENTATION_READY' })?.timestamp || 0 }); return results.length === 2;"
+          },
+          "action": "execute_task"
+        }
+      ],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "QUICK_VALIDATION_PASSED",
+            "content": {
+              "text": "Stage 1 passed",
+              "data": {}
+            }
+          },
+          "logic": {
+            "engine": "javascript",
+            "script": "if (!result.allApproved) { return { topic: 'VALIDATION_RESULT', content: { text: 'Stage 1 rejected', data: { approved: false, stage: 'quick', errors: ledger.query({ topic: 'QUICK_VALIDATION_RESULT' }).flatMap(r => r.content?.data?.errors || []) } } }; }"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cluster-templates/base-templates/single-worker.json
+++ b/cluster-templates/base-templates/single-worker.json
@@ -35,7 +35,15 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",

--- a/cluster-templates/base-templates/worker-validator.json
+++ b/cluster-templates/base-templates/worker-validator.json
@@ -80,17 +80,29 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "WORKER_PROGRESS",
+            "priority": "medium",
             "since": "last_task_end",
-            "limit": 3
+            "strategy": "latest",
+            "amount": 3
           },
           {
             "topic": "VALIDATION_RESULT",
+            "priority": "high",
             "since": "last_task_end",
-            "limit": 3
+            "strategy": "latest",
+            "amount": 3
           }
         ],
         "format": "chronological",
@@ -172,11 +184,21 @@
         "sources": [
           {
             "topic": "ISSUE_OPENED",
-            "limit": 1
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
+          },
+          {
+            "topic": "STATE_SNAPSHOT",
+            "priority": "required",
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "IMPLEMENTATION_READY",
-            "limit": 1
+            "priority": "high",
+            "strategy": "latest",
+            "amount": 1
           }
         ],
         "format": "chronological",

--- a/cluster-templates/conductor-bootstrap.json
+++ b/cluster-templates/conductor-bootstrap.json
@@ -32,7 +32,9 @@
         "system": "You are the JUNIOR CONDUCTOR - fast task classification.\n\n## Your Job\nClassify the task on TWO dimensions.\n\n## 🔴 COST REMINDER\n- CRITICAL uses Opus ($15/M tokens) + 4 validators = EXPENSIVE\n- STANDARD uses Sonnet ($3/M tokens) + 2 validators = NORMAL\n- Don't waste money on false positives. CRITICAL is rare.\n\n## COMPLEXITY (pick ONE)\n- TRIVIAL - One file, mechanical change; no behavior change.\n- SIMPLE - Small change, 1-2 files, low risk.\n- STANDARD - Multi-file work or user-visible behavior. **DEFAULT CHOICE.**\n- CRITICAL - ONLY when code DIRECTLY modifies: (1) authentication/authorization LOGIC, (2) payment processing/billing calculations, (3) secrets/credentials handling, (4) destructive database operations (DROP, DELETE), (5) production deployment or live infrastructure, (6) PII processing (not just displaying it).\n- UNCERTAIN - Escalate to senior conductor.\n\n**🔴 BIAS: If unsure between STANDARD and CRITICAL, choose STANDARD.** CRITICAL is expensive. Reserve it for actual risk.\n\n## NOT CRITICAL (Common False Positives)\n\nThese are STANDARD, not CRITICAL:\n- Refactoring code that MENTIONS auth/billing/security (not MODIFYING the logic)\n- Adding TypeScript types for existing structures\n- Code cleanup in infra-related files\n- Read-only queries to production data\n- Tests for auth/billing code (tests don't touch prod)\n- Extracting modules or services (code organization)\n- Factory patterns, dependency injection (architecture)\n- Config file reorganization (not production config values)\n\n## TASK TYPE (pick ONE)\n- INQUIRY - Questions, exploration, read-only\n- TASK - Implement something new\n- DEBUG - Fix something broken\n\n## Examples\n\nTask: \"Explain current auth flow (read-only)\"\n```json\n{\"complexity\": \"SIMPLE\", \"taskType\": \"INQUIRY\", \"reasoning\": \"Read-only explanation\"}\n```\n\nTask: \"Refactor auth service into smaller modules\"\n```json\n{\"complexity\": \"STANDARD\", \"taskType\": \"TASK\", \"reasoning\": \"Refactoring code organization, not modifying auth logic\"}\n```\n\nTask: \"Add TypeScript types to payment types\"\n```json\n{\"complexity\": \"STANDARD\", \"taskType\": \"TASK\", \"reasoning\": \"Adding types, not modifying billing logic\"}\n```\n\nTask: \"Fix bug in password validation logic\"\n```json\n{\"complexity\": \"CRITICAL\", \"taskType\": \"DEBUG\", \"reasoning\": \"Directly modifying authentication logic\"}\n```\n\nTask: \"Add new payment method integration\"\n```json\n{\"complexity\": \"CRITICAL\", \"taskType\": \"TASK\", \"reasoning\": \"New billing/payment processing code\"}\n```\n\nTask: \"Rotate production API keys\"\n```json\n{\"complexity\": \"CRITICAL\", \"taskType\": \"TASK\", \"reasoning\": \"Modifying production secrets\"}\n```\n\nTask: \"DROP TABLE users migration\"\n```json\n{\"complexity\": \"CRITICAL\", \"taskType\": \"TASK\", \"reasoning\": \"Destructive database operation\"}\n```\n\n## Critical Rules\n1. Output ONLY valid JSON - no other text\n2. complexity must be EXACTLY one of: TRIVIAL, SIMPLE, STANDARD, CRITICAL, UNCERTAIN\n3. taskType must be EXACTLY one of: INQUIRY, TASK, DEBUG\n\nTask: {{ISSUE_OPENED.content.text}}"
       },
       "contextStrategy": {
-        "sources": [{ "topic": "ISSUE_OPENED", "limit": 1 }],
+        "sources": [
+          { "topic": "ISSUE_OPENED", "priority": "required", "strategy": "latest", "amount": 1 }
+        ],
         "format": "chronological",
         "maxTokens": 100000
       },
@@ -87,16 +89,20 @@
       },
       "contextStrategy": {
         "sources": [
-          { "topic": "ISSUE_OPENED", "limit": 1 },
+          { "topic": "ISSUE_OPENED", "priority": "required", "strategy": "latest", "amount": 1 },
           {
             "topic": "CONDUCTOR_ESCALATE",
+            "priority": "high",
             "since": "last_agent_start",
-            "limit": 1
+            "strategy": "latest",
+            "amount": 1
           },
           {
             "topic": "CLUSTER_OPERATIONS_VALIDATION_FAILED",
+            "priority": "high",
             "since": "cluster_start",
-            "limit": 3
+            "strategy": "latest",
+            "amount": 3
           }
         ],
         "format": "chronological",

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -1,0 +1,182 @@
+# Context Management
+
+Zeroshot builds agent prompts from ledger history with explicit selection rules, a token budget,
+and a durable state snapshot. This document explains the technology and how to configure it in
+templates.
+
+## Technology stack
+
+- Ledger: SQLite message log per cluster (`~/.zeroshot/<id>.db`).
+- MessageBus: publish/subscribe wrapper over the ledger.
+- AgentContextBuilder: assembles prompt sections and context sources.
+- ContextPackBuilder: priority and budget based selection with compact variants.
+- StateSnapshotter: derives `STATE_SNAPSHOT` from structured outputs.
+- Context metrics: optional logs or ledger entries for observability.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  Issue[ISSUE_OPENED] -->|publish| Ledger[(SQLite ledger)]
+  Ledger --> Bus[MessageBus]
+  Bus --> Snapshotter[StateSnapshotter]
+  Snapshotter -->|STATE_SNAPSHOT| Ledger
+  Bus --> Builder[AgentContextBuilder]
+  Builder --> Packs[ContextPackBuilder]
+  Packs --> Prompt[Final agent context]
+  Prompt --> Agent[Agent execution]
+  Agent -->|publish topics| Ledger
+```
+
+## Prompt assembly sections
+
+The builder assembles the prompt as a set of packs:
+
+- Header and non-interactive rules
+- Agent instructions and output schema
+- Source sections from `contextStrategy.sources`
+- Validator skip hints (validator role only)
+- Triggering message (always included at the end)
+
+## Context strategy sources
+
+`contextStrategy.sources` controls which ledger messages are pulled into an agent prompt.
+
+| Field           | Type                              | Purpose                     | Default                                   |
+| --------------- | --------------------------------- | --------------------------- | ----------------------------------------- |
+| topic           | string                            | Ledger topic name           | required                                  |
+| sender          | string                            | Filter by sender            | none                                      |
+| since           | string or timestamp               | Lower bound for timestamps  | none                                      |
+| strategy        | latest \| oldest \| all           | Selection semantics         | latest if amount set, else all            |
+| amount          | number                            | Max messages to include     | none                                      |
+| limit           | number                            | Deprecated alias for amount | none                                      |
+| priority        | required \| high \| medium \| low | Pack priority               | derived if missing                        |
+| compactAmount   | number                            | Amount for compact mode     | 1                                         |
+| compactStrategy | latest \| oldest \| all           | Compact selection           | latest if base strategy is all, else base |
+
+`since` accepts: `cluster_start`, `last_task_end`, `last_agent_start`, or an ISO timestamp string.
+
+### Selection semantics
+
+- `latest`: query DESC with limit, then reverse to render chronologically.
+- `oldest`: query ASC with limit.
+- `all`: query ASC with no limit (or a hard cap if amount is set).
+
+### Priority defaults
+
+If `priority` is missing, the builder assigns:
+
+- required: `STATE_SNAPSHOT`, `ISSUE_OPENED`, `PLAN_READY`
+- high: `VALIDATION_RESULT`, `IMPLEMENTATION_READY`
+- medium: everything else
+
+Templates should set priority explicitly for clarity.
+
+## Context packs and budgeting
+
+Context is built as a set of packs that are selected under a token budget. Each pack can provide
+full and compact text. Required packs are always included first.
+
+```mermaid
+flowchart TD
+  Start --> Required[Include required packs]
+  Required --> Optional[Evaluate optional packs by priority]
+  Optional --> Fits{Fits budget?}
+  Fits -- yes --> Include[Include full pack]
+  Fits -- no --> Compact{Compact fits?}
+  Compact -- yes --> IncludeCompact[Include compact pack]
+  Compact -- no --> Skip[Skip pack]
+  Include --> Next[Next pack]
+  IncludeCompact --> Next
+  Skip --> Next
+  Next --> MaxGuard[Apply max chars guard]
+  MaxGuard --> Done[Final context]
+```
+
+Budgeting details:
+
+- Token estimates use `estimateTokensFromChars` (chars / 4, rounded up).
+- `maxTokens` controls selection; default is 100000 if unset.
+- A defensive max chars guard caps the final context to 500000 chars.
+- Required packs are preserved; if the max chars guard triggers, optional packs are compacted or
+  dropped first, then required packs are truncated as a last resort.
+
+## STATE_SNAPSHOT (durable working memory)
+
+`STATE_SNAPSHOT` is a structured summary of current cluster state. It is derived from ledger
+messages and republished whenever relevant updates occur.
+
+### Update triggers
+
+State is updated from these topics:
+
+- `ISSUE_OPENED`
+- `PLAN_READY`
+- `WORKER_PROGRESS`
+- `IMPLEMENTATION_READY`
+- `VALIDATION_RESULT`
+- `INVESTIGATION_COMPLETE`
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant Bus as MessageBus
+  participant Snapshotter
+  participant Ledger
+  Agent->>Bus: publish PLAN_READY
+  Bus->>Snapshotter: deliver PLAN_READY
+  Snapshotter->>Bus: publish STATE_SNAPSHOT
+  Bus->>Ledger: persist STATE_SNAPSHOT
+```
+
+Include `STATE_SNAPSHOT` as a required context source for workers, planners, and validators.
+
+## Context metrics and observability
+
+Enable context metrics:
+
+- `ZEROSHOT_CONTEXT_METRICS=1` prints metrics to stdout.
+- `ZEROSHOT_CONTEXT_METRICS_LEDGER=1` publishes a `CONTEXT_METRICS` message.
+
+Metrics include:
+
+- total chars and estimated tokens
+- per section and pack breakdown
+- budget and truncation details
+
+## Example context strategy
+
+```json
+{
+  "contextStrategy": {
+    "sources": [
+      { "topic": "ISSUE_OPENED", "priority": "required", "strategy": "latest", "amount": 1 },
+      { "topic": "STATE_SNAPSHOT", "priority": "required", "strategy": "latest", "amount": 1 },
+      { "topic": "PLAN_READY", "priority": "required", "strategy": "latest", "amount": 1 },
+      {
+        "topic": "VALIDATION_RESULT",
+        "priority": "high",
+        "since": "last_task_end",
+        "strategy": "latest",
+        "amount": 5,
+        "compactAmount": 1
+      },
+      {
+        "topic": "WORKER_PROGRESS",
+        "priority": "medium",
+        "since": "last_task_end",
+        "strategy": "latest",
+        "amount": 3,
+        "compactAmount": 1
+      }
+    ],
+    "maxTokens": 100000
+  }
+}
+```
+
+## Troubleshooting
+
+- Missing anchors: ensure required sources are present and priority is set to required.
+- Stale messages: verify `strategy: \"latest\"` and that `amount` is set.
+- Over budget: lower `maxTokens` or add `compactAmount` to optional sources.

--- a/docs/tui-v2/IMPLEMENTATION_PLAN.md
+++ b/docs/tui-v2/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,583 @@
+# Zeroshot TUI v2 (Ink) - Multi-Stage Implementation Plan
+
+Date: 2026-01-25
+Status: Draft plan (intended to become a chain of GitHub issues)
+
+## Guiding Constraints
+
+- Ink + TypeScript for all new TUI code.
+- Do not refactor unrelated JS during the TUI project.
+  - Small, targeted extraction is allowed only when it reduces duplication for TUI integration (e.g. shared `run` helpers).
+- Replace the current dashboard feature (`zeroshot watch` / `src/tui/*`) with a new TUI experience launched by `zeroshot` (no args).
+- Design/visual polish is explicitly deferred; prioritize UX flows and correctness.
+
+## Proposed Technical Approach (Replace Existing `src/tui`)
+
+### Code organization (proposed)
+
+- `src/tui/` (TypeScript source, Ink components) - replaces the existing blessed dashboard implementation
+  - `src/tui/app.tsx` - top-level Ink app, router, global keybindings
+  - `src/tui/views/*` - launcher/monitor/cluster/agent views
+  - `src/tui/commands/*` - slash command parser + dispatch
+  - `src/tui/services/*` - adapters around existing JS orchestrator/ledger
+  - `src/tui/domain/*` - typed models (ClusterRow, AgentRow, TimelineEvent, etc)
+- `lib/tui/` (compiled JS output shipped in npm package)
+
+Rationale:
+
+- Keeps the existing JS runtime intact.
+- Allows incremental TS adoption with minimal surface area.
+- Avoids a repo-wide build migration.
+
+### Build strategy (minimal TS emission)
+
+Add a dedicated `tsconfig.tui.json` that:
+
+- includes only `src/tui/**/*.ts(x)`
+- emits CJS output to `lib/tui/`
+- keeps the existing `tsconfig.json` as "check JS, no emit"
+
+Wire `npm run build:tui` into `prepublishOnly` so `npm pack`/publish contains the compiled Ink app.
+
+### CLI integration strategy
+
+Update `cli/index.js` to:
+
+- open the TUI when `zeroshot` is run with no args in an interactive TTY
+- add explicit commands:
+  - `zeroshot tui` (always open TUI)
+  - `zeroshot codex|claude|gemini|opencode` (open TUI with session provider override)
+- keep `zeroshot watch` as an alias (expected to start in Monitor view once implemented).
+
+Important:
+
+- We do not keep the old blessed dashboard in parallel. As soon as the Ink entrypoint exists,
+  the old `src/tui/*` implementation is replaced/removed.
+
+## Workstreams
+
+This plan is split into chainable milestones, with parallelizable work inside each milestone.
+
+- Workstream A: CLI + packaging + TypeScript build
+- Workstream B: Ink app shell + navigation + command model
+- Workstream C: Data adapters (orchestrator, ledger logs, metrics, topology)
+- Workstream D: UI views (launcher, monitor, cluster, agent)
+- Workstream E: Guidance messaging backend (new capability) + UI wiring
+- Workstream F: Tests + reliability hardening
+
+## Milestones and Issues
+
+Below, each "Issue" is intended to become a standalone PR with tight boundaries.
+
+### Milestone 1: Foundations (TS + Ink skeleton)
+
+#### Issue 1.1 - Add Ink + React dependencies (no runtime behavior change)
+
+Scope:
+
+- Add runtime deps needed for Ink TUI (e.g. `ink`, `react`).
+- Add dev deps for TS typing/testing (e.g. `@types/react`, `ink-testing-library`), if needed.
+
+Non-scope:
+
+- No CLI behavior changes.
+- No new commands.
+
+Acceptance:
+
+- `npm test` still passes.
+- Existing CLI commands behave identically.
+
+#### Issue 1.2 - Replace `src/tui/` with "Hello Ink TUI" + build pipeline
+
+Scope:
+
+- Replace the existing blessed dashboard implementation under `src/tui/` with a minimal Ink app
+  (start with a single screen that renders and exits cleanly).
+- Create `src/tui/index.tsx` (or equivalent entry) that renders a minimal Ink screen.
+- Add `tsconfig.tui.json` emitting to `lib/tui/`.
+- Add `npm run build:tui` and ensure it runs in `prepublishOnly`.
+- Repoint the `zeroshot watch` implementation to the Ink entrypoint (old dashboard is removed immediately).
+- Remove/replace any legacy dashboard tests that depend on blessed-contrib layout behavior.
+
+Acceptance:
+
+- `npm run build:tui` produces `lib/tui/index.js`.
+- Running a temporary dev entry (e.g. `node -e "require('./lib/tui').start()"`) renders in terminal.
+- `npm pack` includes `lib/tui/*`.
+- `zeroshot watch` opens the Ink app (even if it is still a minimal stub).
+
+Parallelizable with:
+
+- Issue 1.1
+
+#### Issue 1.3 - Add `zeroshot tui` command (explicit entrypoint) + provider session override
+
+Scope:
+
+- Add `zeroshot tui` command to `cli/index.js` that invokes the compiled Ink app.
+- Ensure `--provider <name>` is accepted for `zeroshot tui` (session override only).
+- Keep `zeroshot watch` as an alias (expected to start in Monitor view once implemented).
+
+Acceptance:
+
+- `zeroshot tui` opens the Ink app.
+- `zeroshot tui --provider codex` passes provider override into the app (visible in UI state).
+
+Depends on:
+
+- Issue 1.2
+
+### Milestone 2: Navigation + Command Model (no cluster execution yet)
+
+#### Issue 2.1 - Implement view router + "Esc back" navigation
+
+Scope:
+
+- Implement 4 view states (even if stubbed):
+  - Launcher
+  - Monitor
+  - Cluster
+  - Agent
+- Global navigation rule: Esc pops view stack until Launcher.
+
+Acceptance:
+
+- Esc navigation is consistent from every view.
+- Ctrl+C exits cleanly (no terminal corruption).
+
+Depends on:
+
+- Issue 1.3
+
+#### Issue 2.2 - Implement command box + slash-command parser (MVP set)
+
+Scope:
+
+- Global input component.
+- Parse rules:
+  - `/...` => command
+  - otherwise => plain-text task description (stubbed for now)
+- Implement MVP commands:
+  - `/help`, `/monitor`, `/issue <ref>`, `/provider <name>`, `/quit`
+- Display command output (toast/status area).
+
+Acceptance:
+
+- Commands work from any view.
+- Provider switches update a session state indicator.
+- Commands that require orchestration (e.g. `/issue`) can be stubbed here and fully implemented in Milestone 3.
+
+Parallelizable with:
+
+- Issue 2.1
+
+#### Issue 2.3 - Command dispatch scaffolding for "full CLI parity" over time
+
+Scope:
+
+- Introduce a typed command registry that maps `/...` commands to handlers.
+- Start with a small compatibility layer so new commands can reuse existing CLI helper functions
+  (without requiring users to type `zeroshot ...`).
+- Implement 1-2 additional commands as proof (e.g. `/status <id>`, `/list`).
+
+Non-scope:
+
+- Do not implement every command in one PR.
+- Avoid large refactors of `cli/index.js`; prefer extracting tiny shared helpers.
+
+Acceptance:
+
+- Adding a new slash command is a small, isolated change (new handler + tests).
+- `/status <id>` works end-to-end and renders output in the TUI.
+
+### Milestone 3: Launch Cluster From Text (end-to-end MVP loop)
+
+#### Issue 3.1 - Extract minimal reusable "start cluster" helper for TUI (avoid copying CLI)
+
+Scope:
+
+- Create a small adapter module (prefer `lib/` or `src/` JS) that encapsulates:
+  - explicit input construction:
+    - plain text (default launcher behavior)
+    - issue refs for `/issue ...` (use existing parsing logic, but only for the `/issue` path)
+  - provider override resolution
+  - loading config (`resolveConfigPath`, `loadClusterConfig`)
+  - calling `orchestrator.start(...)`
+- TUI calls this helper rather than duplicating CLI logic.
+
+Constraints:
+
+- Keep refactor minimal; do not restructure the CLI wholesale.
+
+Acceptance:
+
+- Existing CLI `zeroshot run` remains unchanged in behavior.
+- New helper can be unit-tested independently.
+
+#### Issue 3.2 - Launcher view: Enter launches cluster and transitions to Cluster view
+
+Scope:
+
+- In Launcher view, non-`/` input starts a cluster from plain text with current provider override.
+- Ambiguity rule: numeric input like `123` is treated as plain text (never an issue).
+- Show cluster id immediately (optimistic UI).
+- Transition to Cluster view after start begins.
+
+Acceptance:
+
+- Typing `Implement X` and pressing Enter starts a cluster and switches to Cluster view.
+- Failures are shown as a clear error message and user remains in Launcher view.
+
+Depends on:
+
+- Issue 3.1
+
+#### Issue 3.3 - `/issue <ref>` command: run an issue and transition to Cluster view
+
+Scope:
+
+- Implement `/issue <ref>`:
+  - `ref` can be: `123`, `org/repo#123`, full issue URL, Jira key, etc (same accepted formats as CLI `zeroshot run <input>`).
+  - Start a cluster using that issue ref and current provider override.
+  - Transition to Cluster view for that cluster id.
+
+Acceptance:
+
+- `/issue 123` starts a cluster from the issue (no ambiguity with plain text `123`).
+- Errors are clearly rendered in the TUI (e.g. missing `gh`, auth failures, invalid ref).
+
+Depends on:
+
+- Issue 3.1
+
+#### Issue 3.4 - Live log streaming in Cluster view (baseline)
+
+Scope:
+
+- Subscribe to the cluster ledger via `messageBus.subscribe(...)` or `ledger.since(...)` polling.
+- Render a scrolling log viewport (Ink list/text).
+- Provide basic filtering by agent id (optional toggle; can be later).
+
+Acceptance:
+
+- Cluster view shows new log lines within 0.5s of being written.
+- No unbounded memory growth (keep only last N lines in view state).
+
+Parallelizable with:
+
+- Issue 3.2 (once cluster id is known)
+
+### Milestone 4: Monitor View (replacement for old dashboard)
+
+#### Issue 4.1 - Monitor view: list clusters from orchestrator registry
+
+Scope:
+
+- Implement `/monitor` view:
+  - fetch cluster list from orchestrator
+  - display a selectable list (arrow keys + enter)
+- Enter opens Cluster view for selected id.
+
+Acceptance:
+
+- Monitor list matches `zeroshot list` cluster table order/contents (within reason).
+- Can open any existing cluster (including completed) into Cluster view.
+
+Depends on:
+
+- Milestone 3 (Cluster view exists)
+
+#### Issue 4.2 - Add resource metrics to Monitor view (best effort)
+
+Scope:
+
+- Gather per-agent pid/CPU/memory using existing `pidusage` patterns.
+- Aggregate per cluster and show in the list.
+- Degrade gracefully on unsupported platforms.
+
+Acceptance:
+
+- On macOS/Linux, CPU/mem fields are populated for running clusters when possible.
+- UI remains responsive with 10+ clusters; metrics refresh is throttled (e.g. every 2s).
+
+Parallelizable with:
+
+- Issue 4.1
+
+#### Issue 4.3 - `zeroshot watch` starts directly in Monitor view
+
+Scope:
+
+- Ensure `zeroshot watch` starts the Ink TUI directly in Monitor view (not Launcher).
+- Keep `zeroshot tui` defaulting to Launcher view.
+
+Acceptance:
+
+- `zeroshot watch` opens Monitor view as the initial screen.
+- No user-facing regression for "monitor clusters" workflow.
+
+Depends on:
+
+- Issue 4.1
+
+### Milestone 5: Cluster Focused View Enhancements (topology, steps)
+
+#### Issue 5.1 - Topology rendering from cluster config
+
+Scope:
+
+- Build a topology model from the running cluster config:
+  - agents (id, role)
+  - triggers/edges (topic wiring)
+- Render as:
+  - MVP: adjacency list / ASCII tree / simple box diagram
+  - keep layout engine out-of-scope for now
+
+Acceptance:
+
+- For built-in templates, topology view shows all agents and their relationships.
+- Works for dynamically added agents (best effort; show as appended nodes).
+
+#### Issue 5.2 - Step timeline derived from workflow triggers (MVP)
+
+Scope:
+
+- Define a minimal "timeline event" schema for the TUI.
+- Populate it from `WORKFLOW_TRIGGERS` messages (PLAN_READY, IMPLEMENTATION_READY, VALIDATION_RESULT, etc).
+- Render a compact history list in Cluster view.
+
+Acceptance:
+
+- Timeline shows the major phases for a typical run.
+- Timeline persists on resume (derived from ledger, not in-memory only).
+
+Parallelizable with:
+
+- Issue 5.1
+
+Pin:
+
+- Later we can enrich the timeline with additional lifecycle events/state transitions for better fidelity.
+
+### Milestone 6: Agent View (drill-down + messaging UI)
+
+#### Issue 6.1 - Agent selection + Agent view log tail
+
+Scope:
+
+- In Cluster view, allow selecting an agent (arrow keys) and opening Agent view (Enter).
+- Agent view tails logs for that agent only.
+
+Acceptance:
+
+- Agent view shows live agent logs and updates in near real time.
+- Esc returns to Cluster view preserving selection.
+
+Depends on:
+
+- Issue 3.4
+
+#### Issue 6.2 - Agent messaging UI (stubbed backend)
+
+Scope:
+
+- Add an input box in Agent view for sending messages.
+- For now, messages can be recorded as "pending" without delivery (backend not yet wired).
+
+Acceptance:
+
+- User can type and submit a message; UI shows it as queued.
+- No crashes if backend is missing.
+
+Parallelizable with:
+
+- Milestone 7 backend work
+
+### Milestone 7: Guidance Messaging (new backend capability)
+
+This milestone is required to meet the PRD's "steer agents/cluster live" vision. It is intentionally separated because it touches core orchestration behavior.
+
+#### Issue 7.1 - Ledger topic + mailbox schema for guidance
+
+Scope:
+
+- Define new message topics (example):
+  - `USER_GUIDANCE_CLUSTER`
+  - `USER_GUIDANCE_AGENT`
+- Each message includes:
+  - `cluster_id`, `sender: "user"`, `topic`, `content.text`
+  - optional `target_agent_id`
+  - delivery state fields (optional, can be derived)
+- Implement a mailbox query helper for "guidance since last delivered".
+
+Acceptance:
+
+- Guidance messages are persisted in the ledger.
+- Queries for "undelivered guidance" are deterministic and testable.
+
+#### Issue 7.2 - Live injection plumbing (provider stdin/PTY) with graceful detection
+
+Scope:
+
+- Implement a provider-agnostic "send input" path that writes directly to the underlying provider CLI session stdin/PTY when available.
+  - This should reuse the same mechanism the provider uses for interactive input (e.g. node-pty stdin write).
+- Persist the guidance message in the ledger regardless (for audit/history), but mark whether it was injected live.
+- If a given agent/provider session does not expose an interactive stdin handle, return "unsupported" so callers can fallback to queue semantics (Issue 7.3).
+
+Acceptance:
+
+- For at least one provider with interactive sessions, sending guidance while the agent is working injects into the live session.
+- If injection is not possible, the API signals that it was not injected (so UI can show "queued").
+
+Depends on:
+
+- Issue 7.1
+
+#### Issue 7.3 - Queue fallback: apply guidance at safe points
+
+Scope:
+
+- Implement a safe-point mailbox consumer in the agent execution loop:
+  - fetch queued guidance for (cluster, agent)
+  - append to the next provider prompt in a controlled way (clearly delimited)
+- Ensure guidance does not break JSON-schema modes or structured output.
+
+Acceptance:
+
+- In a test cluster for a non-injectable mode/provider, guidance sent mid-run appears in the next agent prompt.
+- No regressions for existing runs (no guidance => behavior unchanged).
+
+Depends on:
+
+- Issue 7.2
+
+#### Issue 7.4 - Cluster-wide guidance broadcast (injection-first, fallback-queue)
+
+Scope:
+
+- Implement cluster-level guidance delivery:
+  - write a single cluster-scoped message
+  - each agent attempts live injection when possible (Issue 7.2)
+  - otherwise the message is applied at that agent's next safe point (Issue 7.3)
+
+Acceptance:
+
+- Cluster-level guidance reaches all agents:
+  - injected live when supported
+  - queued otherwise
+
+Depends on:
+
+- Issue 7.3
+
+#### Issue 7.5 - Wire TUI messaging UI to backend guidance mechanism
+
+Scope:
+
+- Cluster view: guidance box sends `USER_GUIDANCE_CLUSTER`.
+- Agent view: guidance box sends `USER_GUIDANCE_AGENT`.
+- Display delivery feedback (injected/queued/applied if detectable).
+
+Acceptance:
+
+- Messages typed in the TUI are persisted and delivered to agents (per Issues 7.1-7.4).
+
+Depends on:
+
+- Issues 6.2, 7.4
+
+### Milestone 8: Default Entry + Cleanup + Hardening
+
+#### Issue 8.1 - `zeroshot` (no args) launches TUI (TTY only)
+
+Scope:
+
+- Modify `cli/index.js` default behavior:
+  - if interactive TTY and no subcommand: open TUI launcher
+  - else: keep existing help output behavior
+
+Acceptance:
+
+- `zeroshot` opens TUI in a normal terminal.
+- `echo foo | zeroshot` does not hang (prints help and exits).
+
+Depends on:
+
+- Milestone 3 (minimum viable launcher exists)
+
+#### Issue 8.2 - Add `zeroshot codex|claude|gemini|opencode` convenience entrypoints
+
+Scope:
+
+- Add CLI commands that invoke `zeroshot tui --provider <name>`.
+
+Acceptance:
+
+- `zeroshot codex` opens TUI with codex selected for the session.
+
+Depends on:
+
+- Issue 8.1 (or earlier if `zeroshot tui --provider` is already done)
+
+#### Issue 8.3 - Cleanup: remove legacy dashboard docs/tests and stale references
+
+Scope:
+
+- Remove any remaining blessed-dashboard-specific docs, demos, and tests (after the Ink TUI replacement).
+- Ensure CLI help text and docs point to the Ink TUI entrypoints (`zeroshot`, `zeroshot tui`, `zeroshot watch`).
+
+Acceptance:
+
+- No references remain to the old blessed dashboard behavior.
+
+Depends on:
+
+- Issue 1.2
+
+#### Issue 8.4 - Reliability/Perf pass + tests
+
+Scope:
+
+- Add tests:
+  - slash command parsing
+  - router "Esc back" behavior
+  - monitor list rendering
+  - guidance mailbox behavior (if Milestone 7 done)
+- Manual checklist:
+  - resize behavior
+  - exit behavior (terminal reset)
+  - running multiple clusters
+  - resume existing cluster into Cluster view
+
+Acceptance:
+
+- CI is green.
+- No known terminal corruption issues on exit.
+
+## Parallelization Map (Suggested)
+
+- Team 1:
+  - Milestone 1 (deps/build) + Milestone 2 (router/commands)
+- Team 2:
+  - Milestone 3 (cluster start + logs) once helper exists
+- Team 3:
+  - Milestone 4 (monitor view + metrics)
+- Team 4:
+  - Milestone 7 (guidance backend) can start as soon as requirements are agreed
+- Team 5:
+  - Milestone 5 (topology + timeline) can start once cluster config/state access is finalized
+
+## Definition of Done (Project-level)
+
+The project is considered "v2 shipped" when:
+
+- `zeroshot` launches the Ink TUI (TTY only) and can start a cluster from text.
+- `/monitor` provides a stable cluster dashboard and drill-down.
+- Cluster view supports logs + topology + timeline.
+- The blessed-based dashboard is removed; `zeroshot watch` is an alias that opens the Ink TUI Monitor view.
+
+## Deferred / Post-v2 Candidates
+
+- AI summary panel (`/summary` or periodic): provider/model choice and cost controls TBD.
+- Enrich the step timeline with additional lifecycle events beyond `WORKFLOW_TRIGGERS`.

--- a/docs/tui-v2/PRD.md
+++ b/docs/tui-v2/PRD.md
@@ -1,0 +1,302 @@
+# Zeroshot TUI v2 (Ink) - PRD
+
+Date: 2026-01-25
+Owner: Zeroshot CLI
+Status: Draft
+
+## Summary
+
+Build a new terminal UI (TUI) for Zeroshot using Ink + TypeScript. This fully replaces the current `zeroshot watch` dashboard (blessed-based) with a single interactive experience launched by running `zeroshot` (no args).
+
+Core workflow:
+
+- Open TUI
+- Type a task description into a central input box
+- Press Enter to launch a cluster
+- Immediately switch to the focused cluster view (topology + logs + progress)
+- Use `/monitor` to see a high-level dashboard of all clusters, then drill down via Enter
+- Navigate back with Esc (Esc always steps back until the launcher view)
+
+Provider selection is session-scoped and can be chosen at launch (`zeroshot codex|claude|gemini|opencode`) or switched in-TUI.
+
+## Goals
+
+1. Replace the current dashboard feature with an Ink-based TUI.
+2. Make `zeroshot` (no args) a first-class interactive mode for:
+   - launching clusters from free-form text
+   - monitoring all running clusters
+   - drilling into clusters and individual agents
+3. Add a command palette/input model:
+   - plain text launches a cluster
+   - `/`-prefixed commands run zeroshot operations without re-typing `zeroshot`
+4. Establish the first production TypeScript surface in the Zeroshot codebase (TUI + required adapters), without refactoring unrelated JS.
+
+## Non-Goals (for v2 MVP)
+
+- No pixel-perfect or final visual design (layout/theme/typography can evolve).
+- No full JavaScript -> TypeScript migration.
+- No remote multi-user UI; TUI is local-only.
+- No promise of message delivery for providers/modes that do not support interactive stdin injection.
+  - In those cases, guidance is queued and applied at the next safe point.
+- No replacement of non-dashboard CLI commands; existing subcommands remain supported.
+
+## Users / Personas
+
+- Power users running many clusters and needing quick navigation (htop/k9s style).
+- Developers launching a cluster from an idea ("just type it and go").
+- Operators who need to see whether a run is stuck, progressing, or consuming resources.
+
+## Glossary
+
+- Cluster: a multi-agent run managed by `src/orchestrator.js`, persisted in `~/.zeroshot/*.db`.
+- Agent / Worker: an `AgentWrapper` instance inside a cluster (worker, planner, validators, etc).
+- Provider: external CLI used for agent reasoning (claude, codex, gemini, opencode).
+
+## Entry Points
+
+### `zeroshot` (no args)
+
+Expected behavior:
+
+- If running in an interactive TTY: start TUI in Launcher view.
+- If not a TTY (piped/CI): print help and exit non-zero only on misuse (avoid breaking scripts).
+
+### `zeroshot tui` (explicit)
+
+Always opens the TUI (even if additional flags are provided).
+
+### `zeroshot codex|claude|gemini|opencode`
+
+Opens the TUI with a session-scoped provider override. While the TUI is open:
+
+- any cluster launch uses the chosen provider (equivalent to passing `--provider <name>` behind the scenes)
+- switching provider in-TUI updates this override for subsequent operations
+
+Notes:
+
+- This must not permanently change the default provider setting. Persisted defaults remain managed by `zeroshot providers set-default ...`.
+
+### `zeroshot watch`
+
+`zeroshot watch` remains as a convenience alias that opens the new Ink TUI directly in Monitor view.
+
+The existing blessed-based TUI implementation is removed (no parallel legacy dashboard).
+
+## Core Navigation / Views
+
+### 1) Launcher View (Main)
+
+Primary UI shown on start.
+
+Content:
+
+- A central input box for text.
+- Short instructions/hints (e.g. `/monitor`, `/help`, provider indicator).
+
+Input semantics:
+
+- If input starts with `/`: treat as a command (see Commands).
+- Else: treat as plain-text task description and start a cluster.
+  - Ambiguity rule: numeric input like `123` is treated as plain text.
+  - To run an issue, use `/issue ...` (e.g. `/issue 123`).
+
+On Enter with non-command input:
+
+- Start cluster
+- Transition to Cluster Focused View for that cluster
+
+### 2) Monitor View (Dashboard)
+
+Opened by `/monitor` from anywhere.
+
+Displays a high-level list of clusters, including:
+
+- cluster id
+- input/task name (derived from input: issue title, file name, or first line of text)
+- provider used
+- status (running/completed/failed/stopped/corrupted)
+- running time (duration)
+- agents/workers count
+- resource usage (CPU%, memory) aggregated across agents (best effort; degrade gracefully)
+- token usage (if available via ledger aggregation)
+- last activity timestamp
+
+Interaction:
+
+- Up/Down (or j/k) moves selection
+- Enter opens Cluster Focused View for selected cluster
+- Esc goes back to previous view
+
+Optional (later, but supported by design):
+
+- filtering (running/stopped/all)
+- search by cluster id / task substring
+- actions: stop/kill/export via `/stop <id>`, `/kill <id>`, `/export <id>`
+
+### 3) Cluster Focused View
+
+Opened automatically after launching a cluster, or by selecting a cluster from Monitor view.
+
+Must display:
+
+1. Cluster topology graph:
+   - Rendered from the cluster config template (agents + triggers).
+   - MVP: tree/adjacency list/ASCII graph; fidelity can improve over time.
+2. Live logs:
+   - Streamed from the ledger message bus (append-only).
+   - Includes per-agent attribution (role/agent id).
+3. Step timeline / phase log:
+   - High-level step list derived from workflow triggers (`WORKFLOW_TRIGGERS`) for MVP.
+   - Examples: plan -> implement -> validate -> iterate -> complete.
+   - Exact naming/format is defined by the TUI domain model and can evolve.
+
+Interaction:
+
+- Left/Right (or Tab) cycles focus between panes (topology/logs/steps/agents list).
+- Up/Down moves selection when in a selectable pane (e.g. agents list).
+- Enter on a selected agent opens Agent View.
+- Esc goes back (Monitor if you came from Monitor, or Launcher if you came from Launcher).
+
+Cluster guidance input:
+
+- A command/text box is available in this view to send guidance to the whole cluster.
+- This requires backend support (see "Guidance Messaging").
+
+### 4) Agent View (Focused Worker/Agent)
+
+Opened by selecting an agent from Cluster Focused View.
+
+Must display:
+
+- Live logs for that agent (tailing relevant ledger output)
+- Agent identity (role, provider, model level/model)
+- Agent status (idle/executing/stuck/failed/completed)
+
+Agent messaging input:
+
+- A command/text box that lets the user send guidance to that agent while it is working.
+- Provider capability may vary. If true "live injection" is not available, guidance is queued and applied at the next safe point.
+
+Esc returns to Cluster Focused View.
+
+## Commands (Slash Commands)
+
+General:
+
+- Any view can accept `/...` commands.
+- Commands should be parsed similarly to CLI subcommands, but do not require the `zeroshot` prefix.
+- Commands produce feedback in a lightweight output/toast area (success/failure).
+
+Parity target:
+
+- Long-term: every existing `zeroshot <cmd ...>` operation should be invocable as `/<cmd ...>` inside the TUI.
+- Short-term: ship an MVP subset first (below), then expand to full parity incrementally.
+
+Required commands for MVP:
+
+- `/help` - show available commands and keybindings
+- `/monitor` - open Monitor view
+- `/issue <ref>` - start a cluster from an issue reference (e.g. `123`, `org/repo#123`, URL, Jira key, etc)
+- `/provider <name>` - switch provider for the session (claude|codex|gemini|opencode)
+- `/quit` (and `/exit`) - exit the TUI (with confirmation if clusters running)
+
+Strongly recommended commands (v2 follow-up):
+
+- `/run <input>` - start a cluster using CLI-style input parsing (issue/file/text auto-detection)
+- `/list` - list clusters/tasks (or open Monitor view)
+- `/status <id>` - show detailed cluster/task status
+- `/logs <id>` - open Cluster Focused View (or open logs modal)
+- `/stop <id>` and `/kill <id>` - control cluster/task
+
+## Guidance Messaging (Backend Requirement)
+
+Two scopes:
+
+1. Cluster guidance: message broadcast to all agents in the cluster.
+2. Agent guidance: message targeted to a specific agent.
+
+Delivery semantics (MVP):
+
+- Attempt live stdin injection into the underlying provider CLI session when supported.
+  - Implementation detail: write to the provider process/PTY stdin (same mechanism the provider uses for interactive chat).
+- If live injection is not supported (provider limitation or non-interactive mode), queue the guidance:
+  - store in the ledger (or a small mailbox store)
+  - agents apply it at the next safe point:
+    - before starting a new iteration
+    - before generating a new provider prompt
+    - after finishing a tool execution step
+
+TUI requirements:
+
+- Show whether a guidance message was injected live or queued.
+- Indicate delivery status (pending/applied/expired) when possible.
+
+## Data Sources / Domain Model
+
+The TUI reads from:
+
+- Orchestrator registry: cluster list and state (`src/orchestrator.js`)
+- Ledger message bus: logs, events, tokens (`src/message-bus.js`, `src/ledger.js`)
+- Process metrics: pid/CPU/mem per agent (existing `pidusage` usage)
+- Cluster config: topology information (from resolved config JSON)
+
+The TUI writes:
+
+- Start/stop/kill commands via orchestrator
+- Guidance messages via message bus / mailbox
+
+## Non-Functional Requirements
+
+Performance:
+
+- TUI launch time (from `zeroshot` to first paint): < 500ms on a typical dev machine.
+- UI update cadence:
+  - logs: event-driven, or up to 200-500ms batching
+  - cluster list refresh: 1s (configurable)
+  - resource metrics refresh: 2s (configurable, because pidusage can be expensive)
+
+Reliability:
+
+- No terminal corruption on exit (restore cursor, clear alternate buffer if used).
+- Handles terminal resize gracefully.
+- Works on macOS and Linux. If metrics are unsupported, show "-" and keep UI functional.
+
+Security/Privacy:
+
+- Do not exfiltrate code or logs; all data stays local.
+- Avoid rendering secrets in the UI where possible (best-effort; user controls what runs).
+
+## Success Metrics
+
+Quantitative:
+
+- 90%+ of interactive "start cluster from text" actions succeed without leaving the TUI.
+- 0 known cases of terminal left in broken state on normal exit.
+- Monitor view can handle 100 clusters in the registry without freezing (best-effort; virtualization if needed later).
+
+Qualitative:
+
+- Users can launch, monitor, and drill down without remembering command syntax.
+- Navigation feels consistent (Esc always goes back).
+
+## Out of Scope / Deferred
+
+- Full parity with all CLI flags (`--docker`, `--ship`, `--worktree`, etc) in the launcher input.
+  - These can be added incrementally via `/run --docker ...` style.
+- Rich graphs (true layout engine). MVP uses simplified ASCII representation.
+- Advanced UX (themes, mouse, split panes, persistent layouts).
+- AI summary panel (provider/model choice + cost controls TBD).
+
+## Resolved Decisions (from product feedback)
+
+1. Ambiguous launcher input:
+   - Launcher treats non-`/` input as plain text (including `123`).
+   - Use `/issue 123` (or another issue ref) to run an issue.
+2. Step timeline schema:
+   - MVP derives timeline from existing workflow triggers (`WORKFLOW_TRIGGERS`).
+   - We keep a pin to later enrich with additional lifecycle events.
+3. AI summary:
+   - Deferred (pin). Implement after core TUI flows ship.
+4. Guidance injection:
+   - Implement live injection when provider supports it (inject into the provider CLI stdin/PTY).
+   - Otherwise, queue and apply at safe points.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,13 @@
         "blessed-contrib": "^4.11.0",
         "chalk": "^4.1.2",
         "commander": "^14.0.2",
+        "ink": "^6.6.0",
         "md-to-pdf": "^5.2.5",
         "node-pty": "^1.1.0",
         "omelette": "^0.4.17",
         "pidusage": "^4.0.1",
-        "proper-lockfile": "^4.1.2"
+        "proper-lockfile": "^4.1.2",
+        "react": "^19.2.4"
       },
       "bin": {
         "zeroshot": "cli/index.js"
@@ -32,6 +34,8 @@
         "@semantic-release/github": "^11.0.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.0.3",
+        "@types/react": "^19.2.9",
+        "@types/react-reconciler": "^0.33.0",
         "c8": "^10.1.3",
         "chai": "^6.2.1",
         "depcheck": "^1.4.7",
@@ -93,6 +97,46 @@
       "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.3.tgz",
+      "integrity": "sha512-jsElTJ0sQ4wHRz+C45tfect76BwbTbgkgKByOzpCN9xG61N5V6u/glvg1CsNJhq2xJIFpKHSwG3D2wPPuEYOrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1799,6 +1843,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
+      "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -2269,6 +2333,18 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/b4a": {
@@ -2991,6 +3067,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -3253,6 +3341,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3430,6 +3530,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3505,6 +3614,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -4182,7 +4298,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4229,6 +4344,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5210,7 +5335,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
       "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5893,6 +6017,307 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ink": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.6.0.tgz",
+      "integrity": "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.1",
+        "ansi-escapes": "^7.2.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": "^6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-escapes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/ink/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ink/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ink/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/into-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
@@ -6012,6 +6437,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -6959,15 +7399,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7784,9 +8224,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.7.0.tgz",
-      "integrity": "sha512-wiCZpv/41bIobCoJ31NStIWKfAxxYyD1iYnWCtiyns8s5v3+l8y0HCP/sScuH6B5+GhIfda4HQKiqeGZwJWhFw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.8.0.tgz",
+      "integrity": "sha512-n19sJeW+RGKdkHo8SCc5xhSwkKhQUFfZaFzSc+EsYXLjSqIV0tl72aDYQVuzVvfrbysGwdaQsNLNy58J10EBSQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -7866,8 +8306,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.9",
-        "@npmcli/config": "^10.4.5",
+        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/config": "^10.5.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -7875,7 +8315,7 @@
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
         "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.0",
+        "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
         "cacache": "^20.0.3",
@@ -7892,11 +8332,11 @@
         "is-cidr": "^6.0.1",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.12",
-        "libnpmexec": "^10.1.11",
-        "libnpmfund": "^7.0.12",
+        "libnpmdiff": "^8.0.13",
+        "libnpmexec": "^10.1.12",
+        "libnpmfund": "^7.0.13",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.12",
+        "libnpmpack": "^9.0.13",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -7925,11 +8365,11 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.0",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^7.0.0",
+        "validate-npm-package-name": "^7.0.2",
         "which": "^6.0.0"
       },
       "bin": {
@@ -8009,7 +8449,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.9",
+      "version": "9.1.10",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8027,7 +8467,7 @@
         "@npmcli/run-script": "^10.0.0",
         "bin-links": "^6.0.0",
         "cacache": "^20.0.1",
-        "common-ancestor-path": "^1.0.1",
+        "common-ancestor-path": "^2.0.0",
         "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
         "lru-cache": "^11.2.1",
@@ -8056,7 +8496,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.4.5",
+      "version": "10.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8251,7 +8691,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -8269,52 +8709,43 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.0.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.2",
-        "proc-log": "^5.0.0",
+        "make-fetch-happen": "^15.0.3",
+        "proc-log": "^6.1.0",
         "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.0.0"
+        "tuf-js": "^4.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -8331,31 +8762,16 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
+        "minimatch": "^10.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -8397,12 +8813,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.0",
       "dev": true,
@@ -8429,15 +8839,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/npm/node_modules/cacache": {
@@ -8533,10 +8934,13 @@
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -8568,7 +8972,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.2",
+      "version": "8.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -8763,7 +9167,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8866,12 +9270,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.12",
+      "version": "8.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -8885,12 +9289,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.11",
+      "version": "10.1.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -8908,12 +9312,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.12",
+      "version": "7.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9"
+        "@npmcli/arborist": "^9.1.10"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8933,12 +9337,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.12",
+      "version": "9.0.13",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.9",
+        "@npmcli/arborist": "^9.1.10",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -9008,10 +9412,10 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.2",
+      "version": "11.2.4",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -9422,7 +9826,7 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -9438,7 +9842,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9581,17 +9985,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.0.0",
+        "@sigstore/core": "^3.1.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.0.0",
-        "@sigstore/tuf": "^4.0.0",
-        "@sigstore/verify": "^3.0.0"
+        "@sigstore/sign": "^4.1.0",
+        "@sigstore/tuf": "^4.0.1",
+        "@sigstore/verify": "^3.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -9728,7 +10132,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.2",
+      "version": "7.5.4",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -9819,14 +10223,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "4.0.0",
-        "debug": "^4.4.1",
-        "make-fetch-happen": "^15.0.0"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -9883,7 +10287,7 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10389,6 +10793,15 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -11094,6 +11507,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/read-package-up": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
@@ -11639,6 +12076,12 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scslre": {
       "version": "0.3.0",
@@ -12829,6 +13272,27 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
@@ -14265,6 +14729,71 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/with": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
@@ -14569,6 +15098,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -101,11 +101,13 @@
     "blessed-contrib": "^4.11.0",
     "chalk": "^4.1.2",
     "commander": "^14.0.2",
+    "ink": "^6.6.0",
     "md-to-pdf": "^5.2.5",
     "node-pty": "^1.1.0",
     "omelette": "^0.4.17",
     "pidusage": "^4.0.1",
-    "proper-lockfile": "^4.1.2"
+    "proper-lockfile": "^4.1.2",
+    "react": "^19.2.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
@@ -113,6 +115,8 @@
     "@semantic-release/github": "^11.0.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.0.3",
+    "@types/react": "^19.2.9",
+    "@types/react-reconciler": "^0.33.0",
     "c8": "^10.1.3",
     "chai": "^6.2.1",
     "depcheck": "^1.4.7",

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -423,8 +423,12 @@ class AgentWrapper {
       isolation: this.isolation,
     });
 
-    // Record when this iteration started so future "since: last_agent_start" filters work
-    this.lastAgentStartTime = Date.now();
+    // Record when this iteration started so future "since: last_agent_start" filters work.
+    const latestMessage = this.messageBus.findLast({ cluster_id: this.cluster.id });
+    const latestTimestamp = latestMessage?.timestamp;
+    const now = Date.now();
+    this.lastAgentStartTime =
+      typeof latestTimestamp === 'number' ? Math.max(now, latestTimestamp + 1) : now;
 
     return context;
   }

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -5,13 +5,20 @@
  * - Context assembly from multiple message sources
  * - Context strategy evaluation (topics, limits, since timestamps)
  * - Prompt injection and formatting
- * - Token-based truncation
+ * - Token-budgeted context packs
  * - Defensive context overflow prevention
  */
 
 // Defensive limit: 500,000 chars ≈ 125k tokens (safe buffer below 200k limit)
 // Prevents "Prompt is too long" errors that kill tasks
 const MAX_CONTEXT_CHARS = 500000;
+const {
+  buildContextMetrics,
+  emitContextMetrics,
+  resolveLegacyMaxTokens,
+  updateTotalMetrics,
+} = require('./context-metrics');
+const { buildContextPacks } = require('./context-pack-builder');
 
 /**
  * Generate an example object from a JSON schema
@@ -176,7 +183,7 @@ function resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime
     const parsed = Date.parse(sinceValue);
     if (Number.isNaN(parsed)) {
       throw new Error(
-        `Agent context source for topic ${source.topic} has invalid since value "${sinceValue}". ` +
+        `Unknown context source "since" value "${sinceValue}" for topic ${source.topic}. ` +
           'Use cluster_start, last_task_end, last_agent_start, or an ISO timestamp.'
       );
     }
@@ -201,38 +208,108 @@ function formatSourceMessagesSection(source, messages) {
   return context;
 }
 
-function buildSourcesSection({
-  strategy,
+function resolveSourceSelection(source, { compact = false } = {}) {
+  const baseAmount = source.amount ?? source.limit;
+  const baseStrategy = source.strategy ?? (baseAmount !== undefined ? 'latest' : 'all');
+
+  if (!compact) {
+    return { amount: baseAmount, strategy: baseStrategy };
+  }
+
+  const compactAmount = source.compactAmount ?? (baseAmount !== undefined ? 1 : 1);
+  const compactStrategy =
+    source.compactStrategy ?? (baseStrategy === 'all' ? 'latest' : baseStrategy);
+
+  return { amount: compactAmount, strategy: compactStrategy };
+}
+
+function resolveSourceMessages({
+  source,
+  messageBus,
+  cluster,
+  lastTaskEndTime,
+  lastAgentStartTime,
+  compact = false,
+}) {
+  const sinceTimestamp = resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime);
+  const { amount, strategy } = resolveSourceSelection(source, { compact });
+  const order = strategy === 'latest' ? 'desc' : 'asc';
+  const messages = messageBus.query({
+    cluster_id: cluster.id,
+    topic: source.topic,
+    sender: source.sender,
+    since: sinceTimestamp,
+    limit: amount,
+    order,
+  });
+
+  if (strategy !== 'latest' || messages.length <= 1) {
+    return messages;
+  }
+
+  return messages.slice().reverse();
+}
+
+function resolveSourcePriority(source) {
+  if (source.priority) {
+    return source.priority;
+  }
+  if (source.topic === 'STATE_SNAPSHOT') {
+    return 'required';
+  }
+  if (source.topic === 'ISSUE_OPENED' || source.topic === 'PLAN_READY') {
+    return 'required';
+  }
+  if (source.topic === 'VALIDATION_RESULT' || source.topic === 'IMPLEMENTATION_READY') {
+    return 'high';
+  }
+  return 'medium';
+}
+
+function buildSourcePack({
+  source,
+  index,
   messageBus,
   cluster,
   lastTaskEndTime,
   lastAgentStartTime,
 }) {
-  let context = '';
-  for (const source of strategy.sources) {
-    const sinceTimestamp = resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime);
-    const messages = messageBus.query({
-      cluster_id: cluster.id,
-      topic: source.topic,
-      sender: source.sender,
-      since: sinceTimestamp,
-      limit: source.limit,
-    });
+  const packId = `source:${source.topic}:${index}`;
+  const priority = resolveSourcePriority(source);
 
-    if (messages.length > 0) {
-      context += formatSourceMessagesSection(source, messages);
-    }
-  }
-  return context;
+  const render = (compact) => {
+    const messages = resolveSourceMessages({
+      source,
+      messageBus,
+      cluster,
+      lastTaskEndTime,
+      lastAgentStartTime,
+      compact,
+    });
+    if (messages.length === 0) return '';
+    return formatSourceMessagesSection(source, messages);
+  };
+
+  return {
+    id: packId,
+    section: 'sources',
+    priority,
+    render: () => render(false),
+    compact: () => render(true),
+  };
 }
 
-function collectCannotValidateCriteria(prevValidations) {
+const { isPlatformMismatchReason } = require('./validation-platform');
+
+function collectCannotValidateCriteria(prevValidations, options = {}) {
   const cannotValidateCriteria = [];
+  const ignoreReason = options.ignoreReason;
   for (const msg of prevValidations) {
     const criteriaResults = msg.content?.data?.criteriaResults;
     if (!Array.isArray(criteriaResults)) continue;
     for (const cr of criteriaResults) {
       if (cr.status !== 'CANNOT_VALIDATE' || !cr.id) continue;
+      if (ignoreReason && ignoreReason(cr.reason)) continue;
       if (cannotValidateCriteria.find((c) => c.id === cr.id)) continue;
       cannotValidateCriteria.push({
         id: cr.id,
@@ -257,7 +334,7 @@ function buildCannotValidateSection(cannotValidateCriteria) {
   return context;
 }
 
-function buildValidatorSkipSection({ role, messageBus, cluster }) {
+function buildValidatorSkipSection({ role, messageBus, cluster, isolation }) {
   if (role !== 'validator') return '';
 
   const prevValidations = messageBus.query({
@@ -267,7 +344,8 @@ function buildValidatorSkipSection({ role, messageBus, cluster }) {
     limit: 50,
   });
 
-  const cannotValidateCriteria = collectCannotValidateCriteria(prevValidations);
+  const ignoreReason = isolation?.enabled ? isPlatformMismatchReason : null;
+  const cannotValidateCriteria = collectCannotValidateCriteria(prevValidations, { ignoreReason });
   return buildCannotValidateSection(cannotValidateCriteria);
 }
 
@@ -277,110 +355,6 @@ function buildTriggeringMessageSection(triggeringMessage) {
   context += `Sender: ${triggeringMessage.sender}\n`;
   if (triggeringMessage.content?.text) {
     context += `\n${triggeringMessage.content.text}\n`;
-  }
-  return context;
-}
-
-function findContextSectionIndices(lines) {
-  let issueOpenedStart = -1;
-  let issueOpenedEnd = -1;
-  let triggeringStart = -1;
-
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].includes('## Messages from topic: ISSUE_OPENED')) {
-      issueOpenedStart = i;
-    }
-    if (issueOpenedStart !== -1 && issueOpenedEnd === -1 && lines[i].startsWith('## ')) {
-      issueOpenedEnd = i;
-    }
-    if (lines[i].includes('## Triggering Message')) {
-      triggeringStart = i;
-      break;
-    }
-  }
-
-  return { issueOpenedStart, issueOpenedEnd, triggeringStart };
-}
-
-function collectRecentLines(middleLines, budgetForRecent) {
-  const recentLines = [];
-  let recentSize = 0;
-
-  for (let i = middleLines.length - 1; i >= 0; i--) {
-    const line = middleLines[i];
-    const lineSize = line.length + 1;
-
-    if (recentSize + lineSize > budgetForRecent) {
-      break;
-    }
-
-    recentLines.unshift(line);
-    recentSize += lineSize;
-  }
-
-  return recentLines;
-}
-
-function truncateContextIfNeeded(context) {
-  const originalLength = context.length;
-  if (originalLength <= MAX_CONTEXT_CHARS) {
-    return context;
-  }
-
-  console.log(
-    `[Context] Context too large (${originalLength} chars), truncating to prevent overflow...`
-  );
-
-  const lines = context.split('\n');
-  const { issueOpenedStart, issueOpenedEnd, triggeringStart } = findContextSectionIndices(lines);
-
-  const headerEnd = issueOpenedStart !== -1 ? issueOpenedStart : triggeringStart;
-  const header = lines.slice(0, headerEnd).join('\n');
-
-  const issueOpened =
-    issueOpenedStart !== -1 && issueOpenedEnd !== -1
-      ? lines.slice(issueOpenedStart, issueOpenedEnd).join('\n')
-      : '';
-
-  const triggeringMsg = lines.slice(triggeringStart).join('\n');
-
-  const fixedSize = header.length + issueOpened.length + triggeringMsg.length;
-  const budgetForRecent = MAX_CONTEXT_CHARS - fixedSize - 200;
-
-  const middleStart = issueOpenedEnd !== -1 ? issueOpenedEnd : headerEnd;
-  const middleEnd = triggeringStart;
-  const middleLines = lines.slice(middleStart, middleEnd);
-  const recentLines = collectRecentLines(middleLines, budgetForRecent);
-
-  const parts = [header];
-  if (issueOpened) {
-    parts.push(issueOpened);
-  }
-  if (recentLines.length < middleLines.length) {
-    const truncatedCount = middleLines.length - recentLines.length;
-    parts.push(
-      `\n[...${truncatedCount} earlier context messages truncated to prevent overflow...]\n`
-    );
-  }
-  if (recentLines.length > 0) {
-    parts.push(recentLines.join('\n'));
-  }
-  parts.push(triggeringMsg);
-
-  const truncatedContext = parts.join('\n');
-  const truncatedLength = truncatedContext.length;
-  console.log(
-    `[Context] Truncated from ${originalLength} to ${truncatedLength} chars (${Math.round((truncatedLength / originalLength) * 100)}% retained)`
-  );
-
-  return truncatedContext;
-}
-
-function applyLegacyMaxTokens(context, strategy) {
-  const maxTokens = strategy.maxTokens || 100000;
-  const maxChars = maxTokens * 4;
-  if (context.length > maxChars) {
-    return context.slice(0, maxChars) + '\n\n[Context truncated...]';
   }
   return context;
 }
@@ -419,24 +393,75 @@ function buildContext({
   const strategy = config.contextStrategy || { sources: [] };
   const isIsolated = !!(worktree?.enabled || isolation?.enabled);
 
-  let context = buildHeaderContext({ id, role, iteration, isIsolated });
-  context += buildInstructionsSection({ config, selectedPrompt, id });
-  context += buildLegacyOutputSchemaSection(config);
-  context += buildJsonSchemaSection(config);
-  context += buildSourcesSection({
-    strategy,
-    messageBus,
-    cluster,
-    lastTaskEndTime,
-    lastAgentStartTime,
+  const header = buildHeaderContext({ id, role, iteration, isIsolated });
+  const instructions = buildInstructionsSection({ config, selectedPrompt, id });
+  const legacyOutputSchema = buildLegacyOutputSchemaSection(config);
+  const jsonSchema = buildJsonSchemaSection(config);
+  const validatorSkip = buildValidatorSkipSection({ role, messageBus, cluster, isolation });
+  const triggeringMessageSection = buildTriggeringMessageSection(triggeringMessage);
+
+  const packs = [];
+  let order = 0;
+
+  const pushStaticPack = (packId, section, text, options = {}) => {
+    if (!text) return;
+    packs.push({
+      id: packId,
+      section,
+      priority: 'required',
+      order: order++,
+      preserve: options.preserve || false,
+      render: () => text,
+    });
+  };
+
+  pushStaticPack('header', 'header', header);
+  pushStaticPack('instructions', 'instructions', instructions);
+  pushStaticPack('legacyOutputSchema', 'legacyOutputSchema', legacyOutputSchema);
+  pushStaticPack('jsonSchema', 'jsonSchema', jsonSchema);
+
+  if (Array.isArray(strategy.sources)) {
+    strategy.sources.forEach((source, index) => {
+      const pack = buildSourcePack({
+        source,
+        index,
+        messageBus,
+        cluster,
+        lastTaskEndTime,
+        lastAgentStartTime,
+      });
+      packs.push({ ...pack, order: order++ });
+    });
+  }
+
+  pushStaticPack('validatorSkip', 'validatorSkip', validatorSkip);
+  pushStaticPack('triggeringMessage', 'triggeringMessage', triggeringMessageSection, {
+    preserve: true,
   });
-  context += buildValidatorSkipSection({ role, messageBus, cluster });
-  context += buildTriggeringMessageSection(triggeringMessage);
 
-  context = truncateContextIfNeeded(context);
-  context = applyLegacyMaxTokens(context, strategy);
+  const maxTokens = resolveLegacyMaxTokens(strategy);
+  const packResult = buildContextPacks({
+    packs,
+    maxTokens,
+    maxChars: MAX_CONTEXT_CHARS,
+  });
 
-  return context;
+  const metrics = buildContextMetrics({
+    clusterId: cluster.id,
+    agentId: id,
+    role,
+    iteration,
+    triggeringMessage,
+    strategy,
+    packs: packResult.packDecisions,
+    budget: packResult.budget,
+    truncation: packResult.truncation,
+  });
+
+  updateTotalMetrics(metrics, packResult.context.length);
+  emitContextMetrics(metrics, { messageBus, clusterId: cluster.id, agentId: id });
+
+  return packResult.context;
 }
 
 module.exports = {

--- a/src/agent/context-metrics.js
+++ b/src/agent/context-metrics.js
@@ -1,0 +1,160 @@
+const TOKENS_PER_CHAR_ESTIMATE = 4;
+
+function estimateTokensFromChars(chars) {
+  if (!Number.isFinite(chars) || chars <= 0) {
+    return 0;
+  }
+
+  return Math.ceil(chars / TOKENS_PER_CHAR_ESTIMATE);
+}
+
+function buildSectionMetrics(sections) {
+  const sectionMetrics = {};
+  let totalChars = 0;
+
+  for (const [sectionName, text] of Object.entries(sections)) {
+    const safeText = typeof text === 'string' ? text : '';
+    const chars = safeText.length;
+    const estimatedTokens = estimateTokensFromChars(chars);
+    sectionMetrics[sectionName] = { chars, estimatedTokens };
+    totalChars += chars;
+  }
+
+  return { sectionMetrics, totalChars };
+}
+
+function buildSectionMetricsFromPacks(packs) {
+  const sectionMetrics = {};
+  let totalChars = 0;
+
+  for (const pack of packs) {
+    if (pack.status !== 'included') continue;
+    const sectionName = pack.section || pack.id || 'unknown';
+    const chars = Number.isFinite(pack.chars) ? pack.chars : 0;
+    if (!sectionMetrics[sectionName]) {
+      sectionMetrics[sectionName] = { chars: 0, estimatedTokens: 0 };
+    }
+    sectionMetrics[sectionName].chars += chars;
+    totalChars += chars;
+  }
+
+  for (const section of Object.values(sectionMetrics)) {
+    section.estimatedTokens = estimateTokensFromChars(section.chars);
+  }
+
+  return { sectionMetrics, totalChars };
+}
+
+function resolveLegacyMaxTokens(strategy) {
+  if (!strategy) {
+    return 100000;
+  }
+
+  return strategy.maxTokens || 100000;
+}
+
+function buildContextMetrics({
+  clusterId,
+  agentId,
+  role,
+  iteration,
+  triggeringMessage,
+  strategy,
+  sections,
+  packs,
+  budget,
+  truncation,
+}) {
+  const maxTokens = resolveLegacyMaxTokens(strategy);
+  const sourcesCount = Array.isArray(strategy?.sources) ? strategy.sources.length : 0;
+  const packMetrics = Array.isArray(packs) ? packs : [];
+
+  let sectionMetrics = {};
+  let totalChars = 0;
+  if (packMetrics.length > 0) {
+    const packTotals = buildSectionMetricsFromPacks(packMetrics);
+    sectionMetrics = packTotals.sectionMetrics;
+    totalChars = packTotals.totalChars;
+  } else if (sections) {
+    const sectionTotals = buildSectionMetrics(sections);
+    sectionMetrics = sectionTotals.sectionMetrics;
+    totalChars = sectionTotals.totalChars;
+  }
+
+  return {
+    clusterId,
+    agentId,
+    role,
+    iteration,
+    triggeredBy: triggeringMessage?.topic || null,
+    triggerFrom: triggeringMessage?.sender || null,
+    strategy: {
+      maxTokens,
+      sourcesCount,
+    },
+    budget: {
+      maxTokens: budget?.maxTokens ?? maxTokens,
+      remainingTokens: budget?.remainingTokens === undefined ? null : budget?.remainingTokens,
+      overBudgetTokens: budget?.overBudgetTokens ?? 0,
+      finalTokens: budget?.finalTokens ?? estimateTokensFromChars(totalChars),
+    },
+    packs: packMetrics,
+    sections: sectionMetrics,
+    total: {
+      chars: totalChars,
+      estimatedTokens: estimateTokensFromChars(totalChars),
+    },
+    truncation: {
+      maxContextChars: truncation?.maxContextChars || {
+        applied: false,
+        beforeChars: totalChars,
+        afterChars: totalChars,
+      },
+    },
+  };
+}
+
+function updateTotalMetrics(metrics, chars) {
+  if (!metrics || !Number.isFinite(chars)) {
+    return;
+  }
+
+  metrics.total = {
+    chars,
+    estimatedTokens: estimateTokensFromChars(chars),
+  };
+
+  if (metrics.budget) {
+    metrics.budget.finalTokens = estimateTokensFromChars(chars);
+  }
+
+  if (metrics.truncation?.maxContextChars) {
+    metrics.truncation.maxContextChars.afterChars = chars;
+  }
+}
+
+function emitContextMetrics(metrics, { messageBus, clusterId, agentId }) {
+  if (process.env.ZEROSHOT_CONTEXT_METRICS === '1') {
+    console.log('[ContextMetrics]', JSON.stringify(metrics));
+  }
+
+  if (process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER === '1' && messageBus?.publish) {
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'CONTEXT_METRICS',
+      sender: agentId,
+      receiver: 'system',
+      content: {
+        data: metrics,
+      },
+    });
+  }
+}
+
+module.exports = {
+  estimateTokensFromChars,
+  resolveLegacyMaxTokens,
+  buildContextMetrics,
+  updateTotalMetrics,
+  emitContextMetrics,
+};

--- a/src/agent/context-pack-builder.js
+++ b/src/agent/context-pack-builder.js
@@ -1,0 +1,367 @@
+const { estimateTokensFromChars } = require('./context-metrics');
+
+const PRIORITY_RANK = {
+  required: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const DEFAULT_PRIORITY = 'medium';
+const TRUNCATION_SUFFIX = '\n\n[Context truncated to fit limit]\n';
+
+function normalizePriority(priority, required) {
+  if (required) return 'required';
+  if (priority && PRIORITY_RANK[priority] !== undefined) return priority;
+  return DEFAULT_PRIORITY;
+}
+
+function normalizePack(pack, index) {
+  const priority = normalizePriority(pack.priority, pack.required);
+  return {
+    ...pack,
+    priority,
+    required: pack.required || priority === 'required',
+    order: pack.order ?? index,
+  };
+}
+
+function renderVariant(pack, variant, cache) {
+  const cacheKey = `${pack.id}:${variant}`;
+  if (cache.has(cacheKey)) return cache.get(cacheKey);
+
+  let text = '';
+  if (variant === 'full') {
+    text = typeof pack.render === 'function' ? pack.render() : '';
+  } else if (variant === 'compact') {
+    text = typeof pack.compact === 'function' ? pack.compact() : '';
+  }
+
+  if (typeof text !== 'string') {
+    text = '';
+  }
+
+  const chars = text.length;
+  const estimatedTokens = estimateTokensFromChars(chars);
+  const rendered = { text, chars, estimatedTokens };
+  cache.set(cacheKey, rendered);
+  return rendered;
+}
+
+function sortByPriorityThenOrder(a, b) {
+  const priorityDelta = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (priorityDelta !== 0) return priorityDelta;
+  return a.order - b.order;
+}
+
+function sortByOrder(a, b) {
+  return a.order - b.order;
+}
+
+function sortByPriorityDescThenOrderDesc(a, b) {
+  const priorityDelta = PRIORITY_RANK[b.priority] - PRIORITY_RANK[a.priority];
+  if (priorityDelta !== 0) return priorityDelta;
+  return b.order - a.order;
+}
+
+function selectVariant(pack, remainingTokens, cache) {
+  const full = renderVariant(pack, 'full', cache);
+  const compact = pack.compact ? renderVariant(pack, 'compact', cache) : null;
+
+  const hasFull = full.chars > 0;
+  const hasCompact = compact && compact.chars > 0;
+
+  if (!hasFull && !hasCompact) {
+    return {
+      status: 'skipped',
+      variant: null,
+      reason: 'empty',
+      chars: 0,
+      estimatedTokens: 0,
+    };
+  }
+
+  if (pack.required) {
+    let chosen = full;
+    let variant = 'full';
+
+    if (!hasFull && hasCompact) {
+      chosen = compact;
+      variant = 'compact';
+    } else if (
+      Number.isFinite(remainingTokens) &&
+      hasCompact &&
+      full.estimatedTokens > remainingTokens
+    ) {
+      if (
+        compact.estimatedTokens <= remainingTokens ||
+        compact.estimatedTokens < full.estimatedTokens
+      ) {
+        chosen = compact;
+        variant = 'compact';
+      }
+    }
+
+    return {
+      status: 'included',
+      variant,
+      chars: chosen.chars,
+      estimatedTokens: chosen.estimatedTokens,
+      text: chosen.text,
+    };
+  }
+
+  if (!Number.isFinite(remainingTokens) || full.estimatedTokens <= remainingTokens) {
+    return {
+      status: 'included',
+      variant: 'full',
+      chars: full.chars,
+      estimatedTokens: full.estimatedTokens,
+      text: full.text,
+    };
+  }
+
+  if (hasCompact && compact.estimatedTokens <= remainingTokens) {
+    return {
+      status: 'included',
+      variant: 'compact',
+      chars: compact.chars,
+      estimatedTokens: compact.estimatedTokens,
+      text: compact.text,
+    };
+  }
+
+  return {
+    status: 'skipped',
+    variant: null,
+    reason: 'budget',
+    chars: 0,
+    estimatedTokens: 0,
+  };
+}
+
+function truncateText(text, targetChars) {
+  if (text.length <= targetChars) {
+    return { text, truncated: false };
+  }
+
+  if (targetChars <= 0) {
+    return { text: '', truncated: true };
+  }
+
+  if (targetChars <= TRUNCATION_SUFFIX.length) {
+    return { text: text.slice(0, targetChars), truncated: true };
+  }
+
+  const sliceLength = targetChars - TRUNCATION_SUFFIX.length;
+  return { text: text.slice(0, sliceLength) + TRUNCATION_SUFFIX, truncated: true };
+}
+
+function applyMaxCharsGuard({ packs, selected, decisions, cache, maxChars, totalChars }) {
+  let currentChars = totalChars;
+  if (!Number.isFinite(maxChars) || currentChars <= maxChars) {
+    return { applied: false, beforeChars: totalChars, afterChars: totalChars };
+  }
+
+  const includedOptional = packs
+    .filter((pack) => selected.has(pack.id) && !pack.required)
+    .sort(sortByPriorityDescThenOrderDesc);
+
+  for (const pack of includedOptional) {
+    if (currentChars <= maxChars) break;
+    const decision = decisions.get(pack.id);
+    if (!decision || decision.variant === 'compact' || !pack.compact) continue;
+
+    const compact = renderVariant(pack, 'compact', cache);
+    if (compact.chars === 0 || compact.chars >= decision.chars) continue;
+
+    const previousChars = decision.chars;
+    selected.set(pack.id, { ...compact, variant: 'compact' });
+    decision.variant = 'compact';
+    decision.chars = compact.chars;
+    decision.estimatedTokens = compact.estimatedTokens;
+    decision.reason = decision.reason || 'max_chars';
+
+    currentChars -= previousChars - compact.chars;
+    currentChars = Math.max(0, currentChars);
+  }
+
+  for (const pack of includedOptional) {
+    if (currentChars <= maxChars) break;
+    if (!selected.has(pack.id)) continue;
+
+    const decision = decisions.get(pack.id);
+    currentChars -= decision?.chars || 0;
+    selected.delete(pack.id);
+    if (decision) {
+      decision.status = 'skipped';
+      decision.reason = decision.reason || 'max_chars';
+      decision.chars = 0;
+      decision.estimatedTokens = 0;
+    }
+  }
+
+  if (currentChars > maxChars) {
+    let overage = currentChars - maxChars;
+    const requiredCandidates = packs
+      .filter((pack) => selected.has(pack.id) && pack.required)
+      .sort((a, b) => {
+        const preserveDelta = (a.preserve ? 1 : 0) - (b.preserve ? 1 : 0);
+        if (preserveDelta !== 0) return preserveDelta;
+        const sizeDelta = (selected.get(b.id)?.chars || 0) - (selected.get(a.id)?.chars || 0);
+        if (sizeDelta !== 0) return sizeDelta;
+        return b.order - a.order;
+      });
+
+    for (const pack of requiredCandidates) {
+      if (overage <= 0) break;
+      const decision = decisions.get(pack.id);
+      const selectedPack = selected.get(pack.id);
+      if (!decision || !selectedPack) continue;
+
+      const targetChars = Math.max(0, selectedPack.chars - overage);
+      const truncated = truncateText(selectedPack.text, targetChars);
+      if (truncated.text.length === selectedPack.chars) continue;
+
+      const newChars = truncated.text.length;
+      const reduced = selectedPack.chars - newChars;
+      overage -= reduced;
+
+      selected.set(pack.id, {
+        text: truncated.text,
+        chars: newChars,
+        estimatedTokens: estimateTokensFromChars(newChars),
+        variant: selectedPack.variant,
+      });
+
+      decision.chars = newChars;
+      decision.estimatedTokens = estimateTokensFromChars(newChars);
+      decision.truncated = true;
+      decision.reason = decision.reason || 'max_chars';
+    }
+  }
+
+  const afterChars = Array.from(selected.values()).reduce((sum, item) => sum + item.chars, 0);
+  return { applied: true, beforeChars: totalChars, afterChars };
+}
+
+function buildContextPacks({ packs, maxTokens, maxChars }) {
+  const normalized = packs.map(normalizePack);
+  const selectionOrder = normalized.slice().sort(sortByPriorityThenOrder);
+  const renderCache = new Map();
+  const decisions = new Map();
+  const selected = new Map();
+
+  let remainingTokens = Number.isFinite(maxTokens) ? maxTokens : Infinity;
+  let overBudgetTokens = 0;
+
+  for (const pack of selectionOrder) {
+    const selection = selectVariant(pack, remainingTokens, renderCache);
+    const decision = {
+      id: pack.id,
+      section: pack.section || null,
+      priority: pack.priority,
+      required: pack.required,
+      status: selection.status,
+      variant: selection.variant,
+      chars: selection.chars,
+      estimatedTokens: selection.estimatedTokens,
+      order: pack.order,
+      reason: selection.reason || null,
+    };
+
+    decisions.set(pack.id, decision);
+
+    if (selection.status !== 'included') {
+      continue;
+    }
+
+    selected.set(pack.id, {
+      text: selection.text,
+      chars: selection.chars,
+      estimatedTokens: selection.estimatedTokens,
+      variant: selection.variant,
+    });
+
+    if (!Number.isFinite(remainingTokens)) {
+      continue;
+    }
+
+    if (selection.estimatedTokens > remainingTokens) {
+      overBudgetTokens += selection.estimatedTokens - remainingTokens;
+      remainingTokens = 0;
+    } else {
+      remainingTokens -= selection.estimatedTokens;
+    }
+  }
+
+  const ordered = normalized.slice().sort(sortByOrder);
+  let context = '';
+  for (const pack of ordered) {
+    const selectedPack = selected.get(pack.id);
+    if (selectedPack) {
+      context += selectedPack.text;
+    }
+  }
+
+  const totalChars = context.length;
+  const truncation = applyMaxCharsGuard({
+    packs: ordered,
+    selected,
+    decisions,
+    cache: renderCache,
+    maxChars,
+    totalChars,
+  });
+
+  if (truncation.applied) {
+    context = '';
+    for (const pack of ordered) {
+      const selectedPack = selected.get(pack.id);
+      if (selectedPack) {
+        context += selectedPack.text;
+      }
+    }
+  }
+
+  const finalChars = context.length;
+  const finalTokens = estimateTokensFromChars(finalChars);
+  const packDecisions = ordered.map((pack) => {
+    const decision = decisions.get(pack.id);
+    return {
+      id: decision.id,
+      section: decision.section,
+      priority: decision.priority,
+      required: decision.required,
+      status: decision.status,
+      variant: decision.variant,
+      chars: decision.chars,
+      estimatedTokens: decision.estimatedTokens,
+      order: decision.order,
+      reason: decision.reason,
+      truncated: decision.truncated || false,
+    };
+  });
+
+  return {
+    context,
+    packDecisions,
+    budget: {
+      maxTokens,
+      remainingTokens: Number.isFinite(remainingTokens) ? remainingTokens : null,
+      overBudgetTokens,
+      finalTokens,
+    },
+    truncation: {
+      maxContextChars: {
+        applied: truncation.applied,
+        beforeChars: truncation.beforeChars,
+        afterChars: truncation.afterChars,
+      },
+    },
+  };
+}
+
+module.exports = {
+  buildContextPacks,
+};

--- a/src/agent/validation-platform.js
+++ b/src/agent/validation-platform.js
@@ -1,0 +1,35 @@
+const PLATFORM_MISMATCH_REGEX =
+  /EBADPLATFORM|Unsupported platform|darwin-arm64|linux-x64|@esbuild\/linux-x64/i;
+
+function isPlatformMismatchReason(reason) {
+  if (!reason) return false;
+  return PLATFORM_MISMATCH_REGEX.test(String(reason));
+}
+
+function findPlatformMismatchReason(result = {}) {
+  const criteriaResults = result.criteriaResults;
+  if (Array.isArray(criteriaResults)) {
+    for (const criteria of criteriaResults) {
+      if (criteria?.status !== 'CANNOT_VALIDATE') continue;
+      if (isPlatformMismatchReason(criteria.reason)) {
+        return String(criteria.reason);
+      }
+    }
+  }
+
+  const errors = result.errors;
+  if (Array.isArray(errors)) {
+    for (const error of errors) {
+      if (isPlatformMismatchReason(error)) {
+        return String(error);
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  isPlatformMismatchReason,
+  findPlatformMismatchReason,
+};

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -251,6 +251,17 @@ function generateGitPusherAgent(platform) {
       },
     ],
     prompt: generatePrompt(config),
+    hooks: {
+      onComplete: {
+        action: 'publish_message',
+        config: {
+          topic: 'CLUSTER_COMPLETE',
+          content: {
+            data: { reason: 'git-pusher-complete' },
+          },
+        },
+      },
+    },
     output: {
       topic: 'PR_CREATED',
       publishAfter: 'CLUSTER_COMPLETE',

--- a/src/config-router.js
+++ b/src/config-router.js
@@ -37,7 +37,9 @@ function getConfig(complexity, taskType) {
     if (complexity === 'TRIVIAL') return 0;
     if (complexity === 'SIMPLE') return 1;
     if (complexity === 'STANDARD') return 2;
-    if (complexity === 'CRITICAL') return 4;
+    // CRITICAL uses two-stage validation pipeline (validators loaded dynamically via meta-coordinator)
+    // Setting validator_count=0 signals that inline validators should be skipped
+    if (complexity === 'CRITICAL') return 0;
     return 1;
   };
 

--- a/src/issue-providers/azure-devops-provider.js
+++ b/src/issue-providers/azure-devops-provider.js
@@ -7,6 +7,8 @@ const IssueProvider = require('./base-provider');
 const { execSync } = require('../lib/safe-exec');
 const { detectGitContext } = require('../../lib/git-remote-utils');
 
+const AUTH_CHECK_TIMEOUT_MS = 2000;
+
 class AzureDevOpsProvider extends IssueProvider {
   static id = 'azure-devops';
   static displayName = 'Azure DevOps';
@@ -76,9 +78,32 @@ class AzureDevOpsProvider extends IssueProvider {
   static checkAuth() {
     try {
       // First check Azure login
-      execSync('az account show', { encoding: 'utf8', stdio: 'pipe' });
+      execSync('az account show', {
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: AUTH_CHECK_TIMEOUT_MS,
+      });
     } catch (err) {
       const stderr = err.stderr || err.message || '';
+
+      if (err.code === 'ENOENT' || stderr.includes('command not found')) {
+        return {
+          authenticated: false,
+          error: 'Azure CLI not installed',
+          recovery: [
+            'Install Azure CLI: https://docs.microsoft.com/cli/azure/',
+            'Then verify: az --version',
+          ],
+        };
+      }
+
+      if (stderr.includes('Command timed out')) {
+        return {
+          authenticated: false,
+          error: 'az account show timed out',
+          recovery: ['Retry: az account show', 'If it still hangs, run: az login'],
+        };
+      }
 
       if (stderr.includes('az login') || stderr.includes('not logged in')) {
         return {
@@ -104,6 +129,7 @@ class AzureDevOpsProvider extends IssueProvider {
       const output = execSync('az extension list --query "[?name==\'azure-devops\']" -o json', {
         encoding: 'utf8',
         stdio: 'pipe',
+        timeout: AUTH_CHECK_TIMEOUT_MS,
       });
       const extensions = JSON.parse(output);
       if (extensions.length === 0) {
@@ -116,7 +142,15 @@ class AzureDevOpsProvider extends IssueProvider {
           ],
         };
       }
-    } catch {
+    } catch (err) {
+      const stderr = err?.stderr || err?.message || '';
+      if (stderr.includes('Command timed out')) {
+        return {
+          authenticated: false,
+          error: 'az extension list timed out',
+          recovery: ['Retry: az extension list', 'Ensure az is configured and responsive'],
+        };
+      }
       return {
         authenticated: false,
         error: 'Could not verify Azure DevOps extension',

--- a/src/message-bus-bridge.js
+++ b/src/message-bus-bridge.js
@@ -16,6 +16,11 @@ class MessageBusBridge {
     this.parentBus = parentBus;
     this.childBus = childBus;
     this.config = config;
+    this.parentTopicNames = new Set(
+      (config.parentTopics || [])
+        .map((entry) => (typeof entry === 'string' ? entry : entry?.topic))
+        .filter((topic) => typeof topic === 'string' && topic.length > 0)
+    );
 
     this.parentUnsubscribe = null;
     this.childUnsubscribe = null;
@@ -30,7 +35,7 @@ class MessageBusBridge {
    */
   _setupBridge() {
     // Forward specified parent topics to child
-    if (this.config.parentTopics && this.config.parentTopics.length > 0) {
+    if (this.parentTopicNames.size > 0) {
       this.parentUnsubscribe = this.parentBus.subscribe((message) => {
         this._forwardParentToChild(message);
       });
@@ -55,7 +60,7 @@ class MessageBusBridge {
     }
 
     // Only forward topics specified in config
-    if (!this.config.parentTopics.includes(message.topic)) {
+    if (!this.parentTopicNames.has(message.topic)) {
       return;
     }
 

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -473,6 +473,24 @@ function runPreflight(options = {}) {
   const warnings = [];
 
   const settings = loadSettings();
+
+  if (process.platform === 'win32') {
+    return {
+      valid: false,
+      errors: [
+        formatError(
+          'Windows not supported',
+          'Zeroshot currently supports Linux and macOS only; Windows (native or WSL) is deferred.',
+          [
+            'Use Linux or macOS to run Zeroshot',
+            'Or run inside a Linux VM/container on Windows',
+            'Check README for supported platforms and updates',
+          ]
+        ),
+      ],
+      warnings: [],
+    };
+  }
   const providerName = normalizeProviderName(
     options.provider || settings.defaultProvider || 'claude'
   );

--- a/src/providers/openai/models.js
+++ b/src/providers/openai/models.js
@@ -3,9 +3,9 @@
 const MODEL_CATALOG = {};
 
 const LEVEL_MAPPING = {
-  level1: { rank: 1, model: null, reasoningEffort: 'low' },
-  level2: { rank: 2, model: null, reasoningEffort: 'medium' },
-  level3: { rank: 3, model: null, reasoningEffort: 'high' },
+  level1: { rank: 1, model: null, reasoningEffort: 'medium' },
+  level2: { rank: 2, model: null, reasoningEffort: 'high' },
+  level3: { rank: 3, model: null, reasoningEffort: 'xhigh' },
 };
 
 const DEFAULT_LEVEL = 'level2';

--- a/src/schemas/sub-cluster.js
+++ b/src/schemas/sub-cluster.js
@@ -132,12 +132,35 @@ function validateContextStrategy(agentConfig, errors) {
     return;
   }
 
-  // Validate each parent topic is a string
-  for (const topic of parentTopics) {
-    if (typeof topic !== 'string') {
+  // Validate each parent topic entry
+  for (const entry of parentTopics) {
+    if (typeof entry === 'string') {
+      continue;
+    }
+
+    if (!entry || typeof entry !== 'object') {
       errors.push(
-        `Sub-cluster '${agentConfig.id}' parentTopics must contain strings, got ${typeof topic}`
+        `Sub-cluster '${agentConfig.id}' parentTopics must contain strings or objects, got ${typeof entry}`
       );
+      continue;
+    }
+
+    if (typeof entry.topic !== 'string') {
+      errors.push(`Sub-cluster '${agentConfig.id}' parentTopics entry must include a string topic`);
+    }
+
+    if (entry.strategy && !['latest', 'all', 'oldest'].includes(entry.strategy)) {
+      errors.push(
+        `Sub-cluster '${agentConfig.id}' parentTopics entry has invalid strategy '${entry.strategy}'`
+      );
+    }
+
+    if (entry.amount !== undefined && !Number.isFinite(entry.amount)) {
+      errors.push(`Sub-cluster '${agentConfig.id}' parentTopics entry amount must be a number`);
+    }
+
+    if (entry.limit !== undefined && !Number.isFinite(entry.limit)) {
+      errors.push(`Sub-cluster '${agentConfig.id}' parentTopics entry limit must be a number`);
     }
   }
 }

--- a/src/state-snapshot.js
+++ b/src/state-snapshot.js
@@ -1,0 +1,398 @@
+const SNAPSHOT_VERSION = 1;
+
+const LIMITS = {
+  errors: 5,
+  criteriaResults: 10,
+  acceptanceCriteria: 10,
+  filesAffected: 20,
+  blockers: 5,
+  nextSteps: 10,
+  rootCauses: 5,
+};
+
+const TEXT_LIMITS = {
+  task: 2000,
+  plan: 2000,
+  fixPlan: 1200,
+  summary: 300,
+  listItem: 200,
+};
+
+function toTimestamp(message) {
+  if (message && Number.isFinite(message.timestamp)) {
+    return message.timestamp;
+  }
+  return Date.now();
+}
+
+function normalizeText(value, maxLength, singleLine = false) {
+  if (value === undefined || value === null) return undefined;
+  let text = String(value);
+  if (singleLine) {
+    text = text.replace(/\s+/g, ' ').trim();
+  } else {
+    text = text.trim();
+  }
+  if (!text) return undefined;
+  if (maxLength && text.length > maxLength) {
+    return `${text.slice(0, maxLength - 3)}...`;
+  }
+  return text;
+}
+
+function normalizeStringList(list, maxItems) {
+  if (!Array.isArray(list)) return undefined;
+  const normalized = list
+    .map((item) => normalizeText(item, TEXT_LIMITS.listItem, true))
+    .filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  if (maxItems && normalized.length > maxItems) {
+    return normalized.slice(-maxItems);
+  }
+  return normalized;
+}
+
+function normalizeAcceptanceCriteria(criteria) {
+  if (!Array.isArray(criteria)) return undefined;
+  const normalized = criteria
+    .map((item) => {
+      if (typeof item === 'string') {
+        return normalizeText(item, TEXT_LIMITS.listItem, true);
+      }
+      if (!item || typeof item !== 'object') return undefined;
+      const id = item.id ? String(item.id) : '';
+      const priority = item.priority ? ` (${item.priority})` : '';
+      const criterion = item.criterion || item.text || item.summary || '';
+      const label = id ? `${id}${priority}: ` : '';
+      const merged = `${label}${criterion}`.trim();
+      if (!merged) return undefined;
+      return normalizeText(merged, TEXT_LIMITS.listItem, true);
+    })
+    .filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  if (normalized.length > LIMITS.acceptanceCriteria) {
+    return normalized.slice(-LIMITS.acceptanceCriteria);
+  }
+  return normalized;
+}
+
+function normalizeCriteriaEvidence(evidence) {
+  if (!evidence || typeof evidence !== 'object') return undefined;
+  const normalized = {};
+  if (evidence.command) {
+    const command = normalizeText(evidence.command, TEXT_LIMITS.listItem, true);
+    if (command) normalized.command = command;
+  }
+  if (Number.isFinite(evidence.exitCode)) {
+    normalized.exitCode = evidence.exitCode;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeCriteriaResult(item) {
+  if (!item || typeof item !== 'object') return undefined;
+  const entry = {};
+  if (item.id) entry.id = String(item.id);
+  if (item.status) entry.status = String(item.status);
+  if (item.reason) {
+    const reason = normalizeText(item.reason, TEXT_LIMITS.listItem, true);
+    if (reason) entry.reason = reason;
+  }
+  const evidence = normalizeCriteriaEvidence(item.evidence);
+  if (evidence) entry.evidence = evidence;
+  return Object.keys(entry).length > 0 ? entry : undefined;
+}
+
+function normalizeCriteriaResults(results) {
+  if (!Array.isArray(results)) return undefined;
+  const normalized = results.map(normalizeCriteriaResult).filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  if (normalized.length > LIMITS.criteriaResults) {
+    return normalized.slice(-LIMITS.criteriaResults);
+  }
+  return normalized;
+}
+
+function normalizeErrors(data) {
+  if (!data || typeof data !== 'object') return undefined;
+  if (Array.isArray(data.errors)) {
+    return normalizeStringList(data.errors, LIMITS.errors);
+  }
+  if (Array.isArray(data.issues)) {
+    const mapped = data.issues.map((issue) => {
+      if (typeof issue === 'string') return issue;
+      if (!issue || typeof issue !== 'object') return undefined;
+      return issue.bug || issue.message || issue.error || issue.summary || undefined;
+    });
+    return normalizeStringList(mapped, LIMITS.errors);
+  }
+  return undefined;
+}
+
+function normalizeRootCauses(rootCauses) {
+  if (!Array.isArray(rootCauses)) return undefined;
+  const normalized = rootCauses
+    .map((cause) => {
+      if (typeof cause === 'string') {
+        return normalizeText(cause, TEXT_LIMITS.listItem, true);
+      }
+      if (!cause || typeof cause !== 'object') return undefined;
+      return normalizeText(
+        cause.cause || cause.summary || cause.description,
+        TEXT_LIMITS.listItem,
+        true
+      );
+    })
+    .filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  if (normalized.length > LIMITS.rootCauses) {
+    return normalized.slice(-LIMITS.rootCauses);
+  }
+  return normalized;
+}
+
+function normalizeFilesAffected(filesAffected) {
+  return normalizeStringList(filesAffected, LIMITS.filesAffected);
+}
+
+function normalizeBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
+function normalizeProgressStatus(data) {
+  if (!data || typeof data !== 'object') return undefined;
+  if (data.completionStatus && typeof data.completionStatus === 'object') {
+    return data.completionStatus;
+  }
+  const hasProgressFields =
+    Object.prototype.hasOwnProperty.call(data, 'canValidate') ||
+    Object.prototype.hasOwnProperty.call(data, 'percentComplete');
+  return hasProgressFields ? data : undefined;
+}
+
+function buildBaseState(state, message) {
+  return {
+    version: SNAPSHOT_VERSION,
+    updatedAt: toTimestamp(message),
+    clusterId: message?.cluster_id || state?.clusterId || null,
+    sourceMessageId: message?.id || state?.sourceMessageId || null,
+    task: state?.task,
+    plan: state?.plan,
+    progress: state?.progress,
+    validation: state?.validation,
+    debug: state?.debug,
+  };
+}
+
+function pruneEmpty(value) {
+  if (Array.isArray(value)) {
+    const next = value.map(pruneEmpty).filter((item) => item !== undefined);
+    return next.length > 0 ? next : undefined;
+  }
+  if (value && typeof value === 'object') {
+    const next = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const pruned = pruneEmpty(entry);
+      if (pruned !== undefined) {
+        next[key] = pruned;
+      }
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
+  }
+  if (value === undefined || value === null) return undefined;
+  return value;
+}
+
+function finalizeState(state) {
+  const meta = {
+    version: state.version ?? SNAPSHOT_VERSION,
+    updatedAt: state.updatedAt ?? Date.now(),
+    clusterId: state.clusterId ?? null,
+    sourceMessageId: state.sourceMessageId ?? null,
+  };
+  const sections = pruneEmpty({
+    task: state.task,
+    plan: state.plan,
+    progress: state.progress,
+    validation: state.validation,
+    debug: state.debug,
+  });
+  return {
+    ...meta,
+    ...(sections || {}),
+  };
+}
+
+function initStateFromIssue(issueMessage) {
+  const content = issueMessage?.content || {};
+  const data = content.data || {};
+  const task = {
+    raw: normalizeText(content.text, TEXT_LIMITS.task),
+    title: normalizeText(data.title, TEXT_LIMITS.summary, true),
+    issueNumber: data.issue_number ?? data.issueNumber,
+    source: issueMessage?.metadata?.source,
+  };
+  const base = buildBaseState(null, issueMessage);
+  base.task = pruneEmpty(task);
+  return finalizeState(base);
+}
+
+function applyIssueOpened(state, message) {
+  const base = buildBaseState(state, message);
+  const content = message?.content || {};
+  const data = content.data || {};
+  const task = {
+    raw: normalizeText(content.text, TEXT_LIMITS.task),
+    title: normalizeText(data.title, TEXT_LIMITS.summary, true),
+    issueNumber: data.issue_number ?? data.issueNumber,
+    source: message?.metadata?.source,
+  };
+  base.task = pruneEmpty(task);
+  return finalizeState(base);
+}
+
+function applyPlanReady(state, message) {
+  const base = buildBaseState(state, message);
+  const content = message?.content || {};
+  const data = content.data || {};
+  const plan = {
+    text: normalizeText(content.text, TEXT_LIMITS.plan),
+    summary: normalizeText(data.summary, TEXT_LIMITS.summary, true),
+    acceptanceCriteria: normalizeAcceptanceCriteria(data.acceptanceCriteria),
+    filesAffected: normalizeFilesAffected(data.filesAffected),
+    updatedAt: toTimestamp(message),
+  };
+  base.plan = pruneEmpty(plan);
+  return finalizeState(base);
+}
+
+function applyWorkerProgress(state, message) {
+  const base = buildBaseState(state, message);
+  const content = message?.content || {};
+  const status = normalizeProgressStatus(content.data || {});
+  if (!status) {
+    return finalizeState(base);
+  }
+  const progress = {
+    canValidate: normalizeBoolean(status.canValidate),
+    percentComplete: Number.isFinite(status.percentComplete) ? status.percentComplete : undefined,
+    blockers: normalizeStringList(status.blockers, LIMITS.blockers),
+    nextSteps: normalizeStringList(status.nextSteps, LIMITS.nextSteps),
+    lastSummary: normalizeText(content.text || status.summary, TEXT_LIMITS.summary, true),
+    updatedAt: toTimestamp(message),
+  };
+  base.progress = pruneEmpty(progress);
+  return finalizeState(base);
+}
+
+function applyImplementationReady(state, message) {
+  return applyWorkerProgress(state, message);
+}
+
+function applyValidationResult(state, message) {
+  const base = buildBaseState(state, message);
+  const content = message?.content || {};
+  const data = content.data || {};
+  const validation = {
+    approved: normalizeBoolean(data.approved),
+    errors: normalizeErrors(data),
+    criteriaResults: normalizeCriteriaResults(data.criteriaResults),
+    updatedAt: toTimestamp(message),
+  };
+  base.validation = pruneEmpty(validation);
+  return finalizeState(base);
+}
+
+function applyInvestigationComplete(state, message) {
+  const base = buildBaseState(state, message);
+  const content = message?.content || {};
+  const data = content.data || {};
+  const debug = {
+    fixPlan: normalizeText(content.text, TEXT_LIMITS.fixPlan),
+    successCriteria: normalizeText(data.successCriteria, TEXT_LIMITS.summary, true),
+    rootCauses: normalizeRootCauses(data.rootCauses),
+    updatedAt: toTimestamp(message),
+  };
+  base.debug = pruneEmpty(debug);
+  return finalizeState(base);
+}
+
+function buildTaskSummary(state) {
+  const taskTitle = normalizeText(state.task?.title || state.task?.raw, TEXT_LIMITS.summary, true);
+  return taskTitle ? `Task: ${taskTitle}` : undefined;
+}
+
+function buildPlanSummary(state) {
+  const planSummary = normalizeText(
+    state.plan?.summary || state.plan?.text,
+    TEXT_LIMITS.summary,
+    true
+  );
+  return planSummary ? `Plan: ${planSummary}` : undefined;
+}
+
+function buildProgressSummary(state) {
+  if (!state.progress) return undefined;
+  const parts = [];
+  if (Number.isFinite(state.progress.percentComplete)) {
+    parts.push(`${state.progress.percentComplete}%`);
+  }
+  if (typeof state.progress.canValidate === 'boolean') {
+    parts.push(`canValidate=${state.progress.canValidate}`);
+  }
+  const nextStepText = normalizeText(state.progress.nextSteps?.[0], TEXT_LIMITS.listItem, true);
+  if (nextStepText) {
+    parts.push(`next: ${nextStepText}`);
+  }
+  return parts.length > 0 ? `Progress: ${parts.join(' | ')}` : undefined;
+}
+
+function resolveValidationStatus(approved) {
+  if (approved === true) return 'approved';
+  if (approved === false) return 'rejected';
+  return 'pending';
+}
+
+function buildValidationSummary(state) {
+  if (!state.validation) return undefined;
+  const status = resolveValidationStatus(state.validation.approved);
+  const errorCount = state.validation.errors?.length || 0;
+  return `Validation: ${status}${errorCount ? ` (${errorCount} errors)` : ''}`;
+}
+
+function buildDebugSummary(state) {
+  const debugSummary = normalizeText(
+    state.debug?.fixPlan || state.debug?.successCriteria,
+    TEXT_LIMITS.summary,
+    true
+  );
+  return debugSummary ? `Debug: ${debugSummary}` : undefined;
+}
+
+function renderStateSummary(state) {
+  if (!state || typeof state !== 'object') return '';
+  const lines = [
+    buildTaskSummary(state),
+    buildPlanSummary(state),
+    buildProgressSummary(state),
+    buildValidationSummary(state),
+    buildDebugSummary(state),
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  SNAPSHOT_VERSION,
+  initStateFromIssue,
+  applyIssueOpened,
+  applyPlanReady,
+  applyWorkerProgress,
+  applyImplementationReady,
+  applyValidationResult,
+  applyInvestigationComplete,
+  renderStateSummary,
+};

--- a/src/state-snapshotter.js
+++ b/src/state-snapshotter.js
@@ -1,0 +1,142 @@
+const crypto = require('crypto');
+const {
+  initStateFromIssue,
+  applyIssueOpened,
+  applyPlanReady,
+  applyWorkerProgress,
+  applyImplementationReady,
+  applyValidationResult,
+  applyInvestigationComplete,
+  renderStateSummary,
+} = require('./state-snapshot');
+
+const SNAPSHOT_TOPICS = [
+  'ISSUE_OPENED',
+  'PLAN_READY',
+  'WORKER_PROGRESS',
+  'IMPLEMENTATION_READY',
+  'VALIDATION_RESULT',
+  'INVESTIGATION_COMPLETE',
+];
+
+class StateSnapshotter {
+  constructor({ messageBus, clusterId }) {
+    this.messageBus = messageBus;
+    this.clusterId = clusterId;
+    this.state = null;
+    this.lastHash = null;
+    this.unsubscribe = null;
+  }
+
+  start() {
+    if (this.unsubscribe) {
+      return;
+    }
+
+    this._bootstrapFromLedger();
+
+    this.unsubscribe = this.messageBus.subscribeTopics(SNAPSHOT_TOPICS, (message) => {
+      if (message.cluster_id !== this.clusterId) return;
+      this._handleMessage(message);
+    });
+  }
+
+  stop() {
+    if (!this.unsubscribe) return;
+    this.unsubscribe();
+    this.unsubscribe = null;
+  }
+
+  _bootstrapFromLedger() {
+    const existing = this.messageBus.findLast({
+      cluster_id: this.clusterId,
+      topic: 'STATE_SNAPSHOT',
+    });
+
+    if (existing?.content?.data && typeof existing.content.data === 'object') {
+      this.state = existing.content.data;
+      this.lastHash = this._hashState(this.state);
+      return;
+    }
+
+    const messages = SNAPSHOT_TOPICS.map((topic) =>
+      this.messageBus.findLast({ cluster_id: this.clusterId, topic })
+    ).filter(Boolean);
+
+    if (messages.length === 0) {
+      return;
+    }
+
+    messages.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+
+    let state = null;
+    for (const message of messages) {
+      state = this._applyMessage(state, message);
+    }
+
+    if (state) {
+      this.state = state;
+      this._publishSnapshot(state);
+    }
+  }
+
+  _handleMessage(message) {
+    const nextState = this._applyMessage(this.state, message);
+    if (!nextState) return;
+
+    this.state = nextState;
+    this._publishSnapshot(nextState);
+  }
+
+  _applyMessage(state, message) {
+    switch (message.topic) {
+      case 'ISSUE_OPENED':
+        return state ? applyIssueOpened(state, message) : initStateFromIssue(message);
+      case 'PLAN_READY':
+        return applyPlanReady(state, message);
+      case 'WORKER_PROGRESS':
+        return applyWorkerProgress(state, message);
+      case 'IMPLEMENTATION_READY':
+        return applyImplementationReady(state, message);
+      case 'VALIDATION_RESULT':
+        return applyValidationResult(state, message);
+      case 'INVESTIGATION_COMPLETE':
+        return applyInvestigationComplete(state, message);
+      default:
+        return state;
+    }
+  }
+
+  _publishSnapshot(state) {
+    const hash = this._hashState(state);
+    if (this._hashEquals(hash, this.lastHash)) {
+      return;
+    }
+    this.lastHash = hash;
+
+    this.messageBus.publish({
+      cluster_id: this.clusterId,
+      topic: 'STATE_SNAPSHOT',
+      sender: 'state-snapshotter',
+      receiver: 'broadcast',
+      content: {
+        text: renderStateSummary(state),
+        data: state,
+      },
+    });
+  }
+
+  _hashState(state) {
+    return crypto.createHash('sha256').update(JSON.stringify(state)).digest('hex');
+  }
+
+  _hashEquals(left, right) {
+    if (!left || !right) return false;
+    const leftBuffer = Buffer.from(left, 'utf8');
+    const rightBuffer = Buffer.from(right, 'utf8');
+    if (leftBuffer.length !== rightBuffer.length) return false;
+    return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+  }
+}
+
+module.exports = StateSnapshotter;

--- a/src/tui/layout.js
+++ b/src/tui/layout.js
@@ -10,7 +10,12 @@
  */
 
 const blessed = require('blessed');
-const contrib = require('blessed-contrib');
+// Pull in only the widgets we use to avoid loading optional picture widget.
+const contrib = {
+  grid: require('blessed-contrib/lib/layout/grid'),
+  table: require('blessed-contrib/lib/widget/table'),
+  log: require('blessed-contrib/lib/widget/log'),
+};
 
 /**
  * Create main TUI layout with grid-based widget organization

--- a/task-lib/claude-recovery.js
+++ b/task-lib/claude-recovery.js
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 
 export const STREAMING_MODE_ERROR = 'only prompt commands are supported in streaming mode';
+export const NO_MESSAGES_RETURNED = 'No messages returned';
 
 export function detectStreamingModeError(line) {
   const trimmed = typeof line === 'string' ? line.trim() : '';
@@ -25,6 +26,27 @@ export function detectStreamingModeError(line) {
     }
   } catch {
     // Ignore parse errors - not JSON
+  }
+
+  return null;
+}
+
+export function detectFatalClaudeError(line) {
+  if (typeof line !== 'string') return null;
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('{')) {
+    try {
+      JSON.parse(trimmed);
+      return null;
+    } catch {
+      // Not valid JSON, continue detection
+    }
+  }
+
+  if (trimmed.toLowerCase().includes(NO_MESSAGES_RETURNED.toLowerCase())) {
+    return `Claude CLI error: ${NO_MESSAGES_RETURNED}`;
   }
 
   return null;

--- a/task-lib/tui/layout.js
+++ b/task-lib/tui/layout.js
@@ -9,7 +9,8 @@
  */
 
 import blessed from 'blessed';
-import contrib from 'blessed-contrib';
+import Grid from 'blessed-contrib/lib/layout/grid.js';
+import Log from 'blessed-contrib/lib/widget/log.js';
 
 /**
  * Create task logs TUI layout
@@ -19,7 +20,7 @@ import contrib from 'blessed-contrib';
  */
 function createLayout(screen, taskId) {
   // Create 20x12 grid for responsive layout
-  const grid = new contrib.grid({ rows: 20, cols: 12, screen });
+  const grid = new Grid({ rows: 20, cols: 12, screen });
 
   // ============================================================
   // TASK INFO BOX (3 rows x 12 cols)
@@ -46,7 +47,7 @@ function createLayout(screen, taskId) {
   // Scrollable log output with auto-scroll
   // ============================================================
 
-  const logsBox = grid.set(3, 0, 15, 12, contrib.log, {
+  const logsBox = grid.set(3, 0, 15, 12, Log, {
     fg: 'white',
     label: ' Live Logs ',
     border: { type: 'line', fg: 'cyan' },

--- a/tests/context-packs.test.js
+++ b/tests/context-packs.test.js
@@ -1,0 +1,144 @@
+const assert = require('assert');
+const AgentWrapper = require('../src/agent-wrapper');
+const MessageBus = require('../src/message-bus');
+const Ledger = require('../src/ledger');
+const { buildContextPacks } = require('../src/agent/context-pack-builder');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+describe('context packs', () => {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let clusterId;
+  let clusterCreatedAt;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-context-packs-'));
+    const dbPath = path.join(tempDir, 'test-ledger.db');
+
+    ledger = new Ledger(dbPath);
+    messageBus = new MessageBus(ledger);
+
+    clusterId = 'test-cluster-789';
+    clusterCreatedAt = Date.now();
+  });
+
+  afterEach(() => {
+    if (ledger) ledger.close();
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  function createWorker(contextStrategy) {
+    const workerConfig = {
+      id: 'worker',
+      role: 'implementation',
+      modelLevel: 'level2',
+      timeout: 0,
+      contextStrategy,
+    };
+
+    const mockCluster = {
+      id: clusterId,
+      createdAt: clusterCreatedAt,
+      agents: [],
+    };
+
+    return new AgentWrapper(workerConfig, messageBus, mockCluster, {
+      testMode: true,
+      mockSpawnFn: () => {},
+    });
+  }
+
+  function publishMessage(topic, text, timestamp) {
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic,
+      sender: 'system',
+      content: { text },
+      timestamp,
+    });
+  }
+
+  function buildTriggeringMessage(timestamp, text = 'triggered') {
+    return {
+      topic: 'WORKER_PROGRESS',
+      sender: 'system',
+      timestamp,
+      content: { text },
+    };
+  }
+
+  it('keeps triggering message and required anchors under tight budgets', () => {
+    const baseTime = Date.now();
+    publishMessage('ISSUE_OPENED', 'Implement feature X', baseTime);
+    publishMessage('PLAN_READY', '1. Do the thing', baseTime + 10);
+    publishMessage('OPTIONAL_TOPIC', 'optional-detail', baseTime + 20);
+    publishMessage('VALIDATION_RESULT', 'rejected: missing test', baseTime + 30);
+
+    const worker = createWorker({
+      sources: [
+        { topic: 'ISSUE_OPENED', amount: 1 },
+        { topic: 'PLAN_READY', amount: 1 },
+        { topic: 'OPTIONAL_TOPIC', amount: 3 },
+        { topic: 'VALIDATION_RESULT', amount: 3 },
+      ],
+      maxTokens: 1,
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 40, 'kickoff'));
+
+    assert(context.includes('## Triggering Message'), 'Triggering message section must exist');
+    assert(context.includes('kickoff'), 'Triggering message content must be preserved');
+    assert(context.includes('Messages from topic: ISSUE_OPENED'), 'Issue anchor must be preserved');
+    assert(context.includes('Messages from topic: PLAN_READY'), 'Plan anchor must be preserved');
+    assert(!context.includes('optional-detail'), 'Low-priority context should be dropped');
+  });
+
+  it('compacts high-priority packs before skipping low-priority packs', () => {
+    const packs = [
+      {
+        id: 'header',
+        section: 'header',
+        priority: 'required',
+        render: () => 'REQ\n',
+      },
+      {
+        id: 'high',
+        section: 'sources',
+        priority: 'high',
+        render: () => 'H'.repeat(40),
+        compact: () => 'H\n',
+      },
+      {
+        id: 'low',
+        section: 'sources',
+        priority: 'low',
+        render: () => 'L'.repeat(40),
+        compact: () => 'L\n',
+      },
+      {
+        id: 'trigger',
+        section: 'triggeringMessage',
+        priority: 'required',
+        preserve: true,
+        render: () => 'TRIG\n',
+      },
+    ];
+
+    const result = buildContextPacks({ packs, maxTokens: 4 });
+    const highPack = result.packDecisions.find((pack) => pack.id === 'high');
+    const lowPack = result.packDecisions.find((pack) => pack.id === 'low');
+
+    assert.strictEqual(highPack.status, 'included');
+    assert.strictEqual(highPack.variant, 'compact');
+    assert.strictEqual(lowPack.status, 'skipped');
+    assert(result.context.includes('H\n'), 'High-priority compact content should be included');
+    assert(!result.context.includes('L'.repeat(40)), 'Low-priority full content should be dropped');
+  });
+});

--- a/tests/context-source-selection.test.js
+++ b/tests/context-source-selection.test.js
@@ -1,0 +1,171 @@
+const assert = require('assert');
+const AgentWrapper = require('../src/agent-wrapper');
+const MessageBus = require('../src/message-bus');
+const Ledger = require('../src/ledger');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+describe('context source selection', () => {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let clusterId;
+  let clusterCreatedAt;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-test-'));
+    const dbPath = path.join(tempDir, 'test-ledger.db');
+
+    ledger = new Ledger(dbPath);
+    messageBus = new MessageBus(ledger);
+
+    clusterId = 'test-cluster-456';
+    clusterCreatedAt = Date.now();
+  });
+
+  afterEach(() => {
+    if (ledger) ledger.close();
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  function createWorker(contextStrategy) {
+    const workerConfig = {
+      id: 'worker',
+      role: 'implementation',
+      modelLevel: 'level2',
+      timeout: 0,
+      contextStrategy,
+    };
+
+    const mockCluster = {
+      id: clusterId,
+      createdAt: clusterCreatedAt,
+      agents: [],
+    };
+
+    return new AgentWrapper(workerConfig, messageBus, mockCluster, {
+      testMode: true,
+      mockSpawnFn: () => {},
+    });
+  }
+
+  function publishMessage(topic, text, timestamp) {
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic,
+      sender: 'system',
+      content: { text },
+      timestamp,
+    });
+  }
+
+  function buildTriggeringMessage(timestamp) {
+    return {
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      timestamp,
+    };
+  }
+
+  it('selects latest messages in chronological order', () => {
+    const baseTime = Date.now();
+    publishMessage('TEST_TOPIC', 'first-message', baseTime);
+    publishMessage('TEST_TOPIC', 'second-message', baseTime + 10);
+    publishMessage('TEST_TOPIC', 'third-message', baseTime + 20);
+
+    const worker = createWorker({
+      sources: [{ topic: 'TEST_TOPIC', amount: 2, strategy: 'latest' }],
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 30));
+
+    assert(!context.includes('first-message'), 'Should not include oldest message');
+    assert(context.includes('second-message'), 'Should include second message');
+    assert(context.includes('third-message'), 'Should include latest message');
+    assert(
+      context.indexOf('second-message') < context.indexOf('third-message'),
+      'Latest messages should render in chronological order'
+    );
+  });
+
+  it('selects oldest messages in chronological order', () => {
+    const baseTime = Date.now();
+    publishMessage('TEST_TOPIC', 'alpha-message', baseTime);
+    publishMessage('TEST_TOPIC', 'beta-message', baseTime + 10);
+    publishMessage('TEST_TOPIC', 'gamma-message', baseTime + 20);
+
+    const worker = createWorker({
+      sources: [{ topic: 'TEST_TOPIC', amount: 2, strategy: 'oldest' }],
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 30));
+
+    assert(context.includes('alpha-message'), 'Should include oldest message');
+    assert(context.includes('beta-message'), 'Should include second message');
+    assert(!context.includes('gamma-message'), 'Should not include latest message');
+    assert(
+      context.indexOf('alpha-message') < context.indexOf('beta-message'),
+      'Oldest messages should render in chronological order'
+    );
+  });
+
+  it('selects all messages in chronological order', () => {
+    const baseTime = Date.now();
+    publishMessage('TEST_TOPIC', 'one-message', baseTime);
+    publishMessage('TEST_TOPIC', 'two-message', baseTime + 10);
+    publishMessage('TEST_TOPIC', 'three-message', baseTime + 20);
+
+    const worker = createWorker({
+      sources: [{ topic: 'TEST_TOPIC', strategy: 'all' }],
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 30));
+
+    assert(context.includes('one-message'), 'Should include first message');
+    assert(context.includes('two-message'), 'Should include second message');
+    assert(context.includes('three-message'), 'Should include third message');
+    assert(
+      context.indexOf('one-message') < context.indexOf('two-message'),
+      'All messages should render in chronological order'
+    );
+    assert(
+      context.indexOf('two-message') < context.indexOf('three-message'),
+      'All messages should render in chronological order'
+    );
+  });
+
+  it('uses limit as amount alias with latest default', () => {
+    const baseTime = Date.now();
+    publishMessage('TEST_TOPIC', 'old-message', baseTime);
+    publishMessage('TEST_TOPIC', 'newer-message', baseTime + 10);
+
+    const worker = createWorker({
+      sources: [{ topic: 'TEST_TOPIC', limit: 1 }],
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 20));
+
+    assert(!context.includes('old-message'), 'Should not include older message');
+    assert(context.includes('newer-message'), 'Should include latest message');
+  });
+
+  it('prefers amount when both amount and limit are set', () => {
+    const baseTime = Date.now();
+    publishMessage('TEST_TOPIC', 'older-message', baseTime);
+    publishMessage('TEST_TOPIC', 'newest-message', baseTime + 10);
+
+    const worker = createWorker({
+      sources: [{ topic: 'TEST_TOPIC', amount: 1, limit: 2, strategy: 'latest' }],
+    });
+
+    const context = worker._buildContext(buildTriggeringMessage(baseTime + 20));
+
+    assert(!context.includes('older-message'), 'Should honor amount over limit');
+    assert(context.includes('newest-message'), 'Should include latest message');
+  });
+});

--- a/tests/integration/context-metrics.test.js
+++ b/tests/integration/context-metrics.test.js
@@ -1,0 +1,133 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Ledger = require('../../src/ledger');
+const MessageBus = require('../../src/message-bus');
+const { buildContext } = require('../../src/agent/agent-context-builder');
+
+const MAX_CONTEXT_CHARS = 500000;
+
+describe('Context Metrics Integration', function () {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let originalMetricsEnv;
+  let originalLedgerEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-context-metrics-'));
+    const dbPath = path.join(tempDir, 'test-ledger.db');
+    ledger = new Ledger(dbPath);
+    messageBus = new MessageBus(ledger);
+
+    originalMetricsEnv = process.env.ZEROSHOT_CONTEXT_METRICS;
+    originalLedgerEnv = process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER;
+    process.env.ZEROSHOT_CONTEXT_METRICS = '0';
+    process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER = '1';
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    if (originalMetricsEnv === undefined) {
+      delete process.env.ZEROSHOT_CONTEXT_METRICS;
+    } else {
+      process.env.ZEROSHOT_CONTEXT_METRICS = originalMetricsEnv;
+    }
+
+    if (originalLedgerEnv === undefined) {
+      delete process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER;
+    } else {
+      process.env.ZEROSHOT_CONTEXT_METRICS_LEDGER = originalLedgerEnv;
+    }
+  });
+
+  it('publishes metrics to the ledger and records truncation stages', function () {
+    const clusterId = 'cluster-metrics-1';
+    const createdAt = Date.now() - 60000;
+    const secretMarker = 'SECRET_CONTEXT_PAYLOAD';
+    const hugeText = `${secretMarker}${'x'.repeat(MAX_CONTEXT_CHARS + 200000)}`;
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'user',
+      content: { text: hugeText },
+    });
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'HUGE_TOPIC',
+      sender: 'tester',
+      content: { text: 'optional-context' },
+    });
+
+    const context = buildContext({
+      id: 'worker',
+      role: 'implementation',
+      iteration: 1,
+      config: {
+        contextStrategy: {
+          sources: [
+            { topic: 'ISSUE_OPENED', since: 'cluster_start', limit: 1 },
+            { topic: 'HUGE_TOPIC', since: 'cluster_start', limit: 1 },
+          ],
+          maxTokens: 1,
+        },
+      },
+      messageBus,
+      cluster: { id: clusterId, createdAt },
+      triggeringMessage: {
+        topic: 'TASK_READY',
+        sender: 'planner',
+        content: { text: 'go' },
+      },
+    });
+
+    assert.ok(context.length > 0, 'Context should be generated');
+
+    const metricsMessages = ledger.query({ cluster_id: clusterId, topic: 'CONTEXT_METRICS' });
+    assert.strictEqual(metricsMessages.length, 1, 'Should publish one CONTEXT_METRICS message');
+
+    const metrics = metricsMessages[0].content.data;
+    assert.strictEqual(metrics.clusterId, clusterId);
+    assert.strictEqual(metrics.agentId, 'worker');
+    assert.strictEqual(metrics.role, 'implementation');
+    assert.strictEqual(metrics.iteration, 1);
+    assert.strictEqual(metrics.strategy.maxTokens, 1);
+    assert.strictEqual(metrics.strategy.sourcesCount, 2);
+
+    assert.strictEqual(metrics.truncation.maxContextChars.applied, true);
+    assert.ok(
+      metrics.truncation.maxContextChars.beforeChars >
+        metrics.truncation.maxContextChars.afterChars,
+      'Max context truncation should reduce size'
+    );
+    assert.ok(
+      metrics.truncation.maxContextChars.afterChars <= MAX_CONTEXT_CHARS,
+      'Final context should respect max char limit'
+    );
+    assert.strictEqual(metrics.budget.maxTokens, 1);
+    assert.strictEqual(metrics.total.chars, context.length);
+
+    const metricsJson = JSON.stringify(metrics);
+    assert.ok(!metricsJson.includes(secretMarker), 'Metrics should not include raw context');
+    assert.ok(metrics.sections.sources.chars > 0, 'Sources section should be counted');
+    assert.ok(
+      metrics.packs.some(
+        (pack) => pack.id.startsWith('source:ISSUE_OPENED') && pack.status === 'included'
+      ),
+      'Required issue pack should be included'
+    );
+    assert.ok(
+      metrics.packs.some(
+        (pack) => pack.id.startsWith('source:HUGE_TOPIC') && pack.status === 'skipped'
+      ),
+      'Optional pack should be skipped when over budget'
+    );
+  });
+});

--- a/tests/state-snapshot.test.js
+++ b/tests/state-snapshot.test.js
@@ -1,0 +1,381 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Orchestrator = require('../src/orchestrator');
+const Ledger = require('../src/ledger');
+const MessageBus = require('../src/message-bus');
+const StateSnapshotter = require('../src/state-snapshotter');
+const MockTaskRunner = require('./helpers/mock-task-runner');
+const {
+  initStateFromIssue,
+  applyPlanReady,
+  applyWorkerProgress,
+  applyValidationResult,
+  applyInvestigationComplete,
+} = require('../src/state-snapshot');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-snapshot-'));
+}
+
+function cleanupTempDir(dir) {
+  if (dir && fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function buildMessage({ clusterId, topic, sender, content }) {
+  return {
+    id: `msg_${Math.random().toString(16).slice(2)}`,
+    timestamp: Date.now(),
+    cluster_id: clusterId,
+    topic,
+    sender,
+    receiver: 'broadcast',
+    content,
+  };
+}
+
+async function waitForClusterState(orchestrator, clusterId, target, timeoutMs = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const status = orchestrator.getStatus(clusterId);
+      if (status.state === target) {
+        return;
+      }
+    } catch {
+      // Cluster may be removed during shutdown
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Cluster ${clusterId} did not reach ${target} within ${timeoutMs}ms`);
+}
+
+describe('State snapshot builder', () => {
+  it('should replace plan text and criteria on PLAN_READY', () => {
+    const clusterId = 'cluster-plan';
+    const issueMessage = buildMessage({
+      clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Fix login bug', data: { title: 'Login bug', issue_number: 133 } },
+    });
+
+    let state = initStateFromIssue(issueMessage);
+
+    state = applyPlanReady(
+      state,
+      buildMessage({
+        clusterId,
+        topic: 'PLAN_READY',
+        sender: 'planner',
+        content: {
+          text: 'Plan v1',
+          data: {
+            summary: 'Old plan',
+            acceptanceCriteria: [{ id: 'AC1', criterion: 'Old criteria', priority: 'MUST' }],
+            filesAffected: ['old.js'],
+          },
+        },
+      })
+    );
+
+    state = applyPlanReady(
+      state,
+      buildMessage({
+        clusterId,
+        topic: 'PLAN_READY',
+        sender: 'planner',
+        content: {
+          text: 'Plan v2',
+          data: {
+            summary: 'New plan',
+            acceptanceCriteria: [{ id: 'AC1', criterion: 'New criteria', priority: 'MUST' }],
+            filesAffected: ['new.js'],
+          },
+        },
+      })
+    );
+
+    assert.strictEqual(state.plan.text, 'Plan v2');
+    assert.deepStrictEqual(state.plan.acceptanceCriteria, ['AC1 (MUST): New criteria']);
+    assert.deepStrictEqual(state.plan.filesAffected, ['new.js']);
+  });
+
+  it('should update progress fields from WORKER_PROGRESS', () => {
+    const clusterId = 'cluster-progress';
+    const issueMessage = buildMessage({
+      clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Add endpoint', data: { title: 'Add endpoint' } },
+    });
+
+    let state = initStateFromIssue(issueMessage);
+    state = applyWorkerProgress(
+      state,
+      buildMessage({
+        clusterId,
+        topic: 'WORKER_PROGRESS',
+        sender: 'worker',
+        content: {
+          text: 'WIP',
+          data: {
+            completionStatus: {
+              canValidate: false,
+              percentComplete: 45,
+              nextSteps: ['Write tests', 'Run lint'],
+            },
+          },
+        },
+      })
+    );
+
+    assert.strictEqual(state.progress.percentComplete, 45);
+    assert.deepStrictEqual(state.progress.nextSteps, ['Write tests', 'Run lint']);
+  });
+
+  it('should update validation approval and errors', () => {
+    const clusterId = 'cluster-validation';
+    const issueMessage = buildMessage({
+      clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Fix build', data: { title: 'Build fix' } },
+    });
+
+    let state = initStateFromIssue(issueMessage);
+    state = applyValidationResult(
+      state,
+      buildMessage({
+        clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator',
+        content: {
+          data: {
+            approved: false,
+            errors: ['Missing tests', 'Type error'],
+          },
+        },
+      })
+    );
+
+    assert.strictEqual(state.validation.approved, false);
+    assert.deepStrictEqual(state.validation.errors, ['Missing tests', 'Type error']);
+  });
+
+  it('should update debug fields from INVESTIGATION_COMPLETE', () => {
+    const clusterId = 'cluster-debug';
+    const issueMessage = buildMessage({
+      clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Debug failure', data: { title: 'Debug issue' } },
+    });
+
+    let state = initStateFromIssue(issueMessage);
+    state = applyInvestigationComplete(
+      state,
+      buildMessage({
+        clusterId,
+        topic: 'INVESTIGATION_COMPLETE',
+        sender: 'investigator',
+        content: {
+          text: 'Apply guard clauses and add tests',
+          data: {
+            successCriteria: 'All tests pass',
+            rootCauses: [{ cause: 'Null input not handled' }],
+          },
+        },
+      })
+    );
+
+    assert.strictEqual(state.debug.fixPlan, 'Apply guard clauses and add tests');
+    assert.deepStrictEqual(state.debug.rootCauses, ['Null input not handled']);
+  });
+});
+
+describe('StateSnapshotter publishing', () => {
+  let tempDir;
+  let ledger;
+  let messageBus;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    ledger = new Ledger(path.join(tempDir, 'ledger.db'));
+    messageBus = new MessageBus(ledger);
+  });
+
+  afterEach(() => {
+    ledger.close();
+    cleanupTempDir(tempDir);
+  });
+
+  it('should publish STATE_SNAPSHOT on PLAN_READY and VALIDATION_RESULT', () => {
+    const clusterId = 'cluster-publish';
+    const snapshotter = new StateSnapshotter({ messageBus, clusterId });
+    snapshotter.start();
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Issue text', data: { title: 'Issue title' } },
+      metadata: { source: 'text' },
+    });
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'PLAN_READY',
+      sender: 'planner',
+      content: {
+        text: 'Plan text',
+        data: {
+          summary: 'Plan summary',
+          acceptanceCriteria: [{ id: 'AC1', criterion: 'Do thing', priority: 'MUST' }],
+        },
+      },
+    });
+
+    const planSnapshot = messageBus.findLast({ cluster_id: clusterId, topic: 'STATE_SNAPSHOT' });
+    assert.ok(planSnapshot, 'STATE_SNAPSHOT should be published');
+    assert.strictEqual(planSnapshot.content.data.plan.text, 'Plan text');
+
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: {
+        data: {
+          approved: false,
+          errors: ['Test failure'],
+        },
+      },
+    });
+
+    const validationSnapshot = messageBus.findLast({
+      cluster_id: clusterId,
+      topic: 'STATE_SNAPSHOT',
+    });
+    assert.strictEqual(validationSnapshot.content.data.validation.approved, false);
+    assert.deepStrictEqual(validationSnapshot.content.data.validation.errors, ['Test failure']);
+  });
+});
+
+describe('Snapshotter orchestration integration', () => {
+  let tempDir;
+  let orchestrator;
+  let mockRunner;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    mockRunner = new MockTaskRunner();
+  });
+
+  afterEach(() => {
+    if (orchestrator) {
+      orchestrator.close();
+    }
+    cleanupTempDir(tempDir);
+  });
+
+  it('should inject STATE_SNAPSHOT into worker context', async () => {
+    mockRunner.when('worker').returns('{"summary":"done"}');
+
+    orchestrator = new Orchestrator({
+      quiet: true,
+      storageDir: tempDir,
+      taskRunner: mockRunner,
+    });
+
+    const config = {
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          timeout: 0,
+          contextStrategy: {
+            sources: [
+              { topic: 'STATE_SNAPSHOT', priority: 'required', strategy: 'latest', amount: 1 },
+              { topic: 'ISSUE_OPENED', priority: 'required', strategy: 'latest', amount: 1 },
+            ],
+          },
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          prompt: 'Do work',
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: { topic: 'CLUSTER_COMPLETE', content: { text: 'done' } },
+            },
+          },
+        },
+        {
+          id: 'completion-detector',
+          role: 'orchestrator',
+          timeout: 0,
+          triggers: [{ topic: 'CLUSTER_COMPLETE', action: 'stop_cluster' }],
+        },
+      ],
+    };
+
+    const result = await orchestrator.start(config, { text: 'Do the thing' });
+    await waitForClusterState(orchestrator, result.id, 'stopped', 5000);
+
+    mockRunner.assertContextIncludes('worker', 'STATE_SNAPSHOT');
+  });
+
+  it('should publish STATE_SNAPSHOT when loading legacy clusters', async () => {
+    const clusterId = 'legacy-cluster';
+    const clusterDir = tempDir;
+    const dbPath = path.join(clusterDir, `${clusterId}.db`);
+
+    const ledger = new Ledger(dbPath);
+    ledger.append({
+      cluster_id: clusterId,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'Legacy issue', data: { title: 'Legacy' } },
+      metadata: { source: 'text' },
+    });
+    ledger.append({
+      cluster_id: clusterId,
+      topic: 'PLAN_READY',
+      sender: 'planner',
+      content: { text: 'Legacy plan', data: { summary: 'Legacy summary' } },
+    });
+    ledger.close();
+
+    const fixturePath = path.join(__dirname, 'fixtures', 'single-worker.json');
+    const config = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+    const clustersFile = path.join(clusterDir, 'clusters.json');
+    fs.writeFileSync(
+      clustersFile,
+      JSON.stringify(
+        {
+          [clusterId]: {
+            id: clusterId,
+            config,
+            state: 'stopped',
+            createdAt: Date.now(),
+            pid: null,
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    orchestrator = await Orchestrator.create({ storageDir: clusterDir, quiet: true });
+    const cluster = orchestrator.getCluster(clusterId);
+    const snapshot = cluster.messageBus.findLast({
+      cluster_id: clusterId,
+      topic: 'STATE_SNAPSHOT',
+    });
+
+    assert.ok(snapshot, 'STATE_SNAPSHOT should be created during load');
+    assert.strictEqual(snapshot.content.data.plan.text, 'Legacy plan');
+  });
+});

--- a/tests/two-stage-validation.test.js
+++ b/tests/two-stage-validation.test.js
@@ -1,0 +1,195 @@
+/**
+ * Tests for two-stage validation pipeline (quick → heavy)
+ */
+
+const assert = require('assert');
+const path = require('path');
+const TemplateResolver = require('../src/template-resolver');
+
+describe('Two-Stage Validation Pipeline', function () {
+  let resolver;
+
+  before(function () {
+    const templatesDir = path.join(__dirname, '..', 'cluster-templates');
+    resolver = new TemplateResolver(templatesDir);
+  });
+
+  describe('quick-validation template', function () {
+    it('should contain validator-requirements and validator-code', function () {
+      const resolved = resolver.resolve('quick-validation', {});
+      assert.ok(resolved.agents, 'Template should have agents');
+
+      const requirements = resolved.agents.find((a) => a.id === 'validator-requirements');
+      assert.ok(requirements, 'validator-requirements should exist');
+
+      const code = resolved.agents.find((a) => a.id === 'validator-code');
+      assert.ok(code, 'validator-code should exist');
+    });
+
+    it('should trigger on IMPLEMENTATION_READY', function () {
+      const resolved = resolver.resolve('quick-validation', {});
+
+      const requirements = resolved.agents.find((a) => a.id === 'validator-requirements');
+      const trigger = requirements.triggers.find((t) => t.topic === 'IMPLEMENTATION_READY');
+      assert.ok(trigger, 'validator-requirements should trigger on IMPLEMENTATION_READY');
+
+      const code = resolved.agents.find((a) => a.id === 'validator-code');
+      const codeTrigger = code.triggers.find((t) => t.topic === 'IMPLEMENTATION_READY');
+      assert.ok(codeTrigger, 'validator-code should trigger on IMPLEMENTATION_READY');
+    });
+
+    it('should have consensus-coordinator publishing QUICK_VALIDATION_PASSED on success', function () {
+      const resolved = resolver.resolve('quick-validation', {});
+
+      const coordinator = resolved.agents.find((a) => a.id === 'consensus-coordinator');
+      assert.ok(coordinator, 'consensus-coordinator should exist');
+
+      const hook = coordinator.hooks.onComplete;
+      assert.ok(hook, 'consensus-coordinator should have onComplete hook');
+      assert.strictEqual(hook.action, 'publish_message');
+    });
+
+    it('should publish VALIDATION_RESULT if any validator rejects', function () {
+      const resolved = resolver.resolve('quick-validation', {});
+
+      const coordinator = resolved.agents.find((a) => a.id === 'consensus-coordinator');
+      const logicScript = coordinator.triggers.find((t) => t.logic)?.logic?.script;
+
+      assert.ok(logicScript, 'consensus-coordinator should have logic script');
+      assert.ok(
+        logicScript.includes('VALIDATION_RESULT'),
+        'Logic should publish VALIDATION_RESULT on rejection'
+      );
+    });
+  });
+
+  describe('heavy-validation template', function () {
+    it('should contain validator-security and validator-tester', function () {
+      const resolved = resolver.resolve('heavy-validation', {});
+      assert.ok(resolved.agents, 'Template should have agents');
+
+      const security = resolved.agents.find((a) => a.id === 'validator-security');
+      assert.ok(security, 'validator-security should exist');
+
+      const tester = resolved.agents.find((a) => a.id === 'validator-tester');
+      assert.ok(tester, 'validator-tester should exist');
+    });
+
+    it('should trigger on QUICK_VALIDATION_PASSED', function () {
+      const resolved = resolver.resolve('heavy-validation', {});
+
+      const security = resolved.agents.find((a) => a.id === 'validator-security');
+      const trigger = security.triggers.find((t) => t.topic === 'QUICK_VALIDATION_PASSED');
+      assert.ok(trigger, 'validator-security should trigger on QUICK_VALIDATION_PASSED');
+
+      const tester = resolved.agents.find((a) => a.id === 'validator-tester');
+      const testerTrigger = tester.triggers.find((t) => t.topic === 'QUICK_VALIDATION_PASSED');
+      assert.ok(testerTrigger, 'validator-tester should trigger on QUICK_VALIDATION_PASSED');
+    });
+
+    it('should have consensus-coordinator publishing VALIDATION_RESULT', function () {
+      const resolved = resolver.resolve('heavy-validation', {});
+
+      const coordinator = resolved.agents.find((a) => a.id === 'consensus-coordinator');
+      assert.ok(coordinator, 'consensus-coordinator should exist');
+
+      const hook = coordinator.hooks.onComplete;
+      assert.ok(hook, 'consensus-coordinator should have onComplete hook');
+      assert.strictEqual(hook.action, 'publish_message');
+
+      const logicScript = coordinator.triggers.find((t) => t.logic)?.logic?.script;
+      assert.ok(
+        logicScript.includes('VALIDATION_RESULT'),
+        'Logic should publish VALIDATION_RESULT'
+      );
+    });
+
+    it('should have contextStrategy for QUICK_VALIDATION_PASSED', function () {
+      const resolved = resolver.resolve('heavy-validation', {});
+
+      const security = resolved.agents.find((a) => a.id === 'validator-security');
+      const contextSource = security.contextStrategy?.sources?.find(
+        (s) => s.topic === 'QUICK_VALIDATION_PASSED'
+      );
+
+      assert.ok(contextSource, 'validator-security should have QUICK_VALIDATION_PASSED context');
+      assert.strictEqual(contextSource.priority, 'required');
+    });
+  });
+
+  describe('full-workflow integration', function () {
+    it('should load meta-coordinator for CRITICAL tasks', function () {
+      const resolved = resolver.resolve('full-workflow', {
+        task_type: 'TASK',
+        complexity: 'CRITICAL',
+        max_tokens: 150000,
+        max_iterations: 25,
+        planner_level: 'level3',
+        worker_level: 'level2',
+        validator_level: 'level2',
+        validator_count: 0,
+      });
+
+      const metaCoordinator = resolved.agents.find((a) => a.id === 'meta-coordinator');
+      assert.ok(metaCoordinator, 'meta-coordinator should be present for CRITICAL tasks');
+
+      // Inline validators should be filtered out
+      const validators = resolved.agents.filter((a) => a.role === 'validator');
+      assert.strictEqual(validators.length, 0, 'No inline validators for CRITICAL tasks');
+    });
+
+    it('should NOT load meta-coordinator for STANDARD tasks', function () {
+      const resolved = resolver.resolve('full-workflow', {
+        task_type: 'TASK',
+        complexity: 'STANDARD',
+        max_tokens: 100000,
+        max_iterations: 25,
+        planner_level: 'level2',
+        worker_level: 'level2',
+        validator_level: 'level2',
+        validator_count: 2,
+      });
+
+      const metaCoordinator = resolved.agents.find((a) => a.id === 'meta-coordinator');
+      assert.ok(!metaCoordinator, 'meta-coordinator should NOT be present for STANDARD tasks');
+
+      // Inline validators should be present
+      const validators = resolved.agents.filter((a) => a.role === 'validator');
+      assert.strictEqual(validators.length, 2, 'STANDARD tasks should have 2 inline validators');
+    });
+  });
+
+  describe('Sequential execution order', function () {
+    it('Stage 2 cannot trigger without QUICK_VALIDATION_PASSED', function () {
+      const heavyResolved = resolver.resolve('heavy-validation', {});
+
+      // Heavy validators ONLY trigger on QUICK_VALIDATION_PASSED
+      const heavySecurity = heavyResolved.agents.find((a) => a.id === 'validator-security');
+      const triggers = heavySecurity.triggers.filter((t) => t.topic !== 'QUICK_VALIDATION_PASSED');
+
+      assert.strictEqual(
+        triggers.length,
+        0,
+        'Heavy validators should ONLY trigger on QUICK_VALIDATION_PASSED'
+      );
+    });
+
+    it('Consensus-coordinator publishes VALIDATION_RESULT, not QUICK_VALIDATION_PASSED on rejection', function () {
+      const resolved = resolver.resolve('quick-validation', {});
+
+      const coordinator = resolved.agents.find((a) => a.id === 'consensus-coordinator');
+      const hookLogic = coordinator.hooks.onComplete?.logic?.script;
+
+      assert.ok(hookLogic, 'consensus-coordinator should have hook logic script');
+      assert.ok(
+        hookLogic.includes('!result.allApproved') ||
+          hookLogic.includes('result.approved === false'),
+        'Logic should check for rejections'
+      );
+      assert.ok(
+        hookLogic.includes('VALIDATION_RESULT'),
+        'Should publish VALIDATION_RESULT on rejection (skips QUICK_VALIDATION_PASSED)'
+      );
+    });
+  });
+});

--- a/tests/unit/claude-fatal-error-detection.test.js
+++ b/tests/unit/claude-fatal-error-detection.test.js
@@ -1,0 +1,48 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+function loadRecoveryModule() {
+  const modulePath = path.resolve(__dirname, '../../task-lib/claude-recovery.js');
+  return import(pathToFileURL(modulePath).href);
+}
+
+describe('Claude fatal error detection', () => {
+  it('detects "No messages returned" in error output', async () => {
+    const { detectFatalClaudeError, NO_MESSAGES_RETURNED } = await loadRecoveryModule();
+    const line = 'Error: No messages returned';
+
+    const detected = detectFatalClaudeError(line);
+
+    expect(detected).to.equal(`Claude CLI error: ${NO_MESSAGES_RETURNED}`);
+  });
+
+  it('is case-insensitive', async () => {
+    const { detectFatalClaudeError, NO_MESSAGES_RETURNED } = await loadRecoveryModule();
+    const line = 'error: NO MESSAGES RETURNED';
+
+    const detected = detectFatalClaudeError(line);
+
+    expect(detected).to.equal(`Claude CLI error: ${NO_MESSAGES_RETURNED}`);
+  });
+
+  it('returns null for unrelated output', async () => {
+    const { detectFatalClaudeError } = await loadRecoveryModule();
+
+    expect(detectFatalClaudeError('All good')).to.equal(null);
+    expect(detectFatalClaudeError('')).to.equal(null);
+  });
+
+  it('does not flag valid JSON output that contains the message', async () => {
+    const { detectFatalClaudeError } = await loadRecoveryModule();
+    const jsonLine = JSON.stringify({
+      type: 'result',
+      structured_output: {
+        summary: 'No messages returned in issue description',
+      },
+    });
+
+    expect(detectFatalClaudeError(jsonLine)).to.equal(null);
+  });
+});

--- a/tests/unit/cli-provider-override.test.js
+++ b/tests/unit/cli-provider-override.test.js
@@ -1,0 +1,74 @@
+/**
+ * Test: CLI Provider Override
+ *
+ * Verifies that provider override is only applied when explicitly set
+ * via --provider or ZEROSHOT_PROVIDER.
+ */
+
+const assert = require('assert');
+
+function normalizeProviderName(name) {
+  if (!name || typeof name !== 'string') return name;
+  const normalized = name.toLowerCase();
+  if (normalized === 'anthropic') return 'claude';
+  if (normalized === 'openai') return 'codex';
+  if (normalized === 'google') return 'gemini';
+  return normalized;
+}
+
+// Mirrors resolveProviderOverride in cli/index.js
+function resolveProviderOverride(options) {
+  const override = options.provider || process.env.ZEROSHOT_PROVIDER;
+  if (!override || (typeof override === 'string' && !override.trim())) {
+    return null;
+  }
+  return normalizeProviderName(override);
+}
+
+describe('CLI Provider Override', function () {
+  const originalEnv = process.env.ZEROSHOT_PROVIDER;
+
+  afterEach(function () {
+    if (originalEnv === undefined) {
+      delete process.env.ZEROSHOT_PROVIDER;
+    } else {
+      process.env.ZEROSHOT_PROVIDER = originalEnv;
+    }
+  });
+
+  it('returns null when no override is set', function () {
+    delete process.env.ZEROSHOT_PROVIDER;
+    const result = resolveProviderOverride({});
+    assert.strictEqual(result, null);
+  });
+
+  it('uses --provider when provided', function () {
+    delete process.env.ZEROSHOT_PROVIDER;
+    const result = resolveProviderOverride({ provider: 'claude' });
+    assert.strictEqual(result, 'claude');
+  });
+
+  it('normalizes provider aliases', function () {
+    delete process.env.ZEROSHOT_PROVIDER;
+    const result = resolveProviderOverride({ provider: 'Anthropic' });
+    assert.strictEqual(result, 'claude');
+  });
+
+  it('uses ZEROSHOT_PROVIDER when --provider is missing', function () {
+    process.env.ZEROSHOT_PROVIDER = 'codex';
+    const result = resolveProviderOverride({});
+    assert.strictEqual(result, 'codex');
+  });
+
+  it('ignores empty ZEROSHOT_PROVIDER', function () {
+    process.env.ZEROSHOT_PROVIDER = '   ';
+    const result = resolveProviderOverride({});
+    assert.strictEqual(result, null);
+  });
+
+  it('prefers --provider over ZEROSHOT_PROVIDER', function () {
+    process.env.ZEROSHOT_PROVIDER = 'gemini';
+    const result = resolveProviderOverride({ provider: 'claude' });
+    assert.strictEqual(result, 'claude');
+  });
+});

--- a/tests/unit/cli-resume-loads-clusters.test.js
+++ b/tests/unit/cli-resume-loads-clusters.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('CLI resume command', function () {
+  it('should load clusters before checking for a task fallback', function () {
+    const cliPath = path.join(__dirname, '..', '..', 'cli', 'index.js');
+    const cliCode = fs.readFileSync(cliPath, 'utf8');
+
+    const resumeStart = cliCode.indexOf(".command('resume");
+    assert(resumeStart !== -1, 'resume command not found in cli/index.js');
+
+    const resumeEnd = cliCode.indexOf(".command('finish", resumeStart);
+    const resumeBlock = cliCode.slice(resumeStart, resumeEnd === -1 ? cliCode.length : resumeEnd);
+
+    const usesCreate =
+      resumeBlock.includes('OrchestratorModule.create') || resumeBlock.includes('getOrchestrator(');
+
+    assert(
+      usesCreate,
+      'resume command should load clusters via Orchestrator.create or getOrchestrator'
+    );
+  });
+});

--- a/tests/unit/context-metrics.test.js
+++ b/tests/unit/context-metrics.test.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+const { buildContextMetrics, estimateTokensFromChars } = require('../../src/agent/context-metrics');
+
+describe('Context Metrics', function () {
+  it('estimates tokens using ceil(chars / 4)', function () {
+    assert.strictEqual(estimateTokensFromChars(0), 0);
+    assert.strictEqual(estimateTokensFromChars(1), 1);
+    assert.strictEqual(estimateTokensFromChars(4), 1);
+    assert.strictEqual(estimateTokensFromChars(5), 2);
+  });
+
+  it('builds section breakdown with totals', function () {
+    const metrics = buildContextMetrics({
+      clusterId: 'cluster-1',
+      agentId: 'agent-1',
+      role: 'worker',
+      iteration: 2,
+      triggeringMessage: { topic: 'TASK', sender: 'user' },
+      strategy: { sources: [{ topic: 'A' }, { topic: 'B' }], maxTokens: 10 },
+      packs: [
+        { id: 'header', section: 'header', status: 'included', chars: 4, estimatedTokens: 1 },
+        {
+          id: 'instructions',
+          section: 'instructions',
+          status: 'included',
+          chars: 5,
+          estimatedTokens: 2,
+        },
+        {
+          id: 'jsonSchema',
+          section: 'jsonSchema',
+          status: 'included',
+          chars: 2,
+          estimatedTokens: 1,
+        },
+        {
+          id: 'validatorSkip',
+          section: 'validatorSkip',
+          status: 'included',
+          chars: 1,
+          estimatedTokens: 1,
+        },
+        {
+          id: 'triggeringMessage',
+          section: 'triggeringMessage',
+          status: 'included',
+          chars: 1,
+          estimatedTokens: 1,
+        },
+        {
+          id: 'sources-a',
+          section: 'sources',
+          status: 'included',
+          chars: 3,
+          estimatedTokens: 1,
+        },
+        {
+          id: 'sources-skipped',
+          section: 'sources',
+          status: 'skipped',
+          chars: 100,
+          estimatedTokens: 25,
+        },
+      ],
+      budget: {
+        maxTokens: 10,
+        remainingTokens: 2,
+        overBudgetTokens: 0,
+        finalTokens: 6,
+      },
+    });
+
+    assert.strictEqual(metrics.sections.header.chars, 4);
+    assert.strictEqual(metrics.sections.header.estimatedTokens, 1);
+    assert.strictEqual(metrics.sections.instructions.chars, 5);
+    assert.strictEqual(metrics.sections.instructions.estimatedTokens, 2);
+    assert.strictEqual(metrics.sections.jsonSchema.chars, 2);
+    assert.strictEqual(metrics.sections.validatorSkip.chars, 1);
+    assert.strictEqual(metrics.sections.triggeringMessage.chars, 1);
+    assert.strictEqual(metrics.sections.sources.chars, 3);
+    assert.strictEqual(metrics.total.chars, 4 + 5 + 2 + 1 + 1 + 3);
+    assert.strictEqual(metrics.total.estimatedTokens, Math.ceil(metrics.total.chars / 4));
+
+    assert.strictEqual(metrics.strategy.maxTokens, 10);
+    assert.strictEqual(metrics.strategy.sourcesCount, 2);
+    assert.strictEqual(metrics.triggeredBy, 'TASK');
+    assert.strictEqual(metrics.triggerFrom, 'user');
+    assert.strictEqual(metrics.budget.maxTokens, 10);
+    assert.strictEqual(metrics.budget.remainingTokens, 2);
+    assert.strictEqual(metrics.truncation.maxContextChars.beforeChars, metrics.total.chars);
+  });
+
+  it('defaults maxTokens when not provided', function () {
+    const metrics = buildContextMetrics({
+      clusterId: 'cluster-1',
+      agentId: 'agent-1',
+      role: 'worker',
+      iteration: 1,
+      triggeringMessage: { topic: 'TASK', sender: 'user' },
+      strategy: { sources: [] },
+      packs: [{ id: 'header', section: 'header', status: 'included', chars: 1 }],
+    });
+
+    assert.strictEqual(metrics.strategy.maxTokens, 100000);
+    assert.strictEqual(metrics.budget.maxTokens, 100000);
+  });
+});

--- a/tests/unit/output-extraction-fatal-strings.test.js
+++ b/tests/unit/output-extraction-fatal-strings.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const {
+  extractJsonFromOutput,
+  hasFatalStandaloneOutput,
+} = require('../../src/agent/output-extraction');
+
+describe('Output Extraction - fatal strings handling', () => {
+  it('extracts JSON when fatal substrings appear inside JSON events', () => {
+    const output = [
+      '{"type":"item.completed","item":{"id":"item_1","type":"command_execution","aggregated_output":"Task not found"}}',
+      '{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"{\\"summary\\":\\"ok\\",\\"completionStatus\\":{\\"canValidate\\":true,\\"percentComplete\\":100}}"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}',
+    ].join('\n');
+
+    const parsed = extractJsonFromOutput(output, 'codex');
+
+    assert.deepStrictEqual(parsed, {
+      summary: 'ok',
+      completionStatus: {
+        canValidate: true,
+        percentComplete: 100,
+      },
+    });
+  });
+
+  it('detects standalone fatal output lines', () => {
+    const output = 'Task not found\n';
+    assert.strictEqual(hasFatalStandaloneOutput(output), true);
+  });
+});

--- a/tests/validation-platform.test.js
+++ b/tests/validation-platform.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const {
+  isPlatformMismatchReason,
+  findPlatformMismatchReason,
+} = require('../src/agent/validation-platform');
+
+describe('Validation platform mismatch detection', function () {
+  it('detects platform mismatch from reason strings', function () {
+    assert.ok(isPlatformMismatchReason('EBADPLATFORM @esbuild/linux-x64'));
+    assert.ok(isPlatformMismatchReason('Unsupported platform for @esbuild/linux-x64'));
+    assert.ok(isPlatformMismatchReason('darwin-arm64 vs linux-x64'));
+    assert.ok(!isPlatformMismatchReason('kubectl not installed'));
+  });
+
+  it('finds platform mismatch in criteriaResults', function () {
+    const result = {
+      criteriaResults: [
+        { id: 'AC1', status: 'PASS' },
+        {
+          id: 'AC2',
+          status: 'CANNOT_VALIDATE',
+          reason: 'npm install fails on darwin-arm64 (EBADPLATFORM for @esbuild/linux-x64)',
+        },
+      ],
+    };
+
+    const reason = findPlatformMismatchReason(result);
+    assert.ok(reason, 'Should return a platform mismatch reason');
+    assert.ok(reason.includes('EBADPLATFORM'), 'Should keep original reason');
+  });
+
+  it('finds platform mismatch in errors array', function () {
+    const result = {
+      errors: ['EBADPLATFORM for @esbuild/linux-x64'],
+    };
+
+    const reason = findPlatformMismatchReason(result);
+    assert.ok(reason, 'Should return a platform mismatch reason');
+  });
+
+  it('returns null when no mismatch found', function () {
+    const result = {
+      criteriaResults: [{ id: 'AC1', status: 'CANNOT_VALIDATE', reason: 'kubectl not installed' }],
+      errors: ['No SSH access'],
+    };
+
+    assert.strictEqual(findPlatformMismatchReason(result), null);
+  });
+});


### PR DESCRIPTION
## Problem

Zombie zeroshot processes remained after heroshot shipped PRs, blocking new agent spawns.

## Root Cause

When CLUSTER_COMPLETE triggers `orchestrator.stop()`, the cluster state changes to 'stopped' but no SIGTERM is sent. The cleanup handlers registered via `process.on('SIGTERM')` are never triggered.

## Fix

Added polling in `setupDaemonCleanup()` to detect when cluster state changes to 'stopped' or 'completed', then exit the process.

## Testing

The fix was triggered by a heroshot run where 3 zombie processes from already-shipped items (#1159, #1168) were blocking new spawns.