### PR TITLE
fix: auto-upgrade models below minLevel/minModel floor instead of crashing

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -49,13 +49,16 @@ const MODEL_HIERARCHY = {
 const VALID_MODELS = Object.keys(MODEL_HIERARCHY);
 const LEVEL_RANKS = { level1: 1, level2: 2, level3: 3 };
 
+// Track warned upgrades to avoid log spam (warn once per unique upgrade)
+const _warnedModelUpgrades = new Set();
+
 /**
  * Validate a requested model against the maxModel ceiling and minModel floor
  * @param {string} requestedModel - Model the agent wants to use
  * @param {string} maxModel - Maximum allowed model (cost ceiling)
  * @param {string|null} minModel - Minimum required model (cost floor)
- * @returns {string} The validated model
- * @throws {Error} If requested model exceeds ceiling or falls below floor
+ * @returns {string} The validated model (auto-upgraded if below minModel floor)
+ * @throws {Error} If requested model exceeds ceiling or has invalid values
  */
 function validateModelAgainstMax(requestedModel, maxModel, minModel = null) {
   if (!requestedModel) return maxModel; // Default to ceiling if unspecified
@@ -82,10 +85,16 @@ function validateModelAgainstMax(requestedModel, maxModel, minModel = null) {
       throw new Error(`minModel "${minModel}" cannot be higher than maxModel "${maxModel}".`);
     }
     if (MODEL_HIERARCHY[requestedModel] < MODEL_HIERARCHY[minModel]) {
-      throw new Error(
-        `Agent requests "${requestedModel}" but minModel is "${minModel}". ` +
-          `Either raise agent's model or lower minModel.`
-      );
+      // Auto-upgrade to meet minModel floor (fix for issue #162)
+      // Warn once per unique upgrade to avoid log spam
+      const upgradeKey = `${requestedModel}→${minModel}`;
+      if (!_warnedModelUpgrades.has(upgradeKey)) {
+        _warnedModelUpgrades.add(upgradeKey);
+        console.warn(
+          `[zeroshot] Model auto-upgrade: "${requestedModel}" → "${minModel}" (minModel floor)`
+        );
+      }
+      return minModel;
     }
   }
 

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -569,13 +569,39 @@ class AgentWrapper {
 
   /**
    * Get current agent state
+   * Note: Uses defensive try-catch for model resolution to prevent crashes
+   * during read-only operations (e.g., `zeroshot logs`) when minLevel
+   * validation would otherwise throw. See issue #162.
    */
   getState() {
-    const modelSpec = this._resolveModelSpec();
+    let modelSpec = null;
+    let model = null;
+    try {
+      modelSpec = this._resolveModelSpec();
+      model = this._selectModel();
+    } catch (error) {
+      // Only handle expected min/max level validation errors for read-only display
+      const isLevelValidation =
+        error.message?.includes('minModel') ||
+        error.message?.includes('minLevel') ||
+        error.message?.includes('maxModel') ||
+        error.message?.includes('maxLevel');
+      if (!isLevelValidation) {
+        // Unexpected error - re-throw to avoid hiding bugs
+        throw error;
+      }
+      // Use raw config values for display; include error for diagnostics
+      model = this.modelConfig?.model || this.modelConfig?.modelLevel || null;
+      modelSpec = {
+        model,
+        level: this.modelConfig?.modelLevel || 'unknown',
+        validationError: error.message,
+      };
+    }
     return {
       id: this.id,
       role: this.role,
-      model: this._selectModel(),
+      model,
       provider: this._resolveProvider(),
       modelSpec,
       state: this.state,

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -590,7 +590,10 @@ async function spawnClaudeTask(agent, context) {
 }
 
 function resolveAgentModelSpec(agent) {
-  return agent._resolveModelSpec ? agent._resolveModelSpec() : { model: agent._selectModel() };
+  const spec = agent._resolveModelSpec ? agent._resolveModelSpec() : { model: null };
+  // Use _selectModel() to get the validated/upgraded model (applies minModel/maxModel bounds)
+  const validatedModel = agent._selectModel();
+  return { ...spec, model: validatedModel };
 }
 
 function resolveOutputFormatConfig(agent) {

--- a/src/providers/base-provider.js
+++ b/src/providers/base-provider.js
@@ -1,3 +1,6 @@
+// Track warned level upgrades to avoid log spam (warn once per unique upgrade)
+const _warnedLevelUpgrades = new Set();
+
 /**
  * BaseProvider - Abstract provider interface
  *
@@ -254,9 +257,16 @@ class BaseProvider {
     }
 
     if (minLevel && rank(level) < rank(minLevel)) {
-      throw new Error(
-        `Level "${level}" is below minLevel "${minLevel}" for provider "${this.name}"`
-      );
+      // Auto-upgrade to meet minLevel floor (fix for issue #162)
+      // Warn once per unique upgrade to avoid log spam
+      const upgradeKey = `${this.name}:${level}→${minLevel}`;
+      if (!_warnedLevelUpgrades.has(upgradeKey)) {
+        _warnedLevelUpgrades.add(upgradeKey);
+        console.warn(
+          `[zeroshot] Level auto-upgrade: "${level}" → "${minLevel}" for provider "${this.name}" (minLevel floor)`
+        );
+      }
+      return minLevel;
     }
 
     return level;

--- a/tests/max-model.test.js
+++ b/tests/max-model.test.js
@@ -319,6 +319,36 @@ function registerModelHierarchyValidationTests() {
         /Agent requests "opus" but maxModel is "sonnet"/
       );
     });
+
+    it('should auto-upgrade when requested is below minModel floor', function () {
+      // haiku < sonnet (minModel), should auto-upgrade to sonnet
+      const result = settingsModule.validateModelAgainstMax('haiku', 'opus', 'sonnet');
+      assert.strictEqual(result, 'sonnet');
+    });
+
+    it('should return requested model when at or above minModel floor', function () {
+      // sonnet >= sonnet (minModel), should return as-is
+      const result = settingsModule.validateModelAgainstMax('sonnet', 'opus', 'sonnet');
+      assert.strictEqual(result, 'sonnet');
+
+      // opus > sonnet (minModel), should return as-is
+      const result2 = settingsModule.validateModelAgainstMax('opus', 'opus', 'sonnet');
+      assert.strictEqual(result2, 'opus');
+    });
+
+    it('should throw for invalid minModel', function () {
+      assert.throws(
+        () => settingsModule.validateModelAgainstMax('haiku', 'opus', 'gpt4'),
+        /Invalid minModel "gpt4"/
+      );
+    });
+
+    it('should throw when minModel exceeds maxModel', function () {
+      assert.throws(
+        () => settingsModule.validateModelAgainstMax('haiku', 'haiku', 'opus'),
+        /minModel "opus" cannot be higher than maxModel "haiku"/
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Auto-upgrade models/levels to meet floor instead of throwing errors.

## Motivation

When users set `minModel` or `minLevel` to a higher tier, agents configured with lower models (like the hardcoded `haiku` in `completion-detector`) cause validation errors and crash the cluster. This affects both cluster execution (#98) and read-only operations like `zeroshot logs` (#162).

Instead of throwing, we now auto-upgrade to the minimum required level with a warning.

Closes #162
Closes #98

## Changes

- `lib/settings.js` - auto-upgrade for minModel, warn-once logging
- `src/providers/base-provider.js` - auto-upgrade for minLevel, warn-once logging  
- `src/agent-wrapper.js` - defensive getState() for status display
- `src/agent/agent-task-executor.js` - use validated model in CLI args
- `tests/max-model.test.js` - tests for auto-upgrade behavior

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests pass locally

## Breaking Changes

None

## Checklist

- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run typecheck`)
- [ ] Documentation updated
- [ ] CLAUDE.md updated (if architecture changed)