### PR TITLE
fix(orchestrator): validate trivial pr-mode topologies

### DIFF
--- a/src/config-router.js
+++ b/src/config-router.js
@@ -11,12 +11,19 @@ const { DEFAULT_MAX_ITERATIONS } = require('./agent/agent-config');
  * Get cluster config based on complexity and task type
  * @param {string} complexity - TRIVIAL, SIMPLE, STANDARD, CRITICAL
  * @param {string} taskType - INQUIRY, TASK, DEBUG
+ * @param {object} [options]
+ * @param {boolean} [options.autoPr] - Whether the cluster will inject git-pusher/PR flow
  * @returns {{ base: string, params: object }}
  */
-function getConfig(complexity, taskType) {
+function getConfig(complexity, taskType, options = {}) {
+  const isPrMode = options.autoPr === true || process.env.ZEROSHOT_PR === '1';
+
   const getBase = () => {
     if (taskType === 'DEBUG' && complexity !== 'TRIVIAL') {
       return 'debug-workflow';
+    }
+    if (complexity === 'TRIVIAL' && isPrMode && taskType !== 'INQUIRY') {
+      return 'worker-validator';
     }
     if (complexity === 'TRIVIAL') {
       return 'single-worker';

--- a/src/template-validation/index.js
+++ b/src/template-validation/index.js
@@ -109,32 +109,77 @@ function augmentCriticalResolvedConfig({ resolver, config, params }) {
   return mergeAgentsById(config, quickValidationConfig);
 }
 
-function ensureCompletionHandler(config) {
-  if (hasCompletionHandler(config)) {
-    return config;
-  }
-
+function buildSyntheticGitPusher() {
   return {
-    ...config,
-    agents: [
-      ...(config.agents || []),
+    id: 'git-pusher',
+    role: 'completion-detector',
+    modelLevel: 'level1',
+    triggers: [
       {
-        id: 'completion-detector',
-        role: 'orchestrator',
-        modelLevel: 'level1',
-        triggers: [
-          {
-            topic: 'VALIDATION_RESULT',
-            logic: {
-              engine: 'javascript',
-              script: SHARED_TRIGGER_SCRIPT,
-            },
-            action: 'stop_cluster',
+        topic: 'VALIDATION_RESULT',
+        logic: {
+          engine: 'javascript',
+          script: SHARED_TRIGGER_SCRIPT,
+        },
+        action: 'execute_task',
+      },
+    ],
+    hooks: {
+      onComplete: {
+        action: 'publish_message',
+        config: {
+          topic: 'CLUSTER_COMPLETE',
+          content: {
+            text: 'PR flow completed.',
           },
-        ],
+        },
+      },
+    },
+  };
+}
+
+function buildSyntheticCompletionDetector() {
+  return {
+    id: 'completion-detector',
+    role: 'orchestrator',
+    modelLevel: 'level1',
+    triggers: [
+      {
+        topic: 'VALIDATION_RESULT',
+        logic: {
+          engine: 'javascript',
+          script: SHARED_TRIGGER_SCRIPT,
+        },
+        action: 'stop_cluster',
       },
     ],
   };
+}
+
+function buildResolvedRoute({ conductorTemplatePath, resolver, complexity, taskType, autoPr }) {
+  const { base, params } = getConfig(complexity, taskType, { autoPr });
+  const resolved = resolver.resolve(base, params);
+  const augmented = augmentCriticalResolvedConfig({
+    resolver,
+    config: resolved,
+    params,
+  });
+  const configWithCompletion = ensureCompletionHandler(augmented, { autoPr });
+  const modeSuffix = autoPr ? '-autopr' : '';
+
+  return {
+    filePath: `${conductorTemplatePath}#resolved${modeSuffix}:${complexity}-${taskType}`,
+    templateId: `resolved-${base}${modeSuffix}`,
+    config: configWithCompletion,
+  };
+}
+
+function getRouteModes(taskType) {
+  if (taskType === 'INQUIRY') {
+    return [false];
+  }
+
+  return [false, true];
 }
 
 function buildResolvedConductorRoutes(templatesDir) {
@@ -148,24 +193,61 @@ function buildResolvedConductorRoutes(templatesDir) {
 
   for (const complexity of CONDUCTOR_COMPLEXITIES) {
     for (const taskType of CONDUCTOR_TASK_TYPES) {
-      const { base, params } = getConfig(complexity, taskType);
-      const resolved = resolver.resolve(base, params);
-      const augmented = augmentCriticalResolvedConfig({
-        resolver,
-        config: resolved,
-        params,
-      });
-      const configWithCompletion = ensureCompletionHandler(augmented);
-
-      routeConfigs.push({
-        filePath: `${conductorTemplatePath}#resolved:${complexity}-${taskType}`,
-        templateId: `resolved-${base}`,
-        config: configWithCompletion,
-      });
+      for (const autoPr of getRouteModes(taskType)) {
+        routeConfigs.push(
+          buildResolvedRoute({
+            conductorTemplatePath,
+            resolver,
+            complexity,
+            taskType,
+            autoPr,
+          })
+        );
+      }
     }
   }
 
   return routeConfigs;
+}
+
+function shouldSkipConfig(config) {
+  return !config.agents && !config.name;
+}
+
+function updateValidationSummary(summary, result) {
+  summary.results.push(result);
+  summary.validated++;
+  if (!result.result.valid) {
+    summary.hasErrors = true;
+  }
+}
+
+async function validateConfigEntry({
+  filePath,
+  config,
+  templateId,
+  deep,
+  randomSampling,
+  templatesDir,
+  randomOptions,
+}) {
+  try {
+    const result = await validateTemplateConfig({
+      config,
+      templateId,
+      deep,
+      randomSampling,
+      templatesDir,
+      randomOptions,
+    });
+
+    return { filePath, result };
+  } catch (err) {
+    return {
+      filePath,
+      result: { valid: false, errors: [err.message], warnings: [] },
+    };
+  }
 }
 
 async function validateTemplates({
@@ -178,70 +260,68 @@ async function validateTemplates({
   const templateFiles = [...findJsonFiles(templatesDir)];
   const resolvedConductorRoutes = buildResolvedConductorRoutes(templatesDir);
 
-  let hasErrors = false;
-  let validated = 0;
-  let skipped = 0;
-  const results = [];
+  const summary = {
+    hasErrors: false,
+    validated: 0,
+    skipped: 0,
+    results: [],
+  };
 
   for (const filePath of templateFiles) {
-    try {
-      const content = fs.readFileSync(filePath, 'utf-8');
-      const config = JSON.parse(content);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const config = JSON.parse(content);
 
-      // Skip non-cluster configs (like package.json)
-      if (!config.agents && !config.name) {
-        skipped++;
-        continue;
-      }
-
-      const templateId = inferTemplateIdFromPath(filePath);
-      const result = await validateTemplateConfig({
-        config,
-        templateId,
-        deep,
-        randomSampling: randomSampling && randomScope === 'all',
-        templatesDir,
-        randomOptions,
-      });
-
-      results.push({ filePath, result });
-      validated++;
-      if (!result.valid) hasErrors = true;
-    } catch (err) {
-      results.push({ filePath, result: { valid: false, errors: [err.message], warnings: [] } });
-      validated++;
-      hasErrors = true;
+    if (shouldSkipConfig(config)) {
+      summary.skipped++;
+      continue;
     }
+
+    const result = await validateConfigEntry({
+      filePath,
+      config,
+      templateId: inferTemplateIdFromPath(filePath),
+      deep,
+      randomSampling: randomSampling && randomScope === 'all',
+      templatesDir,
+      randomOptions,
+    });
+    updateValidationSummary(summary, result);
   }
 
   for (const resolvedRoute of resolvedConductorRoutes) {
-    try {
-      const result = await validateTemplateConfig({
-        config: resolvedRoute.config,
-        templateId: resolvedRoute.templateId,
-        deep,
-        randomSampling,
-        templatesDir,
-        randomOptions,
-      });
-      results.push({ filePath: resolvedRoute.filePath, result });
-      validated++;
-      if (!result.valid) hasErrors = true;
-    } catch (err) {
-      results.push({
-        filePath: resolvedRoute.filePath,
-        result: { valid: false, errors: [err.message], warnings: [] },
-      });
-      validated++;
-      hasErrors = true;
-    }
+    const result = await validateConfigEntry({
+      filePath: resolvedRoute.filePath,
+      config: resolvedRoute.config,
+      templateId: resolvedRoute.templateId,
+      deep,
+      randomSampling,
+      templatesDir,
+      randomOptions,
+    });
+    updateValidationSummary(summary, result);
   }
 
   return {
-    valid: !hasErrors,
-    validated,
-    skipped,
-    results,
+    valid: !summary.hasErrors,
+    validated: summary.validated,
+    skipped: summary.skipped,
+    results: summary.results,
+  };
+}
+
+function ensureCompletionHandler(config, options = {}) {
+  const { autoPr = false } = options;
+
+  if (hasCompletionHandler(config)) {
+    return config;
+  }
+
+  return {
+    ...config,
+    agents: [
+      ...(config.agents || []),
+      autoPr ? buildSyntheticGitPusher() : buildSyntheticCompletionDetector(),
+    ],
   };
 }
 

--- a/tests/unit/config-router-pr-mode.test.js
+++ b/tests/unit/config-router-pr-mode.test.js
@@ -1,0 +1,34 @@
+const assert = require('node:assert');
+
+const { getConfig } = require('../../src/config-router');
+
+describe('config-router pr mode', function () {
+  const originalPrEnv = process.env.ZEROSHOT_PR;
+
+  afterEach(function () {
+    if (originalPrEnv === undefined) {
+      delete process.env.ZEROSHOT_PR;
+      return;
+    }
+
+    process.env.ZEROSHOT_PR = originalPrEnv;
+  });
+
+  it('routes trivial task through worker-validator when autoPr is enabled', function () {
+    const { base, params } = getConfig('TRIVIAL', 'TASK', { autoPr: true });
+
+    assert.strictEqual(base, 'worker-validator');
+    assert.strictEqual(params.worker_level, 'level1');
+    assert.strictEqual(params.validator_level, 'level1');
+  });
+
+  it('routes trivial task through worker-validator when ZEROSHOT_PR=1', function () {
+    process.env.ZEROSHOT_PR = '1';
+
+    const { base, params } = getConfig('TRIVIAL', 'TASK');
+
+    assert.strictEqual(base, 'worker-validator');
+    assert.strictEqual(params.worker_level, 'level1');
+    assert.strictEqual(params.validator_level, 'level1');
+  });
+});

--- a/tests/unit/pr-mode-cluster-validation.test.js
+++ b/tests/unit/pr-mode-cluster-validation.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert');
+
+const Orchestrator = require('../../src/orchestrator');
+const { getConfig } = require('../../src/config-router');
+
+describe('pr-mode cluster validation', function () {
+  it('accepts trivial task topology in autoPr mode', function () {
+    const orchestrator = new Orchestrator({ quiet: true, skipLoad: true });
+    const cluster = {
+      id: 'cluster-pr',
+      autoPr: true,
+      agents: [{ id: 'git-pusher', config: { id: 'git-pusher' } }],
+      config: {
+        agents: [{ id: 'git-pusher', role: 'completion-detector' }],
+      },
+      messageBus: {
+        publish: () => {},
+      },
+    };
+    const operations = [
+      {
+        action: 'load_config',
+        config: getConfig('TRIVIAL', 'TASK', { autoPr: true }),
+      },
+    ];
+    const proposed = orchestrator._buildProposedAgentConfigs([], operations);
+
+    assert(proposed.some((agent) => agent.id === 'validator'));
+    assert.doesNotThrow(() => {
+      orchestrator._validateProposedConfig(cluster.id, cluster, proposed, operations);
+    });
+  });
+});

--- a/tests/unit/template-validation-deep.test.js
+++ b/tests/unit/template-validation-deep.test.js
@@ -15,11 +15,13 @@ describe('Template validation (deep)', function () {
   it('validates resolved conductor topology for all classification routes', async function () {
     const templatesDir = path.join(__dirname, '..', '..', 'cluster-templates');
     const report = await validateTemplates({ templatesDir, deep: false });
-    const resolvedRouteResults = report.results.filter((entry) =>
-      entry.filePath.includes('conductor-bootstrap.json#resolved:')
+    const resolvedRouteResults = report.results.filter(
+      (entry) =>
+        entry.filePath.includes('conductor-bootstrap.json#resolved:') ||
+        entry.filePath.includes('conductor-bootstrap.json#resolved-autopr:')
     );
 
-    assert.strictEqual(resolvedRouteResults.length, 12);
+    assert.strictEqual(resolvedRouteResults.length, 20);
     const invalidRoutes = resolvedRouteResults.filter((entry) => !entry.result.valid);
     assert.strictEqual(
       invalidRoutes.length,

--- a/tests/unit/template-validation-pr-mode.test.js
+++ b/tests/unit/template-validation-pr-mode.test.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { validateTemplates } = require('../../src/template-validation');
+
+describe('template validation pr mode', function () {
+  it('validates resolved autoPr conductor routes', async function () {
+    const templatesDir = path.join(__dirname, '..', '..', 'cluster-templates');
+    const report = await validateTemplates({ templatesDir, deep: false });
+    const autoPrRoutes = report.results.filter((entry) =>
+      entry.filePath.includes('conductor-bootstrap.json#resolved-autopr:')
+    );
+    const invalidRoutes = autoPrRoutes.filter((entry) => !entry.result.valid);
+
+    assert.strictEqual(autoPrRoutes.length, 8);
+    assert.strictEqual(
+      invalidRoutes.length,
+      0,
+      invalidRoutes
+        .map((entry) => `${entry.filePath}: ${entry.result.errors.join(' | ')}`)
+        .join('\n')
+    );
+  });
+});


### PR DESCRIPTION
Fixes the ship-mode failure where TRIVIAL TASK/DEBUG routes produced an invalid topology after git-pusher injection. Adds router and template-validation regression tests for PR-mode conductor routes.