### PR TITLE
fix(update): bridge legacy covibes package migration

### DIFF
--- a/.github/workflows/publish-covibes-bridge.yml
+++ b/.github/workflows/publish-covibes-bridge.yml
@@ -1,0 +1,51 @@
+name: Publish Covibes Bridge
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run npm publish in dry-run mode'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-bridge:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: legacy/covibes-zeroshot-bridge
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify bridge metadata
+        run: |
+          node -e "
+          const pkg = require('./package.json');
+          if (pkg.name !== '@covibes/zeroshot') throw new Error('wrong package name');
+          if (pkg.version !== '5.4.1') throw new Error('wrong bridge version');
+          if (pkg.bin.zeroshot !== 'cli/index.js') throw new Error('missing zeroshot bin');
+          console.log(pkg.name + '@' + pkg.version);
+          "
+
+      - name: Pack bridge
+        run: npm pack --dry-run
+
+      - name: Dry-run publish bridge
+        if: inputs.dry_run == true
+        run: npm publish --dry-run --access public
+
+      - name: Publish bridge
+        if: inputs.dry_run == false
+        run: npm publish --provenance --access public

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -169,6 +169,33 @@ git commit -m "feat!: remove deprecated API"
 git commit -m "feat: new API" -m "BREAKING CHANGE: removes old API"
 ```
 
+## Legacy @covibes Bridge
+
+The old `@covibes/zeroshot` npm package is deprecated in favor of
+`@the-open-engine/zeroshot`.
+
+The bridge package lives in `legacy/covibes-zeroshot-bridge` and publishes as
+`@covibes/zeroshot@5.4.1`. Its CLI prints a migration notice on every run, delegates normal
+commands to `@the-open-engine/zeroshot`, and makes `zeroshot update` install
+`@the-open-engine/zeroshot@latest` with `--force` so the global `zeroshot` bin moves to the new
+package.
+
+Publish the bridge with the manual `Publish Covibes Bridge` workflow
+(`.github/workflows/publish-covibes-bridge.yml`). It defaults to dry-run. Before running with
+`dry_run=false`, configure npm trusted publishing for:
+
+- package: `@covibes/zeroshot`
+- repository: `the-open-engine/zeroshot`
+- workflow filename: `publish-covibes-bridge.yml`
+
+After the bridge version is published, deprecate the old package versions with an npm maintainer
+account:
+
+```bash
+npm deprecate '@covibes/zeroshot@<=5.4.0' \
+  'Zeroshot has moved to @the-open-engine/zeroshot. Run: npm install -g @the-open-engine/zeroshot'
+```
+
 ## Troubleshooting
 
 ### Error: "npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@the-open-engine%2fzeroshot"

--- a/cli/index.js
+++ b/cli/index.js
@@ -5387,15 +5387,15 @@ function printMessage(msg, showClusterId = false, watchMode = false, isActive = 
 
 // Main async entry point
 async function main() {
-  const isQuiet =
-    process.argv.includes('-q') ||
-    process.argv.includes('--quiet') ||
-    process.env.NODE_ENV === 'test';
+  const isTest = process.env.NODE_ENV === 'test';
+  const isQuiet = process.argv.includes('-q') || process.argv.includes('--quiet') || isTest;
 
   printLegacyDistroNotice();
 
   // Check for updates (non-blocking if offline)
-  await checkForUpdates({ quiet: isQuiet });
+  if (!isTest) {
+    await checkForUpdates({ quiet: isQuiet });
+  }
 
   let args = process.argv.slice(2);
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -67,7 +67,7 @@ const {
   registerDetachedSetupCluster,
 } = require('../lib/detached-startup');
 // Setup wizard removed - use: zeroshot settings set <key> <value>
-const { checkForUpdates } = require('./lib/update-checker');
+const { checkForUpdates, printLegacyDistroNotice } = require('./lib/update-checker');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
 
 // =============================================================================
@@ -5391,6 +5391,8 @@ async function main() {
     process.argv.includes('-q') ||
     process.argv.includes('--quiet') ||
     process.env.NODE_ENV === 'test';
+
+  printLegacyDistroNotice();
 
   // Check for updates (non-blocking if offline)
   await checkForUpdates({ quiet: isQuiet });

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -9,9 +9,15 @@
  */
 
 const https = require('https');
-const { spawn } = require('child_process');
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const readline = require('readline');
 const { loadSettings, saveSettings } = require('../../lib/settings');
+
+const NEW_PACKAGE_NAME = '@the-open-engine/zeroshot';
+const LEGACY_PACKAGE_NAME = '@covibes/zeroshot';
+const NEW_PACKAGE_SPEC = `${NEW_PACKAGE_NAME}@latest`;
 
 // 24 hours in milliseconds
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -20,15 +26,177 @@ const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 5000;
 
 // npm registry URL
-const REGISTRY_URL = 'https://registry.npmjs.org/@the-open-engine/zeroshot/latest';
+const REGISTRY_URL = `https://registry.npmjs.org/${NEW_PACKAGE_NAME}/latest`;
+
+function getPackageMetadata() {
+  return require('../../package.json');
+}
+
+function getCurrentPackageName() {
+  return getPackageMetadata().name || NEW_PACKAGE_NAME;
+}
 
 /**
  * Get current package version
  * @returns {string}
  */
 function getCurrentVersion() {
-  const pkg = require('../../package.json');
-  return pkg.version;
+  return getPackageMetadata().version;
+}
+
+function isLegacyDistro(packageName = getCurrentPackageName()) {
+  return packageName === LEGACY_PACKAGE_NAME;
+}
+
+function printLegacyDistroNotice(packageName = getCurrentPackageName()) {
+  if (!isLegacyDistro(packageName)) {
+    return false;
+  }
+
+  console.error(
+    `\n⚠️  ${LEGACY_PACKAGE_NAME} has moved to ${NEW_PACKAGE_NAME}. ` +
+      'Run `zeroshot update` to switch this installation.\n'
+  );
+  return true;
+}
+
+function getPackageRoot() {
+  return path.dirname(require.resolve('../../package.json'));
+}
+
+function hasPathSuffix(parts, suffix) {
+  if (suffix.length > parts.length) {
+    return false;
+  }
+
+  const start = parts.length - suffix.length;
+  return suffix.every((part, index) => parts[start + index] === part);
+}
+
+function joinPathParts(parts) {
+  const joined = parts.join(path.sep);
+  return joined === '' ? path.parse(process.cwd()).root : joined;
+}
+
+function deriveInstallPrefixFromPackageRoot(packageRoot, packageName) {
+  const parts = path.resolve(packageRoot).split(path.sep);
+  const packageParts = packageName.split('/');
+
+  if (!hasPathSuffix(parts, packageParts)) {
+    return null;
+  }
+
+  const nodeModulesIndex = parts.length - packageParts.length - 1;
+  if (nodeModulesIndex < 0 || parts[nodeModulesIndex] !== 'node_modules') {
+    return null;
+  }
+
+  if (parts[nodeModulesIndex - 1] === 'lib') {
+    return joinPathParts(parts.slice(0, nodeModulesIndex - 1));
+  }
+
+  return joinPathParts(parts.slice(0, nodeModulesIndex));
+}
+
+function resolveNpmCommand(installPrefix = null) {
+  const npmName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const candidates = [];
+
+  if (installPrefix) {
+    candidates.push(path.join(installPrefix, 'bin', npmName));
+  }
+
+  candidates.push(path.join(path.dirname(process.execPath), npmName));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return npmName;
+}
+
+function getNpmConfiguredPrefix(npmCommand = resolveNpmCommand()) {
+  return childProcess
+    .execFileSync(npmCommand, ['config', 'get', 'prefix'], {
+      encoding: 'utf8',
+    })
+    .trim();
+}
+
+function getInstallPrefix(options = {}) {
+  if (options.installPrefix) {
+    return options.installPrefix;
+  }
+
+  const packageName = options.packageName || getCurrentPackageName();
+  const packageRoot = options.packageRoot || getPackageRoot();
+  const derivedPrefix = deriveInstallPrefixFromPackageRoot(packageRoot, packageName);
+
+  if (derivedPrefix) {
+    return derivedPrefix;
+  }
+
+  return getNpmConfiguredPrefix(options.npmCommand);
+}
+
+function getGlobalModulesDir(installPrefix) {
+  const unixGlobalModulesDir = path.join(installPrefix, 'lib', 'node_modules');
+  if (fs.existsSync(unixGlobalModulesDir)) {
+    return unixGlobalModulesDir;
+  }
+
+  return path.join(installPrefix, 'node_modules');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:@+-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function buildManualInstallCommand(installPrefix = null, useSudo = false) {
+  const command = [
+    useSudo ? 'sudo' : null,
+    'npm',
+    'install',
+    '-g',
+    installPrefix ? '--prefix' : null,
+    installPrefix ? shellQuote(installPrefix) : null,
+    NEW_PACKAGE_SPEC,
+  ].filter(Boolean);
+
+  return command.join(' ');
+}
+
+function getUpdateTarget(options = {}) {
+  const packageName = options.packageName || getCurrentPackageName();
+  const legacy = isLegacyDistro(packageName);
+  const installPrefix = getInstallPrefix(options);
+  const npmCommand = options.npmCommand || resolveNpmCommand(installPrefix);
+
+  return {
+    packageName,
+    legacy,
+    installPrefix,
+    npmCommand,
+    globalModulesDir: getGlobalModulesDir(installPrefix),
+  };
+}
+
+function buildInstallArgs(updateTarget) {
+  const args = ['install', '-g', '--prefix', updateTarget.installPrefix];
+
+  if (updateTarget.legacy) {
+    // npm refuses to replace the legacy package's `zeroshot` bin without this.
+    args.push('--force');
+  }
+
+  args.push(NEW_PACKAGE_SPEC);
+  return args;
 }
 
 /**
@@ -119,17 +287,10 @@ function promptForUpdate(currentVersion, latestVersion) {
  * Check if we have write permission to npm global directory
  * @returns {boolean} True if we can write to npm global prefix
  */
-function canWriteToNpmGlobal() {
-  const { execSync } = require('child_process');
-  const fs = require('fs');
-
+function canWriteToNpmGlobal(options = {}) {
   try {
-    // Get npm global prefix (e.g., /usr/lib or /home/user/.nvm/versions/node/...)
-    const prefix = execSync('npm config get prefix', { encoding: 'utf8' }).trim();
-    const globalModulesDir = require('path').join(prefix, 'lib', 'node_modules');
-
-    // Check if directory exists and is writable
-    fs.accessSync(globalModulesDir, fs.constants.W_OK);
+    const updateTarget = getUpdateTarget(options);
+    fs.accessSync(updateTarget.globalModulesDir, fs.constants.W_OK);
     return true;
   } catch {
     return false;
@@ -140,22 +301,32 @@ function canWriteToNpmGlobal() {
  * Run npm install to update the package
  * @returns {Promise<boolean>} True if update succeeded
  */
-function runUpdate() {
+function runUpdate(options = {}) {
   return new Promise((resolve) => {
+    let updateTarget;
+    try {
+      updateTarget = getUpdateTarget(options);
+    } catch {
+      console.log('❌ Update failed. Try manually:');
+      console.log(`   ${buildManualInstallCommand()}\n`);
+      resolve(false);
+      return;
+    }
+
     // Check permissions BEFORE attempting update
-    if (!canWriteToNpmGlobal()) {
+    if (!canWriteToNpmGlobal(options)) {
       console.log('\n⚠️  Cannot auto-update: no write permission to npm global directory.');
       console.log('   Run manually with sudo:');
-      console.log('   sudo npm install -g @the-open-engine/zeroshot@latest\n');
+      console.log(`   ${buildManualInstallCommand(updateTarget.installPrefix, true)}\n`);
       resolve(false);
       return;
     }
 
     console.log('\n📥 Installing update...');
 
-    const proc = spawn('npm', ['install', '-g', '@the-open-engine/zeroshot@latest'], {
+    const proc = childProcess.spawn(updateTarget.npmCommand, buildInstallArgs(updateTarget), {
       stdio: 'inherit',
-      shell: true,
+      shell: false,
     });
 
     proc.on('close', (code) => {
@@ -165,14 +336,14 @@ function runUpdate() {
         resolve(true);
       } else {
         console.log('❌ Update failed. Try manually:');
-        console.log('   sudo npm install -g @the-open-engine/zeroshot@latest\n');
+        console.log(`   ${buildManualInstallCommand(updateTarget.installPrefix, true)}\n`);
         resolve(false);
       }
     });
 
     proc.on('error', () => {
       console.log('❌ Update failed. Try manually:');
-      console.log('   sudo npm install -g @the-open-engine/zeroshot@latest\n');
+      console.log(`   ${buildManualInstallCommand(updateTarget.installPrefix, true)}\n`);
       resolve(false);
     });
   });
@@ -246,9 +417,9 @@ async function checkForUpdates(options = {}) {
   if (options.quiet) {
     console.log(`📦 Update available: ${currentVersion} → ${latestVersion}`);
     if (hasWriteAccess) {
-      console.log('   Run: npm install -g @the-open-engine/zeroshot@latest\n');
+      console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), false)}\n`);
     } else {
-      console.log('   Run: sudo npm install -g @the-open-engine/zeroshot@latest\n');
+      console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), true)}\n`);
     }
     return;
   }
@@ -257,7 +428,7 @@ async function checkForUpdates(options = {}) {
   // (they'd say yes then get an error, which is frustrating UX)
   if (!hasWriteAccess) {
     console.log(`\n📦 Update available: ${currentVersion} → ${latestVersion}`);
-    console.log('   Run: sudo npm install -g @the-open-engine/zeroshot@latest\n');
+    console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), true)}\n`);
     return;
   }
 
@@ -271,7 +442,17 @@ async function checkForUpdates(options = {}) {
 module.exports = {
   checkForUpdates,
   // Exported for testing and CLI update command
+  NEW_PACKAGE_NAME,
+  LEGACY_PACKAGE_NAME,
   getCurrentVersion,
+  getCurrentPackageName,
+  isLegacyDistro,
+  printLegacyDistroNotice,
+  deriveInstallPrefixFromPackageRoot,
+  getInstallPrefix,
+  resolveNpmCommand,
+  getUpdateTarget,
+  buildInstallArgs,
   isNewerVersion,
   fetchLatestVersion,
   runUpdate,

--- a/legacy/covibes-zeroshot-bridge/LICENSE
+++ b/legacy/covibes-zeroshot-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The Open Engine Company
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/legacy/covibes-zeroshot-bridge/README.md
+++ b/legacy/covibes-zeroshot-bridge/README.md
@@ -1,0 +1,18 @@
+# @covibes/zeroshot
+
+This package has moved to `@the-open-engine/zeroshot`.
+
+Install the maintained package directly:
+
+```bash
+npm install -g @the-open-engine/zeroshot
+```
+
+If this bridge package is already installed, run:
+
+```bash
+zeroshot update
+```
+
+The bridge prints a migration notice on every CLI invocation and delegates normal commands to
+`@the-open-engine/zeroshot`.

--- a/legacy/covibes-zeroshot-bridge/cli/index.js
+++ b/legacy/covibes-zeroshot-bridge/cli/index.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const LEGACY_PACKAGE_NAME = '@covibes/zeroshot';
+const NEW_PACKAGE_NAME = '@the-open-engine/zeroshot';
+const NEW_PACKAGE_SPEC = `${NEW_PACKAGE_NAME}@latest`;
+
+function printNotice() {
+  console.error(
+    `\n⚠️  ${LEGACY_PACKAGE_NAME} has moved to ${NEW_PACKAGE_NAME}. ` +
+      'Run `zeroshot update` to switch this installation.\n'
+  );
+}
+
+function hasPathSuffix(parts, suffix) {
+  if (suffix.length > parts.length) {
+    return false;
+  }
+
+  const start = parts.length - suffix.length;
+  return suffix.every((part, index) => parts[start + index] === part);
+}
+
+function joinPathParts(parts) {
+  const joined = parts.join(path.sep);
+  return joined === '' ? path.parse(process.cwd()).root : joined;
+}
+
+function deriveInstallPrefixFromPackageRoot(packageRoot, packageName = LEGACY_PACKAGE_NAME) {
+  const parts = path.resolve(packageRoot).split(path.sep);
+  const packageParts = packageName.split('/');
+
+  if (!hasPathSuffix(parts, packageParts)) {
+    return null;
+  }
+
+  const nodeModulesIndex = parts.length - packageParts.length - 1;
+  if (nodeModulesIndex < 0 || parts[nodeModulesIndex] !== 'node_modules') {
+    return null;
+  }
+
+  if (parts[nodeModulesIndex - 1] === 'lib') {
+    return joinPathParts(parts.slice(0, nodeModulesIndex - 1));
+  }
+
+  return joinPathParts(parts.slice(0, nodeModulesIndex));
+}
+
+function getPackageRoot() {
+  return path.dirname(path.dirname(__filename));
+}
+
+function resolveNpmCommand(installPrefix) {
+  const npmName = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const candidates = [];
+
+  if (installPrefix) {
+    candidates.push(path.join(installPrefix, 'bin', npmName));
+  }
+
+  candidates.push(path.join(path.dirname(process.execPath), npmName));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return npmName;
+}
+
+function getInstallPrefix(packageRoot = getPackageRoot()) {
+  const derivedPrefix = deriveInstallPrefixFromPackageRoot(packageRoot);
+  if (derivedPrefix) {
+    return derivedPrefix;
+  }
+
+  return childProcess
+    .execFileSync(resolveNpmCommand(null), ['config', 'get', 'prefix'], { encoding: 'utf8' })
+    .trim();
+}
+
+function buildInstallArgs(installPrefix) {
+  return ['install', '-g', '--prefix', installPrefix, '--force', NEW_PACKAGE_SPEC];
+}
+
+function runUpdate(options = {}) {
+  const installPrefix = options.installPrefix || getInstallPrefix(options.packageRoot);
+  const npmCommand = options.npmCommand || resolveNpmCommand(installPrefix);
+  const spawn = options.spawn || childProcess.spawn;
+
+  console.error(`Installing ${NEW_PACKAGE_NAME} into ${installPrefix}...`);
+
+  return new Promise((resolve) => {
+    const proc = spawn(npmCommand, buildInstallArgs(installPrefix), {
+      stdio: 'inherit',
+      shell: false,
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        console.error(`\nDone. ${NEW_PACKAGE_NAME} now owns the global zeroshot command.\n`);
+        resolve(true);
+        return;
+      }
+
+      console.error(`\nUpdate failed. Run manually: npm install -g --force ${NEW_PACKAGE_SPEC}\n`);
+      resolve(false);
+    });
+
+    proc.on('error', () => {
+      console.error(`\nUpdate failed. Run manually: npm install -g --force ${NEW_PACKAGE_SPEC}\n`);
+      resolve(false);
+    });
+  });
+}
+
+function resolveNewCli() {
+  return require.resolve(`${NEW_PACKAGE_NAME}/cli/index.js`);
+}
+
+function delegateToNewCli(args, options = {}) {
+  const spawn = options.spawn || childProcess.spawn;
+  const cliPath = options.cliPath || resolveNewCli();
+
+  const proc = spawn(process.execPath, [cliPath, ...args], {
+    stdio: 'inherit',
+    shell: false,
+  });
+
+  proc.on('close', (code) => {
+    process.exit(code ?? 1);
+  });
+
+  proc.on('error', () => {
+    console.error(`Could not start ${NEW_PACKAGE_NAME}. Run: zeroshot update`);
+    process.exit(1);
+  });
+}
+
+async function main(args = process.argv.slice(2)) {
+  printNotice();
+
+  if (args[0] === 'update') {
+    const success = await runUpdate();
+    process.exit(success ? 0 : 1);
+    return;
+  }
+
+  delegateToNewCli(args);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  LEGACY_PACKAGE_NAME,
+  NEW_PACKAGE_NAME,
+  NEW_PACKAGE_SPEC,
+  printNotice,
+  deriveInstallPrefixFromPackageRoot,
+  getInstallPrefix,
+  buildInstallArgs,
+  runUpdate,
+  delegateToNewCli,
+};

--- a/legacy/covibes-zeroshot-bridge/package.json
+++ b/legacy/covibes-zeroshot-bridge/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@covibes/zeroshot",
+  "version": "5.4.1",
+  "description": "Migration bridge from @covibes/zeroshot to @the-open-engine/zeroshot",
+  "bin": {
+    "zeroshot": "cli/index.js"
+  },
+  "scripts": {
+    "test": "node cli/index.js --version"
+  },
+  "dependencies": {
+    "@the-open-engine/zeroshot": "^6.0.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "cli/",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/the-open-engine/zeroshot",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/the-open-engine/zeroshot.git"
+  },
+  "bugs": {
+    "url": "https://github.com/the-open-engine/zeroshot/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/tests/legacy-covibes-bridge.test.js
+++ b/tests/legacy-covibes-bridge.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+
+const bridge = require('../legacy/covibes-zeroshot-bridge/cli/index.js');
+
+describe('Covibes Zeroshot legacy bridge', function () {
+  it('derives the legacy package npm prefix from a global package root', function () {
+    const prefix = bridge.deriveInstallPrefixFromPackageRoot(
+      '/opt/homebrew/lib/node_modules/@covibes/zeroshot'
+    );
+
+    assert.strictEqual(prefix, '/opt/homebrew');
+  });
+
+  it('builds the forced install command that lets the new package take over the bin', function () {
+    assert.deepStrictEqual(bridge.buildInstallArgs('/tmp/zeroshot-prefix'), [
+      'install',
+      '-g',
+      '--prefix',
+      '/tmp/zeroshot-prefix',
+      '--force',
+      '@the-open-engine/zeroshot@latest',
+    ]);
+  });
+
+  it('runs update through npm with the resolved prefix', async function () {
+    let spawnCommand = null;
+    let spawnArgs = null;
+    let spawnOptions = null;
+
+    const spawn = (command, args, options) => {
+      spawnCommand = command;
+      spawnArgs = args;
+      spawnOptions = options;
+
+      const proc = new EventEmitter();
+      process.nextTick(() => proc.emit('close', 0));
+      return proc;
+    };
+
+    const success = await bridge.runUpdate({
+      installPrefix: '/tmp/zeroshot-prefix',
+      npmCommand: '/tmp/npm-for-test',
+      spawn,
+    });
+
+    assert.strictEqual(success, true);
+    assert.strictEqual(spawnCommand, '/tmp/npm-for-test');
+    assert.deepStrictEqual(spawnArgs, [
+      'install',
+      '-g',
+      '--prefix',
+      '/tmp/zeroshot-prefix',
+      '--force',
+      '@the-open-engine/zeroshot@latest',
+    ]);
+    assert.deepStrictEqual(spawnOptions, {
+      stdio: 'inherit',
+      shell: false,
+    });
+  });
+});

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -9,6 +9,8 @@
  */
 const { spawn } = require('child_process');
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
 const testFileAliases = new Map([
   ['provider-cli-builder', ['tests/provider-cli-builder.test.js']],
   ['providers', ['tests/providers/**/*.test.js']],

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -12,6 +12,8 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const assert = require('assert');
+const EventEmitter = require('events');
+const childProcess = require('child_process');
 
 // Test storage directory (isolated)
 const TEST_STORAGE_DIR = path.join(os.tmpdir(), 'zeroshot-update-checker-test-' + Date.now());
@@ -141,6 +143,145 @@ describe('Update Checker', function () {
     it('should be 24 hours in milliseconds', function () {
       const expectedMs = 24 * 60 * 60 * 1000;
       assert.strictEqual(updateChecker.CHECK_INTERVAL_MS, expectedMs);
+    });
+  });
+
+  describe('legacy package migration', function () {
+    it('detects the legacy covibes package name', function () {
+      assert.strictEqual(updateChecker.isLegacyDistro('@covibes/zeroshot'), true);
+      assert.strictEqual(updateChecker.isLegacyDistro('@the-open-engine/zeroshot'), false);
+    });
+
+    it('prints the legacy distro notice to stderr', function () {
+      const originalError = console.error;
+      const messages = [];
+      console.error = (message) => messages.push(message);
+
+      try {
+        const printed = updateChecker.printLegacyDistroNotice('@covibes/zeroshot');
+
+        assert.strictEqual(printed, true);
+        assert.ok(messages.join('\n').includes('@covibes/zeroshot has moved'));
+        assert.ok(messages.join('\n').includes('@the-open-engine/zeroshot'));
+      } finally {
+        console.error = originalError;
+      }
+    });
+
+    it('does not print the legacy distro notice for the new package', function () {
+      const originalError = console.error;
+      const messages = [];
+      console.error = (message) => messages.push(message);
+
+      try {
+        const printed = updateChecker.printLegacyDistroNotice('@the-open-engine/zeroshot');
+
+        assert.strictEqual(printed, false);
+        assert.deepStrictEqual(messages, []);
+      } finally {
+        console.error = originalError;
+      }
+    });
+  });
+
+  describe('install target resolution', function () {
+    it('derives a Unix npm prefix from a scoped global package root', function () {
+      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
+        '/opt/homebrew/lib/node_modules/@the-open-engine/zeroshot',
+        '@the-open-engine/zeroshot'
+      );
+
+      assert.strictEqual(prefix, '/opt/homebrew');
+    });
+
+    it('derives a Unix npm prefix from the legacy scoped package root', function () {
+      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
+        '/Users/tom/.hermes/node/lib/node_modules/@covibes/zeroshot',
+        '@covibes/zeroshot'
+      );
+
+      assert.strictEqual(prefix, '/Users/tom/.hermes/node');
+    });
+
+    it('returns null for a local development checkout', function () {
+      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
+        '/Users/tom/code/covibes/zeroshot',
+        '@the-open-engine/zeroshot'
+      );
+
+      assert.strictEqual(prefix, null);
+    });
+
+    it('uses --force only when migrating the legacy package', function () {
+      const legacyArgs = updateChecker.buildInstallArgs({
+        installPrefix: '/tmp/prefix',
+        legacy: true,
+      });
+      const newArgs = updateChecker.buildInstallArgs({
+        installPrefix: '/tmp/prefix',
+        legacy: false,
+      });
+
+      assert.deepStrictEqual(legacyArgs, [
+        'install',
+        '-g',
+        '--prefix',
+        '/tmp/prefix',
+        '--force',
+        '@the-open-engine/zeroshot@latest',
+      ]);
+      assert.deepStrictEqual(newArgs, [
+        'install',
+        '-g',
+        '--prefix',
+        '/tmp/prefix',
+        '@the-open-engine/zeroshot@latest',
+      ]);
+    });
+
+    it('runs npm with the resolved prefix when updating the legacy package', async function () {
+      const originalSpawn = childProcess.spawn;
+      const installPrefix = path.join(TEST_STORAGE_DIR, 'legacy-prefix');
+      fs.mkdirSync(path.join(installPrefix, 'lib', 'node_modules'), { recursive: true });
+
+      let spawnCommand = null;
+      let spawnArgs = null;
+      let spawnOptions = null;
+
+      childProcess.spawn = (command, args, options) => {
+        spawnCommand = command;
+        spawnArgs = args;
+        spawnOptions = options;
+
+        const proc = new EventEmitter();
+        process.nextTick(() => proc.emit('close', 0));
+        return proc;
+      };
+
+      try {
+        const success = await updateChecker.runUpdate({
+          packageName: '@covibes/zeroshot',
+          installPrefix,
+          npmCommand: '/tmp/npm-for-test',
+        });
+
+        assert.strictEqual(success, true);
+        assert.strictEqual(spawnCommand, '/tmp/npm-for-test');
+        assert.deepStrictEqual(spawnArgs, [
+          'install',
+          '-g',
+          '--prefix',
+          installPrefix,
+          '--force',
+          '@the-open-engine/zeroshot@latest',
+        ]);
+        assert.deepStrictEqual(spawnOptions, {
+          stdio: 'inherit',
+          shell: false,
+        });
+      } finally {
+        childProcess.spawn = originalSpawn;
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- fix updater installs so they target the prefix of the running package instead of PATH's npm/global prefix
- add legacy @covibes/zeroshot bridge package that prints a migration notice and delegates to @the-open-engine/zeroshot
- make bridge update install @the-open-engine/zeroshot with --force so the global zeroshot bin switches packages
- add manual dry-run-first workflow for publishing @covibes/zeroshot@5.4.1 bridge

## Investigation notes
- current local zeroshot resolves through /opt/homebrew/bin but runs under /Users/tom/.hermes/node
- previous updater used plain npm config/install, which targets the Hermes npm prefix in this shell
- npm refuses old-package -> new-package bin replacement without --force because @covibes/zeroshot owns the zeroshot bin

## Validation
- npm test -- tests/update-checker.test.js tests/legacy-covibes-bridge.test.js
- npm run lint
- npm run typecheck
- npm run validate:templates
- npm publish --dry-run --access public (legacy/covibes-zeroshot-bridge)
- isolated bridge install + zeroshot update switched temp bin to @the-open-engine/zeroshot
- isolated @covibes/zeroshot@5.4.0 -> bridge tarball install prints migration notice and delegates to 6.0.1
- npm pack --dry-run --json
- npm test