### PR TITLE
Security: Path traversal/arbitrary file write risk in parallel copy worker

### DIFF
--- a/src/copy-worker.js
+++ b/src/copy-worker.js
@@ -14,10 +14,17 @@ const { files, sourceBase, destBase } = workerData;
 let copied = 0;
 let skipped = 0;
 const errors = [];
+const resolvedDestBase = path.resolve(destBase);
 
 for (const relativePath of files) {
   const srcPath = path.join(sourceBase, relativePath);
-  const destPath = path.join(destBase, relativePath);
+  const destPath = path.resolve(destBase, relativePath);
+
+  if (destPath !== resolvedDestBase && !destPath.startsWith(resolvedDestBase + path.sep)) {
+    skipped++;
+    errors.push({ file: relativePath, error: 'Invalid destination path' });
+    continue;
+  }
 
   try {
     // Ensure parent directory exists


### PR DESCRIPTION
## Problem

Destination paths are created using `path.join(destBase, relativePath)` without validating that `relativePath` stays within `destBase`. If `files` contains `../` segments or absolute-like traversal payloads, writes can escape the intended directory and overwrite arbitrary files.

**Severity**: `high`
**File**: `src/copy-worker.js`

## Solution

Normalize and validate each path before copy: resolve destination (`path.resolve(destBase, relativePath)`) and enforce it starts with `path.resolve(destBase) + path.sep`. Reject entries that fail this check.

## Changes

- `src/copy-worker.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
