### PR TITLE
fix(config): allow CRITICAL validator_count=0 + load_config prevalidation

### DIFF
--- a/cluster-templates/base-templates/full-workflow.json
+++ b/cluster-templates/base-templates/full-workflow.json
@@ -252,7 +252,7 @@
           "topic": "VALIDATION_RESULT",
           "logic": {
             "engine": "javascript",
-            "script": "const validators = cluster.getAgentsByRole('validator');\nconst lastPush = ledger.findLast({ topic: 'IMPLEMENTATION_READY' });\nif (!lastPush) return false;\nconst responses = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.timestamp });\nif (responses.length < validators.length) return false;\nreturn responses.some(r => r.content?.data?.approved === false || r.content?.data?.approved === 'false');"
+            "script": "const validators = cluster.getAgentsByRole('validator');\nif (validators.length === 0) return false;\nconst lastPush = ledger.findLast({ topic: 'IMPLEMENTATION_READY' });\nif (!lastPush) return false;\nconst responses = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.timestamp });\nif (responses.length < validators.length) return false;\nreturn responses.some(r => r.content?.data?.approved === false || r.content?.data?.approved === 'false');"
           },
           "action": "execute_task"
         }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2411,6 +2411,14 @@ Continue from where you left off. Review your previous output to understand what
             proposedAgentConfigs.push(agentConfig);
           }
         }
+      } else if (op.action === 'load_config' && op.config) {
+        const loadedAgentConfigs = this._resolveLoadConfigAgents(op.config);
+        for (const agentConfig of loadedAgentConfigs) {
+          const existingIdx = proposedAgentConfigs.findIndex((a) => a.id === agentConfig.id);
+          if (existingIdx === -1) {
+            proposedAgentConfigs.push(agentConfig);
+          }
+        }
       } else if (op.action === 'remove_agents' && op.agentIds) {
         for (const agentId of op.agentIds) {
           const idx = proposedAgentConfigs.findIndex((a) => a.id === agentId);
@@ -2427,6 +2435,40 @@ Continue from where you left off. Review your previous output to understand what
     }
 
     return proposedAgentConfigs;
+  }
+
+  _resolveLoadConfigAgents(config) {
+    if (!config) {
+      throw new Error('load_config operation missing config');
+    }
+
+    const templatesDir = path.join(__dirname, '..', 'cluster-templates');
+    let loadedConfig;
+
+    // Parameterized template - resolve with TemplateResolver
+    if (typeof config === 'object' && config.base) {
+      const { base, params } = config;
+      const resolver = new TemplateResolver(templatesDir);
+      loadedConfig = resolver.resolve(base, params || {});
+    } else if (typeof config === 'string') {
+      // Static config - load directly from file
+      const configPath = path.join(templatesDir, `${config}.json`);
+      if (!fs.existsSync(configPath)) {
+        throw new Error(`Config not found: ${config} (looked in ${configPath})`);
+      }
+      const configContent = fs.readFileSync(configPath, 'utf8');
+      loadedConfig = JSON.parse(configContent);
+    } else {
+      throw new Error(
+        `Invalid config format: expected string or {base, params}, got ${typeof config}`
+      );
+    }
+
+    if (!loadedConfig.agents || !Array.isArray(loadedConfig.agents)) {
+      throw new Error(`Config has no agents array`);
+    }
+
+    return loadedConfig.agents;
   }
 
   _validateProposedConfig(clusterId, cluster, proposedAgentConfigs, operations) {

--- a/tests/cluster-operations.test.js
+++ b/tests/cluster-operations.test.js
@@ -116,6 +116,34 @@ describe('CLUSTER_OPERATIONS', function () {
         'Should have error about missing ISSUE_OPENED trigger'
       );
     });
+
+    it('should include agents from load_config when building proposed config (parameterized)', function () {
+      const existing = [
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+        },
+      ];
+
+      const ops = [
+        {
+          action: 'load_config',
+          config: { base: 'quick-validation', params: {} },
+        },
+      ];
+
+      const proposed = orchestrator._buildProposedAgentConfigs(existing, ops);
+
+      assert(
+        proposed.some((a) => a.id === 'validator-requirements'),
+        'Expected load_config to add validator-requirements'
+      );
+      assert(
+        proposed.some((a) => a.id === 'validator-code'),
+        'Expected load_config to add validator-code'
+      );
+    });
   });
 
   describe('VALID_OPERATIONS constant', function () {

--- a/tests/two-stage-validation.test.js
+++ b/tests/two-stage-validation.test.js
@@ -5,6 +5,7 @@
 const assert = require('assert');
 const path = require('path');
 const TemplateResolver = require('../src/template-resolver');
+const { validateConfig } = require('../src/config-validator');
 
 describe('Two-Stage Validation Pipeline', function () {
   let resolver;
@@ -136,6 +137,16 @@ describe('Two-Stage Validation Pipeline', function () {
       // Inline validators should be filtered out
       const validators = resolved.agents.filter((a) => a.role === 'validator');
       assert.strictEqual(validators.length, 0, 'No inline validators for CRITICAL tasks');
+
+      // Regression: config-validator should NOT raise Gap 15 role-reference errors when validators are absent.
+      const validation = validateConfig(resolved);
+      const roleErrors = validation.errors.filter(
+        (e) =>
+          e.includes('[Gap 15]') ||
+          e.includes("Logic references role 'validator'") ||
+          e.includes('Logic references role "validator"')
+      );
+      assert.strictEqual(roleErrors.length, 0, `Unexpected role reference errors: ${roleErrors}`);
     });
 
     it('should NOT load meta-coordinator for STANDARD tasks', function () {


### PR DESCRIPTION
Fixes Zeroshot config validation failures when CRITICAL clusters resolve full-workflow with validator_count=0.

- Guard validator role reference in full-workflow template trigger (prevents Gap 15 hard-fail)
- Include load_config agents when building proposed config for CLUSTER_OPERATIONS prevalidation
- Add regression assertions in two-stage + cluster-ops tests

Context: Heroshot runs were exhausting retries because  rejected the config before execution.