### PR TITLE
fix: use where for provider detection on Windows

### DIFF
--- a/lib/provider-detection.js
+++ b/lib/provider-detection.js
@@ -1,6 +1,11 @@
-const { execSync, spawnSync } = require('child_process');
+const childProcess = require('child_process');
+const { execSync, spawnSync } = childProcess;
 const fs = require('fs');
 const path = require('path');
+
+function commandLookupCommand(command) {
+  return process.platform === 'win32' ? `where ${command}` : `command -v ${command}`;
+}
 
 function commandExists(command) {
   if (!command) return false;
@@ -8,7 +13,7 @@ function commandExists(command) {
     return fs.existsSync(command);
   }
   try {
-    execSync(`command -v ${command}`, { stdio: 'pipe' });
+    execSync(commandLookupCommand(command), { stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -21,7 +26,7 @@ function getCommandPath(command) {
     return fs.existsSync(command) ? command : null;
   }
   try {
-    const output = execSync(`command -v ${command}`, { encoding: 'utf8', stdio: 'pipe' });
+    const output = execSync(commandLookupCommand(command), { encoding: 'utf8', stdio: 'pipe' });
     return output.trim() || null;
   } catch {
     return null;
@@ -56,4 +61,5 @@ module.exports = {
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 };

--- a/tests/providers/detection.test.js
+++ b/tests/providers/detection.test.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const {
   commandExists,
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 } = require('../../lib/provider-detection');
 
 describe('Provider CLI detection', () => {
@@ -26,5 +28,23 @@ describe('Provider CLI detection', () => {
     assert.ok(typeof help === 'string');
     assert.ok(typeof version === 'string');
     assert.ok(version.length > 0);
+  });
+});
+
+describe('commandLookupCommand', () => {
+  let platformStub;
+
+  afterEach(() => {
+    if (platformStub) platformStub.restore();
+  });
+
+  it('uses where on Windows', () => {
+    platformStub = sinon.stub(process, 'platform').value('win32');
+    assert.strictEqual(commandLookupCommand('claude'), 'where claude');
+  });
+
+  it('uses command -v on non-Windows platforms', () => {
+    platformStub = sinon.stub(process, 'platform').value('linux');
+    assert.strictEqual(commandLookupCommand('claude'), 'command -v claude');
   });
 });


### PR DESCRIPTION
## Summary
- use `where` instead of `command -v` when detecting provider CLIs on Windows
- share the lookup command logic through a small helper used by both `commandExists()` and `getCommandPath()`
- add regression coverage for the Windows vs non-Windows command selection

## Why
Issue #456 reports that provider detection always fails on Windows because `execSync()` runs through `cmd.exe`, where `command -v` is not available.

That means `zeroshot providers setup claude` can incorrectly report `✗ claude CLI not found` even when the CLI is installed and on PATH.

## Testing
- `./node_modules/.bin/mocha tests/providers/detection.test.js`

Fixes #456
