### PR TITLE
fix: execute worktree.setup command from repo settings

### DIFF
--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -1348,10 +1348,12 @@ class IsolationManager {
 
     // Priority: 1) options.baseRef, 2) repo settings, 3) HEAD (default)
     let worktreeBaseRef = options.baseRef || null;
+    let worktreeSetupCommand = null;
     try {
       const repoSettingsResult = readRepoSettings(repoRoot);
       const repoSettings = repoSettingsResult.settings || {};
       const candidate = repoSettings.worktree?.baseRef;
+      worktreeSetupCommand = repoSettings.worktree?.setup || null;
       if (
         !worktreeBaseRef &&
         typeof candidate === 'string' &&
@@ -1458,6 +1460,17 @@ class IsolationManager {
         }
         throw err;
       }
+    }
+
+    // Run repo-configured setup command (e.g. npm ci)
+    if (worktreeSetupCommand && typeof worktreeSetupCommand === "string") {
+      console.log(`[IsolationManager] Running worktree setup: ${worktreeSetupCommand}`);
+      execSync(worktreeSetupCommand, {
+        cwd: worktreePath,
+        encoding: "utf8",
+        stdio: "inherit",
+      });
+      console.log(`[IsolationManager] ✓ Worktree setup complete`);
     }
 
     return {

--- a/tests/integration/worktree-isolation.test.js
+++ b/tests/integration/worktree-isolation.test.js
@@ -65,6 +65,7 @@ function registerCreateWorktreeIsolationTests() {
     registerWorktreeIsolationTest();
     registerWorktreeNonGitTest();
     registerWorktreeCleanupBeforeCreateTest();
+    registerWorktreeSetupCommandTest();
   });
 }
 
@@ -207,6 +208,29 @@ function registerWorktreeCleanupBeforeCreateTest() {
     assert(
       !fs.existsSync(path.join(info2.path, 'marker.txt')),
       'Old marker should be removed (fresh worktree)'
+    );
+  });
+}
+
+function registerWorktreeSetupCommandTest() {
+  it('should run worktree.setup command from repo settings', function () {
+    const settingsDir = path.join(testRepoDir, '.zeroshot');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify({ worktree: { setup: 'touch setup-ran.marker' } })
+    );
+    execSync('git add -A && git commit -m "Add zeroshot settings"', {
+      cwd: testRepoDir,
+      stdio: 'pipe',
+    });
+
+    const info = manager.createWorktreeIsolation(testClusterId, testRepoDir);
+
+    const markerPath = path.join(info.path, 'setup-ran.marker');
+    assert(
+      fs.existsSync(markerPath),
+      'Setup command should have created marker file in worktree'
     );
   });
 }


### PR DESCRIPTION
## Summary

- `worktree.setup` in `.zeroshot/settings.json` was defined but never consumed
- Worktrees were created without running the configured setup command (e.g. `npm ci`)
- This caused missing `node_modules`, broken `tsc`, and 2646 phantom TypeScript errors during validation

## Fix

Read `worktree.setup` from repo settings in `createWorktree()` and `execSync()` it in the worktree directory after creation. Fails fast if the command fails.

## Test plan

- [x] New integration test: creates settings with `"setup": "touch setup-ran.marker"`, verifies marker file exists after worktree creation
- [x] All 20 existing worktree tests pass
- [x] Pre-push lint + typecheck pass