### PR TITLE
docs: fix Claude login command in setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ npm i -g @google/gemini-cli
 # Opencode: see https://opencode.ai
 
 # Authenticate with the provider CLI
-claude login        # Claude
+claude auth login   # Claude
 codex login         # Codex
 gemini auth login   # Gemini
 opencode auth login # Opencode


### PR DESCRIPTION
## Summary\nFix an incorrect Claude login command in docs.\n\n## Why\nThe current command is inconsistent with actual Claude CLI usage and can confuse first-time setup.\n\n## Change\n- Update documentation to use the correct Claude login command.\n