### PR TITLE
feat: forward worktree tool bins into spawned agents

### DIFF
--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -101,6 +101,8 @@ class AgentWrapper {
           model: this._selectModel(),
           modelSpec: spec,
           provider: this._resolveProvider(),
+          cwd: this.config.cwd || process.cwd(),
+          worktreePath: this.worktree?.path || null,
         });
       };
     } else {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -19,6 +19,7 @@ const { getProvider, parseChunkWithProvider } = require('../providers');
 const { getTask } = require('../../task-lib/store.js');
 const { loadSettings } = require('../../lib/settings.js');
 const { resolveClaudeAuth } = require('../../lib/settings/claude-auth.js');
+const { prependWorktreeToolBinToEnv } = require('../worktree-tooling-env.js');
 
 // Schema utilities for normalizing LLM output
 const { normalizeEnumValues } = require('./schema-utils');
@@ -700,6 +701,7 @@ function ensureProviderHooks(agent, providerName) {
 
 function buildSpawnEnv(agent, providerName, modelSpec) {
   const spawnEnv = { ...process.env };
+  const agentCwd = agent.config?.cwd || agent.worktree?.path || process.cwd();
 
   if (providerName === 'claude') {
     Object.assign(spawnEnv, buildClaudeEnv(modelSpec));
@@ -709,6 +711,11 @@ function buildSpawnEnv(agent, providerName, modelSpec) {
       spawnEnv.ZEROSHOT_WORKTREE = '1';
     }
   }
+
+  prependWorktreeToolBinToEnv(spawnEnv, {
+    cwd: agentCwd,
+    worktreePath: agent.worktree?.path || null,
+  });
 
   return spawnEnv;
 }

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,6 +12,7 @@ const TaskRunner = require('./task-runner');
 const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
+const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 
 class ClaudeTaskRunner extends TaskRunner {
   /**
@@ -42,7 +43,7 @@ class ClaudeTaskRunner extends TaskRunner {
    * Execute a task via zeroshot CLI
    *
    * @param {string} context - Full prompt/context
-   * @param {{agentId?: string, model?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, isolation?: any}} options - Execution options
+   * @param {{agentId?: string, model?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, worktreePath?: string|null, isolation?: any}} options - Execution options
    * @returns {Promise<{success: boolean, output: string, error: string|null, taskId?: string}>}
    */
   async run(context, options = {}) {
@@ -57,6 +58,7 @@ class ClaudeTaskRunner extends TaskRunner {
       jsonSchema = null,
       strictSchema = false, // false = live streaming (default), true = CLI schema enforcement (no streaming)
       cwd = process.cwd(),
+      worktreePath = null,
       isolation = null,
     } = options;
 
@@ -101,7 +103,10 @@ class ClaudeTaskRunner extends TaskRunner {
     });
 
     // Spawn and get task ID
-    const spawnEnv = this._buildSpawnEnv(providerName, resolvedModelSpec);
+    const spawnEnv = this._buildSpawnEnv(providerName, resolvedModelSpec, {
+      cwd,
+      worktreePath,
+    });
 
     const taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
 
@@ -179,13 +184,16 @@ class ClaudeTaskRunner extends TaskRunner {
     return args;
   }
 
-  _buildSpawnEnv(providerName, resolvedModelSpec) {
+  _buildSpawnEnv(providerName, resolvedModelSpec, options = {}) {
+    const { cwd = process.cwd(), worktreePath = null } = options;
     const spawnEnv = {
       ...process.env,
     };
     if (providerName === 'claude' && resolvedModelSpec?.model) {
       spawnEnv.ANTHROPIC_MODEL = resolvedModelSpec.model;
     }
+
+    prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });
 
     return spawnEnv;
   }

--- a/src/worktree-tooling-env.js
+++ b/src/worktree-tooling-env.js
@@ -1,0 +1,145 @@
+const fs = require('fs');
+const path = require('path');
+
+const TOOLING_METADATA_RELATIVE_PATH = path.join('.zeroshot', 'tooling-env.json');
+const DEFAULT_TOOL_BIN_RELATIVE_PATHS = ['.zeroshot/bin', '.worktree-tool-bin'];
+const FALLBACK_BIN_PREFIX = '.worktree-tool-bin.';
+
+function pathKeyForEnv(env) {
+  return Object.keys(env).find((key) => key.toUpperCase() === 'PATH') || 'PATH';
+}
+
+function resolveExistingRealPath(candidatePath) {
+  try {
+    return fs.realpathSync(candidatePath);
+  } catch {
+    return null;
+  }
+}
+
+function isWithinRoot(candidatePath, rootPath) {
+  const candidateRealPath = resolveExistingRealPath(candidatePath);
+  const rootRealPath = resolveExistingRealPath(rootPath);
+  if (!candidateRealPath || !rootRealPath) {
+    return false;
+  }
+
+  return candidateRealPath === rootRealPath || candidateRealPath.startsWith(`${rootRealPath}${path.sep}`);
+}
+
+function dedupePaths(entries) {
+  const seen = new Set();
+  const orderedEntries = [];
+
+  for (const entry of entries) {
+    if (!entry || seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    orderedEntries.push(entry);
+  }
+
+  return orderedEntries;
+}
+
+function hasToolingMetadata(dirPath) {
+  return fs.existsSync(path.join(dirPath, TOOLING_METADATA_RELATIVE_PATH));
+}
+
+function hasGitEntry(dirPath) {
+  return fs.existsSync(path.join(dirPath, '.git'));
+}
+
+function resolveWorktreeRoot(startDir) {
+  if (!startDir) {
+    return null;
+  }
+
+  let currentDir = path.resolve(startDir);
+  let nearestGitRoot = null;
+  while (true) {
+    if (hasToolingMetadata(currentDir)) {
+      return currentDir;
+    }
+    if (!nearestGitRoot && hasGitEntry(currentDir)) {
+      nearestGitRoot = currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return nearestGitRoot;
+    }
+    currentDir = parentDir;
+  }
+}
+
+function readToolingMetadata(worktreeRoot) {
+  const metadataPath = path.join(worktreeRoot, TOOLING_METADATA_RELATIVE_PATH);
+  if (!fs.existsSync(metadataPath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function listFallbackBinDirectories(worktreeRoot) {
+  try {
+    return fs
+      .readdirSync(worktreeRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(FALLBACK_BIN_PREFIX))
+      .map((entry) => path.join(worktreeRoot, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function resolveWorktreeToolBinEntries(options = {}) {
+  const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
+  if (!worktreeRoot) {
+    return [];
+  }
+
+  const metadata = readToolingMetadata(worktreeRoot);
+  const hasExplicitWorktreePath =
+    typeof options.worktreePath === 'string' && options.worktreePath.trim().length > 0;
+  if (!metadata && !hasExplicitWorktreePath) {
+    return [];
+  }
+
+  const candidates = [];
+  if (typeof metadata?.toolBinDir === 'string' && metadata.toolBinDir.trim()) {
+    candidates.push(metadata.toolBinDir.trim());
+  }
+
+  for (const relativePath of DEFAULT_TOOL_BIN_RELATIVE_PATHS) {
+    candidates.push(path.join(worktreeRoot, relativePath));
+  }
+  candidates.push(...listFallbackBinDirectories(worktreeRoot));
+
+  return dedupePaths(candidates).filter((candidatePath) => isWithinRoot(candidatePath, worktreeRoot));
+}
+
+function prependWorktreeToolBinToEnv(env, options = {}) {
+  const toolBinEntries = resolveWorktreeToolBinEntries(options);
+  if (toolBinEntries.length === 0) {
+    return env;
+  }
+
+  const pathKey = pathKeyForEnv(env);
+  const existingEntries = (env[pathKey] || '').split(path.delimiter).filter(Boolean);
+  env[pathKey] = dedupePaths([...toolBinEntries, ...existingEntries]).join(path.delimiter);
+  return env;
+}
+
+module.exports = {
+  prependWorktreeToolBinToEnv,
+  resolveWorktreeToolBinEntries,
+};

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ClaudeTaskRunner = require('../../src/claude-task-runner');
+
+describe('ClaudeTaskRunner worktree env forwarding', function () {
+  /** @type {string[]} */
+  let tempDirs = [];
+
+  afterEach(function () {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prepends worktree-local tool bins when cwd is inside a nested submodule', function () {
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-runner-worktree-'));
+    tempDirs.push(worktreeRoot);
+
+    const toolBinDir = path.join(worktreeRoot, '.zeroshot', 'bin');
+    const submoduleCwd = path.join(worktreeRoot, 'external', 'zeroshot', 'src');
+    fs.mkdirSync(toolBinDir, { recursive: true });
+    fs.mkdirSync(submoduleCwd, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeRoot, '.zeroshot', 'tooling-env.json'),
+      JSON.stringify({
+        version: 1,
+        worktreeRoot,
+        toolBinDir,
+      }),
+      'utf8'
+    );
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: main-worktree\n', 'utf8');
+    fs.writeFileSync(
+      path.join(worktreeRoot, 'external', 'zeroshot', '.git'),
+      'gitdir: nested-submodule\n',
+      'utf8'
+    );
+
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    const originalPathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+
+    const spawnEnv = runner._buildSpawnEnv('claude', null, {
+      cwd: submoduleCwd,
+      worktreePath: worktreeRoot,
+    });
+
+    const pathEntries = spawnEnv.PATH.split(path.delimiter);
+    assert.strictEqual(pathEntries[0], toolBinDir);
+    for (const entry of originalPathEntries) {
+      assert.ok(pathEntries.includes(entry));
+    }
+  });
+});

--- a/tests/unit/worktree-tooling-env.test.js
+++ b/tests/unit/worktree-tooling-env.test.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  prependWorktreeToolBinToEnv,
+  resolveWorktreeToolBinEntries,
+} = require('../../src/worktree-tooling-env');
+
+describe('worktree-tooling-env', function () {
+  /** @type {string[]} */
+  let tempDirs = [];
+
+  afterEach(function () {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prepends persisted worktree tool bins to PATH for nested cwd values', function () {
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-worktree-tools-'));
+    tempDirs.push(worktreeRoot);
+
+    const toolBinDir = path.join(worktreeRoot, '.zeroshot', 'bin');
+    fs.mkdirSync(toolBinDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeRoot, '.zeroshot', 'tooling-env.json'),
+      JSON.stringify({
+        version: 1,
+        worktreeRoot,
+        toolBinDir,
+      }),
+      'utf8'
+    );
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
+    fs.mkdirSync(path.join(worktreeRoot, 'nested', 'dir'), { recursive: true });
+
+    const env = { PATH: `/usr/bin${path.delimiter}/bin` };
+    prependWorktreeToolBinToEnv(env, {
+      cwd: path.join(worktreeRoot, 'nested', 'dir'),
+    });
+
+    const pathEntries = env.PATH.split(path.delimiter);
+    assert.strictEqual(pathEntries[0], toolBinDir);
+    assert.ok(pathEntries.includes('/usr/bin'));
+    assert.deepStrictEqual(resolveWorktreeToolBinEntries({ cwd: worktreeRoot }), [toolBinDir]);
+  });
+
+  it('prefers the ancestor with tooling metadata over nested submodule .git roots', function () {
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-worktree-tools-'));
+    tempDirs.push(worktreeRoot);
+
+    const toolBinDir = path.join(worktreeRoot, '.zeroshot', 'bin');
+    const submoduleRoot = path.join(worktreeRoot, 'external', 'zeroshot');
+    const submoduleNestedDir = path.join(submoduleRoot, 'src');
+    fs.mkdirSync(toolBinDir, { recursive: true });
+    fs.mkdirSync(submoduleNestedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeRoot, '.zeroshot', 'tooling-env.json'),
+      JSON.stringify({
+        version: 1,
+        worktreeRoot,
+        toolBinDir,
+      }),
+      'utf8'
+    );
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: main-worktree\n', 'utf8');
+    fs.writeFileSync(path.join(submoduleRoot, '.git'), 'gitdir: nested-submodule\n', 'utf8');
+
+    const env = { PATH: `/usr/bin${path.delimiter}/bin` };
+    prependWorktreeToolBinToEnv(env, { cwd: submoduleNestedDir });
+
+    const pathEntries = env.PATH.split(path.delimiter);
+    assert.strictEqual(pathEntries[0], toolBinDir);
+    assert.deepStrictEqual(resolveWorktreeToolBinEntries({ cwd: submoduleNestedDir }), [toolBinDir]);
+  });
+
+  it('ignores symlinked tool bins that escape the worktree root', function () {
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-worktree-tools-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-shared-tools-'));
+    tempDirs.push(worktreeRoot, outsideDir);
+
+    const toolBinLink = path.join(worktreeRoot, '.zeroshot', 'bin');
+    fs.mkdirSync(path.dirname(toolBinLink), { recursive: true });
+    fs.symlinkSync(outsideDir, toolBinLink, 'dir');
+    fs.writeFileSync(
+      path.join(worktreeRoot, '.zeroshot', 'tooling-env.json'),
+      JSON.stringify({
+        version: 1,
+        worktreeRoot,
+        toolBinDir: toolBinLink,
+      }),
+      'utf8'
+    );
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
+
+    const env = { PATH: `/usr/bin${path.delimiter}/bin` };
+    prependWorktreeToolBinToEnv(env, { cwd: worktreeRoot });
+
+    assert.strictEqual(env.PATH, `/usr/bin${path.delimiter}/bin`);
+    assert.deepStrictEqual(resolveWorktreeToolBinEntries({ cwd: worktreeRoot }), []);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `worktree-tooling-env.js` — resolves worktree-local tool bin directories from `.zeroshot/tooling-env.json` metadata
- Prepend resolved tool bins to PATH in `claude-task-runner.js` and `agent-task-executor.js` before spawning agents
- Handles submodule `.git` traversal (prefers ancestor with tooling metadata over nested submodule roots)
- Symlink escape protection (realpath validation against worktree root)

## Context

When zeroshot runs in `--worktree` mode, a bootstrap script may install tool wrappers (e.g. `crg`, `rox`, `cix`) into `.zeroshot/bin/` and persist metadata in `.zeroshot/tooling-env.json`. Without this change, spawned agent tasks don't have that bin on PATH and can't find the tools.

## Test plan

- [x] Unit tests for `worktree-tooling-env.js` (nested cwd, submodule traversal, symlink escape)
- [x] Unit test for `ClaudeTaskRunner._buildSpawnEnv` worktree forwarding