### PR TITLE
test(tui-backend): rebuild when output is stale

### DIFF
--- a/tests/unit/tui-backend-cluster-launcher.test.js
+++ b/tests/unit/tui-backend-cluster-launcher.test.js
@@ -12,10 +12,27 @@ const buildOutput = path.join(
   'services',
   'cluster-launcher.js'
 );
+const sourcePath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'tui-backend',
+  'services',
+  'cluster-launcher.ts'
+);
 
 function ensureBackendBuild() {
   if (!fs.existsSync(buildOutput)) {
     execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    return;
+  }
+  if (fs.existsSync(sourcePath)) {
+    const buildMtime = fs.statSync(buildOutput).mtimeMs;
+    const sourceMtime = fs.statSync(sourcePath).mtimeMs;
+    if (sourceMtime > buildMtime) {
+      execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    }
   }
 }
 

--- a/tests/unit/tui-backend-cluster-registry.test.js
+++ b/tests/unit/tui-backend-cluster-registry.test.js
@@ -12,10 +12,27 @@ const buildOutput = path.join(
   'services',
   'cluster-registry.js'
 );
+const sourcePath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'tui-backend',
+  'services',
+  'cluster-registry.ts'
+);
 
 function ensureBackendBuild() {
   if (!fs.existsSync(buildOutput)) {
     execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    return;
+  }
+  if (fs.existsSync(sourcePath)) {
+    const buildMtime = fs.statSync(buildOutput).mtimeMs;
+    const sourceMtime = fs.statSync(sourcePath).mtimeMs;
+    if (sourceMtime > buildMtime) {
+      execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    }
   }
 }
 

--- a/tests/unit/tui-backend-smoke.test.js
+++ b/tests/unit/tui-backend-smoke.test.js
@@ -12,10 +12,27 @@ const buildOutput = path.join(
   'services',
   'cluster-registry.js'
 );
+const sourcePath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'src',
+  'tui-backend',
+  'services',
+  'cluster-registry.ts'
+);
 
 function ensureBackendBuild() {
   if (!fs.existsSync(buildOutput)) {
     execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    return;
+  }
+  if (fs.existsSync(sourcePath)) {
+    const buildMtime = fs.statSync(buildOutput).mtimeMs;
+    const sourceMtime = fs.statSync(sourcePath).mtimeMs;
+    if (sourceMtime > buildMtime) {
+      execSync('npm run build:tui-backend', { stdio: 'inherit' });
+    }
   }
 }
 

--- a/tests/unit/tui-backend-stdio.test.js
+++ b/tests/unit/tui-backend-stdio.test.js
@@ -5,6 +5,17 @@ const { execSync, spawn } = require('child_process');
 
 const PROJECT_ROOT = path.resolve(__dirname, '../..');
 const SERVER_PATH = path.join(PROJECT_ROOT, 'lib', 'tui-backend', 'server.js');
+const SERVER_SOURCE_PATH = path.join(PROJECT_ROOT, 'src', 'tui-backend', 'server.ts');
+
+function isBuildStale(sourcePath, buildPath) {
+  if (!fs.existsSync(buildPath)) {
+    return true;
+  }
+  if (!fs.existsSync(sourcePath)) {
+    return false;
+  }
+  return fs.statSync(sourcePath).mtimeMs > fs.statSync(buildPath).mtimeMs;
+}
 
 const encodeFrame = (payload) => {
   const body = Buffer.from(typeof payload === 'string' ? payload : JSON.stringify(payload), 'utf8');
@@ -78,7 +89,7 @@ describe('tui-backend stdio JSON-RPC', function () {
   let queue;
 
   before(function () {
-    if (!fs.existsSync(SERVER_PATH)) {
+    if (isBuildStale(SERVER_SOURCE_PATH, SERVER_PATH)) {
       execSync('npm run build:tui-backend', { cwd: PROJECT_ROOT, stdio: 'inherit' });
     }
 


### PR DESCRIPTION
## Summary
- rebuild tui-backend tests when build output is missing or stale
- avoids stale lib artifacts causing method-not-found failures

## Testing
- npm test -- tests/unit/tui-backend-smoke.test.js