### PR TITLE
feat(cmdproof): add proof-backed command reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,52 @@ The `id` and optional `scope` are generic. A repo may bind `repo-quality` to any
 
 The pusher fails closed before commit, push, PR creation, or merge when a configured gate is missing, failing, unavailable, stale, older than `IMPLEMENTATION_READY`, or lacks usable evidence. If no `requiredQualityGates` are configured, Zeroshot preserves its existing validator consensus behavior.
 
+## Cmdproof Command Reuse
+
+Clusters can make expensive exact commands reusable across workers and validators with `cmdproof`. Zeroshot does not intercept arbitrary shell commands; it gives agents a cluster-scoped helper for configured command proofs.
+
+Issue bodies can opt in per run:
+
+````markdown
+```zeroshot-command-proofs
+[
+  {
+    "id": "repo-ci",
+    "profile": "ci-equivalent",
+    "scope": "repo",
+    "description": "Repository local CI-equivalent gate",
+    "command": "bash ./scripts/ci/run-local-ci-equivalent.sh"
+  }
+]
+```
+````
+
+Repos can also configure the same commands in `.zeroshot/settings.json`:
+
+```json
+{
+  "ship": {
+    "commandProofs": [
+      {
+        "id": "repo-ci",
+        "profile": "ci-equivalent",
+        "scope": "repo",
+        "description": "Repository local CI-equivalent gate",
+        "command": "bash ./scripts/ci/run-local-ci-equivalent.sh"
+      }
+    ]
+  }
+}
+```
+
+Agents receive instructions to use:
+
+```bash
+zeroshot cmdproof check repo-ci
+```
+
+The helper uses a cluster-local cache and trusted-agent key under `~/.zeroshot/cmdproof/<cluster-id>/`, runs `cmdproof verify` first, and falls back to `cmdproof prove --fallback run` on misses. In `--ship` flows, configured command proofs are also required handoff quality gates.
+
 ## When to Use Zeroshot
 
 Zeroshot performs best when tasks have clear acceptance criteria.

