### PR TITLE
feat: default validators and planner to Opus

### DIFF
--- a/cluster-templates/base-templates/full-workflow.json
+++ b/cluster-templates/base-templates/full-workflow.json
@@ -5,7 +5,7 @@
     "planner_level": {
       "type": "string",
       "enum": ["level1", "level2", "level3"],
-      "default": "level2"
+      "default": "level3"
     },
     "worker_level": {
       "type": "string",
@@ -15,7 +15,7 @@
     "validator_level": {
       "type": "string",
       "enum": ["level1", "level2", "level3"],
-      "default": "level2"
+      "default": "level3"
     },
     "validator_count": {
       "type": "number",

--- a/cluster-templates/base-templates/heavy-validation.json
+++ b/cluster-templates/base-templates/heavy-validation.json
@@ -5,7 +5,7 @@
     "validator_level": {
       "type": "string",
       "enum": ["level1", "level2", "level3"],
-      "default": "level2"
+      "default": "level3"
     },
     "max_tokens": {
       "type": "number",

--- a/cluster-templates/base-templates/quick-validation.json
+++ b/cluster-templates/base-templates/quick-validation.json
@@ -5,7 +5,7 @@
     "validator_level": {
       "type": "string",
       "enum": ["level1", "level2", "level3"],
-      "default": "level2"
+      "default": "level3"
     },
     "max_tokens": {
       "type": "number",

--- a/cluster-templates/base-templates/worker-validator.json
+++ b/cluster-templates/base-templates/worker-validator.json
@@ -10,7 +10,7 @@
     "validator_level": {
       "type": "string",
       "enum": ["level1", "level2", "level3"],
-      "default": "level2"
+      "default": "level3"
     },
     "max_iterations": {
       "type": "number",


### PR DESCRIPTION
## Summary
- Validators default to level3 (Opus) instead of level2 (Sonnet) — reduces false positives on codebase conventions
- Planner defaults to level3 (Opus) — better architecture reasoning

Cherry-picked from `fix/completed-state-lifecycle` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)