### PR TITLE
ci(release): use trusted publishing capable npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: 'npm'
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -164,7 +164,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # SAFETY: Manual triggers MUST be dry-run only
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary
- run the release job on Node 24 so the bundled npm supports trusted publishing
- set the npm registry URL for the release setup step
- remove the stale token fallback so publish uses OIDC

## Verification
- workflow-only change
- release still runs only after main CI succeeds or as manual dry-run