### PR TITLE
fix: eliminate debug/full-workflow termination dead-ends

### DIFF
--- a/cluster-templates/base-templates/debug-workflow.json
+++ b/cluster-templates/base-templates/debug-workflow.json
@@ -402,6 +402,21 @@
           }
         }
       }
+    },
+    {
+      "id": "completion-detector",
+      "role": "orchestrator",
+      "modelLevel": "level1",
+      "triggers": [
+        {
+          "topic": "VALIDATION_RESULT",
+          "logic": {
+            "engine": "javascript",
+            "script": "const approved = message?.content?.data?.approved; return approved === true || approved === 'true';"
+          },
+          "action": "stop_cluster"
+        }
+      ]
     }
   ]
 }

--- a/cluster-templates/base-templates/full-workflow.json
+++ b/cluster-templates/base-templates/full-workflow.json
@@ -289,13 +289,13 @@
         "properties": {
           "action": {
             "type": "string",
-            "enum": ["load_quick", "load_heavy", "skip"]
+            "enum": ["load_quick", "load_heavy"]
           }
         },
         "required": ["action"]
       },
       "prompt": {
-        "system": "Coordinate two-stage validation. On IMPLEMENTATION_READY: output {\"action\":\"load_quick\"}. On QUICK_VALIDATION_PASSED: output {\"action\":\"load_heavy\"}. On VALIDATION_RESULT from Stage 1 (rejection): output {\"action\":\"skip\"}"
+        "system": "Coordinate two-stage validation. On IMPLEMENTATION_READY: output {\"action\":\"load_quick\"}. On QUICK_VALIDATION_PASSED: output {\"action\":\"load_heavy\"}."
       },
       "contextStrategy": {
         "sources": [
@@ -348,10 +348,6 @@
           "transform": {
             "engine": "javascript",
             "script": "const template = result.action === 'load_quick' ? 'quick-validation' : 'heavy-validation'; const republishTopic = result.action === 'load_quick' ? 'IMPLEMENTATION_READY' : 'QUICK_VALIDATION_PASSED'; const republishContent = triggeringMessage && triggeringMessage.content ? triggeringMessage.content : { text: '', data: {} }; return { topic: 'CLUSTER_OPERATIONS', content: { text: result.action === 'load_quick' ? 'Stage 1 (quick)' : 'Stage 2 (heavy)', data: { operations: [{ action: 'load_config', config: { base: template, params: { validator_level: '{{validator_level}}', max_tokens: {{max_tokens}}, timeout: {{timeout}} } } }, { action: 'publish', topic: republishTopic, content: republishContent, metadata: { _republished: true } }] } } };"
-          },
-          "logic": {
-            "engine": "javascript",
-            "script": "return result.action !== 'skip';"
           }
         }
       }


### PR DESCRIPTION
## Summary
- add explicit completion-detector agent to debug-workflow on approved VALIDATION_RESULT
- remove meta-coordinator "skip" action path from full-workflow CRITICAL mode
- ensure stage coordinator always publishes CLUSTER_OPERATIONS for valid actions

## Why
- debug-workflow could dead-end because injected completion logic waits for IMPLEMENTATION_READY, which debug flow never emits
- CRITICAL full-workflow allowed schema-valid "skip" output that produced no follow-up operations

## Verification
- npm run validate:templates
