### PR TITLE
fix: validate resolved conductor topology before token spend

### DIFF
--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -24,7 +24,8 @@ const { GUIDANCE_TOPICS } = require('./guidance-topics');
  * @returns {boolean}
  */
 function isConductorConfig(config) {
-  return config.agents?.some(
+  const agents = Array.isArray(config?.agents) ? config.agents : [];
+  const hasConductorOps = agents.some(
     (a) =>
       a.role === 'conductor' &&
       // Old style: static topic in config
@@ -32,6 +33,25 @@ function isConductorConfig(config) {
         // New style: topic set in transform script (check for CLUSTER_OPERATIONS in script)
         a.hooks?.onComplete?.transform?.script?.includes('CLUSTER_OPERATIONS'))
   );
+
+  if (!hasConductorOps) {
+    return false;
+  }
+
+  // Once runtime agents are present (after load_config/add_agents), we should NOT
+  // skip message-flow validation. Skipping here caused proposed runtime topologies
+  // to bypass dead-topic checks.
+  const runtimeRoles = new Set([
+    'implementation',
+    'worker',
+    'planner',
+    'validator',
+    'tester',
+    'coordinator',
+  ]);
+  const hasRuntimeAgents = agents.some((a) => runtimeRoles.has(a.role));
+
+  return !hasRuntimeAgents;
 }
 
 /**
@@ -514,6 +534,204 @@ function reportMissingContextTopics(config, warnings) {
   }
 }
 
+function hasDynamicLoadConfigPath(config) {
+  for (const agent of config.agents || []) {
+    const onComplete = agent?.hooks?.onComplete;
+    if (!onComplete) continue;
+
+    const configOps = onComplete.config?.content?.data?.operations;
+    if (Array.isArray(configOps) && configOps.some((op) => op?.action === 'load_config')) {
+      return true;
+    }
+
+    const script = onComplete.transform?.script;
+    if (typeof script === 'string' && script.includes('load_config')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasReachableCompletionPath(config, topicConsumers, agentOutputTopics) {
+  const agentsById = new Map((config.agents || []).map((agent) => [agent.id, agent]));
+  const queue = ['ISSUE_OPENED'];
+  const visitedTopics = new Set(queue);
+
+  while (queue.length > 0) {
+    const topic = queue.shift();
+    if (topic === 'CLUSTER_COMPLETE') {
+      return true;
+    }
+
+    const consumers = topicConsumers.get(topic) || [];
+    for (const agentId of consumers) {
+      const agent = agentsById.get(agentId);
+      if (!agent) continue;
+
+      const stopTrigger = (agent.triggers || []).some(
+        (trigger) => trigger.topic === topic && trigger.action === 'stop_cluster'
+      );
+      if (stopTrigger) {
+        return true;
+      }
+
+      const outputs = agentOutputTopics.get(agentId) || [];
+      for (const nextTopic of outputs) {
+        if (!visitedTopics.has(nextTopic)) {
+          visitedTopics.add(nextTopic);
+          queue.push(nextTopic);
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function reportMissingCompletionPath(config, topicConsumers, agentOutputTopics, errors, warnings) {
+  const hasPath = hasReachableCompletionPath(config, topicConsumers, agentOutputTopics);
+  if (hasPath) {
+    return;
+  }
+
+  const message =
+    'No reachable path from ISSUE_OPENED to terminal signal (stop_cluster or CLUSTER_COMPLETE). ' +
+    'Cluster may run until timeout even when validation appears to pass.';
+  const isDynamic = hasDynamicLoadConfigPath(config);
+  if (isDynamic) {
+    warnings.push(
+      `${message} Dynamic load_config path detected; add explicit resolved-topology simulation.`
+    );
+    return;
+  }
+
+  const isSubTemplate = config.params && Object.keys(config.params).length > 0;
+  if (isSubTemplate) {
+    warnings.push(`${message} Template mode may rely on orchestrator completion injection.`);
+    return;
+  }
+
+  errors.push(message);
+}
+
+function extractPublishedDataKeys(hook) {
+  if (hook?.action !== 'publish_message') {
+    return null;
+  }
+  if (hook?.config?.topic && hook?.config?.content) {
+    const data = hook.config.content.data;
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      return new Set(Object.keys(data));
+    }
+    return new Set();
+  }
+  return null;
+}
+
+function extractHookTopics(hook) {
+  const topics = new Set();
+  if (hook?.config?.topic) {
+    topics.add(String(hook.config.topic));
+  }
+
+  const script = hook?.transform?.script;
+  if (typeof script === 'string') {
+    const matches = script.match(/topic:\s*['"]([A-Za-z0-9_-]+)['"]/g) || [];
+    for (const match of matches) {
+      const topic = match.match(/['"]([A-Za-z0-9_-]+)['"]/)?.[1];
+      if (topic) topics.add(topic);
+    }
+  }
+
+  return topics;
+}
+
+function collectTopicContracts(config) {
+  const contracts = new Map(); // topic -> [{ agentId, keys: Set<string>|null }]
+
+  const addContract = (topic, contract) => {
+    if (!contracts.has(topic)) {
+      contracts.set(topic, []);
+    }
+    contracts.get(topic).push(contract);
+  };
+
+  for (const agent of config.agents || []) {
+    const hook = agent?.hooks?.onComplete;
+    if (!hook) continue;
+
+    const topics = extractHookTopics(hook);
+    const staticKeys = extractPublishedDataKeys(hook);
+
+    for (const topic of topics) {
+      const isStaticTopic = hook?.config?.topic === topic;
+      if (isStaticTopic) {
+        addContract(topic, { agentId: agent.id, keys: staticKeys ?? new Set() });
+      } else {
+        // Topic inferred from transform script. Treat as dynamic payload shape.
+        addContract(topic, { agentId: agent.id, keys: null });
+      }
+    }
+  }
+
+  return contracts;
+}
+
+function extractRequiredDataKeys(script) {
+  if (typeof script !== 'string') return new Set();
+  const required = new Set();
+  // Only treat direct `content.data.key` access as required contract keys.
+  // Optional-chained access (`content?.data?.key`) is intentionally excluded.
+  const regex = /\.content\.data\.([A-Za-z_][A-Za-z0-9_]*)/g;
+  let match;
+  while ((match = regex.exec(script)) !== null) {
+    required.add(match[1]);
+  }
+  return required;
+}
+
+function reportSchemaContractMismatches(config, errors, warnings) {
+  const contracts = collectTopicContracts(config);
+  const seen = new Set();
+
+  for (const agent of config.agents || []) {
+    for (const trigger of agent.triggers || []) {
+      if (!trigger?.topic || !trigger?.logic?.script) continue;
+
+      const requiredKeys = extractRequiredDataKeys(trigger.logic.script);
+      if (requiredKeys.size === 0) continue;
+
+      const producers = contracts.get(trigger.topic) || [];
+      if (producers.length === 0) continue;
+
+      const staticProducers = producers.filter((producer) => producer.keys instanceof Set);
+      const hasDynamicProducers = producers.some((producer) => producer.keys === null);
+      if (staticProducers.length === 0) continue;
+
+      for (const key of requiredKeys) {
+        const token = `${agent.id}:${trigger.topic}:${key}`;
+        if (seen.has(token)) continue;
+        seen.add(token);
+
+        const hasStaticKey = staticProducers.some((producer) => producer.keys.has(key));
+        if (hasStaticKey) continue;
+
+        if (hasDynamicProducers) {
+          warnings.push(
+            `Agent '${agent.id}' trigger on '${trigger.topic}' expects content.data.${key}, ` +
+              `but static producers for '${trigger.topic}' do not publish it (dynamic producers present).`
+          );
+        } else {
+          errors.push(
+            `Agent '${agent.id}' trigger on '${trigger.topic}' expects content.data.${key}, ` +
+              `but no producer for '${trigger.topic}' publishes that data key.`
+          );
+        }
+      }
+    }
+  }
+}
+
 function analyzeMessageFlow(config) {
   const errors = [];
   const warnings = [];
@@ -529,6 +747,8 @@ function analyzeMessageFlow(config) {
   reportTwoAgentCycles(config, agentInputTopics, agentOutputTopics, warnings);
   reportMissingValidationTriggers(config, errors);
   reportMissingContextTopics(config, warnings);
+  reportMissingCompletionPath(config, topicConsumers, agentOutputTopics, errors, warnings);
+  reportSchemaContractMismatches(config, errors, warnings);
 
   return { errors, warnings };
 }

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -411,6 +411,10 @@ function reportUnproducedTopics(topicConsumers, topicProducers, errors, config) 
     'CLUSTER_RESUMED',
     'QUICK_VALIDATION_PASSED',
     'IMPLEMENTATION_READY',
+    // Produced conditionally by conductor/orchestrator fallback paths.
+    // These should not fail static flow validation when absent in the happy path.
+    'CONDUCTOR_ESCALATE',
+    'CLUSTER_OPERATIONS_VALIDATION_FAILED',
     ...GUIDANCE_TOPICS,
   ];
   const isSubTemplate = config.params && Object.keys(config.params).length > 0;

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2695,8 +2695,69 @@ Continue from where you left off. Review your previous output to understand what
     return loadedConfig.agents;
   }
 
+  _hasCompletionHandler(agentConfigs) {
+    return (agentConfigs || []).some(
+      (agent) =>
+        agent.id === 'completion-detector' ||
+        agent.id === 'git-pusher' ||
+        agent.hooks?.onComplete?.config?.topic === 'CLUSTER_COMPLETE' ||
+        agent.triggers?.some((trigger) => trigger.action === 'stop_cluster')
+    );
+  }
+
+  _injectCriticalValidationResultProducer(agentConfigs) {
+    const hasMetaCoordinator = agentConfigs.some((agent) => agent.id === 'meta-coordinator');
+    const hasRuntimeValidator = agentConfigs.some((agent) => agent.role === 'validator');
+    const hasSimulator = agentConfigs.some((agent) => agent.id === '__validation-result-simulator');
+
+    // CRITICAL flow loads quick/heavy validators dynamically; simulate stage-1 producer
+    // for static validation so we don't reject legitimate staged topologies.
+    if (hasMetaCoordinator && !hasRuntimeValidator && !hasSimulator) {
+      agentConfigs.push({
+        id: '__validation-result-simulator',
+        role: 'validator',
+        triggers: [{ topic: 'IMPLEMENTATION_READY', action: 'execute_task' }],
+        hooks: {
+          onComplete: {
+            action: 'publish_message',
+            config: {
+              topic: 'VALIDATION_RESULT',
+              content: {
+                data: {
+                  approved: true,
+                  errors: [],
+                  criteriaResults: [],
+                },
+              },
+            },
+          },
+        },
+      });
+    }
+  }
+
+  _prepareValidationAgentConfigs(proposedAgentConfigs) {
+    const validationAgents = JSON.parse(JSON.stringify(proposedAgentConfigs || []));
+
+    this._injectCriticalValidationResultProducer(validationAgents);
+
+    // Operation-chain validation runs before _injectCompletionAgent executes.
+    // Add a synthetic completion handler so transient missing completion detectors
+    // don't invalidate otherwise-correct topology changes.
+    if (!this._hasCompletionHandler(validationAgents)) {
+      validationAgents.push({
+        id: '__completion-validator',
+        role: 'orchestrator',
+        triggers: [{ topic: 'VALIDATION_RESULT', action: 'stop_cluster' }],
+      });
+    }
+
+    return validationAgents;
+  }
+
   _validateProposedConfig(clusterId, cluster, proposedAgentConfigs, operations) {
-    const mockConfig = { agents: proposedAgentConfigs };
+    const validationAgents = this._prepareValidationAgentConfigs(proposedAgentConfigs);
+    const mockConfig = { agents: validationAgents };
     const validation = configValidator.validateConfig(mockConfig);
 
     if (!validation.valid) {

--- a/src/template-validation/index.js
+++ b/src/template-validation/index.js
@@ -2,8 +2,14 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { validateConfig } = require('../config-validator');
+const { getConfig } = require('../config-router');
+const TemplateResolver = require('../template-resolver');
+const { SHARED_TRIGGER_SCRIPT } = require('../agents/git-pusher-template');
 const { simulateConsensusGates } = require('./simulate-consensus-gates');
 const { simulateTwoStageValidation } = require('./simulate-two-stage-validation');
+
+const CONDUCTOR_COMPLEXITIES = ['TRIVIAL', 'SIMPLE', 'STANDARD', 'CRITICAL'];
+const CONDUCTOR_TASK_TYPES = ['TASK', 'DEBUG', 'INQUIRY'];
 
 function findJsonFiles(dir) {
   const files = [];
@@ -43,8 +49,110 @@ async function validateTemplateConfig({ config, templateId, deep }) {
   return result;
 }
 
+function hasCompletionHandler(config) {
+  const agents = Array.isArray(config?.agents) ? config.agents : [];
+  return agents.some(
+    (agent) =>
+      agent.id === 'completion-detector' ||
+      agent.id === 'git-pusher' ||
+      agent.hooks?.onComplete?.config?.topic === 'CLUSTER_COMPLETE' ||
+      agent.triggers?.some((trigger) => trigger.action === 'stop_cluster')
+  );
+}
+
+function mergeAgentsById(primaryConfig, additionalConfig) {
+  const merged = {
+    ...primaryConfig,
+    agents: Array.isArray(primaryConfig?.agents) ? [...primaryConfig.agents] : [],
+  };
+  const seen = new Set(merged.agents.map((agent) => agent.id));
+
+  for (const agent of additionalConfig?.agents || []) {
+    if (seen.has(agent.id)) {
+      continue;
+    }
+    merged.agents.push(agent);
+    seen.add(agent.id);
+  }
+
+  return merged;
+}
+
+function augmentCriticalResolvedConfig({ resolver, config, params }) {
+  if (params?.complexity !== 'CRITICAL' || params?.validator_count !== 0) {
+    return config;
+  }
+
+  const quickValidationConfig = resolver.resolve('quick-validation', {
+    validator_level: params.validator_level,
+    max_tokens: params.max_tokens,
+    timeout: params.timeout || 0,
+  });
+  return mergeAgentsById(config, quickValidationConfig);
+}
+
+function ensureCompletionHandler(config) {
+  if (hasCompletionHandler(config)) {
+    return config;
+  }
+
+  return {
+    ...config,
+    agents: [
+      ...(config.agents || []),
+      {
+        id: 'completion-detector',
+        role: 'orchestrator',
+        modelLevel: 'level1',
+        triggers: [
+          {
+            topic: 'VALIDATION_RESULT',
+            logic: {
+              engine: 'javascript',
+              script: SHARED_TRIGGER_SCRIPT,
+            },
+            action: 'stop_cluster',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildResolvedConductorRoutes(templatesDir) {
+  const conductorTemplatePath = path.join(templatesDir, 'conductor-bootstrap.json');
+  if (!fs.existsSync(conductorTemplatePath)) {
+    return [];
+  }
+
+  const resolver = new TemplateResolver(templatesDir);
+  const routeConfigs = [];
+
+  for (const complexity of CONDUCTOR_COMPLEXITIES) {
+    for (const taskType of CONDUCTOR_TASK_TYPES) {
+      const { base, params } = getConfig(complexity, taskType);
+      const resolved = resolver.resolve(base, params);
+      const augmented = augmentCriticalResolvedConfig({
+        resolver,
+        config: resolved,
+        params,
+      });
+      const configWithCompletion = ensureCompletionHandler(augmented);
+
+      routeConfigs.push({
+        filePath: `${conductorTemplatePath}#resolved:${complexity}-${taskType}`,
+        templateId: `resolved-${base}`,
+        config: configWithCompletion,
+      });
+    }
+  }
+
+  return routeConfigs;
+}
+
 async function validateTemplates({ templatesDir, deep = false }) {
   const templateFiles = [...findJsonFiles(templatesDir)];
+  const resolvedConductorRoutes = buildResolvedConductorRoutes(templatesDir);
 
   let hasErrors = false;
   let validated = 0;
@@ -70,6 +178,26 @@ async function validateTemplates({ templatesDir, deep = false }) {
       if (!result.valid) hasErrors = true;
     } catch (err) {
       results.push({ filePath, result: { valid: false, errors: [err.message], warnings: [] } });
+      validated++;
+      hasErrors = true;
+    }
+  }
+
+  for (const resolvedRoute of resolvedConductorRoutes) {
+    try {
+      const result = await validateTemplateConfig({
+        config: resolvedRoute.config,
+        templateId: resolvedRoute.templateId,
+        deep,
+      });
+      results.push({ filePath: resolvedRoute.filePath, result });
+      validated++;
+      if (!result.valid) hasErrors = true;
+    } catch (err) {
+      results.push({
+        filePath: resolvedRoute.filePath,
+        result: { valid: false, errors: [err.message], warnings: [] },
+      });
       validated++;
       hasErrors = true;
     }

--- a/tests/config-validator.test.js
+++ b/tests/config-validator.test.js
@@ -429,6 +429,180 @@ describe('analyzeMessageFlow - validator flows', function () {
   });
 });
 
+describe('analyzeMessageFlow - resolved topology regression checks', function () {
+  it('should not skip flow validation when conductor config already has runtime agents', function () {
+    const result = validateConfig({
+      agents: [
+        {
+          id: 'junior-conductor',
+          role: 'conductor',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: {
+                topic: 'CLUSTER_OPERATIONS',
+                content: {
+                  data: {
+                    operations: [{ action: 'load_config', config: 'worker-validator' }],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'PLAN_READY', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: { topic: 'IMPLEMENTATION_READY' },
+            },
+          },
+        },
+        {
+          id: 'completion-detector',
+          role: 'orchestrator',
+          triggers: [{ topic: 'IMPLEMENTATION_READY', action: 'stop_cluster' }],
+        },
+      ],
+    });
+
+    assert.ok(
+      result.errors.some((e) => e.includes('PLAN_READY') && e.includes('never produced')),
+      `Expected unproduced PLAN_READY error, got: ${result.errors.join(' | ')}`
+    );
+  });
+
+  it('should flag dead-end flows that cannot reach completion', function () {
+    const result = analyzeMessageFlow({
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: { topic: 'WORKER_PROGRESS' },
+            },
+          },
+        },
+        {
+          id: 'completion',
+          role: 'orchestrator',
+          triggers: [{ topic: 'DONE', action: 'stop_cluster' }],
+        },
+      ],
+    });
+
+    assert.ok(
+      result.errors.some((e) =>
+        e.includes('No reachable path from ISSUE_OPENED to terminal signal')
+      ),
+      `Expected missing completion path error, got: ${result.errors.join(' | ')}`
+    );
+  });
+});
+
+describe('analyzeMessageFlow - schema contract regression checks', function () {
+  it('should flag trigger scripts that require missing content.data keys', function () {
+    const result = analyzeMessageFlow({
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: {
+                topic: 'VALIDATION_RESULT',
+                content: {
+                  data: {
+                    approved: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          id: 'downstream-consumer',
+          role: 'implementation',
+          triggers: [
+            {
+              topic: 'VALIDATION_RESULT',
+              logic: {
+                script: 'return message.content.data.errors.length === 0;',
+              },
+              action: 'execute_task',
+            },
+          ],
+        },
+        {
+          id: 'completion',
+          role: 'orchestrator',
+          triggers: [{ topic: 'VALIDATION_RESULT', action: 'stop_cluster' }],
+        },
+      ],
+    });
+
+    assert.ok(
+      result.errors.some(
+        (e) => e.includes('expects content.data.errors') && e.includes('VALIDATION_RESULT')
+      ),
+      `Expected schema contract error, got: ${result.errors.join(' | ')}`
+    );
+  });
+
+  it('should not treat optional chained content.data access as required', function () {
+    const result = analyzeMessageFlow({
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: {
+                topic: 'VALIDATION_RESULT',
+                content: {
+                  data: {
+                    approved: true,
+                    errors: [],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          id: 'completion',
+          role: 'orchestrator',
+          triggers: [
+            {
+              topic: 'VALIDATION_RESULT',
+              action: 'stop_cluster',
+              logic: {
+                script: 'return message?.content?.data?.criteriaResults?.length > 0;',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.ok(
+      !result.errors.some((e) => e.includes('criteriaResults') && e.includes('no producer for')),
+      `Expected no criteriaResults schema error, got: ${result.errors.join(' | ')}`
+    );
+  });
+});
+
 // === AGENT VALIDATION TESTS ===
 
 describe('validateAgents', function () {

--- a/tests/unit/template-validation-deep.test.js
+++ b/tests/unit/template-validation-deep.test.js
@@ -11,4 +11,22 @@ describe('Template validation (deep)', function () {
     const report = await validateTemplates({ templatesDir, deep: true });
     assert.strictEqual(report.valid, true);
   });
+
+  it('validates resolved conductor topology for all classification routes', async function () {
+    const templatesDir = path.join(__dirname, '..', '..', 'cluster-templates');
+    const report = await validateTemplates({ templatesDir, deep: false });
+    const resolvedRouteResults = report.results.filter((entry) =>
+      entry.filePath.includes('conductor-bootstrap.json#resolved:')
+    );
+
+    assert.strictEqual(resolvedRouteResults.length, 12);
+    const invalidRoutes = resolvedRouteResults.filter((entry) => !entry.result.valid);
+    assert.strictEqual(
+      invalidRoutes.length,
+      0,
+      invalidRoutes
+        .map((entry) => `${entry.filePath}: ${entry.result.errors.join(' | ')}`)
+        .join('\n')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add resolved-topology validation for conductor routes (all 12 complexity/taskType combinations)
- validate resolved routes with injected completion handler and critical quick-validation augmentation
- strengthen flow checks for completion reachability and trigger schema contract mismatches
- add regressions for conductor+runtime validation, dead-end flow, missing content.data keys, and optional-chain behavior

## Verification
- npx mocha tests/config-validator.test.js tests/unit/template-validation-deep.test.js --timeout 30000
- npm run validate:templates

Closes #418