### PR TITLE
chore: default worktree/PR base to dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ tmp/
 *.tmp
 
 # Zeroshot runtime
-.zeroshot/
+.zeroshot/*
+!.zeroshot/settings.json
 .claude-zeroshots/
 zeroshot-isolated/
 zeroshot-cluster-configs/

--- a/.zeroshot/settings.json
+++ b/.zeroshot/settings.json
@@ -1,0 +1,8 @@
+{
+  "github": {
+    "prBase": "dev"
+  },
+  "worktree": {
+    "baseRef": "origin/dev"
+  }
+}


### PR DESCRIPTION
## Summary
- track repo-local .zeroshot/settings.json (prBase dev, worktree baseRef origin/dev)
- allow settings file in .gitignore while keeping other runtime data ignored

## Testing
- not run (config-only change)