### PR TITLE
fix: use origin/${prBase} as worktree base ref when prBase is set

### DIFF
--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -1300,14 +1300,14 @@ class IsolationManager {
    * @param {string} workDir - Original working directory (must be a git repo)
    * @returns {{ path: string, branch: string, repoRoot: string }}
    */
-  createWorktreeIsolation(clusterId, workDir) {
+  createWorktreeIsolation(clusterId, workDir, options = {}) {
     if (!this._isGitRepo(workDir)) {
       throw new Error(
         `Worktree isolation requires a git repository. ${workDir} is not a git repo.`
       );
     }
 
-    const worktreeInfo = this.createWorktree(clusterId, workDir);
+    const worktreeInfo = this.createWorktree(clusterId, workDir, options);
     this.worktrees.set(clusterId, worktreeInfo);
 
     console.log(`[IsolationManager] Created worktree isolation at ${worktreeInfo.path}`);
@@ -1340,18 +1340,23 @@ class IsolationManager {
    * @param {string} workDir - Original working directory
    * @returns {{ path: string, branch: string, repoRoot: string }}
    */
-  createWorktree(clusterId, workDir) {
+  createWorktree(clusterId, workDir, options = {}) {
     const repoRoot = this._getGitRoot(workDir);
     if (!repoRoot) {
       throw new Error(`Cannot find git root for ${workDir}`);
     }
 
-    let worktreeBaseRef = null;
+    // Priority: 1) options.baseRef, 2) repo settings, 3) HEAD (default)
+    let worktreeBaseRef = options.baseRef || null;
     try {
       const repoSettingsResult = readRepoSettings(repoRoot);
       const repoSettings = repoSettingsResult.settings || {};
       const candidate = repoSettings.worktree?.baseRef;
-      if (typeof candidate === 'string' && /^[A-Za-z0-9._/-]+$/.test(candidate.trim())) {
+      if (
+        !worktreeBaseRef &&
+        typeof candidate === 'string' &&
+        /^[A-Za-z0-9._/-]+$/.test(candidate.trim())
+      ) {
         worktreeBaseRef = candidate.trim();
       }
     } catch {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1270,7 +1270,13 @@ class Orchestrator {
       const workDir = options.cwd || process.cwd();
 
       isolationManager = new IsolationManager({});
-      worktreeInfo = isolationManager.createWorktreeIsolation(clusterId, workDir);
+      // Use origin/${prBase} if prBase is set (ensures worktree is up-to-date with remote)
+      const worktreeOptions = {};
+      if (options.prBase) {
+        worktreeOptions.baseRef = `origin/${options.prBase}`;
+        this._log(`[Orchestrator] Using remote base ref: origin/${options.prBase}`);
+      }
+      worktreeInfo = isolationManager.createWorktreeIsolation(clusterId, workDir, worktreeOptions);
 
       this._log(`[Orchestrator] Starting cluster in worktree isolation mode`);
       this._log(`[Orchestrator] Worktree: ${worktreeInfo.path}`);


### PR DESCRIPTION
## Summary
When using `--pr` mode, worktrees were being created from local `HEAD` instead of the remote PR base branch. This caused PRs to be hundreds of commits behind the base branch.

## Root Cause
`isolation-manager.js` `createWorktree()` used `HEAD` as default, which could be arbitrarily behind `origin/${prBase}`.

## Fix
- Added `options.baseRef` parameter to `createWorktreeIsolation()` and `createWorktree()`
- Orchestrator now passes `origin/${prBase}` when prBase is set
- Priority: 1) options.baseRef, 2) repo settings, 3) HEAD (default)
- Auto-fetches remote branch if `origin/` prefix detected

## Test Plan
- [x] Manual test: `zeroshot run --pr --pr-base main` creates worktree from `origin/main`
- [x] Verify git log shows worktree is up-to-date with remote base

🤖 Generated with [Claude Code](https://claude.com/claude-code)