### PR TITLE
fix(validation): model git-pusher repair hook outputs

### DIFF
--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -17,6 +17,13 @@ const { getProvider } = require('./providers');
 const { CAPABILITIES } = require('./providers/capabilities');
 const { GUIDANCE_TOPICS } = require('./guidance-topics');
 
+const HOOK_ACTION_TOPIC_CONTRACTS = Object.freeze({
+  verify_pull_request: Object.freeze([
+    { topic: 'CLUSTER_COMPLETE', keys: null },
+    { topic: 'PUSH_BLOCKED', keys: null },
+  ]),
+});
+
 /**
  * Check if config is a conductor-bootstrap style config
  * Conductor configs dynamically spawn agents via CLUSTER_OPERATIONS
@@ -288,6 +295,25 @@ function ensureTopicList(map, topic) {
   return map.get(topic);
 }
 
+function getHookActionTopicContracts(hook) {
+  if (!hook?.action) {
+    return [];
+  }
+  return HOOK_ACTION_TOPIC_CONTRACTS[hook.action] || [];
+}
+
+function recordOutputTopic(agent, topic, topicProducers, agentOutputTopics, producerId = agent.id) {
+  const producers = ensureTopicList(topicProducers, topic);
+  if (!producers.includes(producerId)) {
+    producers.push(producerId);
+  }
+
+  const outputs = agentOutputTopics.get(agent.id);
+  if (!outputs.includes(topic)) {
+    outputs.push(topic);
+  }
+}
+
 function recordAgentTriggers(agent, topicConsumers, agentInputTopics) {
   for (const trigger of agent.triggers || []) {
     const topic = trigger.topic;
@@ -321,16 +347,19 @@ function extractDynamicTopicsFromScript(script, ctx) {
 }
 
 function recordAgentOutputs(agent, topicProducers, agentOutputTopics) {
+  const hook = agent.hooks?.onComplete;
   const outputTopic = agent.hooks?.onComplete?.config?.topic;
   if (outputTopic) {
-    ensureTopicList(topicProducers, outputTopic).push(agent.id);
-    agentOutputTopics.get(agent.id).push(outputTopic);
+    recordOutputTopic(agent, outputTopic, topicProducers, agentOutputTopics);
   }
 
   const ctx = { outputTopic, agentId: agent.id, topicProducers, agentOutputTopics };
-  const hook = agent.hooks?.onComplete;
   extractDynamicTopicsFromScript(hook?.logic?.script, ctx);
   extractDynamicTopicsFromScript(hook?.transform?.script, ctx);
+
+  for (const contract of getHookActionTopicContracts(hook)) {
+    recordOutputTopic(agent, contract.topic, topicProducers, agentOutputTopics);
+  }
 }
 
 function buildMessageFlowGraph(config) {
@@ -682,6 +711,13 @@ function collectTopicContracts(config) {
         // Topic inferred from transform script. Treat as dynamic payload shape.
         addContract(topic, { agentId: agent.id, keys: null });
       }
+    }
+
+    for (const contract of getHookActionTopicContracts(hook)) {
+      addContract(contract.topic, {
+        agentId: agent.id,
+        keys: contract.keys instanceof Set ? new Set(contract.keys) : contract.keys,
+      });
     }
   }
 

--- a/tests/unit/pr-mode-cluster-validation.test.js
+++ b/tests/unit/pr-mode-cluster-validation.test.js
@@ -1,22 +1,42 @@
 const assert = require('node:assert');
 
 const Orchestrator = require('../../src/orchestrator');
+const { generateGitPusherAgent } = require('../../src/agents/git-pusher-template');
 const { getConfig } = require('../../src/config-router');
+
+function createPrCluster() {
+  const gitPusher = generateGitPusherAgent('github');
+  return {
+    id: 'cluster-pr',
+    autoPr: true,
+    agents: [{ id: 'git-pusher', config: gitPusher }],
+    config: {
+      agents: [gitPusher],
+    },
+    messageBus: {
+      publish: () => {},
+    },
+  };
+}
+
+function addPrRepairTrigger(agent) {
+  if (agent.role !== 'implementation') {
+    return agent;
+  }
+  const hasRepairTrigger = agent.triggers?.some((trigger) => trigger.topic === 'PUSH_BLOCKED');
+  if (hasRepairTrigger) {
+    return agent;
+  }
+  return {
+    ...agent,
+    triggers: [...(agent.triggers || []), { topic: 'PUSH_BLOCKED', action: 'execute_task' }],
+  };
+}
 
 describe('pr-mode cluster validation', function () {
   it('accepts trivial task topology in autoPr mode', function () {
     const orchestrator = new Orchestrator({ quiet: true, skipLoad: true });
-    const cluster = {
-      id: 'cluster-pr',
-      autoPr: true,
-      agents: [{ id: 'git-pusher', config: { id: 'git-pusher' } }],
-      config: {
-        agents: [{ id: 'git-pusher', role: 'completion-detector' }],
-      },
-      messageBus: {
-        publish: () => {},
-      },
-    };
+    const cluster = createPrCluster();
     const operations = [
       {
         action: 'load_config',
@@ -26,6 +46,58 @@ describe('pr-mode cluster validation', function () {
     const proposed = orchestrator._buildProposedAgentConfigs([], operations);
 
     assert(proposed.some((agent) => agent.id === 'validator'));
+    assert.doesNotThrow(() => {
+      orchestrator._validateProposedConfig(cluster.id, cluster, proposed, operations);
+    });
+  });
+
+  it('accepts critical staged validation when git-pusher can publish PUSH_BLOCKED', function () {
+    const orchestrator = new Orchestrator({ quiet: true, skipLoad: true });
+    const cluster = createPrCluster();
+    const gitPusher = cluster.config.agents[0];
+
+    const fullWorkflowAgents = orchestrator
+      ._buildProposedAgentConfigs(
+        [],
+        [
+          {
+            action: 'load_config',
+            config: getConfig('CRITICAL', 'TASK', { autoPr: true }),
+          },
+        ]
+      )
+      .map(addPrRepairTrigger);
+
+    const existingAgents = [gitPusher, ...fullWorkflowAgents];
+    const operations = [
+      {
+        action: 'load_config',
+        config: {
+          base: 'quick-validation',
+          params: { validator_level: 'level2', max_tokens: 150000, timeout: 0 },
+        },
+      },
+      {
+        action: 'publish',
+        topic: 'IMPLEMENTATION_READY',
+        content: {
+          text: 'done',
+          data: { completionStatus: { canValidate: true } },
+        },
+        metadata: { _republished: true },
+      },
+    ];
+    const proposed = orchestrator._buildProposedAgentConfigs(existingAgents, operations);
+
+    assert(proposed.some((agent) => agent.id === 'meta-coordinator'));
+    assert(proposed.some((agent) => agent.id === 'consensus-coordinator'));
+    assert(
+      proposed
+        .find((agent) => agent.id === 'worker')
+        ?.triggers?.some((trigger) => trigger.topic === 'PUSH_BLOCKED'),
+      'worker should keep the PR repair trigger that the runtime injected'
+    );
+
     assert.doesNotThrow(() => {
       orchestrator._validateProposedConfig(cluster.id, cluster, proposed, operations);
     });


### PR DESCRIPTION
## Summary
- teach config validation that git-pusher verify_pull_request can emit PUSH_BLOCKED and CLUSTER_COMPLETE
- include hook action output contracts when checking topic producer/consumer validity
- add a critical PR-mode regression covering runtime-injected PUSH_BLOCKED repair triggers

## Validation
- npm test -- tests/unit/pr-mode-cluster-validation.test.js
- npm test -- tests/unit/pr-mode-cluster-validation.test.js tests/two-stage-validation.test.js tests/unit/template-validation-pr-mode.test.js tests/unit/template-simulation.test.js
- npm test -- tests/unit/pr-mode-cluster-validation.test.js tests/two-stage-validation.test.js tests/unit/template-validation-pr-mode.test.js tests/unit/template-simulation.test.js tests/verify-github-pr-hook.test.js
- npm run validate:templates
- npm run lint
- npm run typecheck
- npm test