### PR TITLE
fix: fail fast on invalid provider model ids

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -345,14 +345,11 @@ function applyModelOverrideToConfig(config, modelOverride, providerOverride, set
     providerOverride || config.defaultProvider || settings.defaultProvider || 'claude'
   );
   const provider = getProvider(providerName);
-  const catalog = provider.getModelCatalog();
-
-  if (catalog && !catalog[modelOverride]) {
-    console.warn(
-      chalk.yellow(
-        `Warning: model override "${modelOverride}" is not in the ${providerName} catalog`
-      )
-    );
+  try {
+    provider.validateModelId(modelOverride);
+  } catch (err) {
+    console.error(chalk.red(`Error: ${err.message}`));
+    process.exit(1);
   }
 
   if (providerName === 'claude') {

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -162,6 +162,7 @@ class AgentWrapper {
       for (const rule of this.modelConfig.rules) {
         if (this._matchesIterationRange(rule.iterations)) {
           if (rule.model) {
+            provider.validateModelId(rule.model);
             return {
               level: 'custom',
               model: rule.model,
@@ -186,6 +187,7 @@ class AgentWrapper {
     }
 
     if (this.modelConfig.model) {
+      provider.validateModelId(this.modelConfig.model);
       return {
         level: 'custom',
         model: this.modelConfig.model,

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -833,6 +833,14 @@ async function executeTask(agent, triggeringMessage) {
       await runTaskAttempt(agent, triggeringMessage);
       return;
     } catch (error) {
+      if (!agent.running || agent.state === 'stopped') {
+        agent._log(`[${agent.id}] Task interrupted during shutdown; skipping retry`);
+        return;
+      }
+      if (error?.permanent) {
+        await handleFinalFailure(agent, triggeringMessage, error, attempt);
+        return;
+      }
       if (error instanceof HookExecutionError) {
         // Hook failures are deterministic; do not waste tokens retrying the provider task.
         await handleFinalFailure(agent, triggeringMessage, error, 1);

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -131,10 +131,14 @@ class ClaudeTaskRunner extends TaskRunner {
     levelOverrides,
   }) {
     if (explicitModelSpec) {
+      if (explicitModelSpec.model) {
+        providerModule.validateModelId(explicitModelSpec.model);
+      }
       return explicitModelSpec;
     }
 
     if (model) {
+      providerModule.validateModelId(model);
       return { model, reasoningEffort };
     }
 

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -1772,6 +1772,9 @@ function validateProviderSettings(provider, providerSettings) {
         `Invalid model override (must be non-empty string) for provider "${provider}"`
       );
     }
+    if (override?.model) {
+      providerModule.validateModelId(override.model);
+    }
     if (override?.reasoningEffort && !['codex', 'opencode'].includes(provider)) {
       throw new Error(`reasoningEffort overrides are only supported for Codex and Opencode`);
     }

--- a/src/providers/anthropic/index.js
+++ b/src/providers/anthropic/index.js
@@ -95,6 +95,11 @@ class AnthropicProvider extends BaseProvider {
   buildCommand(context, options) {
     const { command, args } = getClaudeCommand();
     const cliFeatures = options.cliFeatures || {};
+    const model = options.modelSpec?.model;
+
+    if (model) {
+      this.validateModelId(model);
+    }
 
     if (options.jsonSchema && options.outputFormat !== 'json' && !options.strictSchema) {
       this._warnOnce(
@@ -149,6 +154,21 @@ class AnthropicProvider extends BaseProvider {
 
   getDefaultMinLevel() {
     return DEFAULT_MIN_LEVEL;
+  }
+
+  validateModelId(modelId) {
+    try {
+      return super.validateModelId(modelId);
+    } catch (error) {
+      if (modelId && ['opus-4.6', 'claude-opus-4-6'].includes(modelId)) {
+        const err = new Error(
+          `Invalid model "${modelId}" for provider "claude". Use canonical model ids: haiku, sonnet, opus.`
+        );
+        err.permanent = true;
+        throw err;
+      }
+      throw error;
+    }
   }
 
   _warnOnce(key, message) {

--- a/src/providers/anthropic/models.js
+++ b/src/providers/anthropic/models.js
@@ -2,13 +2,12 @@ const MODEL_CATALOG = {
   haiku: { rank: 1 },
   sonnet: { rank: 2 },
   opus: { rank: 3 },
-  'opus-4.6': { rank: 3 },
 };
 
 const LEVEL_MAPPING = {
   level1: { rank: 1, model: 'haiku' },
   level2: { rank: 2, model: 'sonnet' },
-  level3: { rank: 3, model: 'opus-4.6' },
+  level3: { rank: 3, model: 'opus' },
 };
 
 const DEFAULT_LEVEL = 'level2';

--- a/src/providers/base-provider.js
+++ b/src/providers/base-provider.js
@@ -218,9 +218,10 @@ class BaseProvider {
       throw new Error(`Unknown level "${level}" for provider "${this.name}"`);
     }
     const override = overrides[level] || {};
+    const resolvedModel = this.validateModelId(override.model || base.model);
     return {
       level,
-      model: override.model || base.model,
+      model: resolvedModel,
       reasoningEffort: override.reasoningEffort || base.reasoningEffort,
     };
   }
@@ -265,7 +266,13 @@ class BaseProvider {
   validateModelId(modelId) {
     const catalog = this.getModelCatalog();
     if (modelId && !catalog[modelId]) {
-      throw new Error(`Invalid model "${modelId}" for provider "${this.name}"`);
+      const err = new Error(
+        `Invalid model "${modelId}" for provider "${this.name}". ` +
+          `Use a model listed in provider settings/catalog.`
+      );
+      // Permanent misconfiguration/user input error - retries cannot fix this.
+      err.permanent = true;
+      throw err;
     }
     return modelId;
   }

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -97,6 +97,7 @@ function resolveJsonSchema(options, outputFormat) {
 
 function resolveModelSpec(options, provider, providerSettings, levelOverrides) {
   if (options.model) {
+    provider.validateModelId(options.model);
     return {
       model: options.model,
       reasoningEffort: options.reasoningEffort,

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -206,6 +206,17 @@ describe('Claude CLI Builder', function () {
 
     assert.ok(!result.args.includes('--json-schema'));
   });
+
+  it('passes model value through without alias normalization', function () {
+    const result = buildCommand('test context', {
+      modelSpec: { model: 'opus-4.6' },
+      cliFeatures: { supportsModel: true },
+    });
+
+    const modelFlagIndex = result.args.indexOf('--model');
+    assert.ok(modelFlagIndex >= 0);
+    assert.strictEqual(result.args[modelFlagIndex + 1], 'opus-4.6');
+  });
 });
 
 // ============================================================================

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -48,7 +48,7 @@ describe('Provider settings', function () {
         maxLevel: 'level3',
         defaultLevel: 'level2',
         levelOverrides: {
-          level1: { model: 'codex-model-main', reasoningEffort: 'low' },
+          level1: { model: 'gpt-5.3-codex', reasoningEffort: 'low' },
         },
       });
     });
@@ -95,5 +95,34 @@ describe('Provider settings', function () {
     const claude = getProvider('claude');
     const modelSpec = claude.resolveModelSpec('level3', {});
     assert.strictEqual(modelSpec.model, 'opus-4.6');
+  });
+
+  it('rejects legacy claude model aliases as invalid input', function () {
+    const claude = getProvider('claude');
+    assert.throws(() => {
+      claude.validateModelId('opus-4.6');
+    }, /Use canonical model ids: haiku, sonnet, opus/);
+  });
+
+  it('marks invalid model errors as permanent', function () {
+    const claude = getProvider('claude');
+    assert.throws(() => {
+      try {
+        claude.validateModelId('not-a-model');
+      } catch (error) {
+        assert.strictEqual(error.permanent, true);
+        throw error;
+      }
+    }, /Invalid model "not-a-model"/);
+  });
+
+  it('fails before command build when model override is invalid', function () {
+    const claude = getProvider('claude');
+    assert.throws(() => {
+      claude.buildCommand('test context', {
+        modelSpec: { model: 'opus-4.6' },
+        cliFeatures: { supportsModel: true },
+      });
+    }, /Use canonical model ids: haiku, sonnet, opus/);
   });
 });

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -91,10 +91,10 @@ describe('Provider settings', function () {
     assert.strictEqual(modelSpec.model, 'gpt-5.3-codex');
   });
 
-  it('maps claude level3 to opus-4.6', function () {
+  it('maps claude level3 to opus alias', function () {
     const claude = getProvider('claude');
     const modelSpec = claude.resolveModelSpec('level3', {});
-    assert.strictEqual(modelSpec.model, 'opus-4.6');
+    assert.strictEqual(modelSpec.model, 'opus');
   });
 
   it('rejects legacy claude model aliases as invalid input', function () {


### PR DESCRIPTION
## Summary
- remove Claude legacy model alias fallback (`opus-4.6`)
- validate provider model IDs at command build/resolve time and mark invalid input as permanent
- stop retry loops for permanent input/config errors
- enforce strict model override validation in CLI and provider override config
- add/update tests for canonical Claude model mapping and invalid model rejection

## Validation
- `npx mocha tests/provider-cli-builder.test.js tests/settings-providers.test.js tests/unit/provider-retryable-errors.test.js`
- live smoke: invalid `--model opus-4.6` now fails immediately; valid `--model opus` task completes
