### PR TITLE
docs(tui-v2): mark issue progress

### DIFF
--- a/docs/tui-v2/IMPLEMENTATION_PLAN.md
+++ b/docs/tui-v2/IMPLEMENTATION_PLAN.md
@@ -409,6 +409,8 @@ Status: Completed (Issue #242, closed 2026-01-31)
 
 ### Issue 4 — Cluster Listing + Summary APIs
 
+Status: Open (Issue #249)
+
 **Goal:** Expose baseline cluster discovery for Launcher/Monitor.
 
 **Scope**
@@ -427,6 +429,8 @@ Status: Completed (Issue #242, closed 2026-01-31)
 ---
 
 ### Issue 5 — Start Cluster from Text / Issue
+
+Status: Open (Issue #250)
 
 **Goal:** Enable TUI to launch clusters using existing CLI paths.
 
@@ -447,6 +451,8 @@ Status: Completed (Issue #242, closed 2026-01-31)
 ---
 
 ### Issue 6 — Log + Timeline Subscriptions
+
+Status: Open (Issue #251)
 
 **Goal:** Stream live logs and timeline events to the UI.
 


### PR DESCRIPTION
Goal: track completion and open issue status in the TUI v2 plan.

- Mark issues 1–3 as completed
- Note issues 4–6 as open