### PR TITLE
fix: invoke zeroshot via node on Windows

### DIFF
--- a/lib/provider-detection.js
+++ b/lib/provider-detection.js
@@ -1,6 +1,11 @@
-const { execSync, spawnSync } = require('child_process');
+const childProcess = require('child_process');
+const { execSync, spawnSync } = childProcess;
 const fs = require('fs');
 const path = require('path');
+
+function commandLookupCommand(command) {
+  return process.platform === 'win32' ? `where ${command}` : `command -v ${command}`;
+}
 
 function commandExists(command) {
   if (!command) return false;
@@ -8,7 +13,7 @@ function commandExists(command) {
     return fs.existsSync(command);
   }
   try {
-    execSync(`command -v ${command}`, { stdio: 'pipe' });
+    execSync(commandLookupCommand(command), { stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -21,7 +26,7 @@ function getCommandPath(command) {
     return fs.existsSync(command) ? command : null;
   }
   try {
-    const output = execSync(`command -v ${command}`, { encoding: 'utf8', stdio: 'pipe' });
+    const output = execSync(commandLookupCommand(command), { encoding: 'utf8', stdio: 'pipe' });
     return output.trim() || null;
   } catch {
     return null;
@@ -56,4 +61,5 @@ module.exports = {
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -723,7 +723,8 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
   const SPAWN_TIMEOUT_MS = 30000; // 30 seconds to spawn task
 
   return new Promise((resolve, reject) => {
-    const proc = spawn(ctPath, args, {
+    const spawnSpec = buildZeroshotSpawnSpec(ctPath, args);
+    const proc = spawn(spawnSpec.command, spawnSpec.args, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: spawnEnv,
@@ -1255,6 +1256,21 @@ function followClaudeTaskLogs(agent, taskId) {
   const providerName = agent._resolveProvider ? agent._resolveProvider() : 'claude';
 
   return createLogFollower({ agent, taskId, fsModule, ctPath, providerName });
+}
+
+
+function buildZeroshotSpawnSpec(ctPath, args) {
+  if (process.platform === 'win32') {
+    return {
+      command: process.execPath,
+      args: [path.join(__dirname, '../../cli/index.js'), ...args],
+    };
+  }
+
+  return {
+    command: ctPath,
+    args,
+  };
 }
 
 // Cache zeroshot path at module load time (when PATH is correct)
@@ -1918,6 +1934,7 @@ module.exports = {
   waitForTaskReady,
   spawnClaudeTaskIsolated,
   getClaudeTasksPath,
+  buildZeroshotSpawnSpec,
   parseResultOutput,
   killTask,
 };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -727,6 +727,7 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: spawnEnv,
+      windowsHide: true,
     });
 
     // NOTE: Don't emit PROCESS_SPAWNED here - proc.pid is a wrapper that exits immediately.

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,6 +12,7 @@ const TaskRunner = require('./task-runner');
 const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
+const { buildZeroshotSpawnSpec } = require('./agent/agent-task-executor');
 
 class ClaudeTaskRunner extends TaskRunner {
   /**
@@ -196,7 +197,8 @@ class ClaudeTaskRunner extends TaskRunner {
    */
   _spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, _agentId) {
     return new Promise((resolve, reject) => {
-      const proc = spawn(ctPath, args, {
+      const spawnSpec = buildZeroshotSpawnSpec(ctPath, args);
+      const proc = spawn(spawnSpec.command, spawnSpec.args, {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: spawnEnv,

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -200,6 +200,7 @@ class ClaudeTaskRunner extends TaskRunner {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: spawnEnv,
+        windowsHide: true,
       });
 
       let stdout = '';

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -173,6 +173,7 @@ function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfi
     {
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
     }
   );
 

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -37,6 +37,7 @@ const child = spawn(command, finalArgs, {
   cwd,
   env,
   stdio: ['ignore', 'pipe', 'pipe'],
+  windowsHide: true,
 });
 
 updateTask(taskId, { pid: child.pid });

--- a/tests/providers/detection.test.js
+++ b/tests/providers/detection.test.js
@@ -1,9 +1,11 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const {
   commandExists,
   getCommandPath,
   getHelpOutput,
   getVersionOutput,
+  commandLookupCommand,
 } = require('../../lib/provider-detection');
 
 describe('Provider CLI detection', () => {
@@ -26,5 +28,23 @@ describe('Provider CLI detection', () => {
     assert.ok(typeof help === 'string');
     assert.ok(typeof version === 'string');
     assert.ok(version.length > 0);
+  });
+});
+
+describe('commandLookupCommand', () => {
+  let platformStub;
+
+  afterEach(() => {
+    if (platformStub) platformStub.restore();
+  });
+
+  it('uses where on Windows', () => {
+    platformStub = sinon.stub(process, 'platform').value('win32');
+    assert.strictEqual(commandLookupCommand('claude'), 'where claude');
+  });
+
+  it('uses command -v on non-Windows platforms', () => {
+    platformStub = sinon.stub(process, 'platform').value('linux');
+    assert.strictEqual(commandLookupCommand('claude'), 'command -v claude');
   });
 });

--- a/tests/providers/detection.test.js
+++ b/tests/providers/detection.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
+const path = require('path');
 const {
   commandExists,
   getCommandPath,
@@ -46,5 +47,30 @@ describe('commandLookupCommand', () => {
   it('uses command -v on non-Windows platforms', () => {
     platformStub = sinon.stub(process, 'platform').value('linux');
     assert.strictEqual(commandLookupCommand('claude'), 'command -v claude');
+  });
+});
+
+const { buildZeroshotSpawnSpec } = require('../../src/agent/agent-task-executor');
+
+describe('buildZeroshotSpawnSpec', () => {
+  let platformStub;
+
+  afterEach(() => {
+    if (platformStub) platformStub.restore();
+  });
+
+  it('uses node + cli script on Windows', () => {
+    platformStub = sinon.stub(process, 'platform').value('win32');
+    const spec = buildZeroshotSpawnSpec('zeroshot', ['task', 'run']);
+    assert.strictEqual(spec.command, process.execPath);
+    assert.strictEqual(spec.args[0], path.resolve(process.cwd(), 'cli/index.js'));
+    assert.deepStrictEqual(spec.args.slice(1), ['task', 'run']);
+  });
+
+  it('uses the resolved zeroshot command on non-Windows platforms', () => {
+    platformStub = sinon.stub(process, 'platform').value('linux');
+    const spec = buildZeroshotSpawnSpec('/usr/local/bin/zeroshot', ['task', 'run']);
+    assert.strictEqual(spec.command, '/usr/local/bin/zeroshot');
+    assert.deepStrictEqual(spec.args, ['task', 'run']);
   });
 });


### PR DESCRIPTION
## Summary
- add a small `buildZeroshotSpawnSpec()` helper for self-invocation
- on Windows, spawn `process.execPath` with `cli/index.js` instead of trying to execute bare `zeroshot`
- reuse that helper in both `agent-task-executor` and `claude-task-runner`
- add regression coverage for the Windows vs non-Windows spawn spec

## Why
Issue #457 reports that `spawn('zeroshot', ...)` fails on Windows because npm global commands are exposed as `.cmd` wrappers, which Node cannot execute the same way as Unix binaries.

This PR fixes the smallest high-impact part first: zeroshot spawning **itself**. On Windows it now invokes Node directly with the CLI script path, avoiding the `.cmd` wrapper and the resulting `ENOENT` failures.

## Testing
- `./node_modules/.bin/mocha tests/providers/detection.test.js`

Part of #457
