### PR TITLE
fix: prevent startup GC from deleting active cluster ledgers

### DIFF
--- a/src/lib/gc.js
+++ b/src/lib/gc.js
@@ -19,6 +19,15 @@ function isClusterDir(entry) {
   return entry.isDirectory() && CLUSTER_ID_PATTERN.test(entry.name);
 }
 
+function resolveActiveClusterIdFromEnv() {
+  const clusterId = process.env.ZEROSHOT_CLUSTER_ID;
+  if (typeof clusterId !== 'string' || clusterId.trim().length === 0) {
+    return null;
+  }
+  const normalized = clusterId.trim();
+  return CLUSTER_ID_PATTERN.test(normalized) ? normalized : null;
+}
+
 /**
  * Read known cluster IDs from clusters.json (synchronous, no locking).
  * @param {string} storageDir
@@ -37,15 +46,35 @@ function readKnownClusterIds(storageDir) {
   return ids;
 }
 
-/** Count orphaned worktree directories (for error messages). */
-function countOrphanedWorktrees(storageDir = DEFAULT_STORAGE_DIR) {
+function resolveStorageAndKnownIds(storageDirOrOptions = DEFAULT_STORAGE_DIR) {
+  const options =
+    typeof storageDirOrOptions === 'string'
+      ? { storageDir: storageDirOrOptions }
+      : storageDirOrOptions || {};
+  const storageDir = options.storageDir || DEFAULT_STORAGE_DIR;
+  const knownIds = readKnownClusterIds(storageDir);
+  const activeClusterId = resolveActiveClusterIdFromEnv();
+  if (activeClusterId) {
+    knownIds.add(activeClusterId);
+  }
+  if (options.extraKnownIds) {
+    for (const id of options.extraKnownIds) knownIds.add(id);
+  }
+  return { storageDir, knownIds };
+}
+
+/**
+ * Count orphaned worktree directories (for error messages).
+ * @param {string|{storageDir?: string, extraKnownIds?: Set<string>}} [storageDirOrOptions]
+ */
+function countOrphanedWorktrees(storageDirOrOptions = DEFAULT_STORAGE_DIR) {
+  const { storageDir, knownIds } = resolveStorageAndKnownIds(storageDirOrOptions);
   const worktreeDir = path.join(storageDir, 'worktrees');
   if (!fs.existsSync(worktreeDir)) return 0;
-  const knownIds = readKnownClusterIds(storageDir);
   try {
-    return fs.readdirSync(worktreeDir, { withFileTypes: true })
-      .filter(e => isClusterDir(e) && !knownIds.has(e.name))
-      .length;
+    return fs
+      .readdirSync(worktreeDir, { withFileTypes: true })
+      .filter((e) => isClusterDir(e) && !knownIds.has(e.name)).length;
   } catch {
     return 0;
   }
@@ -53,18 +82,32 @@ function countOrphanedWorktrees(storageDir = DEFAULT_STORAGE_DIR) {
 
 /** Try to remove a single file. Returns error string or null. */
 function tryUnlink(filePath) {
-  try { fs.unlinkSync(filePath); return null; } catch (err) { return err.message; }
+  try {
+    fs.unlinkSync(filePath);
+    return null;
+  } catch (err) {
+    return err.message;
+  }
 }
 
 /** Try to remove a directory tree. Returns error string or null. */
 function tryRmdir(dirPath) {
-  try { fs.rmSync(dirPath, { recursive: true, force: true }); return null; } catch (err) { return err.message; }
+  try {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+    return null;
+  } catch (err) {
+    return err.message;
+  }
 }
 
 /** Find repo root from a worktree's .git file (gitdir pointer). */
 function findRepoRootFromWorktree(worktreeDir) {
   let entries;
-  try { entries = fs.readdirSync(worktreeDir, { withFileTypes: true }); } catch { return null; }
+  try {
+    entries = fs.readdirSync(worktreeDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const dotGit = path.join(worktreeDir, entry.name, '.git');
@@ -88,7 +131,10 @@ function pruneGitWorktrees(worktreeDir) {
   if (!repoRoot) return;
   try {
     require('child_process').execSync('git worktree prune', {
-      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe', timeout: 10000,
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      timeout: 10000,
     });
   } catch {
     // Best effort
@@ -102,21 +148,27 @@ function pruneGitWorktrees(worktreeDir) {
  * @param {string} [options.storageDir]
  * @param {Set<string>} [options.extraKnownIds]
  * @param {boolean} [options.dryRun=false]
+ * @param {boolean} [options.removeDbFiles] - Defaults to false when ZEROSHOT_CLUSTER_ID is set, else true
  * @returns {{ orphanedWorktrees: string[], orphanedDbs: string[], errors: string[] }}
  */
 function gcOrphanedWorktrees(options = {}) {
   const storageDir = options.storageDir || DEFAULT_STORAGE_DIR;
   const dryRun = options.dryRun || false;
+  const activeClusterId = resolveActiveClusterIdFromEnv();
+  const removeDbFiles =
+    typeof options.removeDbFiles === 'boolean' ? options.removeDbFiles : activeClusterId === null;
   const worktreeDir = path.join(storageDir, 'worktrees');
   const result = { orphanedWorktrees: [], orphanedDbs: [], errors: [] };
 
-  const knownIds = readKnownClusterIds(storageDir);
-  if (options.extraKnownIds) {
-    for (const id of options.extraKnownIds) knownIds.add(id);
-  }
+  const { knownIds } = resolveStorageAndKnownIds({
+    storageDir,
+    extraKnownIds: options.extraKnownIds,
+  });
 
   collectOrphanedWorktrees(worktreeDir, knownIds, dryRun, result);
-  collectOrphanedDbFiles(storageDir, knownIds, dryRun, result);
+  if (removeDbFiles) {
+    collectOrphanedDbFiles(storageDir, knownIds, dryRun, result);
+  }
 
   if (!dryRun && result.orphanedWorktrees.length > 0) {
     pruneGitWorktrees(worktreeDir);
@@ -128,7 +180,9 @@ function gcOrphanedWorktrees(options = {}) {
 function collectOrphanedWorktrees(worktreeDir, knownIds, dryRun, result) {
   if (!fs.existsSync(worktreeDir)) return;
   let entries;
-  try { entries = fs.readdirSync(worktreeDir, { withFileTypes: true }); } catch (err) {
+  try {
+    entries = fs.readdirSync(worktreeDir, { withFileTypes: true });
+  } catch (err) {
     result.errors.push(`Failed to read worktree dir: ${err.message}`);
     return;
   }
@@ -143,7 +197,11 @@ function collectOrphanedWorktrees(worktreeDir, knownIds, dryRun, result) {
 
 function collectOrphanedDbFiles(storageDir, knownIds, dryRun, result) {
   let entries;
-  try { entries = fs.readdirSync(storageDir); } catch { return; }
+  try {
+    entries = fs.readdirSync(storageDir);
+  } catch {
+    return;
+  }
   for (const entry of entries) {
     const match = entry.match(/^(.+)\.(db|db-wal|db-shm)$/);
     if (!match || knownIds.has(match[1])) continue;

--- a/tests/unit/gc-orphan-protection.test.js
+++ b/tests/unit/gc-orphan-protection.test.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { gcOrphanedWorktrees, countOrphanedWorktrees } = require('../../src/lib/gc');
+
+function createTempStorageDir() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-gc-'));
+  fs.mkdirSync(path.join(tempRoot, 'worktrees'), { recursive: true });
+  fs.writeFileSync(path.join(tempRoot, 'clusters.json'), '{}', 'utf8');
+  return tempRoot;
+}
+
+describe('gc orphan protection', function () {
+  let storageDir;
+  const originalClusterIdEnv = process.env.ZEROSHOT_CLUSTER_ID;
+
+  beforeEach(function () {
+    storageDir = createTempStorageDir();
+    delete process.env.ZEROSHOT_CLUSTER_ID;
+  });
+
+  afterEach(function () {
+    fs.rmSync(storageDir, { recursive: true, force: true });
+    if (typeof originalClusterIdEnv === 'string') {
+      process.env.ZEROSHOT_CLUSTER_ID = originalClusterIdEnv;
+    } else {
+      delete process.env.ZEROSHOT_CLUSTER_ID;
+    }
+  });
+
+  it('supports extraKnownIds in orphan counting', function () {
+    const clusterId = 'neural-mountain-14';
+    fs.mkdirSync(path.join(storageDir, 'worktrees', clusterId), { recursive: true });
+
+    const orphanCountWithoutProtection = countOrphanedWorktrees(storageDir);
+    const orphanCountWithProtection = countOrphanedWorktrees({
+      storageDir,
+      extraKnownIds: new Set([clusterId]),
+    });
+
+    assert.strictEqual(orphanCountWithoutProtection, 1);
+    assert.strictEqual(orphanCountWithProtection, 0);
+  });
+
+  it('skips database deletion when removeDbFiles=false', function () {
+    const clusterId = 'neural-mountain-14';
+    const dbPath = path.join(storageDir, `${clusterId}.db`);
+    fs.writeFileSync(dbPath, '', 'utf8');
+
+    const result = gcOrphanedWorktrees({
+      storageDir,
+      extraKnownIds: new Set([clusterId]),
+      removeDbFiles: false,
+    });
+
+    assert.strictEqual(result.orphanedDbs.length, 0);
+    assert.ok(fs.existsSync(dbPath));
+  });
+
+  it('still deletes orphaned database files by default', function () {
+    const orphanClusterId = 'floating-hawk-22';
+    const orphanDbPath = path.join(storageDir, `${orphanClusterId}.db`);
+    fs.writeFileSync(orphanDbPath, '', 'utf8');
+
+    const result = gcOrphanedWorktrees({ storageDir });
+
+    assert.deepStrictEqual(result.orphanedDbs, [`${orphanClusterId}.db`]);
+    assert.ok(!fs.existsSync(orphanDbPath));
+  });
+
+  it('auto-protects active cluster id from env and avoids db deletion in cluster context', function () {
+    const clusterId = 'neural-mountain-14';
+    const activeDbPath = path.join(storageDir, `${clusterId}.db`);
+    const orphanDbPath = path.join(storageDir, 'floating-hawk-22.db');
+    process.env.ZEROSHOT_CLUSTER_ID = clusterId;
+    fs.writeFileSync(activeDbPath, '', 'utf8');
+    fs.writeFileSync(orphanDbPath, '', 'utf8');
+    fs.mkdirSync(path.join(storageDir, 'worktrees', clusterId), { recursive: true });
+
+    const orphanCount = countOrphanedWorktrees({ storageDir });
+    const result = gcOrphanedWorktrees({ storageDir });
+
+    assert.strictEqual(orphanCount, 0);
+    assert.strictEqual(result.orphanedDbs.length, 0);
+    assert.ok(fs.existsSync(activeDbPath));
+    assert.ok(fs.existsSync(orphanDbPath));
+  });
+});


### PR DESCRIPTION
## Summary
- protect the active cluster id (from `ZEROSHOT_CLUSTER_ID`) from orphan GC decisions
- make GC default skip DB-file deletion while running in active cluster context
- add unit coverage for extraKnownIds + env-based protection behavior

## Validation
- npx eslint src/lib/gc.js tests/unit/gc-orphan-protection.test.js
- npx mocha tests/unit/gc-orphan-protection.test.js --timeout 120000
- npx mocha tests/unit/detached-startup.test.js --timeout 120000
- npx mocha tests/orchestrator.test.js --grep "missing \\.db file for cluster" --timeout 120000