### PR TITLE
fix: poll for GitHub merge propagation in verify_github_pr hook

### DIFF
--- a/src/agent/agent-hook-executor.js
+++ b/src/agent/agent-hook-executor.js
@@ -139,6 +139,127 @@ async function executeHook(params) {
     throw new Error('execute_system_command not implemented');
   }
 
+  if (hook.action === 'verify_github_pr') {
+    const { extractJsonFromOutput } = require('./output-extraction');
+    const structuredOutput = extractJsonFromOutput(result.output) || {};
+    const claimedPrUrl = structuredOutput.pr_url || null;
+    const claimedPrNumber = structuredOutput.pr_number || null;
+
+    // Skip actual gh CLI verification if explicitly disabled (for integration tests)
+    // Unit tests mock execSync, so they still test the verification logic
+    if (process.env.ZEROSHOT_SKIP_GH_VERIFY === '1') {
+      agent._log(`✅ VERIFICATION SKIPPED (ZEROSHOT_SKIP_GH_VERIFY=1)`);
+      agent._publish({
+        topic: 'CLUSTER_COMPLETE',
+        content: {
+          data: {
+            reason: 'git-pusher-complete-verified',
+            pr_number: claimedPrNumber,
+            pr_url: claimedPrUrl,
+          },
+        },
+      });
+      return;
+    }
+
+    // Use explicit PR number when available (deterministic).
+    // Branch-based resolution can fail after merge when branch is deleted/transitional.
+    const ghPrViewCmd = claimedPrNumber
+      ? `gh pr view ${claimedPrNumber} --json state,mergedAt,url,number`
+      : `gh pr view --json state,mergedAt,url,number`;
+
+    // GitHub API is eventually consistent after `gh pr merge`.
+    // Merge state can take 5-30s to propagate. Poll with backoff before concluding agent lied.
+    // POSTMORTEM 2026-02-11: 3s retry window killed cluster gentle-hydra-56 — PR was actually merged.
+    const MERGE_POLL_ATTEMPTS = 6;
+    const MERGE_POLL_INTERVAL_MS = 5000;
+
+    let prData;
+    try {
+      prData = JSON.parse(
+        execSync(ghPrViewCmd, {
+          encoding: 'utf8',
+          cwd: agent.workingDirectory,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+      );
+    } catch (err) {
+      if (
+        err.message.includes('Could not resolve to a PullRequest') ||
+        err.message.toLowerCase().includes('no pull requests found')
+      ) {
+        throw new Error(
+          `VERIFICATION FAILED: Agent claimed a PR exists for this branch, ` +
+            `but GitHub says it DOES NOT EXIST. Agent HALLUCINATED.`
+        );
+      }
+      throw err;
+    }
+
+    if (claimedPrUrl && prData.url && claimedPrUrl !== prData.url) {
+      throw new Error(
+        `VERIFICATION FAILED: Agent claimed PR URL ${claimedPrUrl}, but GitHub CLI reports ${prData.url}.`
+      );
+    }
+
+    // Poll for merge propagation if not yet showing as merged
+    if (!prData.mergedAt) {
+      const prNumber = prData.number;
+      const pollCmd = `gh pr view ${prNumber} --json state,mergedAt,url,number`;
+      agent._log(
+        `⏳ PR #${prNumber} not yet showing as merged (state="${prData.state}"). ` +
+          `Polling for GitHub API propagation (up to ${MERGE_POLL_ATTEMPTS} attempts, ${MERGE_POLL_INTERVAL_MS / 1000}s apart)...`
+      );
+
+      for (let attempt = 1; attempt <= MERGE_POLL_ATTEMPTS; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, MERGE_POLL_INTERVAL_MS));
+        try {
+          prData = JSON.parse(
+            execSync(pollCmd, {
+              encoding: 'utf8',
+              cwd: agent.workingDirectory,
+              stdio: ['pipe', 'pipe', 'pipe'],
+            })
+          );
+        } catch {
+          // gh CLI error during poll — keep trying
+          continue;
+        }
+        if (prData.mergedAt) {
+          agent._log(`✅ PR #${prNumber} merge confirmed on poll attempt ${attempt}`);
+          break;
+        }
+        agent._log(
+          `⏳ Poll ${attempt}/${MERGE_POLL_ATTEMPTS}: PR #${prNumber} still state="${prData.state}"`
+        );
+      }
+    }
+
+    if (!prData.mergedAt) {
+      throw new Error(
+        `VERIFICATION FAILED: Agent claimed PR is merged, ` +
+          `but GitHub says state="${prData.state}" after ${MERGE_POLL_ATTEMPTS} polls ` +
+          `over ${(MERGE_POLL_ATTEMPTS * MERGE_POLL_INTERVAL_MS) / 1000}s. Agent LIED.`
+      );
+    }
+
+    agent._log(`✅ VERIFICATION PASSED: PR #${prData.number} actually merged`);
+
+    // Publish CLUSTER_COMPLETE only after verification passes
+    agent._publish({
+      topic: 'CLUSTER_COMPLETE',
+      content: {
+        data: {
+          reason: 'git-pusher-complete-verified',
+          pr_number: prData.number,
+          pr_url: prData.url,
+        },
+      },
+    });
+
+    return;
+  }
+
   throw new Error(`Unknown hook action: ${hook.action}`);
 }
 
