### PR TITLE
fix: poll for GitHub merge propagation in verify_github_pr hook

### DIFF
--- a/src/agent/agent-hook-executor.js
+++ b/src/agent/agent-hook-executor.js
@@ -143,6 +143,7 @@ async function executeHook(params) {
     const { extractJsonFromOutput } = require('./output-extraction');
     const structuredOutput = extractJsonFromOutput(result.output) || {};
     const claimedPrUrl = structuredOutput.pr_url || null;
+    const claimedPrNumber = structuredOutput.pr_number || null;
 
     // Skip actual gh CLI verification if explicitly disabled (for integration tests)
     // Unit tests mock execSync, so they still test the verification logic
@@ -153,7 +154,7 @@ async function executeHook(params) {
         content: {
           data: {
             reason: 'git-pusher-complete-verified',
-            pr_number: structuredOutput.pr_number || null,
+            pr_number: claimedPrNumber,
             pr_url: claimedPrUrl,
           },
         },
@@ -161,13 +162,22 @@ async function executeHook(params) {
       return;
     }
 
+    // Use explicit PR number when available (deterministic).
+    // Branch-based resolution can fail after merge when branch is deleted/transitional.
+    const ghPrViewCmd = claimedPrNumber
+      ? `gh pr view ${claimedPrNumber} --json state,mergedAt,url,number`
+      : `gh pr view --json state,mergedAt,url,number`;
+
+    // GitHub API is eventually consistent after `gh pr merge`.
+    // Merge state can take 5-30s to propagate. Poll with backoff before concluding agent lied.
+    // POSTMORTEM 2026-02-11: 3s retry window killed cluster gentle-hydra-56 — PR was actually merged.
+    const MERGE_POLL_ATTEMPTS = 6;
+    const MERGE_POLL_INTERVAL_MS = 5000;
+
     let prData;
     try {
       prData = JSON.parse(
-        // IMPORTANT:
-        // Do NOT require pr_number in the agent output. GitHub CLI can infer the PR from the current branch.
-        // Agents sometimes wrap the PR JSON in a text field (summary/result) which is hard to parse reliably.
-        execSync(`gh pr view --json state,mergedAt,url,number`, {
+        execSync(ghPrViewCmd, {
           encoding: 'utf8',
           cwd: agent.workingDirectory,
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -192,10 +202,44 @@ async function executeHook(params) {
       );
     }
 
+    // Poll for merge propagation if not yet showing as merged
+    if (!prData.mergedAt) {
+      const prNumber = prData.number;
+      const pollCmd = `gh pr view ${prNumber} --json state,mergedAt,url,number`;
+      agent._log(
+        `⏳ PR #${prNumber} not yet showing as merged (state="${prData.state}"). ` +
+          `Polling for GitHub API propagation (up to ${MERGE_POLL_ATTEMPTS} attempts, ${MERGE_POLL_INTERVAL_MS / 1000}s apart)...`
+      );
+
+      for (let attempt = 1; attempt <= MERGE_POLL_ATTEMPTS; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, MERGE_POLL_INTERVAL_MS));
+        try {
+          prData = JSON.parse(
+            execSync(pollCmd, {
+              encoding: 'utf8',
+              cwd: agent.workingDirectory,
+              stdio: ['pipe', 'pipe', 'pipe'],
+            })
+          );
+        } catch {
+          // gh CLI error during poll — keep trying
+          continue;
+        }
+        if (prData.mergedAt) {
+          agent._log(`✅ PR #${prNumber} merge confirmed on poll attempt ${attempt}`);
+          break;
+        }
+        agent._log(
+          `⏳ Poll ${attempt}/${MERGE_POLL_ATTEMPTS}: PR #${prNumber} still state="${prData.state}"`
+        );
+      }
+    }
+
     if (!prData.mergedAt) {
       throw new Error(
         `VERIFICATION FAILED: Agent claimed PR is merged, ` +
-          `but GitHub says state="${prData.state}". Agent LIED.`
+          `but GitHub says state="${prData.state}" after ${MERGE_POLL_ATTEMPTS} polls ` +
+          `over ${(MERGE_POLL_ATTEMPTS * MERGE_POLL_INTERVAL_MS) / 1000}s. Agent LIED.`
       );
     }
 

--- a/tests/verify-github-pr-hook.test.js
+++ b/tests/verify-github-pr-hook.test.js
@@ -23,7 +23,7 @@ function createMockAgent(workingDirectory = process.cwd()) {
 }
 
 describe('verify_github_pr hook action', function () {
-  this.timeout(10000);
+  this.timeout(60000);
 
   let executeHook;
   let mockExecSyncFn;
@@ -107,16 +107,18 @@ describe('verify_github_pr hook action', function () {
     }
   });
 
-  it('should throw when PR exists but not merged', async function () {
+  it('should throw when PR exists but genuinely not merged after all polls', async function () {
     const agent = createMockAgent();
     const hook = { action: 'verify_github_pr' };
     const result = {
       output: JSON.stringify({
         pr_url: 'https://github.com/org/repo/pull/123',
+        pr_number: 123,
         merged: true,
       }),
     };
 
+    // Always returns OPEN — genuinely not merged
     mockExecSyncFn = () => {
       return JSON.stringify({
         number: 123,
@@ -130,8 +132,102 @@ describe('verify_github_pr hook action', function () {
       await executeHook({ hook, agent, result });
       assert.fail('Expected error to be thrown');
     } catch (err) {
-      assert.match(err.message, /not merged|LIED/i);
+      assert.match(err.message, /LIED/i);
+      assert.match(err.message, /polls/i);
     }
+  });
+
+  // REGRESSION: gentle-hydra-56 (2026-02-11)
+  // GitHub API returned state="OPEN" immediately after gh pr merge, but PR was actually merged.
+  // Old code had no merge propagation polling — killed the cluster after 3s.
+  it('should succeed when GitHub API shows OPEN initially then MERGED after propagation delay', async function () {
+    const agent = createMockAgent();
+    agent._log = () => {}; // suppress log noise
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/1411',
+        pr_number: 1411,
+        merged: true,
+      }),
+    };
+
+    // Simulate GitHub eventual consistency: OPEN for first 3 calls, then MERGED
+    let callCount = 0;
+    mockExecSyncFn = () => {
+      callCount++;
+      if (callCount <= 3) {
+        return JSON.stringify({
+          number: 1411,
+          state: 'OPEN',
+          mergedAt: null,
+          url: 'https://github.com/org/repo/pull/1411',
+        });
+      }
+      return JSON.stringify({
+        number: 1411,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:08:37Z',
+        url: 'https://github.com/org/repo/pull/1411',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+
+    assert(agent.lastPublished, 'Expected CLUSTER_COMPLETE to be published');
+    assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
+    assert.strictEqual(agent.lastPublished.content.data.pr_number, 1411);
+    assert(callCount >= 4, `Expected at least 4 gh calls (got ${callCount})`);
+  });
+
+  it('should use explicit PR number in gh command when available in agent output', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        pr_url: 'https://github.com/org/repo/pull/555',
+        pr_number: 555,
+        merged: true,
+      }),
+    };
+
+    let capturedCmd;
+    mockExecSyncFn = (cmd) => {
+      capturedCmd = cmd;
+      return JSON.stringify({
+        number: 555,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:00:00Z',
+        url: 'https://github.com/org/repo/pull/555',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert(capturedCmd.includes('gh pr view 555'), `Expected PR number in command, got: ${capturedCmd}`);
+  });
+
+  it('should fall back to branch-based resolution when pr_number not in output', async function () {
+    const agent = createMockAgent();
+    const hook = { action: 'verify_github_pr' };
+    const result = {
+      output: JSON.stringify({
+        summary: 'Done',
+      }),
+    };
+
+    let capturedCmd;
+    mockExecSyncFn = (cmd) => {
+      capturedCmd = cmd;
+      return JSON.stringify({
+        number: 100,
+        state: 'MERGED',
+        mergedAt: '2026-02-11T10:00:00Z',
+        url: 'https://github.com/org/repo/pull/100',
+      });
+    };
+
+    await executeHook({ hook, agent, result });
+    assert.strictEqual(capturedCmd, 'gh pr view --json state,mergedAt,url,number');
   });
 
   it('should publish CLUSTER_COMPLETE when PR verified merged', async function () {


### PR DESCRIPTION
## Summary
- Poll up to 6x/5s (30s window) for merge state propagation before concluding agent lied
- Use explicit PR number from agent output (deterministic vs branch-based)
- 4 regression tests including exact gentle-hydra-56 scenario

POSTMORTEM 2026-02-11: 3s retry killed cluster. PR was actually merged. 130M tokens wasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)