### PR TITLE
fix(orchestration): buffer trigger messages while busy

### DIFF
--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -15,6 +15,8 @@
 const { findMatchingTrigger, evaluateTrigger } = require('./agent-trigger-evaluator');
 const { executeHook } = require('./agent-hook-executor');
 const IsolationManager = require('../isolation-manager');
+const crypto = require('crypto');
+const { bufferMessage, scheduleDrain, drainBufferedMessages } = require('../message-buffer');
 const {
   analyzeProcessHealth,
   isPlatformSupported,
@@ -254,8 +256,16 @@ async function handleMessage(agent, message) {
     return;
   }
   if (agent.state !== 'idle') {
+    // IMPORTANT: Never drop a message that matches a trigger.
+    // Dropping validation/coordinator signals can wedge clusters in "running" state.
+    bufferMessage(agent, message);
     console.warn(
-      `[${agent.id}] ⚠️ DROPPING message (busy, state=${agent.state}): ${message.topic}`
+      `[${agent.id}] ⏸️ BUFFERING message (busy, state=${agent.state}): ${message.topic}`
+    );
+    scheduleDrain(
+      agent,
+      () => drainBufferedMessages(agent, (next) => handleMessage(agent, next), { label: 'Agent' }),
+      { label: 'Agent' }
     );
     return;
   }
@@ -387,7 +397,7 @@ async function applyValidatorJitter(agent) {
     return;
   }
 
-  const jitterMs = Math.floor(Math.random() * 15000); // 0-15 seconds
+  const jitterMs = crypto.randomInt(0, 15000); // 0-15 seconds
   if (!agent.quiet) {
     agent._log(
       `[Agent ${agent.id}] Adding ${Math.round(jitterMs / 1000)}s jitter to prevent lock contention`
@@ -570,7 +580,7 @@ ${'='.repeat(80)}`);
 
 async function handleLockContention() {
   // Lock contention - add significant jittered delay
-  const lockDelay = 10000 + Math.floor(Math.random() * 20000); // 10-30 seconds
+  const lockDelay = 10000 + crypto.randomInt(0, 20000); // 10-30 seconds
   console.error(
     `⚠️ Lock contention detected - waiting ${Math.round(lockDelay / 1000)}s before retry`
   );
@@ -765,6 +775,29 @@ async function handleTaskAttemptFailure({
   return false;
 }
 
+function maybeExtendMaxRetries({
+  error,
+  attempt,
+  maxRetries,
+  sigtermRetryGranted,
+  noMessagesRetryGranted,
+}) {
+  const message = error?.message || '';
+  if (!message || attempt < maxRetries) {
+    return { maxRetries, sigtermRetryGranted, noMessagesRetryGranted };
+  }
+
+  if (message.includes('SIGTERM') && !sigtermRetryGranted) {
+    return { maxRetries: maxRetries + 1, sigtermRetryGranted: true, noMessagesRetryGranted };
+  }
+
+  if (message.toLowerCase().includes('no messages returned') && !noMessagesRetryGranted) {
+    return { maxRetries: maxRetries + 1, sigtermRetryGranted, noMessagesRetryGranted: true };
+  }
+
+  return { maxRetries, sigtermRetryGranted, noMessagesRetryGranted };
+}
+
 /**
  * Execute claude-zeroshots with built context
  * Default: uses settings.maxRetries (default 3) for exponential backoff retries.
@@ -801,17 +834,16 @@ async function executeTask(agent, triggeringMessage) {
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;
       }
-      const isSigterm = error.message && error.message.includes('SIGTERM');
-      const isNoMessages =
-        error.message && error.message.toLowerCase().includes('no messages returned');
-      if (isSigterm && !sigtermRetryGranted && attempt >= maxRetries) {
-        sigtermRetryGranted = true;
-        maxRetries += 1;
-      }
-      if (isNoMessages && !noMessagesRetryGranted && attempt >= maxRetries) {
-        noMessagesRetryGranted = true;
-        maxRetries += 1;
-      }
+      const updated = maybeExtendMaxRetries({
+        error,
+        attempt,
+        maxRetries,
+        sigtermRetryGranted,
+        noMessagesRetryGranted,
+      });
+      maxRetries = updated.maxRetries;
+      sigtermRetryGranted = updated.sigtermRetryGranted;
+      noMessagesRetryGranted = updated.noMessagesRetryGranted;
       const shouldStop = await handleTaskAttemptFailure({
         agent,
         triggeringMessage,

--- a/src/message-buffer.js
+++ b/src/message-buffer.js
@@ -1,0 +1,81 @@
+/**
+ * Message buffering helper
+ *
+ * Ensures trigger-matching messages are never dropped just because an agent/subcluster is busy.
+ * Dropped workflow signals (e.g. VALIDATION_RESULT) can wedge clusters in "running" state.
+ */
+
+function bufferMessage(target, message, options = {}) {
+  const maxBuffered = options.maxBuffered ?? 200;
+
+  if (!target._bufferedMessages) {
+    target._bufferedMessages = [];
+  }
+
+  if (target._bufferedMessages.length >= maxBuffered) {
+    target._bufferedMessages.shift();
+  }
+
+  target._bufferedMessages.push(message);
+}
+
+function scheduleDrain(target, drainFn, options = {}) {
+  if (target._bufferDrainScheduled) {
+    return;
+  }
+
+  target._bufferDrainScheduled = true;
+
+  const label = options.label || 'MessageBuffer';
+  const id = target.id || 'unknown';
+
+  const run = () => {
+    target._bufferDrainScheduled = false;
+    drainFn().catch((error) => {
+      console.error(`\n${'='.repeat(80)}`);
+      console.error(`🔴 FATAL: ${label} drain crashed (${id})`);
+      console.error(`${'='.repeat(80)}`);
+      console.error(`Error: ${error.message}`);
+      console.error(`Stack: ${error.stack}`);
+      console.error(`${'='.repeat(80)}\n`);
+      setImmediate(() => {
+        throw error;
+      });
+    });
+  };
+
+  const current = target._currentExecution;
+  if (current && typeof current.finally === 'function') {
+    current.finally(() => setImmediate(run));
+    return;
+  }
+
+  setImmediate(run);
+}
+
+async function drainBufferedMessages(target, handleFn, options = {}) {
+  if (!target.running) {
+    return;
+  }
+
+  const buffer = target._bufferedMessages;
+  if (!buffer || buffer.length === 0) {
+    return;
+  }
+
+  if (target.state !== 'idle') {
+    scheduleDrain(target, () => drainBufferedMessages(target, handleFn, options), options);
+    return;
+  }
+
+  while (target.running && target.state === 'idle' && buffer.length > 0) {
+    const next = buffer.shift();
+    await handleFn(next);
+  }
+}
+
+module.exports = {
+  bufferMessage,
+  scheduleDrain,
+  drainBufferedMessages,
+};

--- a/src/sub-cluster-wrapper.js
+++ b/src/sub-cluster-wrapper.js
@@ -15,6 +15,7 @@
 const LogicEngine = require('./logic-engine');
 const MessageBusBridge = require('./message-bus-bridge');
 const { DEFAULT_MAX_ITERATIONS } = require('./agent/agent-config');
+const { bufferMessage, scheduleDrain, drainBufferedMessages } = require('./message-buffer');
 
 function normalizeParentTopicConfig(entry) {
   if (typeof entry === 'string') {
@@ -179,8 +180,17 @@ class SubClusterWrapper {
       return;
     }
     if (this.state !== 'idle') {
+      bufferMessage(this, message);
       console.warn(
-        `[${this.id}] ⚠️ DROPPING message (busy, state=${this.state}): ${message.topic}`
+        `[${this.id}] ⏸️ BUFFERING message (busy, state=${this.state}): ${message.topic}`
+      );
+      scheduleDrain(
+        this,
+        () =>
+          drainBufferedMessages(this, (next) => this._handleMessage(next), {
+            label: 'SubCluster',
+          }),
+        { label: 'SubCluster' }
       );
       return;
     }

--- a/tests/message-buffering-while-busy.test.js
+++ b/tests/message-buffering-while-busy.test.js
@@ -1,0 +1,153 @@
+/**
+ * Regression test: never drop trigger-matching messages while an agent is busy.
+ *
+ * BUG:
+ *   Agents dropped trigger-matching messages whenever state !== 'idle'.
+ *   In real clusters this can drop VALIDATION_RESULT / QUICK_VALIDATION_RESULT
+ *   while the worker or coordinator is executing a task, wedging the cluster.
+ *
+ * FIX:
+ *   Buffer trigger-matching messages while busy and drain once idle.
+ */
+
+const { expect } = require('chai');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Orchestrator = require('../src/orchestrator');
+const MockTaskRunner = require('./helpers/mock-task-runner');
+
+describe('Agent message buffering while busy', function () {
+  this.timeout(15000);
+
+  let orchestrator;
+  let mockRunner;
+  let testDir;
+  let clusterId;
+
+  beforeEach(() => {
+    testDir = path.join(
+      os.tmpdir(),
+      `zeroshot-buffering-test-${crypto.randomBytes(8).toString('hex')}`
+    );
+    fs.mkdirSync(testDir, { recursive: true });
+
+    const settingsPath = path.join(testDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          firstRunComplete: true,
+          defaultProvider: 'claude',
+          autoCheckUpdates: false,
+        },
+        null,
+        2
+      )
+    );
+
+    mockRunner = new MockTaskRunner();
+    orchestrator = new Orchestrator({
+      quiet: true,
+      storageDir: testDir,
+      skipLoad: true,
+      taskRunner: mockRunner,
+    });
+  });
+
+  afterEach(async () => {
+    if (clusterId) {
+      try {
+        await orchestrator.kill(clusterId);
+      } catch {
+        // Cluster may already be stopped
+      }
+    }
+
+    try {
+      orchestrator.close();
+    } catch {
+      /* ignore */
+    }
+
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('executes worker twice when VALIDATION_RESULT arrives during an in-flight task', async () => {
+    mockRunner.when('worker').delays(250, 'done');
+
+    const config = {
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          modelLevel: 'level2',
+          prompt: 'do work',
+          triggers: [
+            { topic: 'ISSUE_OPENED', action: 'execute_task' },
+            { topic: 'VALIDATION_RESULT', action: 'execute_task' },
+          ],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: { topic: 'WORK_DONE' },
+            },
+          },
+        },
+        {
+          id: 'completion-detector',
+          role: 'completion-detector',
+          modelLevel: 'level2',
+          prompt: 'stop after 2 work cycles',
+          triggers: [
+            {
+              topic: 'WORK_DONE',
+              action: 'stop_cluster',
+              logic: { script: "return ledger.count({ topic: 'WORK_DONE' }) >= 2;" },
+            },
+          ],
+        },
+      ],
+      completion_detector: {
+        type: 'topic',
+        config: { topic: 'CLUSTER_COMPLETE' },
+      },
+    };
+
+    const result = await orchestrator.start(config, { text: 'test' }, { cwd: process.cwd() });
+    clusterId = result.id;
+
+    const cluster = orchestrator.getCluster(clusterId);
+    expect(cluster).to.exist;
+
+    // Publish a trigger-matching message while the worker is still busy with the first task.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    cluster.messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'VALIDATION_RESULT',
+      sender: 'consensus-coordinator',
+      receiver: 'broadcast',
+      timestamp: Date.now(),
+      content: { text: 'stage 1 rejected' },
+    });
+
+    // Wait for the cluster to stop (completion-detector publishes CLUSTER_COMPLETE after 2 WORK_DONE).
+    const start = Date.now();
+    while (Date.now() - start < 10000) {
+      const current = orchestrator.getCluster(clusterId);
+      if (current.state === 'stopped') {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const finalCluster = orchestrator.getCluster(clusterId);
+    expect(finalCluster.state).to.equal('stopped');
+
+    mockRunner.assertCalled('worker', 2);
+  });
+});


### PR DESCRIPTION
Prevents agents/subclusters from dropping trigger-matching messages while executing a task (buffers + drains on idle). Adds regression test.