### PR TITLE
chore(deps): target dev branch for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot PRs now target `dev` instead of `main`, aligning with the repo's PR workflow.