### PR TITLE
fix: hide child process windows on Windows

### DIFF
--- a/lib/provider-detection.js
+++ b/lib/provider-detection.js
@@ -1,6 +1,11 @@
-const { execSync, spawnSync } = require('child_process');
+const childProcess = require('child_process');
+const { execSync, spawnSync } = childProcess;
 const fs = require('fs');
 const path = require('path');
+
+function commandLookupCommand(command) {
+  return process.platform === 'win32' ? `where ${command}` : `command -v ${command}`;
+}
 
 function commandExists(command) {
   if (!command) return false;
@@ -8,7 +13,7 @@ function commandExists(command) {
     return fs.existsSync(command);
   }
   try {
-    execSync(`command -v ${command}`, { stdio: 'pipe' });
+    execSync(commandLookupCommand(command), { stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -21,7 +26,7 @@ function getCommandPath(command) {
     return fs.existsSync(command) ? command : null;
   }
   try {
-    const output = execSync(`command -v ${command}`, { encoding: 'utf8', stdio: 'pipe' });
+    const output = execSync(commandLookupCommand(command), { encoding: 'utf8', stdio: 'pipe' });
     return output.trim() || null;
   } catch {
     return null;
@@ -56,4 +61,5 @@ module.exports = {
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -727,6 +727,7 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: spawnEnv,
+      windowsHide: true,
     });
 
     // NOTE: Don't emit PROCESS_SPAWNED here - proc.pid is a wrapper that exits immediately.

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -200,6 +200,7 @@ class ClaudeTaskRunner extends TaskRunner {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: spawnEnv,
+        windowsHide: true,
       });
 
       let stdout = '';

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -173,6 +173,7 @@ function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfi
     {
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
     }
   );
 

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -37,6 +37,7 @@ const child = spawn(command, finalArgs, {
   cwd,
   env,
   stdio: ['ignore', 'pipe', 'pipe'],
+  windowsHide: true,
 });
 
 updateTask(taskId, { pid: child.pid });

--- a/tests/providers/detection.test.js
+++ b/tests/providers/detection.test.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const {
   commandExists,
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 } = require('../../lib/provider-detection');
 
 describe('Provider CLI detection', () => {
@@ -26,5 +28,23 @@ describe('Provider CLI detection', () => {
     assert.ok(typeof help === 'string');
     assert.ok(typeof version === 'string');
     assert.ok(version.length > 0);
+  });
+});
+
+describe('commandLookupCommand', () => {
+  let platformStub;
+
+  afterEach(() => {
+    if (platformStub) platformStub.restore();
+  });
+
+  it('uses where on Windows', () => {
+    platformStub = sinon.stub(process, 'platform').value('win32');
+    assert.strictEqual(commandLookupCommand('claude'), 'where claude');
+  });
+
+  it('uses command -v on non-Windows platforms', () => {
+    platformStub = sinon.stub(process, 'platform').value('linux');
+    assert.strictEqual(commandLookupCommand('claude'), 'command -v claude');
   });
 });


### PR DESCRIPTION
## Summary
- add `windowsHide: true` to the detached watcher `fork()` path
- add `windowsHide: true` to the watcher child spawn path
- add `windowsHide: true` to the agent task executor and Claude task runner spawn paths

## Why
Issue #459 reports that zeroshot spawns visible console windows for child Node.js processes on Windows.

Node's `spawn()` / `fork()` create those windows by default on Windows unless `windowsHide: true` is set. Since zeroshot launches background watcher/task processes, those extra consoles are just UI noise and make the tool feel broken in desktop use.

## Testing
- `./node_modules/.bin/mocha tests/providers/detection.test.js`
- manually verified the four Windows-related spawn/fork call sites now all set `windowsHide: true`

Fixes #459
