### PR TITLE
feat: add inspect command for live process activity

### DIFF
--- a/cli/commands/inspect-render.js
+++ b/cli/commands/inspect-render.js
@@ -1,0 +1,135 @@
+const chalk = require('chalk');
+
+function printProcessHeader(label, processInfo, indent) {
+  if (!processInfo) {
+    console.log(`${indent}${chalk.dim(label)}: N/A`);
+    return false;
+  }
+
+  if (!processInfo.metrics?.exists) {
+    console.log(`${indent}${chalk.dim(label)}: PID ${processInfo.pid} not running`);
+    return false;
+  }
+
+  console.log(
+    `${indent}${chalk.dim(label)}: PID ${processInfo.pid} · activity ${processInfo.activity}`
+  );
+  return true;
+}
+
+function printProcessResources(metrics, indent) {
+  console.log(
+    `${indent}  state=${metrics.state} cpu=${metrics.cpuPercent}% mem=${metrics.memoryMB}MB threads=${metrics.threads} children=${metrics.childCount}`
+  );
+}
+
+function printProcessNetwork(metrics, indent) {
+  const established = metrics.network?.established || 0;
+  if (established === 0 && !metrics.network?.hasActivity) {
+    return;
+  }
+
+  console.log(
+    `${indent}  net=${established} conn sendQ=${metrics.network.sendQueueBytes} recvQ=${metrics.network.recvQueueBytes} activity=${metrics.network.hasActivity ? 'yes' : 'no'}`
+  );
+}
+
+function printProcessHealth(processInfo, indent) {
+  if (!processInfo.health?.analysis) {
+    return;
+  }
+
+  console.log(`${indent}  health=${processInfo.health.analysis}`);
+}
+
+function printWarnings(warnings, indent = '') {
+  if (!warnings || warnings.length === 0) {
+    return;
+  }
+
+  for (const warning of warnings) {
+    console.log(`${indent}${chalk.yellow(`warning: ${warning}`)}`);
+  }
+}
+
+function printProcessSection(label, processInfo, indent = '') {
+  if (!printProcessHeader(label, processInfo, indent)) {
+    return;
+  }
+
+  const { metrics } = processInfo;
+  printProcessResources(metrics, indent);
+  printProcessNetwork(metrics, indent);
+  printProcessHealth(processInfo, indent);
+}
+
+function printTaskSection(task, indent = '') {
+  if (!task) {
+    return;
+  }
+
+  console.log(
+    `${indent}${chalk.dim('Task')}: ${task.id} · ${task.status} · updated ${task.updatedAgeHuman} ago`
+  );
+  console.log(
+    `${indent}  pid=${task.pid || 'N/A'} exit=${task.exitCode ?? 'N/A'} attachable=${task.attachable ? 'yes' : 'no'}`
+  );
+  console.log(
+    `${indent}  log=${task.logFile || 'N/A'} (${task.logFileExists ? 'present' : 'missing'})`
+  );
+  if (task.socketPath) {
+    console.log(
+      `${indent}  socket=${task.socketPath} (${task.socketPathExists ? 'present' : 'missing'})`
+    );
+  }
+  printWarnings(task.warnings, `${indent}  `);
+}
+
+function printAgentSection(agent) {
+  const modelLabel = agent.model ? ` [${agent.model}]` : '';
+  console.log(`  - ${agent.id} (${agent.role})${modelLabel}`);
+  console.log(
+    `    state=${agent.state} iteration=${agent.iteration} runningTask=${agent.currentTask ? 'yes' : 'no'}`
+  );
+  if (agent.currentTaskId) {
+    console.log(`    taskId=${agent.currentTaskId}`);
+  }
+  printProcessSection('process', agent.process, '    ');
+  printTaskSection(agent.task, '    ');
+  printWarnings(agent.warnings, '    ');
+}
+
+function printClusterInspectionHuman(inspection) {
+  console.log(`\nCluster Inspect: ${inspection.id}`);
+  console.log(`State: ${inspection.cluster.state}`);
+  console.log(`PID: ${inspection.cluster.pid || 'N/A'}`);
+  console.log(`Created: ${new Date(inspection.cluster.createdAt).toLocaleString()}`);
+  console.log(`Messages: ${inspection.cluster.messageCount}`);
+  console.log(`Sample: ${inspection.sampleMs}ms`);
+
+  console.log('\nCluster Process:');
+  printProcessSection('process', inspection.process, '  ');
+
+  console.log('\nAgents:');
+  for (const agent of inspection.agents) {
+    printAgentSection(agent);
+  }
+  console.log('');
+}
+
+function printTaskInspectionHuman(inspection) {
+  console.log(`\nTask Inspect: ${inspection.id}`);
+  console.log(`Sample: ${inspection.sampleMs}ms`);
+  printTaskSection(inspection.task);
+  console.log('');
+  printProcessSection('Process', inspection.process);
+  console.log('');
+}
+
+module.exports = {
+  printClusterInspectionHuman,
+  printProcessSection,
+  printTaskInspectionHuman,
+  printTaskSection,
+  printWarnings,
+};

