### PR TITLE
fix: signal detached daemon on stop

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1430,6 +1430,89 @@ class Orchestrator {
   }
 
   /**
+   * Wait for a process to exit
+   * @param {Number} pid - Process ID
+   * @param {Number} timeoutMs - Timeout in milliseconds
+   * @param {Number} intervalMs - Poll interval in milliseconds
+   * @returns {Promise<Boolean>} True if process exited
+   * @private
+   */
+  async _waitForProcessExit(pid, timeoutMs, intervalMs = 100) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!this._isProcessRunning(pid)) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return !this._isProcessRunning(pid);
+  }
+
+  /**
+   * Signal a remote daemon that owns the cluster and wait for exit
+   * @param {Object} cluster - Cluster object
+   * @param {Object} options - { action, timeoutMs, killTimeoutMs, signal }
+   * @returns {Promise<Object>} { handled, remotePid, exited, forced }
+   * @private
+   */
+  async _signalRemoteCluster(cluster, options) {
+    const remotePid = cluster.pid;
+    if (!remotePid || remotePid === process.pid) {
+      return { handled: false };
+    }
+
+    if (!this._isProcessRunning(remotePid)) {
+      return { handled: false, remotePid, alreadyExited: true };
+    }
+
+    const action = options?.action || 'stop';
+    const timeoutMs = options?.timeoutMs ?? 10000;
+    const killTimeoutMs = options?.killTimeoutMs ?? 5000;
+    const signal = options?.signal || 'SIGTERM';
+
+    this._log(`[Orchestrator] Sending ${signal} to daemon PID ${remotePid} for ${cluster.id}...`);
+    try {
+      process.kill(remotePid, signal);
+    } catch (error) {
+      if (error.code === 'ESRCH') {
+        return { handled: true, remotePid, exited: true };
+      }
+      throw error;
+    }
+
+    const exited = await this._waitForProcessExit(remotePid, timeoutMs);
+    if (exited) {
+      return { handled: true, remotePid, exited: true };
+    }
+
+    if (action !== 'kill') {
+      throw new Error(
+        `Timed out waiting for daemon PID ${remotePid} to stop cluster ${cluster.id}`
+      );
+    }
+
+    this._log(
+      `[Orchestrator] Daemon PID ${remotePid} still running after ${timeoutMs}ms, sending SIGKILL...`
+    );
+    try {
+      process.kill(remotePid, 'SIGKILL');
+    } catch (error) {
+      if (error.code !== 'ESRCH') {
+        throw error;
+      }
+    }
+
+    const killed = await this._waitForProcessExit(remotePid, killTimeoutMs);
+    if (!killed) {
+      throw new Error(
+        `Failed to kill daemon PID ${remotePid} for cluster ${cluster.id} after SIGKILL`
+      );
+    }
+
+    return { handled: true, remotePid, exited: true, forced: true };
+  }
+
+  /**
    * Stop a cluster
    * @param {String} clusterId - Cluster ID
    */
