### PR TITLE
ci(release): use trusted publishing capable npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: 'npm'
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -164,7 +164,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # SAFETY: Manual triggers MUST be dry-run only
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary
- run the release job on Node 24 so npm is new enough for Trusted Publishing/OIDC
- set the npm registry URL in setup-node
- remove the stale NPM_TOKEN fallback from semantic-release so CI uses trusted publishing

## Validation
- prior release rerun passed package verification before failing OIDC/token auth
- workflow-only change; release job will validate package again before publishing

## Release note
This is release infrastructure only and does not change package contents.