### PR TITLE
fix(src/logic-engine): prevent global prototype pollution in agent sandbox

### DIFF
--- a/src/logic-engine.js
+++ b/src/logic-engine.js
@@ -82,10 +82,6 @@ function buildAgentContext(agent) {
   };
 }
 
-function getSafeBuiltins() {
-  return { Set, Map, Array, Object, String, Number, Boolean, Math, Date, JSON };
-}
-
 function getQuietConsole() {
   return {
     log: () => {},
@@ -114,33 +110,14 @@ class LogicEngine {
       // Build sandbox context
       const context = this._buildContext(agent, message);
 
-      // Create isolated context with frozen prototypes
-      // This prevents prototype pollution attacks
-      const isolatedContext = {};
-
-      // Freeze Object, Array, Function prototypes in the sandbox
-      isolatedContext.Object = Object.freeze({ ...Object });
-      isolatedContext.Array = Array;
-      isolatedContext.Function = Function;
-
-      // Copy safe context properties
-      Object.assign(isolatedContext, context);
-
-      // Wrap script to prevent prototype access
-      const wrappedScript = `(function() {
-        'use strict';
-        // Prevent prototype pollution
-        const frozenObject = Object;
-        const frozenArray = Array;
-        Object.freeze(frozenObject.prototype);
-        Object.freeze(frozenArray.prototype);
-
-        ${script}
-      })()`;
+      // Create isolated context
+      // vm.createContext already provides a sandbox with its own global environment.
+      // We only need to populate it with the APIs we want to expose.
+      const sandbox = { ...context };
 
       // Create and run in context
-      vm.createContext(isolatedContext);
-      const result = vm.runInContext(wrappedScript, isolatedContext, {
+      vm.createContext(sandbox);
+      const result = vm.runInContext(script, sandbox, {
         timeout: this.timeout,
         displayErrors: true,
       });
@@ -168,7 +145,6 @@ class LogicEngine {
       ledger: ledgerAPI,
       cluster: buildClusterAPI(this.cluster, clusterId),
       helpers: buildHelpers(ledgerAPI),
-      ...getSafeBuiltins(),
       console: getQuietConsole(),
     };
   }
@@ -180,9 +156,8 @@ class LogicEngine {
    */
   validateScript(script) {
     try {
-      // Wrap in function like evaluate() does
-      const wrappedScript = `(function() { ${script} })()`;
-      new vm.Script(wrappedScript);
+      // Validate as a raw script
+      new vm.Script(script);
       return { valid: true, error: null };
     } catch (error) {
       return { valid: false, error: error.message };


### PR DESCRIPTION
The logic engine sandbox was incorrectly attempting to prevent prototype pollution by manually freezing global constructor prototypes from the outer scope, which actually caused the reverse effect and introduced a vulnerability by modifying global behavior. This change removes the unsafe manual prototype freezing and reliance on outer-scope constructors, instead relying on `vm.createContext` to provide a genuinely isolated environment with its own standard globals. This also simplifies the sandbox execution logic and improves security.