### PR TITLE
fix: surface actionable hint when Claude model unavailable on Vertex

### DIFF
--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -573,6 +573,22 @@ async function runTaskAttempt(agent, triggeringMessage) {
   await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
 }
 
+function detectVertexModelError(errorMessage) {
+  try {
+    const parsed = JSON.parse(errorMessage);
+    if (parsed.api_error_status !== 404) return null;
+    const result = parsed.result || '';
+    const isVertexModelError =
+      result.includes('vertex deployment') ||
+      result.includes('may not exist or you may not have access');
+    if (!isVertexModelError) return null;
+    const modelMatch = result.match(/model\s+\(([^)]+)\)/);
+    return { model: modelMatch ? modelMatch[1] : null };
+  } catch {
+    return null;
+  }
+}
+
 function logTaskAttemptFailure(agent, attempt, maxRetries, error) {
   // Log attempt failure
   console.error(`
@@ -580,6 +596,20 @@ ${'='.repeat(80)}`);
   console.error(`🔴 TASK EXECUTION FAILED - AGENT: ${agent.id} (Attempt ${attempt}/${maxRetries})`);
   console.error(`${'='.repeat(80)}`);
   console.error(`Error: ${error.message}`);
+
+  const vertexError = detectVertexModelError(error.message);
+  if (vertexError) {
+    const model = vertexError.model ? `"${vertexError.model}" is` : 'Selected model is';
+    console.error(`
+⚠️  ${model} not available on your Vertex AI deployment.
+    Fix: set explicit model IDs that are enabled on your deployment:
+
+    zeroshot settings set providerSettings.claude.levelOverrides '{"level1": {"model": "claude-sonnet-4-6"}, "level2": {"model": "claude-sonnet-4-6"}, "level3": {"model": "claude-sonnet-4-6"}}'
+
+    Replace "claude-sonnet-4-6" with whichever Claude model your deployment has enabled.
+    You can test a model with: claude --dangerously-skip-permissions -p "hi" --model <model-id>
+`);
+  }
 }
 
 async function handleLockContention() {
@@ -843,6 +873,11 @@ async function executeTask(agent, triggeringMessage) {
       }
       if (error instanceof HookExecutionError) {
         // Hook failures are deterministic; do not waste tokens retrying the provider task.
+        await handleFinalFailure(agent, triggeringMessage, error, 1);
+        return;
+      }
+      if (detectVertexModelError(error.message)) {
+        // Model unavailability on Vertex is deterministic — retrying wastes nothing but time.
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;
       }


### PR DESCRIPTION
## Context

When running zeroshot with `CLAUDE_CODE_USE_VERTEX=1`, the Claude CLI resolves model shorthands (`sonnet`, `haiku`) to versioned Vertex model names (e.g. `claude-sonnet-4-5@20250929`) that may not be enabled on the user's Vertex deployment. The resulting 404 error was swallowed into a raw JSON blob with no guidance on how to fix it.

## Changes

- Added `detectVertexModelError()` to parse the Claude CLI result JSON and identify Vertex model 404 errors
- `logTaskAttemptFailure` now prints an actionable fix with the exact `zeroshot settings set` command when this error is detected
- Vertex model errors short-circuit the retry loop immediately (like `HookExecutionError`) — the model being unavailable is deterministic, so retrying wastes time

## Alternatives considered

**Option B — Skip `--model` on Vertex:** When `CLAUDE_CODE_USE_VERTEX=1` is set and no `levelOverrides` are configured, pass no `--model` flag and let the CLI use the deployment default. Avoids the error entirely but surrenders model-level control.

**Option C — Inherit the parent session model:** When running under Vertex, the model the parent Claude Code session is using is guaranteed to work. Zeroshot could detect `CLAUDE_CODE_USE_VERTEX=1` and default to that model. The challenge is there's no clean way to read which model the parent session resolved to — `ANTHROPIC_MODEL` in the environment is empty even when a model is active.

🤖 Generated with [Claude Code](https://claude.ai/code)