--- a/cli/commands/inspect.js
+++ b/cli/commands/inspect.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const chalk = require('chalk');
 const Orchestrator = require('../../src/orchestrator');
 const { detectIdType } = require('../../lib/id-detector');
 const { getTask } = require('../../task-lib/store.js');
@@ -12,6 +11,10 @@ const {
   analyzeProcessHealth,
   isPlatformSupported: stuckDetectorPlatformSupported,
 } = require('../../src/agent/agent-stuck-detector');
+const {
+  printClusterInspectionHuman,
+  printTaskInspectionHuman,
+} = require('./inspect-render');
 
 const DEFAULT_SAMPLE_MS = 1000;
 const TASK_STALE_WARNING_MS = 5 * 60 * 1000;
@@ -107,20 +110,31 @@ function buildTaskWarnings(task, details) {
   return warnings;
 }
 
-function summarizeTaskRecord(task, now = Date.now(), existsSync = fs.existsSync) {
-  if (!task) {
-    return null;
-  }
+function getOptionalPathState(filePath, existsSync) {
+  return {
+    path: filePath || null,
+    exists: Boolean(filePath && existsSync(filePath)),
+  };
+}
 
+function buildTaskDetails(task, now, existsSync) {
   const updatedAt = safeDate(task.updatedAt);
-  const details = {
+  const logFile = getOptionalPathState(task.logFile, existsSync);
+  const socketPath = getOptionalPathState(task.socketPath, existsSync);
+
+  return {
     updatedAgeMs: updatedAt ? now - updatedAt.getTime() : null,
     processRunning: task.pid ? isProcessRunning(task.pid) : false,
-    logFileExists: Boolean(task.logFile && existsSync(task.logFile)),
-    socketPathExists: Boolean(task.socketPath && existsSync(task.socketPath)),
+    logFile,
+    socketPath,
   };
-  const warnings = buildTaskWarnings(task, details);
+}
 
+function formatUpdatedAgeHuman(updatedAgeMs) {
+  return updatedAgeMs === null ? 'unknown' : formatAgeMs(updatedAgeMs);
+}
+
+function buildTaskSummary(task, details) {
   return {
     id: task.id,
     status: task.status,
@@ -130,18 +144,29 @@ function summarizeTaskRecord(task, now = Date.now(), existsSync = fs.existsSync)
     cwd: task.cwd || null,
     sessionId: task.sessionId || null,
     attachable: Boolean(task.attachable),
-    socketPath: task.socketPath || null,
-    socketPathExists: details.socketPathExists,
-    logFile: task.logFile || null,
-    logFileExists: details.logFileExists,
+    socketPath: details.socketPath.path,
+    socketPathExists: details.socketPath.exists,
+    logFile: details.logFile.path,
+    logFileExists: details.logFile.exists,
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
     updatedAgeMs: details.updatedAgeMs,
-    updatedAgeHuman:
-      details.updatedAgeMs === null ? 'unknown' : formatAgeMs(details.updatedAgeMs),
+    updatedAgeHuman: formatUpdatedAgeHuman(details.updatedAgeMs),
     processRunning: details.processRunning,
-    warnings,
+    warnings: buildTaskWarnings(task, {
+      ...details,
+      logFileExists: details.logFile.exists,
+      socketPathExists: details.socketPath.exists,
+    }),
   };
+}
+
+function summarizeTaskRecord(task, now = Date.now(), existsSync = fs.existsSync) {
+  if (!task) {
+    return null;
+  }
+
+  return buildTaskSummary(task, buildTaskDetails(task, now, existsSync));
 }
 
 async function inspectProcess(pid, sampleMs, options = {}) {
@@ -231,106 +256,6 @@ async function buildTaskInspection(taskId, options = {}, deps = {}) {
     task: summarizeTaskRecord(task, Date.now(), existsSync),
     process: await inspectProcess(task.pid, sampleMs),
   };
-}
-
-function printProcessSection(label, processInfo, indent = '') {
-  if (!processInfo) {
-    console.log(`${indent}${chalk.dim(label)}: N/A`);
-    return;
-  }
-
-  if (!processInfo.metrics?.exists) {
-    console.log(`${indent}${chalk.dim(label)}: PID ${processInfo.pid} not running`);
-    return;
-  }
-
-  const metrics = processInfo.metrics;
-  console.log(
-    `${indent}${chalk.dim(label)}: PID ${processInfo.pid} · activity ${processInfo.activity}`
-  );
-  console.log(
-    `${indent}  state=${metrics.state} cpu=${metrics.cpuPercent}% mem=${metrics.memoryMB}MB threads=${metrics.threads} children=${metrics.childCount}`
-  );
-
-  const established = metrics.network?.established || 0;
-  if (established > 0 || metrics.network?.hasActivity) {
-    console.log(
-      `${indent}  net=${established} conn sendQ=${metrics.network.sendQueueBytes} recvQ=${metrics.network.recvQueueBytes} activity=${metrics.network.hasActivity ? 'yes' : 'no'}`
-    );
-  }
-
-  if (processInfo.health?.analysis) {
-    console.log(`${indent}  health=${processInfo.health.analysis}`);
-  }
-}
-
-function printWarnings(warnings, indent = '') {
-  if (!warnings || warnings.length === 0) {
-    return;
-  }
-
-  for (const warning of warnings) {
-    console.log(`${indent}${chalk.yellow(`warning: ${warning}`)}`);
-  }
-}
-
-function printTaskSection(task, indent = '') {
-  if (!task) {
-    return;
-  }
-
-  console.log(
-    `${indent}${chalk.dim('Task')}: ${task.id} · ${task.status} · updated ${task.updatedAgeHuman} ago`
-  );
-  console.log(
-    `${indent}  pid=${task.pid || 'N/A'} exit=${task.exitCode ?? 'N/A'} attachable=${task.attachable ? 'yes' : 'no'}`
-  );
-  console.log(
-    `${indent}  log=${task.logFile || 'N/A'} (${task.logFileExists ? 'present' : 'missing'})`
-  );
-  if (task.socketPath) {
-    console.log(
-      `${indent}  socket=${task.socketPath} (${task.socketPathExists ? 'present' : 'missing'})`
-    );
-  }
-  printWarnings(task.warnings, `${indent}  `);
-}
-
-function printClusterInspectionHuman(inspection) {
-  console.log(`\nCluster Inspect: ${inspection.id}`);
-  console.log(`State: ${inspection.cluster.state}`);
-  console.log(`PID: ${inspection.cluster.pid || 'N/A'}`);
-  console.log(`Created: ${new Date(inspection.cluster.createdAt).toLocaleString()}`);
-  console.log(`Messages: ${inspection.cluster.messageCount}`);
-  console.log(`Sample: ${inspection.sampleMs}ms`);
-
-  console.log('\nCluster Process:');
-  printProcessSection('process', inspection.process, '  ');
-
-  console.log('\nAgents:');
-  for (const agent of inspection.agents) {
-    const modelLabel = agent.model ? ` [${agent.model}]` : '';
-    console.log(`  - ${agent.id} (${agent.role})${modelLabel}`);
-    console.log(
-      `    state=${agent.state} iteration=${agent.iteration} runningTask=${agent.currentTask ? 'yes' : 'no'}`
-    );
-    if (agent.currentTaskId) {
-      console.log(`    taskId=${agent.currentTaskId}`);
-    }
-    printProcessSection('process', agent.process, '    ');
-    printTaskSection(agent.task, '    ');
-    printWarnings(agent.warnings, '    ');
-  }
-  console.log('');
-}
-
-function printTaskInspectionHuman(inspection) {
-  console.log(`\nTask Inspect: ${inspection.id}`);
-  console.log(`Sample: ${inspection.sampleMs}ms`);
-  printTaskSection(inspection.task);
-  console.log('');
-  printProcessSection('Process', inspection.process);
-  console.log('');
 }
 
 async function runInspectCommand(id, options = {}, deps = {}) {

--- a/cli/commands/inspect.js
+++ b/cli/commands/inspect.js
@@ -1,0 +1,371 @@
+const fs = require('fs');
+const chalk = require('chalk');
+const Orchestrator = require('../../src/orchestrator');
+const { detectIdType } = require('../../lib/id-detector');
+const { getTask } = require('../../task-lib/store.js');
+const { isProcessRunning } = require('../../task-lib/runner.js');
+const {
+  getProcessMetrics,
+  isPlatformSupported: metricsPlatformSupported,
+} = require('../../src/process-metrics');
+const {
+  analyzeProcessHealth,
+  isPlatformSupported: stuckDetectorPlatformSupported,
+} = require('../../src/agent/agent-stuck-detector');
+
+const DEFAULT_SAMPLE_MS = 1000;
+const TASK_STALE_WARNING_MS = 5 * 60 * 1000;
+
+function parseSampleMs(rawValue) {
+  const parsed = parseInt(rawValue ?? String(DEFAULT_SAMPLE_MS), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid sample period: ${rawValue}`);
+  }
+  return parsed;
+}
+
+function safeDate(dateString) {
+  const date = new Date(dateString);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatAgeMs(ageMs) {
+  if (!Number.isFinite(ageMs) || ageMs < 0) {
+    return 'unknown';
+  }
+
+  const totalSeconds = Math.floor(ageMs / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours < 24) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return `${days}d ${remainingHours}h`;
+}
+
+function inferActivity(metrics, health) {
+  if (!metrics) {
+    return 'unknown';
+  }
+
+  if (!metrics.exists) {
+    return 'not-running';
+  }
+
+  if (health?.isLikelyStuck) {
+    return 'likely-stuck';
+  }
+
+  if (metrics.cpuPercent >= 5) {
+    return 'cpu-active';
+  }
+
+  if (metrics.network?.hasActivity) {
+    return 'network-active';
+  }
+
+  if (metrics.childCount > 0) {
+    return 'child-active';
+  }
+
+  if (metrics.state === 'R') {
+    return 'running';
+  }
+
+  return 'idle';
+}
+
+function buildTaskWarnings(task, details) {
+  const warnings = [];
+
+  if (task.status === 'running' && task.pid && !details.processRunning) {
+    warnings.push('task store says running but PID is not alive');
+  }
+  if (task.status === 'running' && task.logFile && !details.logFileExists) {
+    warnings.push('task log file missing');
+  }
+  if (
+    task.status === 'running' &&
+    details.updatedAgeMs !== null &&
+    details.updatedAgeMs > TASK_STALE_WARNING_MS
+  ) {
+    warnings.push(`task record stale for ${formatAgeMs(details.updatedAgeMs)}`);
+  }
+
+  return warnings;
+}
+
+function summarizeTaskRecord(task, now = Date.now(), existsSync = fs.existsSync) {
+  if (!task) {
+    return null;
+  }
+
+  const updatedAt = safeDate(task.updatedAt);
+  const details = {
+    updatedAgeMs: updatedAt ? now - updatedAt.getTime() : null,
+    processRunning: task.pid ? isProcessRunning(task.pid) : false,
+    logFileExists: Boolean(task.logFile && existsSync(task.logFile)),
+    socketPathExists: Boolean(task.socketPath && existsSync(task.socketPath)),
+  };
+  const warnings = buildTaskWarnings(task, details);
+
+  return {
+    id: task.id,
+    status: task.status,
+    pid: task.pid || null,
+    exitCode: task.exitCode ?? null,
+    error: task.error || null,
+    cwd: task.cwd || null,
+    sessionId: task.sessionId || null,
+    attachable: Boolean(task.attachable),
+    socketPath: task.socketPath || null,
+    socketPathExists: details.socketPathExists,
+    logFile: task.logFile || null,
+    logFileExists: details.logFileExists,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    updatedAgeMs: details.updatedAgeMs,
+    updatedAgeHuman:
+      details.updatedAgeMs === null ? 'unknown' : formatAgeMs(details.updatedAgeMs),
+    processRunning: details.processRunning,
+    warnings,
+  };
+}
+
+async function inspectProcess(pid, sampleMs, options = {}) {
+  if (!pid) {
+    return null;
+  }
+
+  const includeHealth = options.includeHealth !== false;
+  const metricsPromise = metricsPlatformSupported()
+    ? getProcessMetrics(pid, { samplePeriodMs: sampleMs })
+    : Promise.resolve(null);
+  const healthPromise = includeHealth && stuckDetectorPlatformSupported()
+    ? analyzeProcessHealth(pid, sampleMs)
+    : Promise.resolve(null);
+
+  const [metrics, health] = await Promise.all([metricsPromise, healthPromise]);
+  return {
+    pid,
+    metrics,
+    health,
+    activity: inferActivity(metrics, health),
+  };
+}
+
+async function inspectAgent(agent, options, deps = {}) {
+  const getTaskImpl = deps.getTask || getTask;
+  const existsSync = deps.existsSync || fs.existsSync;
+
+  const process = await inspectProcess(agent.pid, options.sampleMs);
+  const task = agent.currentTaskId
+    ? summarizeTaskRecord(getTaskImpl(agent.currentTaskId), Date.now(), existsSync)
+    : null;
+
+  const warnings = [];
+  if (agent.currentTask && !agent.currentTaskId) {
+    warnings.push('agent reports running task but currentTaskId is missing');
+  }
+
+  return {
+    ...agent,
+    process,
+    task,
+    warnings,
+  };
+}
+
+async function buildClusterInspection(clusterId, options = {}, deps = {}) {
+  const sampleMs = parseSampleMs(options.sampleMs);
+  const orchestrator =
+    deps.orchestrator ||
+    (deps.createOrchestrator
+      ? await deps.createOrchestrator()
+      : await Orchestrator.create({ quiet: true }));
+
+  const status = deps.status || orchestrator.getStatus(clusterId);
+  const clusterProcess = await inspectProcess(status.pid, sampleMs, { includeHealth: false });
+  const agents = await Promise.all(
+    status.agents.map((agent) => inspectAgent(agent, { sampleMs }, deps))
+  );
+
+  return {
+    type: 'cluster',
+    id: clusterId,
+    sampleMs,
+    inspectedAt: new Date().toISOString(),
+    cluster: status,
+    process: clusterProcess,
+    agents,
+  };
+}
+
+async function buildTaskInspection(taskId, options = {}, deps = {}) {
+  const sampleMs = parseSampleMs(options.sampleMs);
+  const getTaskImpl = deps.getTask || getTask;
+  const existsSync = deps.existsSync || fs.existsSync;
+  const task = getTaskImpl(taskId);
+
+  if (!task) {
+    throw new Error(`Task ${taskId} not found`);
+  }
+
+  return {
+    type: 'task',
+    id: taskId,
+    sampleMs,
+    inspectedAt: new Date().toISOString(),
+    task: summarizeTaskRecord(task, Date.now(), existsSync),
+    process: await inspectProcess(task.pid, sampleMs),
+  };
+}
+
+function printProcessSection(label, processInfo, indent = '') {
+  if (!processInfo) {
+    console.log(`${indent}${chalk.dim(label)}: N/A`);
+    return;
+  }
+
+  if (!processInfo.metrics?.exists) {
+    console.log(`${indent}${chalk.dim(label)}: PID ${processInfo.pid} not running`);
+    return;
+  }
+
+  const metrics = processInfo.metrics;
+  console.log(
+    `${indent}${chalk.dim(label)}: PID ${processInfo.pid} · activity ${processInfo.activity}`
+  );
+  console.log(
+    `${indent}  state=${metrics.state} cpu=${metrics.cpuPercent}% mem=${metrics.memoryMB}MB threads=${metrics.threads} children=${metrics.childCount}`
+  );
+
+  const established = metrics.network?.established || 0;
+  if (established > 0 || metrics.network?.hasActivity) {
+    console.log(
+      `${indent}  net=${established} conn sendQ=${metrics.network.sendQueueBytes} recvQ=${metrics.network.recvQueueBytes} activity=${metrics.network.hasActivity ? 'yes' : 'no'}`
+    );
+  }
+
+  if (processInfo.health?.analysis) {
+    console.log(`${indent}  health=${processInfo.health.analysis}`);
+  }
+}
+
+function printWarnings(warnings, indent = '') {
+  if (!warnings || warnings.length === 0) {
+    return;
+  }
+
+  for (const warning of warnings) {
+    console.log(`${indent}${chalk.yellow(`warning: ${warning}`)}`);
+  }
+}
+
+function printTaskSection(task, indent = '') {
+  if (!task) {
+    return;
+  }
+
+  console.log(
+    `${indent}${chalk.dim('Task')}: ${task.id} · ${task.status} · updated ${task.updatedAgeHuman} ago`
+  );
+  console.log(
+    `${indent}  pid=${task.pid || 'N/A'} exit=${task.exitCode ?? 'N/A'} attachable=${task.attachable ? 'yes' : 'no'}`
+  );
+  console.log(
+    `${indent}  log=${task.logFile || 'N/A'} (${task.logFileExists ? 'present' : 'missing'})`
+  );
+  if (task.socketPath) {
+    console.log(
+      `${indent}  socket=${task.socketPath} (${task.socketPathExists ? 'present' : 'missing'})`
+    );
+  }
+  printWarnings(task.warnings, `${indent}  `);
+}
+
+function printClusterInspectionHuman(inspection) {
+  console.log(`\nCluster Inspect: ${inspection.id}`);
+  console.log(`State: ${inspection.cluster.state}`);
+  console.log(`PID: ${inspection.cluster.pid || 'N/A'}`);
+  console.log(`Created: ${new Date(inspection.cluster.createdAt).toLocaleString()}`);
+  console.log(`Messages: ${inspection.cluster.messageCount}`);
+  console.log(`Sample: ${inspection.sampleMs}ms`);
+
+  console.log('\nCluster Process:');
+  printProcessSection('process', inspection.process, '  ');
+
+  console.log('\nAgents:');
+  for (const agent of inspection.agents) {
+    const modelLabel = agent.model ? ` [${agent.model}]` : '';
+    console.log(`  - ${agent.id} (${agent.role})${modelLabel}`);
+    console.log(
+      `    state=${agent.state} iteration=${agent.iteration} runningTask=${agent.currentTask ? 'yes' : 'no'}`
+    );
+    if (agent.currentTaskId) {
+      console.log(`    taskId=${agent.currentTaskId}`);
+    }
+    printProcessSection('process', agent.process, '    ');
+    printTaskSection(agent.task, '    ');
+    printWarnings(agent.warnings, '    ');
+  }
+  console.log('');
+}
+
+function printTaskInspectionHuman(inspection) {
+  console.log(`\nTask Inspect: ${inspection.id}`);
+  console.log(`Sample: ${inspection.sampleMs}ms`);
+  printTaskSection(inspection.task);
+  console.log('');
+  printProcessSection('Process', inspection.process);
+  console.log('');
+}
+
+async function runInspectCommand(id, options = {}, deps = {}) {
+  const type = deps.detectIdType ? deps.detectIdType(id) : detectIdType(id);
+
+  if (!type) {
+    throw new Error(`ID not found: ${id}`);
+  }
+
+  const inspection =
+    type === 'cluster'
+      ? await buildClusterInspection(id, options, deps)
+      : await buildTaskInspection(id, options, deps);
+
+  if (options.json) {
+    console.log(JSON.stringify(inspection, null, 2));
+    return inspection;
+  }
+
+  if (inspection.type === 'cluster') {
+    printClusterInspectionHuman(inspection);
+  } else {
+    printTaskInspectionHuman(inspection);
+  }
+
+  return inspection;
+}
+
+module.exports = {
+  DEFAULT_SAMPLE_MS,
+  TASK_STALE_WARNING_MS,
+  buildClusterInspection,
+  buildTaskInspection,
+  inferActivity,
+  parseSampleMs,
+  runInspectCommand,
+  summarizeTaskRecord,
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -62,6 +62,7 @@ const {
 } = require('../lib/start-cluster');
 const { requirePreflight } = require('../src/preflight');
 const { providersCommand, setDefaultCommand, setupCommand } = require('./commands/providers');
+const { runInspectCommand } = require('./commands/inspect');
 // Setup wizard removed - use: zeroshot settings set <key> <value>
 const { checkForUpdates } = require('./lib/update-checker');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
@@ -2597,6 +2598,24 @@ program
         console.log(JSON.stringify({ error: error.message }, null, 2));
       } else {
         console.error('Error getting status:', error.message);
+      }
+      process.exit(1);
+    }
+  });
+
+program
+  .command('inspect <id>')
+  .description('Inspect live process activity for a task or cluster')
+  .option('--json', 'Output as JSON')
+  .option('--sample-ms <ms>', 'Sampling period for process activity checks', '1000')
+  .action(async (id, options) => {
+    try {
+      await runInspectCommand(id, options);
+    } catch (error) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: error.message }, null, 2));
+      } else {
+        console.error('Error inspecting:', error.message);
       }
       process.exit(1);
     }

--- a/tests/unit/cli-inspect-command.test.js
+++ b/tests/unit/cli-inspect-command.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('CLI inspect command', function () {
+  it('should register inspect command with sample-ms option', function () {
+    const cliPath = path.join(__dirname, '..', '..', 'cli', 'index.js');
+    const cliCode = fs.readFileSync(cliPath, 'utf8');
+
+    assert(
+      cliCode.includes(".command('inspect <id>')"),
+      'inspect command should be registered in cli/index.js'
+    );
+    assert(
+      cliCode.includes(".option('--sample-ms <ms>'"),
+      'inspect command should expose --sample-ms'
+    );
+    assert(
+      cliCode.includes('runInspectCommand'),
+      'inspect command should delegate to runInspectCommand'
+    );
+  });
+});

--- a/tests/unit/inspect-command.test.js
+++ b/tests/unit/inspect-command.test.js
@@ -1,0 +1,148 @@
+const assert = require('assert');
+
+const {
+  buildClusterInspection,
+  buildTaskInspection,
+  inferActivity,
+  summarizeTaskRecord,
+} = require('../../cli/commands/inspect');
+
+describe('inspect command helpers', function () {
+  it('should flag stale running task records and missing logs', function () {
+    const now = Date.parse('2026-03-08T22:20:00.000Z');
+    const task = summarizeTaskRecord(
+      {
+        id: 'task-123',
+        status: 'running',
+        pid: 4242,
+        exitCode: null,
+        error: null,
+        cwd: '/tmp/work',
+        sessionId: null,
+        attachable: true,
+        socketPath: '/tmp/task.sock',
+        logFile: '/tmp/task.log',
+        createdAt: '2026-03-08T18:52:01.000Z',
+        updatedAt: '2026-03-08T18:52:01.000Z',
+      },
+      now,
+      () => false
+    );
+
+    assert.strictEqual(task.logFileExists, false);
+    assert.strictEqual(task.socketPathExists, false);
+    assert.ok(task.updatedAgeMs > 0);
+    assert(task.warnings.some((warning) => warning.includes('task log file missing')));
+    assert(task.warnings.some((warning) => warning.includes('task record stale')));
+  });
+
+  it('should classify active and stuck process activity', function () {
+    assert.strictEqual(
+      inferActivity(
+        {
+          exists: true,
+          cpuPercent: 12,
+          state: 'S',
+          childCount: 0,
+          network: { hasActivity: false },
+        },
+        null
+      ),
+      'cpu-active'
+    );
+
+    assert.strictEqual(
+      inferActivity(
+        {
+          exists: true,
+          cpuPercent: 0.1,
+          state: 'S',
+          childCount: 0,
+          network: { hasActivity: false },
+        },
+        { isLikelyStuck: true }
+      ),
+      'likely-stuck'
+    );
+  });
+
+  it('should build cluster inspection with agent task diagnostics', async function () {
+    const inspection = await buildClusterInspection(
+      'cluster-1',
+      { sampleMs: 1 },
+      {
+        status: {
+          id: 'cluster-1',
+          state: 'running',
+          isZombie: false,
+          pid: 10,
+          createdAt: Date.parse('2026-03-08T18:48:24.000Z'),
+          messageCount: 30,
+          agents: [
+            {
+              id: 'worker',
+              role: 'implementation',
+              model: 'sonnet',
+              provider: 'claude',
+              state: 'executing_task',
+              iteration: 1,
+              currentTask: true,
+              currentTaskId: 'task-123',
+              pid: 20,
+            },
+          ],
+        },
+        orchestrator: {},
+        getTask: () => ({
+          id: 'task-123',
+          status: 'running',
+          pid: 20,
+          exitCode: null,
+          error: null,
+          cwd: '/tmp/work',
+          sessionId: null,
+          attachable: true,
+          socketPath: '/tmp/task.sock',
+          logFile: '/tmp/task.log',
+          createdAt: '2026-03-08T18:52:01.000Z',
+          updatedAt: '2026-03-08T18:52:01.000Z',
+        }),
+        existsSync: () => false,
+      }
+    );
+
+    assert.strictEqual(inspection.type, 'cluster');
+    assert.strictEqual(inspection.cluster.id, 'cluster-1');
+    assert.strictEqual(inspection.agents.length, 1);
+    assert.strictEqual(inspection.agents[0].task.id, 'task-123');
+    assert(inspection.agents[0].task.warnings.some((warning) => warning.includes('task log file missing')));
+  });
+
+  it('should build task inspection payload', async function () {
+    const inspection = await buildTaskInspection(
+      'task-7',
+      { sampleMs: 1 },
+      {
+        getTask: () => ({
+          id: 'task-7',
+          status: 'running',
+          pid: null,
+          exitCode: null,
+          error: null,
+          cwd: '/tmp/task',
+          sessionId: 'sess-1',
+          attachable: false,
+          socketPath: null,
+          logFile: null,
+          createdAt: '2026-03-08T18:52:01.000Z',
+          updatedAt: '2026-03-08T18:53:01.000Z',
+        }),
+        existsSync: () => false,
+      }
+    );
+
+    assert.strictEqual(inspection.type, 'task');
+    assert.strictEqual(inspection.task.id, 'task-7');
+    assert.strictEqual(inspection.process, null);
+  });
+});


### PR DESCRIPTION
## Summary
- add `zeroshot inspect <id>` for cluster/task process inspection
- include task staleness and missing-log diagnostics
- expose live process activity from the CLI and keep human/json output paths

## Validation
- `npm test -- tests/unit/inspect-command.test.js tests/unit/cli-inspect-command.test.js`
- `npm run typecheck`
- `npm run validate:templates`
- `node cli/index.js inspect turquoise-pulse-17 --json --sample-ms 200`