--- a/cli/commands/cmdproof.js
+++ b/cli/commands/cmdproof.js
@@ -1,0 +1,268 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const {
+  normalizeCommandProofs,
+  resolveConfiguredCommandProofs,
+} = require('../../src/command-proofs');
+
+function pushCurrentArg(state) {
+  if (!state.current) {
+    return;
+  }
+  state.args.push(state.current);
+  state.current = '';
+}
+
+function consumeEscapedChar(state, char) {
+  state.current += char;
+  state.escaped = false;
+}
+
+function consumeQuotedChar(state, char) {
+  if (char === state.quote) {
+    state.quote = null;
+    return;
+  }
+  state.current += char;
+}
+
+function consumeUnquotedChar(state, char) {
+  if (char === '\\') {
+    state.escaped = true;
+    return;
+  }
+  if (char === '"' || char === "'") {
+    state.quote = char;
+    return;
+  }
+  if (/\s/.test(char)) {
+    pushCurrentArg(state);
+    return;
+  }
+  state.current += char;
+}
+
+function consumeCommandChar(state, char) {
+  if (state.escaped) {
+    consumeEscapedChar(state, char);
+    return;
+  }
+  if (state.quote) {
+    consumeQuotedChar(state, char);
+    return;
+  }
+  consumeUnquotedChar(state, char);
+}
+
+function parseCommandToArgv(command) {
+  if (typeof command !== 'string' || command.trim() === '') {
+    return [];
+  }
+
+  const state = { args: [], current: '', quote: null, escaped: false };
+
+  for (const char of command.trim()) {
+    consumeCommandChar(state, char);
+  }
+
+  if (state.escaped) {
+    state.current += '\\';
+  }
+  if (state.quote) {
+    throw new Error(`Unterminated quote in command: ${command}`);
+  }
+  pushCurrentArg(state);
+  return state.args;
+}
+
+function buildCmdproofArgs(mode, proof, paths) {
+  const argv = parseCommandToArgv(proof.command);
+  if (argv.length === 0) {
+    throw new Error(`Command proof ${proof.id} has an empty command`);
+  }
+
+  if (mode === 'prove') {
+    return [
+      'prove',
+      '--profile',
+      proof.profile,
+      '--cas',
+      paths.cacheDir,
+      '--fallback',
+      'run',
+      '--signing-key',
+      paths.privateKeyPath,
+      '--',
+      ...argv,
+    ];
+  }
+
+  if (mode === 'verify') {
+    return [
+      'verify',
+      '--profile',
+      proof.profile,
+      '--cas',
+      paths.cacheDir,
+      '--trusted-key',
+      paths.publicKeyPath,
+      '--',
+      ...argv,
+    ];
+  }
+
+  throw new Error(`Unsupported cmdproof mode: ${mode}`);
+}
+
+function parseEnvProofs(env) {
+  if (!env.ZEROSHOT_COMMAND_PROOFS) {
+    return [];
+  }
+  try {
+    return normalizeCommandProofs(JSON.parse(env.ZEROSHOT_COMMAND_PROOFS));
+  } catch (error) {
+    throw new Error(`Invalid ZEROSHOT_COMMAND_PROOFS JSON: ${error.message}`);
+  }
+}
+
+function resolveProofs(env, cwd) {
+  const envProofs = parseEnvProofs(env);
+  if (envProofs.length > 0) {
+    return envProofs;
+  }
+  return resolveConfiguredCommandProofs({}, { cwd });
+}
+
+function resolveProof(id, env, cwd) {
+  const proofs = resolveProofs(env, cwd);
+  const proof = proofs.find((candidate) => candidate.id === id);
+  if (!proof) {
+    throw new Error(`Unknown command proof id "${id}"`);
+  }
+  return proof;
+}
+
+function resolvePaths(env) {
+  const clusterId = env.ZEROSHOT_CLUSTER_ID || 'local';
+  const root = path.join(os.homedir(), '.zeroshot', 'cmdproof', clusterId);
+  const cacheDir = env.CMDPROOF_CACHE_DIR || path.join(root, 'cache');
+  const keyDir = env.CMDPROOF_KEY_DIR || path.join(root, 'keys');
+  return {
+    cacheDir,
+    keyDir,
+    privateKeyPath: path.join(keyDir, 'private-key.json'),
+    publicKeyPath: path.join(keyDir, 'public-key.json'),
+  };
+}
+
+function statusOf(result) {
+  if (typeof result.status === 'number') {
+    return result.status;
+  }
+  if (result.error) {
+    return 127;
+  }
+  return 1;
+}
+
+function spawnCmdproof(args, options) {
+  const result = options.spawnSyncFn('cmdproof', args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: 'utf8',
+  });
+  if (result.error && result.error.code === 'ENOENT') {
+    throw new Error('cmdproof binary not found on PATH');
+  }
+  return result;
+}
+
+function ensureKeypair(paths, options) {
+  fs.mkdirSync(paths.cacheDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(paths.keyDir, { recursive: true, mode: 0o700 });
+  if (fs.existsSync(paths.privateKeyPath) && fs.existsSync(paths.publicKeyPath)) {
+    return;
+  }
+
+  const result = spawnCmdproof(
+    [
+      'keygen',
+      '--purpose',
+      'trusted-agent',
+      '--out',
+      paths.privateKeyPath,
+      '--public-out',
+      paths.publicKeyPath,
+    ],
+    options
+  );
+  if (statusOf(result) !== 0) {
+    throw new Error(`cmdproof keygen failed with exit code ${statusOf(result)}`);
+  }
+}
+
+function writeResult(result, stdout, stderr) {
+  if (result.stdout) stdout.write(result.stdout);
+  if (result.stderr) stderr.write(result.stderr);
+}
+
+function parseJsonObject(text) {
+  try {
+    return JSON.parse(String(text || '').trim());
+  } catch {
+    return null;
+  }
+}
+
+function shouldFallbackFromVerify(result) {
+  const parsed = parseJsonObject(result.stdout);
+  if (parsed?.status === 'reused_proof') {
+    return false;
+  }
+  return statusOf(result) === 2;
+}
+
+function runMode(mode, proof, paths, options) {
+  const result = spawnCmdproof(buildCmdproofArgs(mode, proof, paths), options);
+  writeResult(result, options.stdout, options.stderr);
+  return statusOf(result);
+}
+
+function runCmdproof({
+  mode,
+  id,
+  env = process.env,
+  cwd = process.cwd(),
+  spawnSyncFn = spawnSync,
+  stdout = process.stdout,
+  stderr = process.stderr,
+}) {
+  if (!['prove', 'verify', 'check'].includes(mode)) {
+    throw new Error(`Unsupported cmdproof mode: ${mode}`);
+  }
+
+  const proof = resolveProof(id, env, cwd);
+  const paths = resolvePaths(env);
+  const options = { cwd, env, spawnSyncFn, stdout, stderr };
+  ensureKeypair(paths, options);
+
+  if (mode === 'check') {
+    const verifyResult = spawnCmdproof(buildCmdproofArgs('verify', proof, paths), options);
+    writeResult(verifyResult, stdout, stderr);
+    if (!shouldFallbackFromVerify(verifyResult)) {
+      return statusOf(verifyResult);
+    }
+    return runMode('prove', proof, paths, options);
+  }
+
+  return runMode(mode, proof, paths, options);
+}
+
+module.exports = {
+  buildCmdproofArgs,
+  parseCommandToArgv,
+  runCmdproof,
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -62,6 +62,7 @@ const {
 const { requirePreflight } = require('../src/preflight');
 const { providersCommand, setDefaultCommand, setupCommand } = require('./commands/providers');
 const { runInspectCommand } = require('./commands/inspect');
+const { runCmdproof } = require('./commands/cmdproof');
 const {
   markDetachedSetupFailed,
   registerDetachedSetupCluster,
@@ -2539,6 +2540,25 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps)
 // === TASK COMMANDS ===
 // Task run - single-agent background task
 const taskCmd = program.command('task').description('Single-agent task management');
+
+const cmdproofCmd = program
+  .command('cmdproof')
+  .description('Run configured cmdproof command proofs');
+
+for (const mode of ['prove', 'verify', 'check']) {
+  cmdproofCmd
+    .command(`${mode} <id>`)
+    .description(`${mode} a configured command proof`)
+    .action((id) => {
+      try {
+        const exitCode = runCmdproof({ mode, id });
+        process.exit(exitCode);
+      } catch (error) {
+        console.error('Error:', error.message);
+        process.exit(1);
+      }
+    });
+}
 
 taskCmd
   .command('run <prompt>')

--- a/src/agent/agent-command-proofs-context.js
+++ b/src/agent/agent-command-proofs-context.js
@@ -1,0 +1,55 @@
+const { normalizeCommandProofs } = require('../command-proofs');
+
+function appendProofDetails(lines, proof, index) {
+  const scope = proof.scope ? `, scope: ${proof.scope}` : '';
+  lines.push(`${index + 1}. id: ${proof.id}, profile: ${proof.profile}${scope}`);
+  if (proof.description) {
+    lines.push(`   description: ${proof.description}`);
+  }
+  lines.push(`   command: ${proof.command}`);
+  lines.push(`   helper: zeroshot cmdproof check ${proof.id}`);
+}
+
+function buildWorkerInstructions(lines) {
+  lines.push(
+    '',
+    'For these exact commands:',
+    '- Run `zeroshot cmdproof check <id>` instead of the raw command.',
+    '- Treat the helper exit code as the command exit code.',
+    '- If you need to mention evidence, include the helper output and the configured command id.',
+    ''
+  );
+}
+
+function buildValidatorInstructions(lines) {
+  lines.push(
+    '',
+    'For proof-backed validation:',
+    '- Run `zeroshot cmdproof check <id>` before considering the raw command.',
+    '- Use the helper output as quality-gate evidence.',
+    '- Only run the raw command directly if the helper itself is unavailable.',
+    ''
+  );
+}
+
+function buildCommandProofsSection(config) {
+  const proofs = normalizeCommandProofs(config.commandProofs);
+  if (proofs.length === 0) {
+    return '';
+  }
+
+  const lines = ['## Reusable Command Proofs', '', 'Configured proof-backed commands:'];
+  proofs.forEach((proof, index) => appendProofDetails(lines, proof, index));
+
+  if (config.role === 'validator') {
+    buildValidatorInstructions(lines);
+  } else {
+    buildWorkerInstructions(lines);
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = {
+  buildCommandProofsSection,
+};

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -30,6 +30,7 @@ const {
   buildValidatorSkipSection,
 } = require('./agent-context-sections');
 const { buildRequiredQualityGatesSection } = require('./agent-quality-gates-context');
+const { buildCommandProofsSection } = require('./agent-command-proofs-context');
 
 function pushStaticPack({ packs, packId, section, text, order, options = {} }) {
   if (!text) {
@@ -82,6 +83,7 @@ function buildStaticSections(params) {
     header: buildHeaderContext({ id, role, iteration, isIsolated }),
     instructions: buildInstructionsSection({ config, selectedPrompt, id }),
     repoTooling: buildRepoToolingSection({ config, worktree }),
+    commandProofs: buildCommandProofsSection(config),
     legacyOutputSchema: buildLegacyOutputSchemaSection(config),
     queuedGuidance: queuedGuidance || '',
     requiredQualityGates: buildRequiredQualityGatesSection(config),
@@ -100,6 +102,7 @@ function buildPacks(params) {
     'header',
     'instructions',
     'repoTooling',
+    'commandProofs',
     'queuedGuidance',
     'legacyOutputSchema',
     'requiredQualityGates',

--- a/src/agent/agent-quality-gate-schema.js
+++ b/src/agent/agent-quality-gate-schema.js
@@ -28,6 +28,15 @@ function buildQualityGateSchema() {
             command: { type: 'string' },
             exitCode: { type: 'integer' },
             output: { type: 'string' },
+            proof: {
+              type: 'object',
+              description: 'Optional command proof metadata when the gate used cmdproof.',
+              properties: {
+                profile: { type: 'string' },
+                reused: { type: 'boolean' },
+                status: { type: 'string' },
+              },
+            },
           },
           required: ['command', 'exitCode', 'output'],
         },

--- a/src/agent/agent-quality-gates-context.js
+++ b/src/agent/agent-quality-gates-context.js
@@ -8,6 +8,10 @@ function appendGateDetails(lines, gate, index) {
   if (gate.command) {
     lines.push(`   command: ${gate.command}`);
   }
+  if (gate.profile || gate.proofProfile) {
+    lines.push(`   cmdproof profile: ${gate.profile || gate.proofProfile}`);
+    lines.push(`   cmdproof helper: zeroshot cmdproof check ${gate.id}`);
+  }
 }
 
 function buildRequiredQualityGatesSection(config) {
@@ -35,6 +39,7 @@ function buildRequiredQualityGatesSection(config) {
     '',
     'For each configured gate:',
     '- Run the configured command when one is provided by repo or cluster config.',
+    '- For gates with a cmdproof profile, run `zeroshot cmdproof check <id>` before considering a raw command.',
     '- Put the command, numeric exit code, and string output in `evidence`.',
     '- Set `status` to `PASS` only when the gate completes successfully.',
     '- If a required gate fails, set `approved` to false and publish status `FAIL`.',

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -780,6 +780,25 @@ function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
   const { claudeConfigDir = null } = options;
   const spawnEnv = { ...process.env };
   const agentCwd = agent.config?.cwd || agent.worktree?.path || process.cwd();
+  const clusterId = agent.cluster?.id || agent.cluster_id || process.env.ZEROSHOT_CLUSTER_ID;
+
+  if (clusterId) {
+    spawnEnv.ZEROSHOT_CLUSTER_ID = clusterId;
+    const cmdproofRoot = path.join(os.homedir(), '.zeroshot', 'cmdproof', clusterId);
+    if (!spawnEnv.CMDPROOF_CACHE_DIR) {
+      spawnEnv.CMDPROOF_CACHE_DIR = path.join(cmdproofRoot, 'cache');
+    }
+    if (!spawnEnv.CMDPROOF_KEY_DIR) {
+      spawnEnv.CMDPROOF_KEY_DIR = path.join(cmdproofRoot, 'keys');
+    }
+  }
+
+  const commandProofs = Array.isArray(agent.config?.commandProofs)
+    ? agent.config.commandProofs
+    : agent.cluster?.commandProofs || [];
+  if (commandProofs.length > 0) {
+    spawnEnv.ZEROSHOT_COMMAND_PROOFS = JSON.stringify(commandProofs);
+  }
 
   if (providerName === 'claude') {
     Object.assign(spawnEnv, buildClaudeEnv(modelSpec));

--- a/src/command-proofs.js
+++ b/src/command-proofs.js
@@ -1,0 +1,169 @@
+const { readRepoSettings } = require('../lib/repo-settings');
+
+const PROOF_BLOCK_PATTERN = /^```zeroshot-command-proofs\s*\n([\s\S]*?)^```/m;
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value || {}, key);
+}
+
+function trimString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function setOptionalString(target, source, key) {
+  const value = trimString(source[key]);
+  if (value) {
+    target[key] = value;
+  }
+}
+
+function normalizeCommandProof(proof) {
+  if (!proof || typeof proof !== 'object') {
+    return null;
+  }
+
+  const id = trimString(proof.id || proof.name);
+  const profile = trimString(proof.profile || proof.proofProfile);
+  const command = trimString(proof.command);
+  if (!id || !profile || !command) {
+    return null;
+  }
+
+  const normalized = { id, profile, command };
+  setOptionalString(normalized, proof, 'scope');
+  setOptionalString(normalized, proof, 'description');
+  return normalized;
+}
+
+function normalizeCommandProofs(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(normalizeCommandProof).filter(Boolean);
+}
+
+function parseCommandProofsFromText(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    return [];
+  }
+
+  const match = text.match(PROOF_BLOCK_PATTERN);
+  if (!match) {
+    return [];
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch (error) {
+    throw new Error(`Invalid zeroshot-command-proofs JSON: ${error.message}`);
+  }
+
+  return normalizeCommandProofs(parsed);
+}
+
+function mergeCommandProofs(...sources) {
+  const byId = new Map();
+  const order = [];
+
+  for (const source of sources) {
+    for (const proof of normalizeCommandProofs(source)) {
+      if (!byId.has(proof.id)) {
+        order.push(proof.id);
+      }
+      byId.set(proof.id, proof);
+    }
+  }
+
+  return order.map((id) => byId.get(id));
+}
+
+function commandProofToQualityGate(proof) {
+  const normalized = normalizeCommandProof(proof);
+  if (!normalized) {
+    return null;
+  }
+
+  const gate = {
+    id: normalized.id,
+    profile: normalized.profile,
+    command: normalized.command,
+    commandProof: true,
+  };
+  setOptionalString(gate, normalized, 'scope');
+  setOptionalString(gate, normalized, 'description');
+  return gate;
+}
+
+function getCommandProofSource(options, repoSettings) {
+  if (hasOwn(options, 'commandProofs')) {
+    return options.commandProofs;
+  }
+
+  if (options.ship && typeof options.ship === 'object' && hasOwn(options.ship, 'commandProofs')) {
+    return options.ship.commandProofs;
+  }
+
+  const settingsShip = repoSettings?.ship;
+  if (settingsShip && typeof settingsShip === 'object' && hasOwn(settingsShip, 'commandProofs')) {
+    return settingsShip.commandProofs;
+  }
+
+  if (hasOwn(repoSettings, 'commandProofs')) {
+    return repoSettings.commandProofs;
+  }
+
+  return [];
+}
+
+function getClusterCommandProofSource(config, options) {
+  if (hasOwn(options, 'commandProofs')) {
+    return options.commandProofs;
+  }
+
+  if (options.ship && typeof options.ship === 'object' && hasOwn(options.ship, 'commandProofs')) {
+    return options.ship.commandProofs;
+  }
+
+  if (config?.ship && typeof config.ship === 'object' && hasOwn(config.ship, 'commandProofs')) {
+    return config.ship.commandProofs;
+  }
+
+  if (hasOwn(config, 'commandProofs')) {
+    return config.commandProofs;
+  }
+
+  return undefined;
+}
+
+function resolveConfiguredCommandProofs(config = {}, options = {}) {
+  const configuredSource = getClusterCommandProofSource(config, options);
+  if (configuredSource !== undefined) {
+    return normalizeCommandProofs(configuredSource);
+  }
+
+  const repoSettingsResult = readRepoSettings(options.cwd || process.cwd());
+  const repoSettings = repoSettingsResult.settings || {};
+  return normalizeCommandProofs(getCommandProofSource(options, repoSettings));
+}
+
+function resolveClusterCommandProofs(config = {}, options = {}, inputText = '') {
+  return mergeCommandProofs(
+    resolveConfiguredCommandProofs(config, options),
+    parseCommandProofsFromText(inputText)
+  );
+}
+
+function commandProofsToQualityGates(commandProofs) {
+  return normalizeCommandProofs(commandProofs).map(commandProofToQualityGate).filter(Boolean);
+}
+
+module.exports = {
+  commandProofToQualityGate,
+  commandProofsToQualityGates,
+  mergeCommandProofs,
+  normalizeCommandProofs,
+  parseCommandProofsFromText,
+  resolveClusterCommandProofs,
+  resolveConfiguredCommandProofs,
+};

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -49,6 +49,11 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
+const {
+  commandProofsToQualityGates,
+  mergeCommandProofs,
+  resolveClusterCommandProofs,
+} = require('./command-proofs');
 const crypto = require('crypto');
 
 function applyModelOverride(agentConfig, modelOverride) {
@@ -116,6 +121,46 @@ function applyRequiredQualityGatesToValidators(config, requiredQualityGates) {
   for (const agentConfig of config.agents || []) {
     applyRequiredQualityGatesToAgent(agentConfig, requiredQualityGates);
   }
+}
+
+function applyCommandProofsToAgent(agentConfig, commandProofs) {
+  if (!Array.isArray(commandProofs) || commandProofs.length === 0) {
+    return;
+  }
+
+  agentConfig.commandProofs = mergeCommandProofs(agentConfig.commandProofs, commandProofs);
+}
+
+function applyCommandProofsToAgents(config, commandProofs) {
+  if (!Array.isArray(commandProofs) || commandProofs.length === 0) {
+    return;
+  }
+
+  for (const agentConfig of config.agents || []) {
+    applyCommandProofsToAgent(agentConfig, commandProofs);
+  }
+}
+
+function mergeQualityGates(...sources) {
+  const byId = new Map();
+  const order = [];
+
+  for (const source of sources) {
+    if (!Array.isArray(source)) {
+      continue;
+    }
+    for (const gate of source) {
+      if (!gate?.id) {
+        continue;
+      }
+      if (!byId.has(gate.id)) {
+        order.push(gate.id);
+      }
+      byId.set(gate.id, gate);
+    }
+  }
+
+  return order.map((id) => byId.get(id));
 }
 
 function getTriggerTopic(trigger) {
@@ -521,6 +566,7 @@ class Orchestrator {
       isolation,
       autoPr: clusterData.autoPr || false,
       prOptions: clusterData.prOptions || null,
+      commandProofs: clusterData.commandProofs || [],
       issue: clusterData.issue || null,
     };
 
@@ -801,6 +847,8 @@ class Orchestrator {
           autoPr: cluster.autoPr || false,
           // Persist PR options for resume
           prOptions: cluster.prOptions || null,
+          // Persist cluster-scoped command proof configuration for resume and dynamic agents
+          commandProofs: cluster.commandProofs || [],
           // Persist model override for consistent agent spawning on resume
           modelOverride: cluster.modelOverride || null,
           // Persist issue number for heroshot/external tools
@@ -1007,9 +1055,9 @@ class Orchestrator {
       config,
       clusterId
     );
-    const requiredQualityGates = resolveClusterRequiredQualityGates(config, options);
+    let requiredQualityGates = resolveClusterRequiredQualityGates(config, options);
+    let commandProofs = resolveClusterCommandProofs(config, options);
     options.requiredQualityGates = requiredQualityGates;
-    applyRequiredQualityGatesToValidators(config, requiredQualityGates);
 
     // Build cluster object
     // CRITICAL: initComplete promise ensures ISSUE_OPENED is published before stop() completes
@@ -1034,6 +1082,7 @@ class Orchestrator {
       _resolveInitComplete: resolveInitComplete,
       autoPr: options.autoPr || false,
       requiredQualityGates,
+      commandProofs,
       // PR configuration options (persisted for resume)
       prOptions: buildPrOptions(options, requiredQualityGates),
       // Model override for all agents (applied to dynamically added agents)
@@ -1133,6 +1182,21 @@ class Orchestrator {
       } else {
         throw new Error('Either issue, file, or text input is required');
       }
+
+      commandProofs = mergeCommandProofs(
+        commandProofs,
+        resolveClusterCommandProofs(config, options, inputData.context)
+      );
+      requiredQualityGates = mergeQualityGates(
+        requiredQualityGates,
+        commandProofsToQualityGates(commandProofs)
+      );
+      options.requiredQualityGates = requiredQualityGates;
+      cluster.requiredQualityGates = requiredQualityGates;
+      cluster.commandProofs = commandProofs;
+      cluster.prOptions = buildPrOptions(options, requiredQualityGates);
+      applyCommandProofsToAgents(config, commandProofs);
+      applyRequiredQualityGatesToValidators(config, requiredQualityGates);
 
       // Detect git platform for --pr mode (independent of issue provider)
       if (options.autoPr) {
@@ -3188,6 +3252,7 @@ Continue from where you left off. Review your previous output to understand what
       }
 
       applyRequiredQualityGatesToAgent(agentConfig, cluster.requiredQualityGates);
+      applyCommandProofsToAgent(agentConfig, cluster.commandProofs);
       if (cluster.autoPr) {
         applyPushBlockedRepairTrigger(agentConfig);
       }

--- a/src/quality-gates.js
+++ b/src/quality-gates.js
@@ -45,6 +45,11 @@ function normalizeObjectGate(gate) {
   setOptionalString(normalized, gate, 'scope');
   setOptionalString(normalized, gate, 'description');
   setOptionalString(normalized, gate, 'command');
+  setOptionalString(normalized, gate, 'profile');
+  setOptionalString(normalized, gate, 'proofProfile');
+  if (gate.commandProof === true) {
+    normalized.commandProof = true;
+  }
   return normalized;
 }
 

--- a/tests/command-proofs-cluster.test.js
+++ b/tests/command-proofs-cluster.test.js
@@ -1,0 +1,132 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Orchestrator = require('../src/orchestrator');
+const MockTaskRunner = require('./helpers/mock-task-runner');
+
+describe('command proofs cluster integration', function () {
+  let tempDir;
+  let orchestrator;
+  let mockRunner;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-command-proofs-'));
+    mockRunner = new MockTaskRunner();
+    orchestrator = new Orchestrator({
+      quiet: true,
+      storageDir: tempDir,
+      taskRunner: mockRunner,
+    });
+  });
+
+  afterEach(async () => {
+    if (orchestrator) {
+      for (const cluster of orchestrator.listClusters()) {
+        try {
+          await orchestrator.kill(cluster.id);
+        } catch {
+          // Best effort cleanup.
+        }
+      }
+      orchestrator.close();
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('uses issue-body command proofs as cluster-scoped required gates and agent instructions', async function () {
+    const config = {
+      ship: {
+        commandProofs: [
+          {
+            id: 'repo-lint',
+            profile: 'lint-equivalent',
+            command: 'npm run lint',
+          },
+        ],
+      },
+      agents: [
+        {
+          id: 'worker',
+          role: 'implementation',
+          timeout: 0,
+          triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+          prompt: 'Implement the requested change.',
+          hooks: {
+            onComplete: {
+              action: 'publish_message',
+              config: { topic: 'TASK_COMPLETE', content: { text: 'Done' } },
+            },
+          },
+        },
+        {
+          id: 'validator',
+          role: 'validator',
+          timeout: 0,
+          triggers: [{ topic: 'TASK_COMPLETE', action: 'execute_task' }],
+          prompt: 'Validate the change.',
+        },
+      ],
+    };
+
+    const issueText = [
+      'Implement opcore change.',
+      '',
+      '```zeroshot-command-proofs',
+      '[',
+      '  {',
+      '    "id": "opcore-ci",',
+      '    "profile": "ci-equivalent",',
+      '    "scope": "repo",',
+      '    "description": "Opcore local CI",',
+      '    "command": "bash ./scripts/ci/run-local-ci-equivalent.sh"',
+      '  }',
+      ']',
+      '```',
+    ].join('\n');
+
+    mockRunner.when('worker').returns(JSON.stringify({ summary: 'Done' }));
+    mockRunner.when('validator').returns(JSON.stringify({ approved: true }));
+
+    const result = await orchestrator.start(config, { text: issueText });
+    const cluster = orchestrator.getCluster(result.id);
+
+    assert.deepStrictEqual(cluster.commandProofs, [
+      { id: 'repo-lint', profile: 'lint-equivalent', command: 'npm run lint' },
+      {
+        id: 'opcore-ci',
+        profile: 'ci-equivalent',
+        scope: 'repo',
+        description: 'Opcore local CI',
+        command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+      },
+    ]);
+    assert.deepStrictEqual(cluster.requiredQualityGates, [
+      {
+        id: 'repo-lint',
+        profile: 'lint-equivalent',
+        command: 'npm run lint',
+        commandProof: true,
+      },
+      {
+        id: 'opcore-ci',
+        profile: 'ci-equivalent',
+        scope: 'repo',
+        description: 'Opcore local CI',
+        command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        commandProof: true,
+      },
+    ]);
+
+    const workerContext = mockRunner.getCalls('worker')[0].context;
+    assert.match(workerContext, /Reusable Command Proofs/);
+    assert.match(workerContext, /zeroshot cmdproof check repo-lint/);
+    assert.match(workerContext, /zeroshot cmdproof check opcore-ci/);
+    assert.match(workerContext, /bash \.\/scripts\/ci\/run-local-ci-equivalent\.sh/);
+
+    const validatorConfig = cluster.config.agents.find((agent) => agent.id === 'validator');
+    assert.deepStrictEqual(validatorConfig.requiredQualityGates, cluster.requiredQualityGates);
+    assert.deepStrictEqual(validatorConfig.commandProofs, cluster.commandProofs);
+  });
+});

--- a/tests/required-quality-gates-context.test.js
+++ b/tests/required-quality-gates-context.test.js
@@ -16,6 +16,31 @@ function baseContextParams(config) {
 }
 
 describe('required handoff quality gate context', function () {
+  it('adds reusable command proof instructions for implementation agents', function () {
+    const config = validateAgentConfig({
+      id: 'worker',
+      role: 'implementation',
+      outputFormat: 'json',
+      commandProofs: [
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          scope: 'repo',
+          description: 'Opcore local CI',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        },
+      ],
+      prompt: 'Do the work.',
+    });
+
+    const context = buildContext(baseContextParams(config));
+
+    assert.match(context, /Reusable Command Proofs/);
+    assert.match(context, /id: opcore-ci, profile: ci-equivalent, scope: repo/);
+    assert.match(context, /bash \.\/scripts\/ci\/run-local-ci-equivalent\.sh/);
+    assert.match(context, /zeroshot cmdproof check opcore-ci/);
+  });
+
   it('adds generic configured gate instructions and schema for validators', function () {
     const config = validateAgentConfig({
       id: 'validator',
@@ -34,6 +59,8 @@ describe('required handoff quality gate context', function () {
           scope: 'workspace',
           description: 'Run the configured workspace quality gate',
           command: 'quality-check --scope workspace',
+          profile: 'ci-equivalent',
+          commandProof: true,
         },
       ],
     });
@@ -45,10 +72,15 @@ describe('required handoff quality gate context', function () {
       config.jsonSchema.properties.qualityGates.items.properties.evidence.required,
       ['command', 'exitCode', 'output']
     );
+    assert.ok(
+      config.jsonSchema.properties.qualityGates.items.properties.evidence.properties.proof,
+      'schema should accept optional cmdproof evidence metadata'
+    );
     assert.match(context, /Required Handoff Quality Gates/);
     assert.match(context, /id: repo-quality, scope: workspace/);
     assert.match(context, /Run the configured workspace quality gate/);
     assert.match(context, /quality-check --scope workspace/);
+    assert.match(context, /zeroshot cmdproof check repo-quality/);
     assert.match(context, /publish one `qualityGates` entry/);
     assert.match(context, /approved` to false and publish status `FAIL`/);
     assert.match(context, /approved` to false and publish status `UNAVAILABLE`/);

--- a/tests/unit/cmdproof-command.test.js
+++ b/tests/unit/cmdproof-command.test.js
@@ -1,0 +1,147 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildCmdproofArgs,
+  parseCommandToArgv,
+  runCmdproof,
+} = require('../../cli/commands/cmdproof');
+
+describe('zeroshot cmdproof command', function () {
+  it('parses configured command strings into argv', function () {
+    assert.deepStrictEqual(parseCommandToArgv('bash ./scripts/ci/run-local-ci-equivalent.sh'), [
+      'bash',
+      './scripts/ci/run-local-ci-equivalent.sh',
+    ]);
+    assert.deepStrictEqual(parseCommandToArgv('npm run "test:unit"'), ['npm', 'run', 'test:unit']);
+  });
+
+  it('builds cmdproof prove and verify argv for a proof', function () {
+    const proof = {
+      id: 'opcore-ci',
+      profile: 'ci-equivalent',
+      command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+    };
+    const paths = {
+      cacheDir: '/tmp/cache',
+      privateKeyPath: '/tmp/keys/private-key.json',
+      publicKeyPath: '/tmp/keys/public-key.json',
+    };
+
+    assert.deepStrictEqual(buildCmdproofArgs('prove', proof, paths), [
+      'prove',
+      '--profile',
+      'ci-equivalent',
+      '--cas',
+      '/tmp/cache',
+      '--fallback',
+      'run',
+      '--signing-key',
+      '/tmp/keys/private-key.json',
+      '--',
+      'bash',
+      './scripts/ci/run-local-ci-equivalent.sh',
+    ]);
+
+    assert.deepStrictEqual(buildCmdproofArgs('verify', proof, paths), [
+      'verify',
+      '--profile',
+      'ci-equivalent',
+      '--cas',
+      '/tmp/cache',
+      '--trusted-key',
+      '/tmp/keys/public-key.json',
+      '--',
+      'bash',
+      './scripts/ci/run-local-ci-equivalent.sh',
+    ]);
+  });
+
+  it('ensures keys and runs prove from environment command proofs', function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-cmdproof-test-'));
+    const calls = [];
+    const env = {
+      ZEROSHOT_CLUSTER_ID: 'cluster-1',
+      ZEROSHOT_COMMAND_PROOFS: JSON.stringify([
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        },
+      ]),
+      CMDPROOF_CACHE_DIR: path.join(tempDir, 'cache'),
+      CMDPROOF_KEY_DIR: path.join(tempDir, 'keys'),
+    };
+
+    try {
+      const exitCode = runCmdproof({
+        mode: 'prove',
+        id: 'opcore-ci',
+        env,
+        cwd: tempDir,
+        spawnSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (args[0] === 'keygen') {
+            fs.writeFileSync(path.join(tempDir, 'keys', 'private-key.json'), '{}');
+            fs.writeFileSync(path.join(tempDir, 'keys', 'public-key.json'), '{}');
+          }
+          return { status: 0, stdout: '', stderr: '' };
+        },
+      });
+
+      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(calls[0].args[0], 'keygen');
+      assert.deepStrictEqual(calls[1].args.slice(0, 2), ['prove', '--profile']);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to prove when check misses verification', function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-cmdproof-test-'));
+    const calls = [];
+    const env = {
+      ZEROSHOT_COMMAND_PROOFS: JSON.stringify([
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        },
+      ]),
+      CMDPROOF_CACHE_DIR: path.join(tempDir, 'cache'),
+      CMDPROOF_KEY_DIR: path.join(tempDir, 'keys'),
+    };
+
+    try {
+      fs.mkdirSync(env.CMDPROOF_KEY_DIR, { recursive: true });
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'private-key.json'), '{}');
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'public-key.json'), '{}');
+
+      const exitCode = runCmdproof({
+        mode: 'check',
+        id: 'opcore-ci',
+        env,
+        cwd: tempDir,
+        spawnSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (args[0] === 'verify') {
+            return { status: 2, stdout: '{"status":"miss"}\n', stderr: '' };
+          }
+          return { status: 0, stdout: '', stderr: '' };
+        },
+        stdout: { write: () => {} },
+        stderr: { write: () => {} },
+      });
+
+      assert.strictEqual(exitCode, 0);
+      assert.deepStrictEqual(
+        calls.map((call) => call.args[0]),
+        ['verify', 'prove']
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/command-proofs.test.js
+++ b/tests/unit/command-proofs.test.js
@@ -1,0 +1,158 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const {
+  commandProofToQualityGate,
+  mergeCommandProofs,
+  normalizeCommandProofs,
+  parseCommandProofsFromText,
+  resolveConfiguredCommandProofs,
+} = require('../../src/command-proofs');
+
+describe('command proofs', function () {
+  it('parses fenced zeroshot-command-proofs JSON from issue text', function () {
+    const text = [
+      '# Task',
+      '',
+      '```zeroshot-command-proofs',
+      '[',
+      '  {',
+      '    "id": "opcore-ci",',
+      '    "profile": "ci-equivalent",',
+      '    "scope": "repo",',
+      '    "description": "Opcore local CI",',
+      '    "command": "bash ./scripts/ci/run-local-ci-equivalent.sh"',
+      '  }',
+      ']',
+      '```',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseCommandProofsFromText(text), [
+      {
+        id: 'opcore-ci',
+        profile: 'ci-equivalent',
+        scope: 'repo',
+        description: 'Opcore local CI',
+        command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+      },
+    ]);
+  });
+
+  it('returns no proofs when the issue text has no proof block', function () {
+    assert.deepStrictEqual(parseCommandProofsFromText('# Task\n\nNo proof config.'), []);
+  });
+
+  it('throws a clear error for malformed proof blocks', function () {
+    assert.throws(
+      () => parseCommandProofsFromText('```zeroshot-command-proofs\n{ nope\n```'),
+      /Invalid zeroshot-command-proofs JSON/
+    );
+  });
+
+  it('normalizes only proofs with id, profile, and command', function () {
+    assert.deepStrictEqual(
+      normalizeCommandProofs([
+        {
+          id: ' opcore-ci ',
+          profile: ' ci-equivalent ',
+          command: ' bash ./scripts/ci/run-local-ci-equivalent.sh ',
+        },
+        { id: 'missing-command', profile: 'ci-equivalent' },
+        'not-an-object',
+      ]),
+      [
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        },
+      ]
+    );
+  });
+
+  it('merges proofs by id with later sources taking precedence', function () {
+    assert.deepStrictEqual(
+      mergeCommandProofs(
+        [
+          {
+            id: 'opcore-ci',
+            profile: 'ci-equivalent',
+            command: 'npm test',
+            description: 'repo default',
+          },
+        ],
+        [
+          {
+            id: 'opcore-ci',
+            profile: 'ci-equivalent',
+            command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+            description: 'issue override',
+          },
+        ]
+      ),
+      [
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+          description: 'issue override',
+        },
+      ]
+    );
+  });
+
+  it('converts proofs into required quality gates', function () {
+    assert.deepStrictEqual(
+      commandProofToQualityGate({
+        id: 'opcore-ci',
+        profile: 'ci-equivalent',
+        scope: 'repo',
+        description: 'Opcore local CI',
+        command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+      }),
+      {
+        id: 'opcore-ci',
+        profile: 'ci-equivalent',
+        scope: 'repo',
+        description: 'Opcore local CI',
+        command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        commandProof: true,
+      }
+    );
+  });
+
+  it('resolves command proofs from repo settings', function () {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-command-proofs-'));
+    try {
+      execFileSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' });
+      fs.mkdirSync(path.join(repoDir, '.zeroshot'), { recursive: true });
+      fs.writeFileSync(
+        path.join(repoDir, '.zeroshot', 'settings.json'),
+        JSON.stringify({
+          ship: {
+            commandProofs: [
+              {
+                id: 'opcore-ci',
+                profile: 'ci-equivalent',
+                command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+              },
+            ],
+          },
+        })
+      );
+
+      assert.deepStrictEqual(resolveConfiguredCommandProofs({}, { cwd: repoDir }), [
+        {
+          id: 'opcore-ci',
+          profile: 'ci-equivalent',
+          command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+        },
+      ]);
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable command proof definitions from repo settings and issue-body `zeroshot-command-proofs` JSON blocks
- inject `zeroshot cmdproof check <id>` guidance into worker and validator contexts
- add a Zeroshot `cmdproof` helper that verifies cached command proofs and falls back to proving/running on misses

## Verification
- npm run test -- tests/unit/command-proofs.test.js tests/unit/cmdproof-command.test.js tests/required-quality-gates-context.test.js tests/command-proofs-cluster.test.js tests/structuredOutput-mapping.test.js
- npm run check
- npm test
- git diff --check

Note: `npm run test:slow` hung in existing worktree integration coverage and was stopped to avoid competing with active clusters.