### PR TITLE
docs(workflow): clarify dev release promotion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,13 @@ const maxValidators = cluster.config.complexity === 'CRITICAL' ? 5 : 3;
 
 **CI blocks PRs to main from any branch except `dev`.** See `.github/workflows/ci.yml` → `enforce-main-pr-source` job.
 
+**Development branch ownership:**
+
+- `dev` is the integration branch for normal development work.
+- Feature branches merge into `dev`, not `main`.
+- `main` is release-only. Promote `dev` to `main` only when you intentionally want a release.
+- If you are "just shipping a fix" during development, ship it to `dev`.
+
 ```bash
 # ❌ CI WILL BLOCK - PRs to main from feature branches
 gh pr create --base main --head fix/my-feature  # FAILS in CI
@@ -397,6 +404,8 @@ gh pr create --base main --head dev --title "Release"  # dev → main (allowed)
 **POSTMORTEM (2026-01-16):** Agent found merge conflicts between dev and main. Instead of resolving conflicts properly (merge main into dev), created a feature branch directly from main and merged fixes to main. This bypassed dev, created divergence, and left dev without the fixes.
 
 **FIX:** Added CI enforcement (`enforce-main-pr-source` job). Now mechanically impossible to merge non-dev branches to main.
+
+**POSTMORTEM RULE:** Treat `main` as the release branch, not the development branch. If you are choosing a destination branch for active work, the answer is `dev`.
 
 ## 🔴 BEHAVIORAL RULES
 
@@ -423,6 +432,13 @@ Merge to dev (only if CI passes on rebased code)
 ```
 
 **Pre-push hook blocks:** Direct pushes to `main` or `dev`. Must use PR workflow.
+
+**Branch intent:**
+
+- `dev`: active development / integration
+- `main`: release only
+- Feature branch → PR to `dev`
+- `dev` → PR to `main` only for release promotion
 
 **Commands:**
 

--- a/docs/postmortems/2026-01-31-pr-base-detached.md
+++ b/docs/postmortems/2026-01-31-pr-base-detached.md
@@ -40,6 +40,7 @@
 - Parse daemon run options in `buildStartOptions` as a fallback for any missing CLI flags.
 - Add unit coverage to ensure env-run-options are honored.
 - Update operator docs to explicitly require forwarding options for detached runs.
+- Re-state branch ownership in repo context: `dev` is the normal development/integration branch; `main` is release-only promotion from `dev`.
 
 ## Action Items
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,15 +2725,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -10711,9 +10711,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"


### PR DESCRIPTION
Clarify that development work integrates into dev and main is release-only promotion from dev.\n\n- reinforce dev -> main release flow in CLAUDE.md\n- add postmortem prevention note for detached PR-base incident