### PR TITLE
chore: upgrade Codex default model from gpt-5.3 to gpt-5.4

### DIFF
--- a/src/providers/openai/models.js
+++ b/src/providers/openai/models.js
@@ -1,12 +1,12 @@
-// Codex defaults to gpt-5.3-codex; levels vary by reasoning effort only.
+// Codex defaults to gpt-5.4-codex; levels vary by reasoning effort only.
 const MODEL_CATALOG = {
-  'gpt-5.3-codex': { rank: 2 },
+  'gpt-5.4-codex': { rank: 2 },
 };
 
 const LEVEL_MAPPING = {
-  level1: { rank: 1, model: 'gpt-5.3-codex', reasoningEffort: 'medium' },
-  level2: { rank: 2, model: 'gpt-5.3-codex', reasoningEffort: 'high' },
-  level3: { rank: 3, model: 'gpt-5.3-codex', reasoningEffort: 'xhigh' },
+  level1: { rank: 1, model: 'gpt-5.4-codex', reasoningEffort: 'medium' },
+  level2: { rank: 2, model: 'gpt-5.4-codex', reasoningEffort: 'high' },
+  level3: { rank: 3, model: 'gpt-5.4-codex', reasoningEffort: 'xhigh' },
 };
 
 const DEFAULT_LEVEL = 'level2';

--- a/src/providers/openai/models.js
+++ b/src/providers/openai/models.js
@@ -1,12 +1,12 @@
-// Codex defaults to gpt-5.4-codex; levels vary by reasoning effort only.
+// Codex defaults to gpt-5.4; levels vary by reasoning effort only.
 const MODEL_CATALOG = {
-  'gpt-5.4-codex': { rank: 2 },
+  'gpt-5.4': { rank: 2 },
 };
 
 const LEVEL_MAPPING = {
-  level1: { rank: 1, model: 'gpt-5.4-codex', reasoningEffort: 'medium' },
-  level2: { rank: 2, model: 'gpt-5.4-codex', reasoningEffort: 'high' },
-  level3: { rank: 3, model: 'gpt-5.4-codex', reasoningEffort: 'xhigh' },
+  level1: { rank: 1, model: 'gpt-5.4', reasoningEffort: 'medium' },
+  level2: { rank: 2, model: 'gpt-5.4', reasoningEffort: 'high' },
+  level3: { rank: 3, model: 'gpt-5.4', reasoningEffort: 'xhigh' },
 };
 
 const DEFAULT_LEVEL = 'level2';

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -48,7 +48,7 @@ describe('Provider settings', function () {
         maxLevel: 'level3',
         defaultLevel: 'level2',
         levelOverrides: {
-          level1: { model: 'gpt-5.3-codex', reasoningEffort: 'low' },
+          level1: { model: 'gpt-5.4-codex', reasoningEffort: 'low' },
         },
       });
     });
@@ -85,10 +85,10 @@ describe('Provider settings', function () {
     assert.strictEqual(settings.providerSettings.claude.defaultLevel, 'level1');
   });
 
-  it('uses gpt-5.3-codex as the default codex model', function () {
+  it('uses gpt-5.4-codex as the default codex model', function () {
     const codex = getProvider('codex');
     const modelSpec = codex.resolveModelSpec(codex.getDefaultLevel(), {});
-    assert.strictEqual(modelSpec.model, 'gpt-5.3-codex');
+    assert.strictEqual(modelSpec.model, 'gpt-5.4-codex');
   });
 
   it('maps claude level3 to opus alias', function () {

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -48,7 +48,7 @@ describe('Provider settings', function () {
         maxLevel: 'level3',
         defaultLevel: 'level2',
         levelOverrides: {
-          level1: { model: 'gpt-5.4-codex', reasoningEffort: 'low' },
+          level1: { model: 'gpt-5.4', reasoningEffort: 'low' },
         },
       });
     });
@@ -85,10 +85,10 @@ describe('Provider settings', function () {
     assert.strictEqual(settings.providerSettings.claude.defaultLevel, 'level1');
   });
 
-  it('uses gpt-5.4-codex as the default codex model', function () {
+  it('uses gpt-5.4 as the default codex model', function () {
     const codex = getProvider('codex');
     const modelSpec = codex.resolveModelSpec(codex.getDefaultLevel(), {});
-    assert.strictEqual(modelSpec.model, 'gpt-5.4-codex');
+    assert.strictEqual(modelSpec.model, 'gpt-5.4');
   });
 
   it('maps claude level3 to opus alias', function () {


### PR DESCRIPTION
## Summary
- Upgrade Codex provider default model from `gpt-5.3-codex` to `gpt-5.4-codex` in model catalog and level mappings
- Update corresponding test assertions

## Test plan
- [x] `settings-providers.test.js` passes with updated model name