@@ -1438,6 +1521,8 @@ class Orchestrator {
     if (!cluster) {
       throw new Error(`Cluster ${clusterId} not found`);
     }
+
+    await this._signalRemoteCluster(cluster, { action: 'stop' });
 
     // CRITICAL: Wait for initialization to complete before stopping
     // This ensures ISSUE_OPENED is published, preventing 0-message clusters
@@ -1504,6 +1589,8 @@ class Orchestrator {
     if (!cluster) {
       throw new Error(`Cluster ${clusterId} not found`);
     }
+
+    await this._signalRemoteCluster(cluster, { action: 'kill' });
 
     cluster.state = 'stopping';
 

--- a/tests/fixtures/detached-daemon.js
+++ b/tests/fixtures/detached-daemon.js
@@ -1,0 +1,55 @@
+const Orchestrator = require('../../src/orchestrator');
+const MockTaskRunner = require('../helpers/mock-task-runner');
+
+const storageDir = process.env.ZEROSHOT_TEST_STORAGE;
+const clusterId = process.env.ZEROSHOT_TEST_CLUSTER_ID;
+
+if (!storageDir || !clusterId) {
+  console.error('Missing ZEROSHOT_TEST_STORAGE or ZEROSHOT_TEST_CLUSTER_ID');
+  process.exit(1);
+}
+
+const mockRunner = new MockTaskRunner();
+const orchestrator = new Orchestrator({
+  quiet: true,
+  storageDir,
+  taskRunner: mockRunner,
+});
+
+const config = {
+  agents: [
+    {
+      id: 'worker',
+      role: 'implementation',
+      timeout: 0,
+      triggers: [{ topic: 'NEVER', action: 'execute_task' }],
+      prompt: 'Idle agent for detached stop test',
+    },
+  ],
+};
+
+async function startCluster() {
+  await orchestrator.start(config, { text: 'Detached stop test' }, { clusterId });
+  console.log('READY');
+}
+
+async function shutdown(signal) {
+  try {
+    await orchestrator.stop(clusterId);
+    console.log(`[DAEMON] Stopped cluster ${clusterId} from ${signal}`);
+  } catch (error) {
+    console.error(`[DAEMON] Failed to stop cluster ${clusterId}: ${error.message}`);
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+startCluster().catch((error) => {
+  console.error(`[DAEMON] Failed to start cluster: ${error.message}`);
+  console.error(error.stack);
+  process.exit(1);
+});
+
+setInterval(() => {}, 1000);

--- a/tests/integration/detached-stop.test.js
+++ b/tests/integration/detached-stop.test.js
@@ -1,0 +1,135 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawn } = require('node:child_process');
+
+const Orchestrator = require('../../src/orchestrator');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForClusterRecord(storageDir, clusterId, expectedPid, timeoutMs = 10000) {
+  const clustersFile = path.join(storageDir, 'clusters.json');
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (fs.existsSync(clustersFile)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(clustersFile, 'utf8'));
+        const record = data[clusterId];
+        if (record && record.state === 'running' && record.pid) {
+          if (expectedPid) {
+            assert.strictEqual(
+              record.pid,
+              expectedPid,
+              `Expected cluster pid ${expectedPid}, got ${record.pid}`
+            );
+          }
+          return record;
+        }
+      } catch {
+        // Ignore transient parse errors while file is being written.
+      }
+    }
+    await sleep(100);
+  }
+
+  throw new Error(`Timed out waiting for cluster ${clusterId} in ${clustersFile}`);
+}
+
+function waitForChildExit(child, timeoutMs = 10000) {
+  if (child.exitCode !== null) {
+    return child.exitCode;
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for child process ${child.pid} to exit`));
+    }, timeoutMs);
+
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+describe('Detached daemon stop', function () {
+  this.timeout(20000);
+
+  let tempDir;
+  let child;
+
+  afterEach(function () {
+    if (child && child.exitCode === null) {
+      try {
+        process.kill(child.pid, 'SIGKILL');
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+
+    if (tempDir && fs.existsSync(tempDir)) {
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('signals remote daemon pid and halts ledger activity', async function () {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zs-detached-stop-'));
+    const clusterId = `detached-stop-${Date.now()}`;
+    const fixturePath = path.join(__dirname, '..', 'fixtures', 'detached-daemon.js');
+
+    child = spawn(process.execPath, [fixturePath], {
+      env: {
+        ...process.env,
+        ZEROSHOT_TEST_STORAGE: tempDir,
+        ZEROSHOT_TEST_CLUSTER_ID: clusterId,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    await waitForClusterRecord(tempDir, clusterId, child.pid);
+    await sleep(200);
+
+    const orchestrator = await Orchestrator.create({
+      quiet: true,
+      storageDir: tempDir,
+    });
+
+    const cluster = orchestrator.getCluster(clusterId);
+    assert(cluster, 'Cluster should be loaded from storage');
+
+    const beforeCount = cluster.messageBus.count({ cluster_id: clusterId });
+
+    await orchestrator.stop(clusterId);
+    await waitForChildExit(child, 10000);
+
+    const afterStopCount = cluster.messageBus.count({ cluster_id: clusterId });
+    await sleep(250);
+    const afterWaitCount = cluster.messageBus.count({ cluster_id: clusterId });
+
+    assert.strictEqual(
+      afterStopCount,
+      afterWaitCount,
+      'No new ledger messages should appear after stop'
+    );
+
+    const status = orchestrator.getStatus(clusterId);
+    assert.strictEqual(status.state, 'stopped');
+    assert.strictEqual(status.pid, null);
+    assert.strictEqual(beforeCount, afterStopCount);
+
+    orchestrator.close();
+  });
+});


### PR DESCRIPTION
Signal the detached daemon PID when stopping or killing a cluster so the remote process actually exits.

Adds integration coverage for detached stop.

Closes #290