### PR TITLE
docs: add JSDoc comments to provider-names.js

### DIFF
--- a/lib/provider-names.js
+++ b/lib/provider-names.js
@@ -1,3 +1,8 @@
+/**
+ * Provider name aliases for normalization
+ * Maps various provider name formats to canonical names
+ * @type {Object<string, string>}
+ */
 const PROVIDER_ALIASES = {
   anthropic: 'claude',
   openai: 'codex',
@@ -8,14 +13,36 @@ const PROVIDER_ALIASES = {
   opencode: 'opencode',
 };
 
+/**
+ * List of valid canonical provider names
+ * @type {string[]}
+ */
 const VALID_PROVIDERS = ['claude', 'codex', 'gemini', 'opencode'];
 
+/**
+ * Normalize a provider name to its canonical form
+ * @param {string} name - Provider name to normalize (e.g., 'anthropic', 'openai')
+ * @returns {string} Canonical provider name or original input if not recognized
+ * @example
+ * normalizeProviderName('anthropic') // 'claude'
+ * normalizeProviderName('openai')    // 'codex'
+ * normalizeProviderName('Claude')    // 'claude' (case-insensitive)
+ */
 function normalizeProviderName(name) {
   if (!name || typeof name !== 'string') return name;
   const normalized = PROVIDER_ALIASES[name.toLowerCase()];
   return normalized || name;
 }
 
+/**
+ * Normalize provider settings object keys to canonical provider names
+ * Merges settings from aliases into their canonical provider keys
+ * @param {Object} providerSettings - Provider settings object with provider names as keys
+ * @returns {Object} Normalized provider settings with canonical names
+ * @example
+ * normalizeProviderSettings({ anthropic: { maxTokens: 100 }, openai: { model: 'gpt-4' } })
+ * // { claude: { maxTokens: 100 }, codex: { model: 'gpt-4' } }
+ */
 function normalizeProviderSettings(providerSettings) {
   if (
     !providerSettings ||


### PR DESCRIPTION
## Summary

Add comprehensive JSDoc documentation to improve code readability and IDE autocomplete support.

## Changes Made

- Document PROVIDER_ALIASES and VALID_PROVIDERS constants with @type annotations
- Add JSDoc to normalizeProviderName() with @param, @returns, and @example
- Add JSDoc to normalizeProviderSettings() with @param, @returns, and @example

## Testing

- Verified syntax with `node --check`
- No functional changes, documentation only

## Checklist

- [x] Tests pass (no test changes needed - docs only)
- [x] Documentation updated
- [x] Follows commit guidelines