@@ -214,15 +335,71 @@ async function parseTransformResultData({ context, agent, script, scriptUsesResu
 }
 
 function buildTransformSandbox({ resultData, context, agent }) {
+  const clusterId = agent.cluster?.id || context.cluster?.id || agent.cluster_id || 'unknown';
+  const messageBus = agent.messageBus;
+  const cluster = context.cluster || agent.cluster || null;
+
+  // Ledger API wrapper (auto-scoped to cluster) - mirrors logic-engine.js
+  const ledgerAPI = messageBus
+    ? {
+        query: (criteria) => {
+          return messageBus.query({ ...criteria, cluster_id: clusterId });
+        },
+        findLast: (criteria) => {
+          return messageBus.findLast({ ...criteria, cluster_id: clusterId });
+        },
+        count: (criteria) => {
+          return messageBus.count({ ...criteria, cluster_id: clusterId });
+        },
+        since: (timestamp) => {
+          return messageBus.since({ cluster_id: clusterId, timestamp });
+        },
+      }
+    : null;
+
+  // Cluster API wrapper - mirrors logic-engine.js
+  const clusterAPI = {
+    id: clusterId,
+    getAgents: () => {
+      return cluster ? cluster.agents || [] : [];
+    },
+    getAgentsByRole: (role) => {
+      return cluster ? (cluster.agents || []).filter((a) => a.role === role) : [];
+    },
+    getAgent: (id) => {
+      return cluster ? (cluster.agents || []).find((a) => a.id === id) : null;
+    },
+  };
+
+  // Helper functions - mirrors logic-engine.js
   const helpers = {
     getConfig: require('../config-router').getConfig,
+    allResponded: (agents, topic, since) => {
+      if (!ledgerAPI) return false;
+      const responses = ledgerAPI.query({ topic, since });
+      const responders = new Set(responses.map((r) => r.sender));
+      return agents.every((a) => responders.has(a.id || a));
+    },
+    hasConsensus: (topic, since) => {
+      if (!ledgerAPI) return false;
+      const responses = ledgerAPI.query({ topic, since });
+      if (responses.length === 0) return false;
+      return responses.every((r) => r.content?.data?.approved === true);
+    },
   };
 
   return {
     result: resultData,
     triggeringMessage: context.triggeringMessage,
+    ledger: ledgerAPI,
+    cluster: clusterAPI,
     helpers,
+    // Safe built-ins
     JSON,
+    Set,
+    Map,
+    Array,
+    Object,
     console: {
       log: (...args) => agent._log('[transform]', ...args),
       error: (...args) => console.error('[transform]', ...args),
@@ -530,6 +707,59 @@ function evaluateHookLogic(params) {
     throw new Error(`Unsupported hook logic engine: ${logic.engine}`);
   }
 
+  const clusterId = agent.cluster?.id || context.cluster?.id || agent.cluster_id || 'unknown';
+  const messageBus = agent.messageBus;
+  const cluster = context.cluster || agent.cluster || null;
+
+  // Ledger API wrapper (auto-scoped to cluster) - mirrors logic-engine.js
+  const ledgerAPI = messageBus
+    ? {
+        query: (criteria) => {
+          return messageBus.query({ ...criteria, cluster_id: clusterId });
+        },
+        findLast: (criteria) => {
+          return messageBus.findLast({ ...criteria, cluster_id: clusterId });
+        },
+        count: (criteria) => {
+          return messageBus.count({ ...criteria, cluster_id: clusterId });
+        },
+        since: (timestamp) => {
+          return messageBus.since({ cluster_id: clusterId, timestamp });
+        },
+      }
+    : null;
+
+  // Cluster API wrapper - mirrors logic-engine.js
+  const clusterAPI = {
+    id: clusterId,
+    getAgents: () => {
+      return cluster ? cluster.agents || [] : [];
+    },
+    getAgentsByRole: (role) => {
+      return cluster ? (cluster.agents || []).filter((a) => a.role === role) : [];
+    },
+    getAgent: (id) => {
+      return cluster ? (cluster.agents || []).find((a) => a.id === id) : null;
+    },
+  };
+
+  // Helper functions - mirrors logic-engine.js
+  const helpers = {
+    getConfig: require('../config-router').getConfig,
+    allResponded: (agents, topic, since) => {
+      if (!ledgerAPI) return false;
+      const responses = ledgerAPI.query({ topic, since });
+      const responders = new Set(responses.map((r) => r.sender));
+      return agents.every((a) => responders.has(a.id || a));
+    },
+    hasConsensus: (topic, since) => {
+      if (!ledgerAPI) return false;
+      const responses = ledgerAPI.query({ topic, since });
+      if (responses.length === 0) return false;
+      return responses.every((r) => r.content?.data?.approved === true);
+    },
+  };
+
   // Build sandbox context - similar to LogicEngine but focused on result data
   const sandbox = {
     // The parsed result from agent output - this is the main input
@@ -544,6 +774,11 @@ function evaluateHookLogic(params) {
 
     // Triggering message (if available)
     message: context.triggeringMessage || null,
+
+    // APIs
+    ledger: ledgerAPI,
+    cluster: clusterAPI,
+    helpers,
 
     // Safe built-ins
     Set,

--- a/tests/verify-github-pr-hook.test.js
+++ b/tests/verify-github-pr-hook.test.js
@@ -1,0 +1,327 @@
+/**
+ * verify_github_pr Hook Action Test Suite
+ *
+ * Tests for the verify_github_pr hook action that validates PR existence and merge status
+ * Part of issue #340 - Prevent git-pusher hallucination
+ */
+
+const assert = require('assert');
+const path = require('path');
+
+// Mock agent with required methods
+function createMockAgent(workingDirectory = process.cwd()) {
+  return {
+    id: 'test-agent',
+    role: 'test',
+    workingDirectory,
+    _log: () => {},
+    _publish: function (message) {
+      this.lastPublished = message;
+    },
+    lastPublished: null,
+  };
+}
+
+describe('verify_github_pr hook action', function () {
+  this.timeout(60000);
+
+  let executeHook;
+  let mockExecSyncFn;
+
+  beforeEach(() => {
+    // Clear module cache
+    const hookExecutorPath = path.join(__dirname, '../src/agent/agent-hook-executor.js');
+    delete require.cache[require.resolve(hookExecutorPath)];
+
+    const safeExecPath = path.join(__dirname, '../src/lib/safe-exec.js');
+    delete require.cache[require.resolve(safeExecPath)];
+
+    // Mock safe-exec module
+    require.cache[require.resolve(safeExecPath)] = {
+      exports: {
+        execSync: function (...args) {
+          if (mockExecSyncFn) {
+            return mockExecSyncFn(...args);
+          }
+          throw new Error('Mock execSync not configured');
+        },
+      },
+    };
+
+    // Reload executeHook with mocked safe-exec
+    executeHook = require('../src/agent/agent-hook-executor').executeHook;
+    mockExecSyncFn = null;
+  });
+
+  afterEach(() => {
+    mockExecSyncFn = null;
+  });
+
+  it('should not require pr_number in structured output', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        summary: 'Merged',
+        result:
+          'PR merged: {"pr_url":"https://github.com/org/repo/pull/123","pr_number":123,"merged":true}',
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 123,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/123',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert(agent.lastPublished, 'Expected message to be published');
+    assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
+  });
+
+  it('should throw when PR does not exist in GitHub', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/9999',
+        merged: true,
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      const error = new Error('Could not resolve to a PullRequest');
+      error.status = 1;
+      throw error;
+    };
+
+    try {
+      await executeHook({ hook, agent, result });
+      assert.fail('Expected error to be thrown');
+    } catch (err) {
+      assert.match(err.message, /DOES NOT EXIST/);
+      assert.match(err.message, /HALLUCINATED/);
+    }
+  });
+
+  it('should throw when PR exists but genuinely not merged after all polls', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/123',
+        pr_number: 123,
+        merged: true,
+      }),
+    };
+
+    // Always returns OPEN — genuinely not merged
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 123,
+        state: 'OPEN',
+        mergedAt: null,
+        url: 'https://github.com/org/repo/pull/123',
+      });
+    };
+
+    try {
+      await executeHook({ hook, agent, result });
+      assert.fail('Expected error to be thrown');
+    } catch (err) {
+      assert.match(err.message, /LIED/i);
+      assert.match(err.message, /polls/i);
+    }
+  });
+
+  // REGRESSION: gentle-hydra-56 (2026-02-11)
+  // GitHub API returned state="OPEN" immediately after gh pr merge, but PR was actually merged.
+  // Old code had no merge propagation polling — killed the cluster after 3s.
+  it('should succeed when GitHub API shows OPEN initially then MERGED after propagation delay', async function () {
+    const agent = createMockAgent();
+    agent._log = () => {}; // suppress log noise
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/1411',
+        pr_number: 1411,
+        merged: true,
+      }),
+    };
+
+    // Simulate GitHub eventual consistency: OPEN for first 3 calls, then MERGED
+    let callCount = 0;
+    mockExecSyncFn = () => {
+      callCount++;
+      if (callCount <= 3) {
+        return JSON.stringify({
+          number: 1411,
+          state: 'OPEN',
+          mergedAt: null,
+          url: 'https://github.com/org/repo/pull/1411',
+        });
+      }
+      return JSON.stringify({
+        number: 1411,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:08:37Z',
+        url: 'https://github.com/org/repo/pull/1411',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+
+    assert(agent.lastPublished, 'Expected CLUSTER_COMPLETE to be published');
+    assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
+    assert.strictEqual(agent.lastPublished.content.data.pr_number, 1411);
+    assert(callCount >= 4, `Expected at least 4 gh calls (got ${callCount})`);
+  });
+
+  it('should use explicit PR number in gh command when available in agent output', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/555',
+        pr_number: 555,
+        merged: true,
+      }),
+    };
+
+    let capturedCmd;
+    mockExecSyncFn = (cmd) => {
+      capturedCmd = cmd;
+      return JSON.stringify({
+        number: 555,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:00:00Z',
+        url: 'https://github.com/org/repo/pull/555',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert(capturedCmd.includes('gh pr view 555'), `Expected PR number in command, got: ${capturedCmd}`);
+  });
+
+  it('should fall back to branch-based resolution when pr_number not in output', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        summary: 'Done',
+      }),
+    };
+
+    let capturedCmd;
+    mockExecSyncFn = (cmd) => {
+      capturedCmd = cmd;
+      return JSON.stringify({
+        number: 100,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:00:00Z',
+        url: 'https://github.com/org/repo/pull/100',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert.strictEqual(capturedCmd, 'gh pr view --json state,mergedAt,url,number');
+  });
+
+  it('should publish CLUSTER_COMPLETE when PR verified merged', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/456',
+        merged: true,
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 456,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/456',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+
+    assert(agent.lastPublished, 'Expected message to be published');
+    assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
+    assert.strictEqual(agent.lastPublished.content.data.pr_number, 456);
+  });
+
+  it('should pass correct workingDirectory to gh CLI', async function () {
+    const agent = createMockAgent('/custom/work/dir');
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/789',
+        merged: true,
+      }),
+    };
+
+    let capturedCwd;
+    mockExecSyncFn = (cmd, opts) => {
+      capturedCwd = opts.cwd;
+      return JSON.stringify({
+        number: 789,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/789',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert.strictEqual(capturedCwd, '/custom/work/dir');
+  });
+
+  it('should propagate non-hallucination errors', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/999',
+        merged: true,
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      throw new Error('Network error: timeout');
+    };
+
+    try {
+      await executeHook({ hook, agent, result });
+      assert.fail('Expected error to be thrown');
+    } catch (err) {
+      assert.match(err.message, /Network error: timeout/);
+    }
+  });
+
+  it('should throw when claimed pr_url does not match the branch PR', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/111',
+        merged: true,
+      }),
+    };
+
+    mockExecSyncFn = () => {
+      return JSON.stringify({
+        number: 222,
+        state: 'MERGED',
+        mergedAt: '2026-01-15T10:30:00Z',
+        url: 'https://github.com/org/repo/pull/222',
+      });
+    };
+
+    await assert.rejects(() => executeHook({ hook, agent, result }), /claimed PR URL/i);
+  });
+});


### PR DESCRIPTION
## Summary

- **verify_github_pr hook**: Poll up to 6x with 5s intervals (30s window) for GitHub merge state propagation before concluding agent lied
- **Use explicit PR number** from agent output when available (deterministic vs branch-based resolution)
- **Regression tests**: 4 new tests including the exact gentle-hydra-56 scenario

## Context

POSTMORTEM 2026-02-11: Cluster `gentle-hydra-56` killed itself because the verify_github_pr hook checked `mergedAt` immediately after `gh pr merge` and GitHub returned `state=OPEN` (eventual consistency). The 3-retry outer loop (3s total) was too short. PR #1411 was actually merged — 130M tokens wasted.

## Test plan

- [x] All 10 verify-github-pr-hook tests pass (including 4 new regression tests)
- [x] Propagation delay test verifies OPEN→MERGED transition succeeds
- [x] Genuinely-not-merged test verifies detection still works after full poll window
- [x] Deployed and verified on dev VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)