### PR TITLE
fix(orchestration): verify_github_pr fallback via gh pr view

### DIFF
--- a/src/agent/agent-hook-executor.js
+++ b/src/agent/agent-hook-executor.js
@@ -142,59 +142,64 @@ async function executeHook(params) {
   if (hook.action === 'verify_github_pr') {
     const { extractJsonFromOutput } = require('./output-extraction');
     const structuredOutput = extractJsonFromOutput(result.output) || {};
-    const prNumber = structuredOutput.pr_number;
+    const claimedPrUrl = structuredOutput.pr_url || null;
 
     // Skip actual gh CLI verification if explicitly disabled (for integration tests)
     // Unit tests mock execSync, so they still test the verification logic
     if (process.env.ZEROSHOT_SKIP_GH_VERIFY === '1') {
-      agent._log(`✅ VERIFICATION SKIPPED (ZEROSHOT_SKIP_GH_VERIFY=1): PR #${prNumber}`);
+      agent._log(`✅ VERIFICATION SKIPPED (ZEROSHOT_SKIP_GH_VERIFY=1)`);
       agent._publish({
         topic: 'CLUSTER_COMPLETE',
         content: {
           data: {
             reason: 'git-pusher-complete-verified',
-            pr_number: prNumber,
-            pr_url: structuredOutput.pr_url,
+            pr_number: structuredOutput.pr_number || null,
+            pr_url: claimedPrUrl,
           },
         },
       });
       return;
     }
 
-    if (!prNumber) {
-      throw new Error(
-        `VERIFICATION FAILED: git-pusher must provide pr_number in structured output. ` +
-          `Got: ${JSON.stringify(structuredOutput)}`
-      );
-    }
-
     let prData;
     try {
       prData = JSON.parse(
-        execSync(`gh pr view ${prNumber} --json state,mergedAt,url,number`, {
+        // IMPORTANT:
+        // Do NOT require pr_number in the agent output. GitHub CLI can infer the PR from the current branch.
+        // Agents sometimes wrap the PR JSON in a text field (summary/result) which is hard to parse reliably.
+        execSync(`gh pr view --json state,mergedAt,url,number`, {
           encoding: 'utf8',
           cwd: agent.workingDirectory,
           stdio: ['pipe', 'pipe', 'pipe'],
         })
       );
     } catch (err) {
-      if (err.message.includes('Could not resolve to a PullRequest')) {
+      if (
+        err.message.includes('Could not resolve to a PullRequest') ||
+        err.message.toLowerCase().includes('no pull requests found')
+      ) {
         throw new Error(
-          `VERIFICATION FAILED: Agent claimed PR #${prNumber} exists, ` +
+          `VERIFICATION FAILED: Agent claimed a PR exists for this branch, ` +
             `but GitHub says it DOES NOT EXIST. Agent HALLUCINATED.`
         );
       }
       throw err;
     }
 
+    if (claimedPrUrl && prData.url && claimedPrUrl !== prData.url) {
+      throw new Error(
+        `VERIFICATION FAILED: Agent claimed PR URL ${claimedPrUrl}, but GitHub CLI reports ${prData.url}.`
+      );
+    }
+
     if (!prData.mergedAt) {
       throw new Error(
-        `VERIFICATION FAILED: Agent claimed PR #${prNumber} is merged, ` +
+        `VERIFICATION FAILED: Agent claimed PR is merged, ` +
           `but GitHub says state="${prData.state}". Agent LIED.`
       );
     }
 
-    agent._log(`✅ VERIFICATION PASSED: PR #${prNumber} actually merged`);
+    agent._log(`✅ VERIFICATION PASSED: PR #${prData.number} actually merged`);
 
     // Publish CLUSTER_COMPLETE only after verification passes
     agent._publish({
@@ -202,7 +207,7 @@ async function executeHook(params) {
       content: {
         data: {
           reason: 'git-pusher-complete-verified',
-          pr_number: prNumber,
+          pr_number: prData.number,
           pr_url: prData.url,
         },
       },

--- a/tests/verify-github-pr-hook.test.js
+++ b/tests/verify-github-pr-hook.test.js
@@ -57,22 +57,29 @@ describe('verify_github_pr hook action', function () {
     mockExecSyncFn = null;
   });
 
-  it('should throw when pr_number missing from output', async function () {
+  it('should not require pr_number in structured output', async function () {
     const agent = createMockAgent();
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_url: 'https://github.com/org/repo/pull/123',
-        merged: true,
+        summary: 'Merged',
+        result:
+          'PR merged: {"pr_url":"https://github.com/org/repo/pull/123","pr_number":123,"merged":true}',
       }),
     };
 
-    try {
-      await executeHook({ hook, agent, result });
-      assert.fail('Expected error to be thrown');
-    } catch (err) {
-      assert.match(err.message, /VERIFICATION FAILED.*pr_number/i);
-    }
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 123,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/123',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert(agent.lastPublished, 'Expected message to be published');
+    assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
   });
 
   it('should throw when PR does not exist in GitHub', async function () {
@@ -80,7 +87,6 @@ describe('verify_github_pr hook action', function () {
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_number: 9999,
         pr_url: 'https://github.com/org/repo/pull/9999',
         merged: true,
       }),
@@ -106,7 +112,6 @@ describe('verify_github_pr hook action', function () {
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_number: 123,
         pr_url: 'https://github.com/org/repo/pull/123',
         merged: true,
       }),
@@ -134,7 +139,6 @@ describe('verify_github_pr hook action', function () {
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_number: 456,
         pr_url: 'https://github.com/org/repo/pull/456',
         merged: true,
       }),
@@ -161,7 +165,6 @@ describe('verify_github_pr hook action', function () {
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_number: 789,
         pr_url: 'https://github.com/org/repo/pull/789',
         merged: true,
       }),
@@ -187,7 +190,6 @@ describe('verify_github_pr hook action', function () {
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
-        pr_number: 999,
         pr_url: 'https://github.com/org/repo/pull/999',
         merged: true,
       }),
@@ -203,5 +205,27 @@ describe('verify_github_pr hook action', function () {
     } catch (err) {
       assert.match(err.message, /Network error: timeout/);
     }
+  });
+
+  it('should throw when claimed pr_url does not match the branch PR', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/111',
+        merged: true,
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 222,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/222',
+      });
+    };
+
+    await assert.rejects(() => executeHook({ hook, agent, result }), /claimed PR URL/i);
   });
 });


### PR DESCRIPTION
Root cause: git-pusher (and other agents) often wrap structured output so pr_number extraction can return {} even when the PR was created/merged. The verify_github_pr hook treated this as fatal, causing CLUSTER_FAILED after a successful ship.

Fix: verify via  in the current branch instead of requiring pr_number. If a pr_url is provided, ensure it matches the branch PR URL to prevent hallucinated links.

Adds/updates regression tests for the hook.