### PR TITLE
fix: preserve cluster config during reload

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -272,18 +272,24 @@ class Orchestrator {
     // Restore isolation manager FIRST if cluster was running in isolation mode
     const { isolation, isolationManager } = this._restoreClusterIsolation(clusterId, clusterData);
 
+    // Create mutable cluster context for reload path (used by AgentWrapper/SubClusterWrapper)
+    const clusterContext = {
+      ...clusterData,
+      id: clusterId,
+      isolation,
+    };
+
     // Reconstruct agent metadata from config (processes are ephemeral)
     // CRITICAL: Pass isolation context to agents if cluster was running in isolation
     const agents = this._rebuildClusterAgents(
-      clusterId,
-      clusterData,
+      clusterContext,
       messageBus,
       isolation,
       isolationManager
     );
 
     const cluster = {
-      ...clusterData,
+      ...clusterContext,
       ledger,
       messageBus,
       agents,
@@ -293,11 +299,13 @@ class Orchestrator {
       issue: clusterData.issue || null,
     };
 
-    this.clusters.set(clusterId, cluster);
-    this._startSnapshotter(cluster);
+    Object.assign(clusterContext, cluster);
+
+    this.clusters.set(clusterId, clusterContext);
+    this._startSnapshotter(clusterContext);
     this._log(`[Orchestrator] Loaded cluster: ${clusterId} with ${agents.length} agents`);
 
-    return cluster;
+    return clusterContext;
   }
 
   _restoreClusterIsolation(clusterId, clusterData) {
@@ -351,12 +359,12 @@ class Orchestrator {
     return agentOptions;
   }
 
-  _instantiateAgent(agentConfig, messageBus, clusterId, agentOptions) {
+  _instantiateAgent(agentConfig, messageBus, clusterContext, agentOptions) {
     if (agentConfig.type === 'subcluster') {
-      return new SubClusterWrapper(agentConfig, messageBus, { id: clusterId }, agentOptions);
+      return new SubClusterWrapper(agentConfig, messageBus, clusterContext, agentOptions);
     }
 
-    return new AgentWrapper(agentConfig, messageBus, { id: clusterId }, agentOptions);
+    return new AgentWrapper(agentConfig, messageBus, clusterContext, agentOptions);
   }
 
   _restoreAgentState(agent, agentConfig, clusterData) {
@@ -372,8 +380,10 @@ class Orchestrator {
     agent.processPid = savedState.processPid || null;
   }
 
-  _rebuildClusterAgents(clusterId, clusterData, messageBus, isolation, isolationManager) {
+  _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
     const agents = [];
+    const clusterId = clusterContext.id;
+    const clusterData = clusterContext;
     const agentCwd = this._resolveAgentCwd(clusterData);
 
     if (!clusterData.config?.agents) {
@@ -396,7 +406,7 @@ class Orchestrator {
         isolation,
         isolationManager
       );
-      const agent = this._instantiateAgent(agentConfig, messageBus, clusterId, agentOptions);
+      const agent = this._instantiateAgent(agentConfig, messageBus, clusterContext, agentOptions);
       this._restoreAgentState(agent, agentConfig, clusterData);
       agents.push(agent);
     }

--- a/tests/unit/orchestrator-provider-reload.test.js
+++ b/tests/unit/orchestrator-provider-reload.test.js
@@ -1,0 +1,100 @@
+/**
+ * Orchestrator Provider Reload Test
+ *
+ * Regression test for provider resolution when reloading clusters from storage.
+ * Ensures forceProvider is honored in status output after reload.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const Orchestrator = require('../../src/orchestrator.js');
+const Ledger = require('../../src/ledger.js');
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanupDir(dirPath) {
+  if (dirPath && fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+describe('Orchestrator provider reload', function () {
+  const originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+
+  afterEach(function () {
+    if (originalSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+  });
+
+  it('uses config.forceProvider after reload', async function () {
+    const storageDir = createTempDir('zeroshot-provider-reload-');
+    const settingsDir = createTempDir('zeroshot-provider-settings-');
+    const settingsFile = path.join(settingsDir, 'settings.json');
+
+    fs.writeFileSync(settingsFile, JSON.stringify({ defaultProvider: 'claude' }));
+    process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+
+    const clusterId = 'provider-reload-test';
+    const clusterData = {
+      id: clusterId,
+      config: {
+        forceProvider: 'codex',
+        agents: [
+          {
+            id: 'worker',
+            role: 'implementation',
+            modelLevel: 'level2',
+            outputFormat: 'text',
+            triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+            prompt: 'Worker',
+          },
+        ],
+      },
+      state: 'stopped',
+      createdAt: Date.now(),
+      autoPr: false,
+      prOptions: null,
+      issue: null,
+      isolation: null,
+      worktree: null,
+      agentStates: null,
+    };
+
+    const clustersFile = path.join(storageDir, 'clusters.json');
+    fs.writeFileSync(clustersFile, JSON.stringify({ [clusterId]: clusterData }, null, 2));
+
+    const dbPath = path.join(storageDir, `${clusterId}.db`);
+    const ledger = new Ledger(dbPath);
+    ledger.append({
+      topic: 'TEST',
+      sender: 'tester',
+      receiver: 'tester',
+      content_text: 'ok',
+      cluster_id: clusterId,
+    });
+    ledger.close();
+
+    let orchestrator;
+    try {
+      orchestrator = await Orchestrator.create({ storageDir, quiet: true });
+      const status = orchestrator.getStatus(clusterId);
+      const providers = status.agents.map((agent) => agent.provider);
+      for (const provider of providers) {
+        assert.strictEqual(provider, 'codex');
+      }
+    } finally {
+      if (orchestrator) {
+        orchestrator.close();
+      }
+      cleanupDir(storageDir);
+      cleanupDir(settingsDir);
+    }
+  });
+});


### PR DESCRIPTION
Fix provider resolution for reloaded clusters by keeping full cluster context when rebuilding agents.

Adds regression test for forceProvider after reload.

Closes #284