### PR TITLE
fix(validation): republish trigger after load_config

### DIFF
--- a/cluster-templates/base-templates/full-workflow.json
+++ b/cluster-templates/base-templates/full-workflow.json
@@ -324,10 +324,18 @@
       "triggers": [
         {
           "topic": "IMPLEMENTATION_READY",
+          "logic": {
+            "engine": "javascript",
+            "script": "return !(message && message.metadata && message.metadata._republished);"
+          },
           "action": "execute_task"
         },
         {
           "topic": "QUICK_VALIDATION_PASSED",
+          "logic": {
+            "engine": "javascript",
+            "script": "return !(message && message.metadata && message.metadata._republished);"
+          },
           "action": "execute_task"
         }
       ],
@@ -339,7 +347,7 @@
           },
           "transform": {
             "engine": "javascript",
-            "script": "const template = result.action === 'load_quick' ? 'quick-validation' : 'heavy-validation'; return { topic: 'CLUSTER_OPERATIONS', content: { text: result.action === 'load_quick' ? 'Stage 1 (quick)' : 'Stage 2 (heavy)', data: { operations: [{ action: 'load_config', config: { base: template, params: { validator_level: '{{validator_level}}', max_tokens: {{max_tokens}}, timeout: {{timeout}} } } }] } } };"
+            "script": "const template = result.action === 'load_quick' ? 'quick-validation' : 'heavy-validation'; const republishTopic = result.action === 'load_quick' ? 'IMPLEMENTATION_READY' : 'QUICK_VALIDATION_PASSED'; const republishContent = triggeringMessage && triggeringMessage.content ? triggeringMessage.content : { text: '', data: {} }; return { topic: 'CLUSTER_OPERATIONS', content: { text: result.action === 'load_quick' ? 'Stage 1 (quick)' : 'Stage 2 (heavy)', data: { operations: [{ action: 'load_config', config: { base: template, params: { validator_level: '{{validator_level}}', max_tokens: {{max_tokens}}, timeout: {{timeout}} } } }, { action: 'publish', topic: republishTopic, content: republishContent, metadata: { _republished: true } }] } } };"
           },
           "logic": {
             "engine": "javascript",

--- a/tests/two-stage-validation.test.js
+++ b/tests/two-stage-validation.test.js
@@ -149,6 +149,41 @@ describe('Two-Stage Validation Pipeline', function () {
       assert.strictEqual(roleErrors.length, 0, `Unexpected role reference errors: ${roleErrors}`);
     });
 
+    it('meta-coordinator should republish trigger topic after load_config (prevents validator deadlock)', function () {
+      const resolved = resolver.resolve('full-workflow', {
+        task_type: 'TASK',
+        complexity: 'CRITICAL',
+        max_tokens: 150000,
+        max_iterations: 25,
+        planner_level: 'level3',
+        worker_level: 'level2',
+        validator_level: 'level2',
+        validator_count: 0,
+      });
+
+      const metaCoordinator = resolved.agents.find((a) => a.id === 'meta-coordinator');
+      assert.ok(metaCoordinator, 'meta-coordinator should be present for CRITICAL tasks');
+
+      const hookTransformScript = metaCoordinator.hooks?.onComplete?.transform?.script || '';
+      assert.ok(
+        hookTransformScript.includes("action: 'publish'") ||
+          hookTransformScript.includes('action: "publish"'),
+        'meta-coordinator should publish a republished trigger topic after load_config'
+      );
+      assert.ok(
+        hookTransformScript.includes('_republished'),
+        'meta-coordinator republish should include _republished metadata'
+      );
+
+      const implTrigger = metaCoordinator.triggers?.find((t) => t.topic === 'IMPLEMENTATION_READY');
+      assert.ok(implTrigger?.logic?.script?.includes('_republished'));
+
+      const stage2Trigger = metaCoordinator.triggers?.find(
+        (t) => t.topic === 'QUICK_VALIDATION_PASSED'
+      );
+      assert.ok(stage2Trigger?.logic?.script?.includes('_republished'));
+    });
+
     it('should NOT load meta-coordinator for STANDARD tasks', function () {
       const resolved = resolver.resolve('full-workflow', {
         task_type: 'TASK',


### PR DESCRIPTION
Fixes deadlock where validation configs loaded after a trigger event never run. Meta-coordinator now republish the trigger topic (with _republished metadata) after load_config, and ignores republished messages to avoid loops. Adds regression test.