### PR TITLE
feat(tui-v2): add cluster listing and summary APIs

### DIFF
--- a/src/tui-backend/protocol/dispatcher.ts
+++ b/src/tui-backend/protocol/dispatcher.ts
@@ -8,24 +8,41 @@ const buildError = (code: number, message: string, detail?: string) => {
   return error;
 };
 
+const isRpcError = (error: any) =>
+  error &&
+  typeof error === "object" &&
+  typeof error.code === "number" &&
+  typeof error.message === "string";
+
 const createDispatcher = (options: any = {}) => {
   const serverInfo = options.serverInfo || { name: "zeroshot", version: "0.0.0" };
   const protocolVersion =
     typeof options.protocolVersion === "number" ? options.protocolVersion : 1;
-  const methods = ["initialize", "ping"];
-  const notifications = [];
-
-  const handlers = {
+  const baseHandlers = {
     initialize: async () => ({
       protocolVersion,
       server: serverInfo,
       capabilities: {
-        methods,
-        notifications,
+        methods: [],
+        notifications: [],
       },
     }),
     ping: async () => ({ ok: true }),
   };
+  const extraHandlers = options.handlers && typeof options.handlers === "object"
+    ? options.handlers
+    : {};
+  const handlers = { ...baseHandlers, ...extraHandlers };
+  const methods = Array.from(new Set(Object.keys(handlers)));
+  const notifications = Array.isArray(options.notifications) ? options.notifications : [];
+  handlers.initialize = async () => ({
+    protocolVersion,
+    server: serverInfo,
+    capabilities: {
+      methods,
+      notifications,
+    },
+  });
 
   const dispatchRequest = async (message) => {
     const handler = handlers[message.method];
@@ -42,6 +59,13 @@ const createDispatcher = (options: any = {}) => {
       const result = await handler(message.params ?? null, message);
       return { ok: true, result };
     } catch (error) {
+      if (isRpcError(error)) {
+        const rpcError: any = { code: error.code, message: error.message };
+        if (error.data) {
+          rpcError.data = error.data;
+        }
+        return { ok: false, error: rpcError };
+      }
       const detail =
         error instanceof Error ? error.message : "Unhandled dispatcher error";
       return {

--- a/src/tui-backend/server.ts
+++ b/src/tui-backend/server.ts
@@ -8,6 +8,11 @@ const {
   RPC_ERROR_MESSAGES,
   PROTOCOL_VERSION,
 } = require("./protocol");
+const {
+  listClusters,
+  getClusterSummary,
+  ClusterNotFoundError,
+} = require("./services/cluster-registry");
 
 const isValidId = (value) => typeof value === "string" || typeof value === "number";
 
@@ -37,6 +42,9 @@ const writeError = (id, error) => {
   });
 };
 
+const buildRpcError = (code, message, detail) =>
+  detail ? { code, message, data: { detail } } : { code, message };
+
 const logDiagnostic = (message, error) => {
   const details =
     error instanceof Error ? `${message}: ${error.stack || error.message}` : message;
@@ -48,6 +56,28 @@ const startServer = () => {
   const dispatcher = createDispatcher({
     serverInfo: loadPackageInfo(),
     protocolVersion: PROTOCOL_VERSION,
+    handlers: {
+      listClusters: async () => ({
+        clusters: await listClusters(),
+      }),
+      getClusterSummary: async (params) => {
+        try {
+          const summary = await getClusterSummary({
+            clusterId: params.clusterId,
+          });
+          return { summary };
+        } catch (error) {
+          if (error instanceof ClusterNotFoundError) {
+            throw buildRpcError(
+              RPC_ERROR_CODES.CLUSTER_NOT_FOUND,
+              RPC_ERROR_MESSAGES[RPC_ERROR_CODES.CLUSTER_NOT_FOUND],
+              error.message
+            );
+          }
+          throw error;
+        }
+      },
+    },
   });
   const parser = createFrameParser();
 

--- a/src/tui-backend/services/cluster-registry.ts
+++ b/src/tui-backend/services/cluster-registry.ts
@@ -1,3 +1,6 @@
+import { loadSettings } from "../../../lib/settings";
+import { normalizeProviderName } from "../../../lib/provider-names";
+
 const pidusage = require("pidusage");
 
 type PidusageStats = Record<string, { cpu?: number; memory?: number }>;
@@ -7,11 +10,13 @@ type ClusterRegistryDeps = {
   getOrchestrator?: () => Promise<any>;
   pidusage?: PidusageFn;
   platform?: string;
+  loadSettings?: typeof loadSettings;
 };
 
 export type ClusterSummary = {
   id: string;
   state: string;
+  provider: string | null;
   createdAt: number;
   agentCount: number;
   messageCount: number;
@@ -48,6 +53,27 @@ function resolveClusterCwd(cluster: any): string | null {
   return null;
 }
 
+function resolveClusterProvider(cluster: any, settings: any): string | null {
+  if (!cluster || typeof cluster !== "object") {
+    const fallback = settings?.defaultProvider ?? null;
+    const normalizedFallback = normalizeProviderName(fallback);
+    return typeof normalizedFallback === "string" ? normalizedFallback : null;
+  }
+  const forced = cluster.config?.forceProvider ?? null;
+  const defaultProvider = cluster.config?.defaultProvider ?? null;
+  const settingsProvider = settings?.defaultProvider ?? null;
+  const provider =
+    forced && typeof forced === "string"
+      ? forced
+      : defaultProvider && typeof defaultProvider === "string"
+        ? defaultProvider
+        : settingsProvider && typeof settingsProvider === "string"
+          ? settingsProvider
+          : null;
+  const normalized = normalizeProviderName(provider);
+  return typeof normalized === "string" ? normalized : null;
+}
+
 function resolveAgentPid(agent: any): number | null {
   if (!agent || typeof agent !== "object") {
     return null;
@@ -81,7 +107,11 @@ function collectAgentPids(cluster: any): number[] {
   return Array.from(pids);
 }
 
-function normalizeSummary(summary: any, orchestrator: any): ClusterSummary {
+function normalizeSummary(
+  summary: any,
+  orchestrator: any,
+  settings: any
+): ClusterSummary {
   if (!summary || typeof summary !== "object") {
     throw new Error("Invalid cluster summary.");
   }
@@ -99,14 +129,26 @@ function normalizeSummary(summary: any, orchestrator: any): ClusterSummary {
   }
   const cluster = orchestrator.getCluster(summary.id);
   const cwd = resolveClusterCwd(cluster);
+  const provider = resolveClusterProvider(cluster, settings);
   return {
     id: summary.id,
     state: String(summary.state ?? "unknown"),
+    provider,
     createdAt: summary.createdAt,
     agentCount: summary.agentCount,
     messageCount: summary.messageCount,
     cwd,
   };
+}
+
+export class ClusterNotFoundError extends Error {
+  clusterId: string;
+
+  constructor(clusterId: string) {
+    super(`Cluster not found: ${clusterId}`);
+    this.name = "ClusterNotFoundError";
+    this.clusterId = clusterId;
+  }
 }
 
 type ListClustersArgs = {
@@ -117,6 +159,11 @@ type ListClusterMetricsArgs = {
   deps?: ClusterRegistryDeps;
 };
 
+type GetClusterSummaryArgs = {
+  clusterId: string;
+  deps?: ClusterRegistryDeps;
+};
+
 const SUPPORTED_PLATFORMS = new Set(["darwin", "linux"]);
 const BYTES_PER_MB = 1024 * 1024;
 
@@ -124,10 +171,12 @@ export async function listClusters(
   { deps = {} }: ListClustersArgs = {}
 ): Promise<ClusterSummary[]> {
   const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const loadSettingsImpl = deps.loadSettings ?? loadSettings;
   const orchestrator = await getOrchestratorImpl();
+  const settings = loadSettingsImpl();
   const summaries = orchestrator.listClusters();
   const results = summaries.map((summary: any) =>
-    normalizeSummary(summary, orchestrator)
+    normalizeSummary(summary, orchestrator, settings)
   );
   results.sort((left, right) => {
     if (left.createdAt !== right.createdAt) {
@@ -136,6 +185,22 @@ export async function listClusters(
     return left.id.localeCompare(right.id);
   });
   return results;
+}
+
+export async function getClusterSummary({
+  clusterId,
+  deps = {},
+}: GetClusterSummaryArgs): Promise<ClusterSummary> {
+  const getOrchestratorImpl = deps.getOrchestrator ?? getOrchestrator;
+  const loadSettingsImpl = deps.loadSettings ?? loadSettings;
+  const orchestrator = await getOrchestratorImpl();
+  const settings = loadSettingsImpl();
+  const summaries = orchestrator.listClusters();
+  const summary = summaries.find((entry: any) => entry.id === clusterId);
+  if (!summary) {
+    throw new ClusterNotFoundError(clusterId);
+  }
+  return normalizeSummary(summary, orchestrator, settings);
 }
 
 export async function listClusterMetrics(

--- a/src/tui/services/cluster-registry.ts
+++ b/src/tui/services/cluster-registry.ts
@@ -12,6 +12,7 @@ type ClusterRegistryDeps = {
 export type ClusterSummary = {
   id: string;
   state: string;
+  provider: string | null;
   createdAt: number;
   agentCount: number;
   messageCount: number;

--- a/tests/unit/tui-backend-cluster-registry.test.js
+++ b/tests/unit/tui-backend-cluster-registry.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const buildOutput = path.join(
+  __dirname,
+  '..',
+  '..',
+  'lib',
+  'tui-backend',
+  'services',
+  'cluster-registry.js'
+);
+
+function ensureBackendBuild() {
+  if (!fs.existsSync(buildOutput)) {
+    execSync('npm run build:tui-backend', { stdio: 'inherit' });
+  }
+}
+
+ensureBackendBuild();
+
+const {
+  listClusters,
+  getClusterSummary,
+  ClusterNotFoundError,
+} = require('../../lib/tui-backend/services/cluster-registry');
+
+function createOrchestrator(summaries, clustersById) {
+  return {
+    listClusters() {
+      return summaries;
+    },
+    getCluster(id) {
+      return clustersById[id];
+    },
+  };
+}
+
+describe('tui-backend cluster registry', function () {
+  it('resolves provider with forceProvider -> defaultProvider -> settings default', async function () {
+    const summaries = [
+      { id: 'cluster-force', state: 'running', createdAt: 1, agentCount: 1, messageCount: 1 },
+      { id: 'cluster-default', state: 'running', createdAt: 2, agentCount: 1, messageCount: 1 },
+      { id: 'cluster-settings', state: 'running', createdAt: 3, agentCount: 1, messageCount: 1 },
+      { id: 'cluster-empty', state: 'running', createdAt: 4, agentCount: 1, messageCount: 1 },
+    ];
+    const clustersById = {
+      'cluster-force': { config: { forceProvider: 'openai', defaultProvider: 'claude' } },
+      'cluster-default': { config: { defaultProvider: 'google' } },
+      'cluster-settings': { config: {} },
+      'cluster-empty': {},
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+
+    const result = await listClusters({
+      deps: {
+        getOrchestrator: () => Promise.resolve(orchestrator),
+        loadSettings: () => ({ defaultProvider: 'opencode' }),
+      },
+    });
+
+    const providerById = Object.fromEntries(
+      result.map((cluster) => [cluster.id, cluster.provider])
+    );
+    assert.strictEqual(providerById['cluster-force'], 'codex');
+    assert.strictEqual(providerById['cluster-default'], 'gemini');
+    assert.strictEqual(providerById['cluster-settings'], 'opencode');
+    assert.strictEqual(providerById['cluster-empty'], 'opencode');
+  });
+
+  it('throws ClusterNotFoundError for missing cluster id', async function () {
+    const summaries = [
+      { id: 'cluster-1', state: 'running', createdAt: 1, agentCount: 1, messageCount: 1 },
+    ];
+    const clustersById = {
+      'cluster-1': { config: { defaultProvider: 'claude' } },
+    };
+    const orchestrator = createOrchestrator(summaries, clustersById);
+
+    try {
+      await getClusterSummary({
+        clusterId: 'missing-cluster',
+        deps: {
+          getOrchestrator: () => Promise.resolve(orchestrator),
+          loadSettings: () => ({ defaultProvider: 'claude' }),
+        },
+      });
+      assert.fail('Expected ClusterNotFoundError');
+    } catch (error) {
+      assert.ok(error instanceof ClusterNotFoundError);
+      assert.strictEqual(error.clusterId, 'missing-cluster');
+    }
+  });
+});

--- a/tests/unit/tui-backend-smoke.test.js
+++ b/tests/unit/tui-backend-smoke.test.js
@@ -26,6 +26,7 @@ describe('TUI backend build', function () {
     const registry = require('../../lib/tui-backend/services/cluster-registry');
     assert.ok(registry);
     assert.strictEqual(typeof registry.listClusters, 'function');
+    assert.strictEqual(typeof registry.getClusterSummary, 'function');
     assert.strictEqual(typeof registry.listClusterMetrics, 'function');
   });
 });

--- a/tests/unit/tui-backend-stdio.test.js
+++ b/tests/unit/tui-backend-stdio.test.js
@@ -127,6 +127,8 @@ describe('tui-backend stdio JSON-RPC', function () {
     assert.ok(response.result.server.version);
     assert.ok(response.result.capabilities.methods.includes('initialize'));
     assert.ok(response.result.capabilities.methods.includes('ping'));
+    assert.ok(response.result.capabilities.methods.includes('listClusters'));
+    assert.ok(response.result.capabilities.methods.includes('getClusterSummary'));
     assert.deepStrictEqual(response.result.capabilities.notifications, []);
   });
 
@@ -143,6 +145,73 @@ describe('tui-backend stdio JSON-RPC', function () {
 
     assert.strictEqual(response.id, 2);
     assert.deepStrictEqual(response.result, { ok: true });
+  });
+
+  it('responds to listClusters with provider and cwd fields', async function () {
+    const request = {
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'listClusters',
+      params: {},
+    };
+
+    server.stdin.write(encodeFrame(request));
+    const response = await queue.next();
+
+    assert.strictEqual(response.id, 7);
+    assert.strictEqual(response.jsonrpc, '2.0');
+    assert.ok(response.result);
+    assert.ok(Array.isArray(response.result.clusters));
+    for (const cluster of response.result.clusters) {
+      assert.ok(Object.prototype.hasOwnProperty.call(cluster, 'provider'));
+      assert.ok(Object.prototype.hasOwnProperty.call(cluster, 'cwd'));
+    }
+  });
+
+  it('returns cluster not found for unknown cluster id', async function () {
+    const request = {
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'getClusterSummary',
+      params: { clusterId: 'missing-cluster-stdio' },
+    };
+
+    server.stdin.write(encodeFrame(request));
+    const response = await queue.next();
+
+    assert.strictEqual(response.id, 8);
+    assert.strictEqual(response.error.code, -32002);
+  });
+
+  it('responds to getClusterSummary for a known cluster when available', async function () {
+    const listRequest = {
+      jsonrpc: '2.0',
+      id: 9,
+      method: 'listClusters',
+      params: {},
+    };
+
+    server.stdin.write(encodeFrame(listRequest));
+    const listResponse = await queue.next();
+    const clusters = listResponse.result?.clusters ?? [];
+    if (clusters.length === 0) {
+      return;
+    }
+
+    const request = {
+      jsonrpc: '2.0',
+      id: 10,
+      method: 'getClusterSummary',
+      params: { clusterId: clusters[0].id },
+    };
+
+    server.stdin.write(encodeFrame(request));
+    const response = await queue.next();
+
+    assert.strictEqual(response.id, 10);
+    assert.strictEqual(response.result.summary.id, clusters[0].id);
+    assert.ok(Object.prototype.hasOwnProperty.call(response.result.summary, 'provider'));
+    assert.ok(Object.prototype.hasOwnProperty.call(response.result.summary, 'cwd'));
   });
 
   it('returns parse error for invalid JSON', async function () {


### PR DESCRIPTION
Expose listClusters and getClusterSummary over TUI v2 stdio so the frontend can display provider/cwd and summary data.

Adds fixtures and tests to lock the protocol response shape.