### PR TITLE
ci: run install matrix for main merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,17 @@ jobs:
   install-matrix:
     needs: check
     if: |
-      github.ref == 'refs/heads/main' ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'merge_group' && (
-        github.event.merge_group.base_ref == 'main' ||
-        github.event.merge_group.base_ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
-      ))
+      always() &&
+      needs.check.result == 'success' &&
+      (
+        github.ref == 'refs/heads/main' ||
+        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+        (github.event_name == 'merge_group' && (
+          github.event.merge_group.base_ref == 'main' ||
+          github.event.merge_group.base_ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
+        ))
+      )
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- keep the main-only install matrix behavior
- force the matrix job to evaluate after the check job succeeds even when the PR-source guard is skipped on merge_group events
- unblocks the main merge queue required install-matrix contexts for release PR #505

## Verification
- git diff --check -- .github/workflows/ci.yml
- npx prettier --check .github/workflows/ci.yml
- pre-commit: typecheck
- pre-commit: validate:templates
- push hook: lint
- push hook: typecheck