### PR TITLE
fix(cli): preserve pr-base in detached runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ TUI command convention: register slash commands in `src/tui/commands/dispatcher.
 zeroshot run 123                  # Local, no isolation
 zeroshot run 123 --worktree       # Git worktree isolation
 zeroshot run 123 --pr             # Worktree + create PR
+zeroshot run 123 --pr --pr-base dev # PR base: dev, worktree base: origin/dev (incl. -d)
 zeroshot run 123 --ship           # Worktree + PR + auto-merge
 zeroshot run 123 --docker         # Docker container isolation
 zeroshot run 123 -d               # Background (daemon) mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ IS THIS HOW A SENIOR STAFF ARCHITECT WOULD DO IT? ACT LIKE ONE.
 zeroshot run 123                  # Local, no isolation
 zeroshot run 123 --worktree       # Git worktree isolation
 zeroshot run 123 --pr             # Worktree + create PR
+zeroshot run 123 --pr --pr-base dev # PR base: dev, worktree base: origin/dev (incl. -d)
 zeroshot run 123 --ship           # Worktree + PR + auto-merge
 zeroshot run 123 --docker         # Docker container isolation
 zeroshot run 123 -d               # Background (daemon) mode

--- a/cli/index.js
+++ b/cli/index.js
@@ -256,6 +256,7 @@ function createDaemonLogFile(clusterId) {
 }
 
 function buildDaemonEnv(options, clusterId, targetCwd) {
+  const mergeQueueEnv = options.mergeQueue === true ? '1' : options.mergeQueue === false ? '0' : '';
   return {
     ...process.env,
     ZEROSHOT_DAEMON: '1',
@@ -267,6 +268,9 @@ function buildDaemonEnv(options, clusterId, targetCwd) {
     ZEROSHOT_WORKERS: options.workers?.toString() || '',
     ZEROSHOT_MODEL: options.model || '',
     ZEROSHOT_PROVIDER: options.provider || '',
+    ZEROSHOT_PR_BASE: options.prBase || '',
+    ZEROSHOT_MERGE_QUEUE: mergeQueueEnv,
+    ZEROSHOT_CLOSE_ISSUE: options.closeIssue || '',
     ZEROSHOT_CWD: targetCwd,
   };
 }

--- a/lib/start-cluster.js
+++ b/lib/start-cluster.js
@@ -22,6 +22,30 @@ function detectGitRepoRoot() {
   }
 }
 
+function resolveOptionalString(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveEnvBool(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === '1' || trimmed === 'true' || trimmed === 'yes') return true;
+  if (trimmed === '0' || trimmed === 'false' || trimmed === 'no') return false;
+  return undefined;
+}
+
+function resolveCloseIssueMode(value) {
+  const trimmed = resolveOptionalString(value);
+  if (!trimmed) return undefined;
+  const normalized = trimmed.toLowerCase();
+  if (normalized === 'auto' || normalized === 'always' || normalized === 'never') {
+    return normalized;
+  }
+  return undefined;
+}
+
 /**
  * Parse CLI mount specs (host:container[:ro]) into mount config objects.
  * @param {string[]} specs - Array of mount specs from CLI.
@@ -138,6 +162,12 @@ function buildStartOptions({
   forceProvider,
 }) {
   const targetCwd = process.env.ZEROSHOT_CWD || detectGitRepoRoot();
+  const envPrBase = resolveOptionalString(process.env.ZEROSHOT_PR_BASE);
+  const envMergeQueue = resolveEnvBool(process.env.ZEROSHOT_MERGE_QUEUE);
+  const envCloseIssue = resolveCloseIssueMode(process.env.ZEROSHOT_CLOSE_ISSUE);
+  const prBase = resolveOptionalString(options.prBase) || envPrBase;
+  const mergeQueue = typeof options.mergeQueue === 'boolean' ? options.mergeQueue : envMergeQueue;
+  const closeIssue = resolveCloseIssueMode(options.closeIssue) || envCloseIssue;
   return {
     clusterId,
     cwd: targetCwd,
@@ -154,9 +184,9 @@ function buildStartOptions({
     containerHome: options.containerHome || undefined,
     forceProvider: forceProvider || undefined,
     // PR configuration options (CLI args)
-    prBase: options.prBase || undefined,
-    mergeQueue: options.mergeQueue || undefined,
-    closeIssue: options.closeIssue || undefined,
+    prBase: prBase || undefined,
+    mergeQueue: mergeQueue,
+    closeIssue: closeIssue || undefined,
     settings,
   };
 }

--- a/tests/unit/cli-pr-base-env.test.js
+++ b/tests/unit/cli-pr-base-env.test.js
@@ -1,0 +1,102 @@
+/**
+ * Test: PR config env fallback
+ *
+ * Ensures detached/daemon runs can read PR config from env vars.
+ */
+
+const assert = require('assert');
+const { buildStartOptions } = require('../../lib/start-cluster');
+
+const ENV_VARS = [
+  'ZEROSHOT_CWD',
+  'ZEROSHOT_PR_BASE',
+  'ZEROSHOT_MERGE_QUEUE',
+  'ZEROSHOT_CLOSE_ISSUE',
+];
+
+const originalEnv = ENV_VARS.reduce((acc, key) => {
+  acc[key] = process.env[key];
+  return acc;
+}, {});
+
+function restoreEnv() {
+  for (const key of ENV_VARS) {
+    if (originalEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalEnv[key];
+    }
+  }
+}
+
+describe('CLI PR config env fallback', function () {
+  afterEach(function () {
+    restoreEnv();
+  });
+
+  it('uses ZEROSHOT_PR_BASE when options.prBase is missing', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_PR_BASE = 'dev';
+
+    const result = buildStartOptions({ clusterId: 'test', options: {}, settings: {} });
+
+    assert.strictEqual(result.prBase, 'dev');
+  });
+
+  it('prefers options.prBase over ZEROSHOT_PR_BASE', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_PR_BASE = 'dev';
+
+    const result = buildStartOptions({
+      clusterId: 'test',
+      options: { prBase: 'main' },
+      settings: {},
+    });
+
+    assert.strictEqual(result.prBase, 'main');
+  });
+
+  it('uses ZEROSHOT_MERGE_QUEUE when options.mergeQueue is missing', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_MERGE_QUEUE = '1';
+
+    const result = buildStartOptions({ clusterId: 'test', options: {}, settings: {} });
+
+    assert.strictEqual(result.mergeQueue, true);
+  });
+
+  it('prefers options.mergeQueue over ZEROSHOT_MERGE_QUEUE', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_MERGE_QUEUE = '0';
+
+    const result = buildStartOptions({
+      clusterId: 'test',
+      options: { mergeQueue: true },
+      settings: {},
+    });
+
+    assert.strictEqual(result.mergeQueue, true);
+  });
+
+  it('uses ZEROSHOT_CLOSE_ISSUE when options.closeIssue is missing', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_CLOSE_ISSUE = 'always';
+
+    const result = buildStartOptions({ clusterId: 'test', options: {}, settings: {} });
+
+    assert.strictEqual(result.closeIssue, 'always');
+  });
+
+  it('prefers options.closeIssue over ZEROSHOT_CLOSE_ISSUE', function () {
+    process.env.ZEROSHOT_CWD = '/tmp/zeroshot-test';
+    process.env.ZEROSHOT_CLOSE_ISSUE = 'always';
+
+    const result = buildStartOptions({
+      clusterId: 'test',
+      options: { closeIssue: 'never' },
+      settings: {},
+    });
+
+    assert.strictEqual(result.closeIssue, 'never');
+  });
+});


### PR DESCRIPTION
Detached mode dropped PR config, so worktrees/PRs defaulted to main even when --pr-base was supplied.

Forward PR config via daemon env and add env fallbacks + unit coverage.

Fixes #257