### PR TITLE
ci: run install matrix for main merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,11 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/main')
+      (github.event_name == 'merge_group' && (
+        github.event.merge_group.base_ref == 'main' ||
+        github.event.merge_group.base_ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
+      ))
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- make main merge-queue runs emit the same install-matrix contexts required by main protection
- accept both `main` and `refs/heads/main` merge-group base refs
- also match the GitHub queue ref prefix for main

## Verification
- workflow-only change
- fixes the merge queue waiting for missing install-matrix contexts