### PR TITLE
chore: update GitHub org links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,8 +399,8 @@ Workers are now explicitly ordered to treat every `VALIDATION_RESULT` line as no
 
 Multiple CI jobs fail → Diagnose each independently.
 
-1. Get exact status: `gh api repos/covibes/zeroshot/actions/runs/{RUN_ID}/jobs`
-2. Read ACTUAL error: `gh api repos/covibes/zeroshot/actions/jobs/{JOB_ID}/logs`
+1. Get exact status: `gh api repos/the-open-engine/zeroshot/actions/runs/{RUN_ID}/jobs`
+2. Read ACTUAL error: `gh api repos/the-open-engine/zeroshot/actions/jobs/{JOB_ID}/logs`
 3. Fix ONE error → Push → Rerun → Repeat
 
 ## Release Pipeline Convention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,7 +520,7 @@ npm run typecheck         # TypeScript (if applicable)
 1. **Get exact status:**
 
    ```bash
-   gh api repos/covibes/zeroshot/actions/runs/{RUN_ID}/jobs \
+   gh api repos/the-open-engine/zeroshot/actions/runs/{RUN_ID}/jobs \
      --jq '.jobs[] | "\(.name): \(.status) (\(.conclusion // "pending"))"'
    ```
 
@@ -528,7 +528,7 @@ npm run typecheck         # TypeScript (if applicable)
 
    ```bash
    # ✅ CORRECT - Uses API, works for completed jobs
-   gh api repos/covibes/zeroshot/actions/jobs/{JOB_ID}/logs 2>&1 | grep -E "FAIL|Error"
+   gh api repos/the-open-engine/zeroshot/actions/jobs/{JOB_ID}/logs 2>&1 | grep -E "FAIL|Error"
 
    # ❌ WRONG - Waits for ENTIRE run to complete
    gh run view {RUN_ID} --log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Thank you for your interest in contributing to Zeroshot! This guide covers every
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/covibes/zeroshot.git
+   git clone https://github.com/the-open-engine/zeroshot.git
    cd zeroshot
    ```
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -79,7 +79,7 @@ The semantic-release workflow expects an `NPM_TOKEN` secret.
 
 ### Add the secret:
 
-1. Go to your GitHub repository: https://github.com/covibes/zeroshot
+1. Go to your GitHub repository: https://github.com/the-open-engine/zeroshot
 
 2. Navigate to: **Settings → Secrets and variables → Actions**
 
@@ -168,7 +168,7 @@ Once the `NPM_TOKEN` secret is configured, publishing happens automatically:
 
 ### Check the release:
 
-- **GitHub**: https://github.com/covibes/zeroshot/releases
+- **GitHub**: https://github.com/the-open-engine/zeroshot/releases
 - **npm**: https://www.npmjs.com/package/@covibes/zeroshot
 
 ## Conventional Commit Format

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <em>Demo (100x speed, 90-minute run, 5 iterations to approval)</em>
 </p>
 
-[![CI](https://github.com/covibes/zeroshot/actions/workflows/ci.yml/badge.svg)](https://github.com/covibes/zeroshot/actions/workflows/ci.yml)
+[![CI](https://github.com/the-open-engine/zeroshot/actions/workflows/ci.yml/badge.svg)](https://github.com/the-open-engine/zeroshot/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@covibes/zeroshot.svg)](https://www.npmjs.com/package/@covibes/zeroshot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node 18+](https://img.shields.io/badge/node-18%2B-brightgreen.svg)](https://nodejs.org/)
@@ -503,6 +503,6 @@ The TUI is not included in this release. Use `zeroshot logs -f`, `zeroshot logs 
 
 ---
 
-MIT - [Covibes](https://github.com/covibes)
+MIT - [Covibes](https://github.com/the-open-engine)
 
 Built on [Claude Code](https://claude.com/product/claude-code) by Anthropic.

--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
   ],
   "author": "Covibes",
   "license": "MIT",
-  "homepage": "https://github.com/covibes/zeroshot",
+  "homepage": "https://github.com/the-open-engine/zeroshot",
   "repository": {
     "type": "git",
-    "url": "https://github.com/covibes/zeroshot.git"
+    "url": "https://github.com/the-open-engine/zeroshot.git"
   },
   "bugs": {
-    "url": "https://github.com/covibes/zeroshot/issues"
+    "url": "https://github.com/the-open-engine/zeroshot/issues"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/setup-merge-queue.sh
+++ b/scripts/setup-merge-queue.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-REPO="covibes/zeroshot"
+REPO="the-open-engine/zeroshot"
 
 echo "╔═══════════════════════════════════════════════════════════════════╗"
 echo "║  Setting up merge queue for $REPO                         ║"


### PR DESCRIPTION
Update repository metadata, docs, and merge-queue setup references after the GitHub organization rename.\n\nKeeps the npm package scope unchanged.\n\nVerification:\n- npm run lint\n- npm run typecheck\n- npm run validate:templates