### PR TITLE
ci(release): promote trusted publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,7 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'merge_group' && (
-        github.event.merge_group.base_ref == 'main' ||
-        github.event.merge_group.base_ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
-      ))
+      github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,11 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/main')
+      (github.event_name == 'merge_group' && (
+        github.event.merge_group.base_ref == 'main' ||
+        github.event.merge_group.base_ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
+      ))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: 'npm'
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -164,7 +164,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # SAFETY: Manual triggers MUST be dry-run only
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary
- promote the release workflow update needed for trusted publishing
- run the release job on Node 24 and configure the npm registry URL
- make main merge-queue runs emit the install-matrix contexts required by branch protection

## Verification
- source tree matches the current `dev` release workflow state
- target diff is scoped to CI/release workflow files