### PR TITLE
fix: add ledger API to hook logic sandbox

### DIFF
--- a/src/agent/agent-hook-executor.js
+++ b/src/agent/agent-hook-executor.js
@@ -530,10 +530,27 @@ function evaluateHookLogic(params) {
     throw new Error(`Unsupported hook logic engine: ${logic.engine}`);
   }
 
+  // Build ledger API wrapper (auto-scoped to cluster) - same as LogicEngine
+  const clusterId = agent.cluster?.id;
+  const ledgerAPI = {
+    query: (criteria) => {
+      return agent.messageBus.query({ ...criteria, cluster_id: clusterId });
+    },
+    findLast: (criteria) => {
+      return agent.messageBus.findLast({ ...criteria, cluster_id: clusterId });
+    },
+    count: (criteria) => {
+      return agent.messageBus.count({ ...criteria, cluster_id: clusterId });
+    },
+  };
+
   // Build sandbox context - similar to LogicEngine but focused on result data
   const sandbox = {
     // The parsed result from agent output - this is the main input
     result: resultData || {},
+
+    // Ledger API for querying message history
+    ledger: ledgerAPI,
 
     // Agent context
     agent: {


### PR DESCRIPTION
## Summary
- Hook logic scripts that use `ledger.query()` fail with "ledger is not defined"
- The sandbox context in `agent-hook-executor.js` didn't include the ledger API
- Add ledgerAPI wrapper to the hook logic sandbox, same as LogicEngine provides

## Test plan
- [ ] Verify consensus-coordinator hook can query validation results
- [ ] Run two-stage validation pipeline end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)