### PR TITLE
feat: scan transform.script for dynamic topics + detached startup lib

### DIFF
--- a/lib/detached-startup.js
+++ b/lib/detached-startup.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DEFAULT_WAIT_TIMEOUT_SECONDS = 180;
+const DEFAULT_WAIT_POLL_MS = 1000;
+
+function getStorageDir(storageDir) {
+  return storageDir || path.join(os.homedir(), '.zeroshot');
+}
+
+function getClustersFilePath(storageDir) {
+  return path.join(getStorageDir(storageDir), 'clusters.json');
+}
+
+function resolveWaitTimeoutMs(waitTimeoutSeconds) {
+  const parsed = Number(waitTimeoutSeconds);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_WAIT_TIMEOUT_SECONDS * 1000;
+  }
+  return Math.floor(parsed * 1000);
+}
+
+function isProcessAlive(pid) {
+  if (!pid || !Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === 'EPERM';
+  }
+}
+
+function isClusterRegistered(clusterId, storageDir) {
+  const clustersFile = getClustersFilePath(storageDir);
+  if (!fs.existsSync(clustersFile)) {
+    return false;
+  }
+
+  let parsed;
+  try {
+    const raw = fs.readFileSync(clustersFile, 'utf8');
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+
+  return parsed !== null && typeof parsed === 'object' && Boolean(parsed[clusterId]);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatLogHint(logPath) {
+  return logPath ? ` Check log: ${logPath}` : '';
+}
+
+async function waitForClusterRegistration({
+  clusterId,
+  timeoutMs,
+  pollMs = DEFAULT_WAIT_POLL_MS,
+  storageDir,
+  daemonPid,
+  logPath,
+}) {
+  const effectiveTimeoutMs =
+    Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? timeoutMs
+      : DEFAULT_WAIT_TIMEOUT_SECONDS * 1000;
+  const startedAt = Date.now();
+  const deadline = startedAt + effectiveTimeoutMs;
+  const logHint = formatLogHint(logPath);
+
+  while (Date.now() < deadline) {
+    if (isClusterRegistered(clusterId, storageDir)) {
+      return { ready: true, elapsedMs: Date.now() - startedAt };
+    }
+
+    if (daemonPid && !isProcessAlive(daemonPid)) {
+      throw new Error(
+        `Detached daemon exited before cluster "${clusterId}" registered in storage.${logHint}`
+      );
+    }
+
+    await sleep(pollMs);
+  }
+
+  const timeoutSeconds = Math.ceil(effectiveTimeoutMs / 1000);
+  throw new Error(
+    `Timed out after ${timeoutSeconds}s waiting for cluster "${clusterId}" to appear in status/list.${logHint}`
+  );
+}
+
+module.exports = {
+  DEFAULT_WAIT_TIMEOUT_SECONDS,
+  getClustersFilePath,
+  isClusterRegistered,
+  isProcessAlive,
+  resolveWaitTimeoutMs,
+  waitForClusterRegistration,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,41 +61,41 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.2.tgz",
-      "integrity": "sha512-Ast1V7yHbGAhplAsuVlnb/5J8Mtr/Zl6byPPL+Qjq3lmfIgWF1ak1iYfF/079cRERiuTALTXkSuEUdZeDCfGtA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.1"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
-      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^2.0.0"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.1.tgz",
-      "integrity": "sha512-SbGS8c/vySbNO3kjFgSW77n83C4MQx/Yoe+b1hAdpuvfHxnkHzDq2pWljUpAA56Si1Gae/7zjeZsV0CYjmLo/w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.28.5"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/io": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
-      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1303,13 +1303,13 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.3.tgz",
-      "integrity": "sha512-q7zreY8n9V0FIP1Cbu63D+lXtRAVAIWb30MH5U3TdrfXt6r2MIrWCY0whAImN53qNvSGp0Zt07U95K+Qp9GpEg==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.4.tgz",
+      "integrity": "sha512-z5Fn9ftK1QQgFxMSuOd3DtYbTl4hWI2trCEvZcEJMQJy1/OBR0WHcxqzfVun455FSkHML8KgvPxJEa9MtZIBsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^2.0.0",
+        "@actions/core": "^3.0.0",
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
         "env-ci": "^11.2.0",
@@ -7779,9 +7779,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -11924,9 +11924,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
-      "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
+      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11956,7 +11956,6 @@
         "read-package-up": "^12.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^5.0.0",
         "signale": "^1.2.1",
         "yargs": "^18.0.0"
       },
@@ -12638,23 +12637,6 @@
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/semver-diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-5.0.0.tgz",
-      "integrity": "sha512-0HbGtOm+S7T6NGQ/pxJSJipJvc4DK3FcRVMRkhsIwJDJ4Jcz5DQC1cPPzB5GhzyHjwttW878HaWQq46CkL3cqg==",
-      "deprecated": "Deprecated as the semver package now supports this built-in.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/semver-regex": {
       "version": "4.0.5",

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -296,6 +296,30 @@ function recordAgentTriggers(agent, topicConsumers, agentInputTopics) {
   }
 }
 
+function extractDynamicTopicsFromScript(script, ctx) {
+  if (!script || typeof script !== 'string') {
+    return;
+  }
+
+  const topicMatches = script.match(/topic:\s*['"]([A-Z_]+)['"]/g) || [];
+  for (const match of topicMatches) {
+    const dynamicTopic = match.match(/['"]([A-Z_]+)['"]/)?.[1];
+    if (!dynamicTopic || dynamicTopic === ctx.outputTopic) {
+      continue;
+    }
+
+    const producers = ensureTopicList(ctx.topicProducers, dynamicTopic);
+    if (!producers.includes(ctx.agentId)) {
+      producers.push(`${ctx.agentId}*`);
+    }
+
+    const outputs = ctx.agentOutputTopics.get(ctx.agentId);
+    if (!outputs.includes(dynamicTopic)) {
+      outputs.push(dynamicTopic);
+    }
+  }
+}
+
 function recordAgentOutputs(agent, topicProducers, agentOutputTopics) {
   const outputTopic = agent.hooks?.onComplete?.config?.topic;
   if (outputTopic) {
@@ -303,28 +327,10 @@ function recordAgentOutputs(agent, topicProducers, agentOutputTopics) {
     agentOutputTopics.get(agent.id).push(outputTopic);
   }
 
-  const hookLogicScript = agent.hooks?.onComplete?.logic?.script;
-  if (!hookLogicScript || typeof hookLogicScript !== 'string') {
-    return;
-  }
-
-  const topicMatches = hookLogicScript.match(/topic:\s*['"]([A-Z_]+)['"]/g) || [];
-  for (const match of topicMatches) {
-    const dynamicTopic = match.match(/['"]([A-Z_]+)['"]/)?.[1];
-    if (!dynamicTopic || dynamicTopic === outputTopic) {
-      continue;
-    }
-
-    const producers = ensureTopicList(topicProducers, dynamicTopic);
-    if (!producers.includes(agent.id)) {
-      producers.push(`${agent.id}*`);
-    }
-
-    const outputs = agentOutputTopics.get(agent.id);
-    if (!outputs.includes(dynamicTopic)) {
-      outputs.push(dynamicTopic);
-    }
-  }
+  const ctx = { outputTopic, agentId: agent.id, topicProducers, agentOutputTopics };
+  const hook = agent.hooks?.onComplete;
+  extractDynamicTopicsFromScript(hook?.logic?.script, ctx);
+  extractDynamicTopicsFromScript(hook?.transform?.script, ctx);
 }
 
 function buildMessageFlowGraph(config) {
@@ -372,13 +378,15 @@ function reportCompletionHandlers(config, errors, warnings) {
       a.hooks?.onComplete?.config?.topic === 'CLUSTER_COMPLETE'
   );
   const isTemplateConfig = config.params && Object.keys(config.params).length > 0;
+  // Conductor-driven configs (merged conductor + template agents) rely on idle timeout
+  const hasConductorAgents = config.agents.some((a) => a.role === 'conductor');
 
   if (completionHandlers.length === 0) {
     const message =
       'No completion handler found. Cluster will run until idle timeout (2 min). ' +
       'Add an agent with trigger action: "stop_cluster"';
-    if (isTemplateConfig) {
-      warnings.push(`${message} (template will rely on orchestrator injection)`);
+    if (isTemplateConfig || hasConductorAgents) {
+      warnings.push(`${message} (${isTemplateConfig ? 'template will rely on orchestrator injection' : 'conductor-driven cluster relies on idle timeout'})`);
     } else {
       errors.push(message);
     }
@@ -411,10 +419,7 @@ function reportUnproducedTopics(topicConsumers, topicProducers, errors, config) 
     'CLUSTER_RESUMED',
     'QUICK_VALIDATION_PASSED',
     'IMPLEMENTATION_READY',
-    // Produced conditionally by conductor/orchestrator fallback paths.
-    // These should not fail static flow validation when absent in the happy path.
-    'CONDUCTOR_ESCALATE',
-    'CLUSTER_OPERATIONS_VALIDATION_FAILED',
+    'CLUSTER_OPERATIONS_VALIDATION_FAILED', // Produced by orchestrator at runtime
     ...GUIDANCE_TOPICS,
   ];
   const isSubTemplate = config.params && Object.keys(config.params).length > 0;
@@ -603,9 +608,7 @@ function reportMissingCompletionPath(config, topicConsumers, agentOutputTopics, 
     'Cluster may run until timeout even when validation appears to pass.';
   const isDynamic = hasDynamicLoadConfigPath(config);
   if (isDynamic) {
-    warnings.push(
-      `${message} Dynamic load_config path detected; add explicit resolved-topology simulation.`
-    );
+    warnings.push(`${message} Dynamic load_config path detected; add explicit resolved-topology simulation.`);
     return;
   }
 

--- a/tests/config-validator.test.js
+++ b/tests/config-validator.test.js
@@ -499,9 +499,7 @@ describe('analyzeMessageFlow - resolved topology regression checks', function ()
     });
 
     assert.ok(
-      result.errors.some((e) =>
-        e.includes('No reachable path from ISSUE_OPENED to terminal signal')
-      ),
+      result.errors.some((e) => e.includes('No reachable path from ISSUE_OPENED to terminal signal')),
       `Expected missing completion path error, got: ${result.errors.join(' | ')}`
     );
   });

--- a/tests/unit/detached-startup.test.js
+++ b/tests/unit/detached-startup.test.js
@@ -1,0 +1,133 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const {
+  getClustersFilePath,
+  isClusterRegistered,
+  resolveWaitTimeoutMs,
+  waitForClusterRegistration,
+} = require('../../lib/detached-startup');
+
+describe('detached-startup helpers', function () {
+  let tempRoot = null;
+  /** @type {NodeJS.Timeout | null} */
+  let pendingTimer = null;
+
+  function createTempStorageDir() {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zs-detached-startup-'));
+    return tempRoot;
+  }
+
+  afterEach(function () {
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    if (tempRoot) {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it('uses default timeout when value is invalid', function () {
+    assert.strictEqual(resolveWaitTimeoutMs(undefined), 180000);
+    assert.strictEqual(resolveWaitTimeoutMs(0), 180000);
+    assert.strictEqual(resolveWaitTimeoutMs(-10), 180000);
+    assert.strictEqual(resolveWaitTimeoutMs('bad-value'), 180000);
+  });
+
+  it('converts valid wait timeout to milliseconds', function () {
+    assert.strictEqual(resolveWaitTimeoutMs(2), 2000);
+    assert.strictEqual(resolveWaitTimeoutMs('2.5'), 2500);
+  });
+
+  it('returns false when clusters.json does not exist', function () {
+    const storageDir = createTempStorageDir();
+    assert.strictEqual(isClusterRegistered('missing-cluster', storageDir), false);
+  });
+
+  it('returns true when cluster is present in clusters.json', function () {
+    const storageDir = createTempStorageDir();
+    const clustersFile = getClustersFilePath(storageDir);
+    fs.mkdirSync(path.dirname(clustersFile), { recursive: true });
+    fs.writeFileSync(
+      clustersFile,
+      JSON.stringify({
+        'ready-cluster': { id: 'ready-cluster' },
+      })
+    );
+
+    assert.strictEqual(isClusterRegistered('ready-cluster', storageDir), true);
+  });
+
+  it('waits until cluster is registered', async function () {
+    this.timeout(5000);
+    const storageDir = createTempStorageDir();
+    const clustersFile = getClustersFilePath(storageDir);
+    const clusterId = 'cluster-waits';
+
+    fs.mkdirSync(path.dirname(clustersFile), { recursive: true });
+    fs.writeFileSync(clustersFile, JSON.stringify({}));
+
+    pendingTimer = setTimeout(() => {
+      fs.writeFileSync(
+        clustersFile,
+        JSON.stringify({
+          [clusterId]: { id: clusterId },
+        })
+      );
+    }, 80);
+
+    const result = await waitForClusterRegistration({
+      clusterId,
+      timeoutMs: 2000,
+      pollMs: 20,
+      storageDir,
+    });
+
+    assert.strictEqual(result.ready, true);
+    assert(result.elapsedMs >= 0);
+  });
+
+  it('fails on timeout when cluster never appears', async function () {
+    const storageDir = createTempStorageDir();
+    const clustersFile = getClustersFilePath(storageDir);
+    fs.mkdirSync(path.dirname(clustersFile), { recursive: true });
+    fs.writeFileSync(clustersFile, JSON.stringify({}));
+
+    await assert.rejects(
+      waitForClusterRegistration({
+        clusterId: 'never-there',
+        timeoutMs: 120,
+        pollMs: 20,
+        storageDir,
+      }),
+      /Timed out/
+    );
+  });
+
+  it('fails fast when daemon exits before registration', async function () {
+    this.timeout(5000);
+    const storageDir = createTempStorageDir();
+    const clustersFile = getClustersFilePath(storageDir);
+    fs.mkdirSync(path.dirname(clustersFile), { recursive: true });
+    fs.writeFileSync(clustersFile, JSON.stringify({}));
+
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    await new Promise((resolve) => child.on('exit', resolve));
+
+    await assert.rejects(
+      waitForClusterRegistration({
+        clusterId: 'daemon-died',
+        timeoutMs: 1000,
+        pollMs: 20,
+        storageDir,
+        daemonPid: child.pid,
+      }),
+      /exited before cluster/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract dynamic topic scanning into reusable `extractDynamicTopicsFromScript` function
- Scan both `logic.script` and `transform.script` for dynamic topic publishing (catches conductor agent patterns)
- Add conductor-aware completion handler detection (no false positive warnings for conductor-driven clusters)
- Remove `CONDUCTOR_ESCALATE` from external topics (no longer needed)
- Add `detached-startup` library with `waitForClusterRegistration` for daemon mode reliability
- Tests for all new functionality

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>