### PR TITLE
fix: enforce strict schema for debug workflow tester

### DIFF
--- a/cluster-templates/base-templates/debug-workflow.json
+++ b/cluster-templates/base-templates/debug-workflow.json
@@ -232,6 +232,7 @@
       "modelLevel": "{{tester_level}}",
       "timeout": "{{timeout}}",
       "outputFormat": "json",
+      "strictSchema": true,
       "jsonSchema": {
         "type": "object",
         "properties": {

--- a/tests/template-resolver.test.js
+++ b/tests/template-resolver.test.js
@@ -109,6 +109,23 @@ describe('TemplateResolver', function () {
   });
 
   describe('resolve', function () {
+    it('should keep strictSchema enabled for the debug-workflow tester', function () {
+      const resolved = resolver.resolve('debug-workflow', {
+        task_type: 'DEBUG',
+        complexity: 'SIMPLE',
+        max_tokens: 100000,
+        max_iterations: DEFAULT_MAX_ITERATIONS,
+        investigator_level: 'level2',
+        fixer_level: 'level2',
+        tester_level: 'level2',
+      });
+
+      const tester = resolved.agents.find((agent) => agent.id === 'tester');
+      assert.ok(tester, 'tester agent should exist');
+      assert.strictEqual(tester.outputFormat, 'json');
+      assert.strictEqual(tester.strictSchema, true);
+    });
+
     it('should resolve single-worker template', function () {
       const resolved = resolver.resolve('single-worker', {
         task_type: 'TASK',


### PR DESCRIPTION
## Summary
- enable `strictSchema: true` for the `tester` agent in `debug-workflow`
- add a template resolver regression test that locks this behavior in

## Related Issues
Fixes #458

## Changes Made
- update `cluster-templates/base-templates/debug-workflow.json` so the tester keeps native CLI schema enforcement instead of falling back to post-validation over `stream-json`
- add coverage in `tests/template-resolver.test.js` to assert the resolved `tester` agent preserves `strictSchema: true`

## Testing
- `./node_modules/.bin/mocha tests/template-resolver.test.js tests/type-safety-validation.test.js`

## Checklist
- [x] Tests pass (`npm test`)
- [ ] Documentation updated (if needed)
- [x] Follows commit guidelines
