### PR TITLE
fix(deps): override lodash and marked to resolve audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7346,9 +7346,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -7566,15 +7566,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/marked-terminal": {
@@ -12303,19 +12303,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/semantic-release/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/semantic-release/node_modules/marked-terminal": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,9 @@
     "diff": ">=8.0.3",
     "tar": ">=7.5.8",
     "undici": ">=7.18.2",
-    "minimatch": ">=10.2.1"
+    "minimatch": ">=10.2.1",
+    "lodash": ">=4.17.24",
+    "marked": ">=15.0.7"
   },
   "lint-staged": {
     "*.{js,mjs,cjs}": [


### PR DESCRIPTION
## Summary

- Add npm overrides for `lodash@>=4.17.24` and `marked@>=15.0.7`
- `blessed-contrib` depends on vulnerable versions that can't be upgraded without breaking changes
- Overrides force safe transitive dependency versions

## Context

`npm audit --audit-level=moderate --omit=dev` was failing on all PRs due to lodash Code Injection (GHSA-r5fr-rjxr-66jc) and Prototype Pollution (GHSA-f23m-r3pf-42rh). This blocked the merge queue for all PRs.

## Test plan

- [x] `npm audit --audit-level=moderate --omit=dev` returns 0 vulnerabilities
- [x] `npm test` passes