### PR TITLE
fix: keep claude default and map level3 to opus-4.6

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -96,7 +96,7 @@ function validateModelAgainstMax(requestedModel, maxModel, minModel = null) {
 const DEFAULT_SETTINGS_BASE = {
   maxModel: 'opus', // Cost ceiling - agents cannot use models above this
   minModel: null, // Cost floor - agents cannot use models below this (null = no minimum)
-  defaultProvider: 'codex',
+  defaultProvider: 'claude',
   get providerSettings() {
     // Dynamically build from providers on first access
     return getProviderDefaults();

--- a/src/providers/anthropic/models.js
+++ b/src/providers/anthropic/models.js
@@ -2,12 +2,13 @@ const MODEL_CATALOG = {
   haiku: { rank: 1 },
   sonnet: { rank: 2 },
   opus: { rank: 3 },
+  'opus-4.6': { rank: 3 },
 };
 
 const LEVEL_MAPPING = {
   level1: { rank: 1, model: 'haiku' },
   level2: { rank: 2, model: 'sonnet' },
-  level3: { rank: 3, model: 'opus' },
+  level3: { rank: 3, model: 'opus-4.6' },
 };
 
 const DEFAULT_LEVEL = 'level2';

--- a/tests/max-model.test.js
+++ b/tests/max-model.test.js
@@ -251,8 +251,8 @@ function registerDefaultModelTests() {
         mockSpawnFn: () => {},
       });
 
-      // Default provider level is level2 (gpt-5.3-codex for codex)
-      assert.strictEqual(agent._selectModel(), 'gpt-5.3-codex');
+      // Default provider level is level2 (sonnet for claude)
+      assert.strictEqual(agent._selectModel(), 'sonnet');
     });
 
     it('should use provider default level even when maxModel allows higher', function () {

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -90,4 +90,10 @@ describe('Provider settings', function () {
     const modelSpec = codex.resolveModelSpec(codex.getDefaultLevel(), {});
     assert.strictEqual(modelSpec.model, 'gpt-5.3-codex');
   });
+
+  it('maps claude level3 to opus-4.6', function () {
+    const claude = getProvider('claude');
+    const modelSpec = claude.resolveModelSpec('level3', {});
+    assert.strictEqual(modelSpec.model, 'opus-4.6');
+  });
 });

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -82,7 +82,7 @@ function registerSettingsDefaultTests() {
     assert.strictEqual(DEFAULT_SETTINGS.defaultDocker, false);
     assert.strictEqual(DEFAULT_SETTINGS.strictSchema, true);
     assert.strictEqual(DEFAULT_SETTINGS.logLevel, 'normal');
-    assert.strictEqual(DEFAULT_SETTINGS.defaultProvider, 'codex');
+    assert.strictEqual(DEFAULT_SETTINGS.defaultProvider, 'claude');
     assert.ok(DEFAULT_SETTINGS.providerSettings);
   });
 


### PR DESCRIPTION
## Summary
- restore `claude` as the global default provider
- bump Claude level3 mapping to `opus-4.6`
- keep Codex default model mapping as `gpt-5.3-codex`
- update settings/provider tests for the corrected defaults and Claude mapping

## Validation
- `npx mocha tests/settings.test.js tests/settings-providers.test.js tests/max-model.test.js tests/model-selection.test.js tests/settings-claude-auth.test.js`
- `npx eslint lib/settings.js src/providers/anthropic/models.js tests/settings.test.js tests/settings-providers.test.js tests/max-model.test.js tests/model-selection.test.js`
