### PR TITLE
feat(cmdproof): serialize proof fallback by action key

### DIFF
--- a/cli/commands/cmdproof.js
+++ b/cli/commands/cmdproof.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const crypto = require('crypto');
 const { spawnSync } = require('child_process');
 
 const {
@@ -153,6 +154,7 @@ function resolvePaths(env) {
   return {
     cacheDir,
     keyDir,
+    lockDir: env.ZEROSHOT_CMDPROOF_LOCK_DIR || path.join(root, 'locks'),
     privateKeyPath: path.join(keyDir, 'private-key.json'),
     publicKeyPath: path.join(keyDir, 'public-key.json'),
   };
@@ -178,6 +180,114 @@ function spawnCmdproof(args, options) {
     throw new Error('cmdproof binary not found on PATH');
   }
   return result;
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleepMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function proofLockName(proof, verifyReport = null) {
+  const actionKey = getVerifyActionKey(verifyReport);
+  const digest = crypto
+    .createHash('sha256')
+    .update(`${proof.id}\0${proof.profile}\0${proof.command}\0${actionKey}`)
+    .digest('hex')
+    .slice(0, 16);
+  const safeId = proof.id.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return `${safeId}-${digest}.lock`;
+}
+
+function getVerifyActionKey(verifyReport) {
+  return verifyReport?.actionKey || verifyReport?.action_key || '';
+}
+
+function proofLockPath(proof, paths, verifyReport = null) {
+  return path.join(paths.lockDir, proofLockName(proof, verifyReport));
+}
+
+function removeLock(lockPath) {
+  fs.rmSync(lockPath, { recursive: true, force: true });
+}
+
+function lockOwnerState(lockPath) {
+  try {
+    const metadata = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+    if (!Number.isInteger(metadata.pid) || metadata.pid <= 0) {
+      return 'unknown';
+    }
+    try {
+      process.kill(metadata.pid, 0);
+      return 'alive';
+    } catch (error) {
+      return error?.code === 'ESRCH' ? 'gone' : 'unknown';
+    }
+  } catch {
+    return 'unknown';
+  }
+}
+
+function lockIsStale(lockPath, staleMs) {
+  try {
+    const stat = fs.statSync(lockPath);
+    const ownerState = lockOwnerState(lockPath);
+    if (ownerState === 'alive') {
+      return false;
+    }
+    if (ownerState === 'gone') {
+      return true;
+    }
+    return Date.now() - stat.mtimeMs > staleMs;
+  } catch {
+    return false;
+  }
+}
+
+function writeLockMetadata(lockPath, proof) {
+  const metadata = {
+    pid: process.pid,
+    proofId: proof.id,
+    profile: proof.profile,
+    command: proof.command,
+    createdAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(lockPath, 'owner.json'), `${JSON.stringify(metadata, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+function tryAcquireProofLock(proof, paths, env, verifyReport = null) {
+  const lockPath = proofLockPath(proof, paths, verifyReport);
+  const staleMs = parsePositiveInt(env.ZEROSHOT_CMDPROOF_LOCK_STALE_MS, 6 * 60 * 60 * 1000);
+  fs.mkdirSync(paths.lockDir, { recursive: true, mode: 0o700 });
+
+  try {
+    fs.mkdirSync(lockPath, { mode: 0o700 });
+    writeLockMetadata(lockPath, proof);
+    return { acquired: true, lockPath };
+  } catch (error) {
+    if (error?.code !== 'EEXIST') {
+      throw error;
+    }
+    if (!lockIsStale(lockPath, staleMs)) {
+      return { acquired: false, lockPath };
+    }
+    removeLock(lockPath);
+    try {
+      fs.mkdirSync(lockPath, { mode: 0o700 });
+      writeLockMetadata(lockPath, proof);
+      return { acquired: true, lockPath };
+    } catch (retryError) {
+      if (retryError?.code === 'EEXIST') {
+        return { acquired: false, lockPath };
+      }
+      throw retryError;
+    }
+  }
 }
 
 function ensureKeypair(paths, options) {
@@ -231,6 +341,74 @@ function runMode(mode, proof, paths, options) {
   return statusOf(result);
 }
 
+function runProveWithLock(proof, paths, options, lockPath) {
+  try {
+    return runMode('prove', proof, paths, options);
+  } finally {
+    removeLock(lockPath);
+  }
+}
+
+function verifyProof(proof, paths, options, { write = true } = {}) {
+  const result = spawnCmdproof(buildCmdproofArgs('verify', proof, paths), options);
+  if (write) {
+    writeResult(result, options.stdout, options.stderr);
+  }
+  return result;
+}
+
+function waitForProofOrProve(proof, paths, options, verifyReport) {
+  const startedAt = Date.now();
+  const waitMs = parsePositiveInt(options.env.ZEROSHOT_CMDPROOF_WAIT_MS, 30 * 60 * 1000);
+  const pollMs = parsePositiveInt(options.env.ZEROSHOT_CMDPROOF_POLL_MS, 2500);
+
+  while (Date.now() - startedAt < waitMs) {
+    sleepMs(pollMs);
+    const verifyResult = verifyProof(proof, paths, options, { write: false });
+    const latestReport = parseJsonObject(verifyResult.stdout) || verifyReport;
+    if (!shouldFallbackFromVerify(verifyResult)) {
+      writeResult(verifyResult, options.stdout, options.stderr);
+      return statusOf(verifyResult);
+    }
+
+    const lockReport = getVerifyActionKey(latestReport) ? latestReport : verifyReport;
+    const lock = tryAcquireProofLock(proof, paths, options.env, lockReport);
+    if (lock.acquired) {
+      options.stderr.write(
+        `zeroshot cmdproof check ${proof.id}: no reusable proof appeared; acquired proof lock after wait.\n`
+      );
+      return runProveWithLock(proof, paths, options, lock.lockPath);
+    }
+  }
+
+  options.stderr.write(
+    `zeroshot cmdproof check ${proof.id}: timed out waiting ${waitMs}ms for in-flight proof; leaving miss for caller.\n`
+  );
+  const finalVerify = verifyProof(proof, paths, options, { write: true });
+  return statusOf(finalVerify);
+}
+
+function runCheck(proof, paths, options) {
+  const verifyResult = verifyProof(proof, paths, options);
+  if (!shouldFallbackFromVerify(verifyResult)) {
+    return statusOf(verifyResult);
+  }
+  const verifyReport = parseJsonObject(verifyResult.stdout);
+  if (!getVerifyActionKey(verifyReport)) {
+    return runMode('prove', proof, paths, options);
+  }
+
+  const lock = tryAcquireProofLock(proof, paths, options.env, verifyReport);
+  if (lock.acquired) {
+    return runProveWithLock(proof, paths, options, lock.lockPath);
+  }
+
+  options.stderr.write(
+    `zeroshot cmdproof check ${proof.id}: proof miss; waiting for in-flight proof from another agent.\n`
+  );
+  return waitForProofOrProve(proof, paths, options, verifyReport);
+}
+
 function runCmdproof({
   mode,
   id,
@@ -250,12 +428,7 @@ function runCmdproof({
   ensureKeypair(paths, options);
 
   if (mode === 'check') {
-    const verifyResult = spawnCmdproof(buildCmdproofArgs('verify', proof, paths), options);
-    writeResult(verifyResult, stdout, stderr);
-    if (!shouldFallbackFromVerify(verifyResult)) {
-      return statusOf(verifyResult);
-    }
-    return runMode('prove', proof, paths, options);
+    return runCheck(proof, paths, options);
   }
 
   return runMode(mode, proof, paths, options);
@@ -265,4 +438,5 @@ module.exports = {
   buildCmdproofArgs,
   parseCommandToArgv,
   runCmdproof,
+  proofLockName,
 };

--- a/tests/unit/cmdproof-command.test.js
+++ b/tests/unit/cmdproof-command.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const {
   buildCmdproofArgs,
   parseCommandToArgv,
+  proofLockName,
   runCmdproof,
 } = require('../../cli/commands/cmdproof');
 
@@ -112,6 +113,7 @@ describe('zeroshot cmdproof command', function () {
       ]),
       CMDPROOF_CACHE_DIR: path.join(tempDir, 'cache'),
       CMDPROOF_KEY_DIR: path.join(tempDir, 'keys'),
+      ZEROSHOT_CMDPROOF_LOCK_DIR: path.join(tempDir, 'locks'),
     };
 
     try {
@@ -140,6 +142,131 @@ describe('zeroshot cmdproof command', function () {
         calls.map((call) => call.args[0]),
         ['verify', 'prove']
       );
+      assert.strictEqual(fs.existsSync(env.ZEROSHOT_CMDPROOF_LOCK_DIR), false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('waits for an in-flight proof and reuses it instead of proving concurrently', function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-cmdproof-test-'));
+    const proof = {
+      id: 'opcore-ci',
+      profile: 'ci-equivalent',
+      command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+    };
+    const env = {
+      ZEROSHOT_COMMAND_PROOFS: JSON.stringify([proof]),
+      CMDPROOF_CACHE_DIR: path.join(tempDir, 'cache'),
+      CMDPROOF_KEY_DIR: path.join(tempDir, 'keys'),
+      ZEROSHOT_CMDPROOF_LOCK_DIR: path.join(tempDir, 'locks'),
+      ZEROSHOT_CMDPROOF_WAIT_MS: '50',
+      ZEROSHOT_CMDPROOF_POLL_MS: '1',
+    };
+    const calls = [];
+    const stdout = [];
+    const stderr = [];
+
+    try {
+      fs.mkdirSync(env.CMDPROOF_KEY_DIR, { recursive: true });
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'private-key.json'), '{}');
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'public-key.json'), '{}');
+      const lockPath = path.join(
+        env.ZEROSHOT_CMDPROOF_LOCK_DIR,
+        proofLockName(proof, { actionKey: 'action-a' })
+      );
+      fs.mkdirSync(lockPath, { recursive: true });
+      fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: process.pid }));
+
+      const exitCode = runCmdproof({
+        mode: 'check',
+        id: 'opcore-ci',
+        env,
+        cwd: tempDir,
+        spawnSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (
+            args[0] === 'verify' &&
+            calls.filter((call) => call.args[0] === 'verify').length === 1
+          ) {
+            return { status: 2, stdout: '{"status":"miss","actionKey":"action-a"}\n', stderr: '' };
+          }
+          if (args[0] === 'verify') {
+            return { status: 0, stdout: '{"status":"reused_proof","reused":true}\n', stderr: '' };
+          }
+          return { status: 0, stdout: '', stderr: '' };
+        },
+        stdout: { write: (chunk) => stdout.push(chunk) },
+        stderr: { write: (chunk) => stderr.push(chunk) },
+      });
+
+      assert.strictEqual(exitCode, 0);
+      assert.deepStrictEqual(
+        calls.map((call) => call.args[0]),
+        ['verify', 'verify']
+      );
+      assert.match(stdout.join(''), /"status":"miss"/);
+      assert.match(stdout.join(''), /"status":"reused_proof"/);
+      assert.match(stderr.join(''), /waiting for in-flight proof/);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('takes over proving when an in-flight proof lock is stale', function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-cmdproof-test-'));
+    const proof = {
+      id: 'opcore-ci',
+      profile: 'ci-equivalent',
+      command: 'bash ./scripts/ci/run-local-ci-equivalent.sh',
+    };
+    const env = {
+      ZEROSHOT_COMMAND_PROOFS: JSON.stringify([proof]),
+      CMDPROOF_CACHE_DIR: path.join(tempDir, 'cache'),
+      CMDPROOF_KEY_DIR: path.join(tempDir, 'keys'),
+      ZEROSHOT_CMDPROOF_LOCK_DIR: path.join(tempDir, 'locks'),
+      ZEROSHOT_CMDPROOF_LOCK_STALE_MS: '1',
+    };
+    const calls = [];
+
+    try {
+      fs.mkdirSync(env.CMDPROOF_KEY_DIR, { recursive: true });
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'private-key.json'), '{}');
+      fs.writeFileSync(path.join(env.CMDPROOF_KEY_DIR, 'public-key.json'), '{}');
+      const lockPath = path.join(
+        env.ZEROSHOT_CMDPROOF_LOCK_DIR,
+        proofLockName(proof, { actionKey: 'action-stale' })
+      );
+      fs.mkdirSync(lockPath, { recursive: true });
+      const old = new Date(Date.now() - 10_000);
+      fs.utimesSync(lockPath, old, old);
+
+      const exitCode = runCmdproof({
+        mode: 'check',
+        id: 'opcore-ci',
+        env,
+        cwd: tempDir,
+        spawnSyncFn: (command, args) => {
+          calls.push({ command, args });
+          if (args[0] === 'verify') {
+            return {
+              status: 2,
+              stdout: '{"status":"miss","actionKey":"action-stale"}\n',
+              stderr: '',
+            };
+          }
+          return { status: 0, stdout: '{"status":"passed"}\n', stderr: '' };
+        },
+        stdout: { write: () => {} },
+        stderr: { write: () => {} },
+      });
+
+      assert.strictEqual(exitCode, 0);
+      assert.deepStrictEqual(
+        calls.map((call) => call.args[0]),
+        ['verify', 'prove']
+      );
+      assert.strictEqual(fs.existsSync(lockPath), false);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- release the cmdproof action-key single-flight fix on top of current `main`
- prevents concurrent validators from launching duplicate raw fallback CI for the same cmdproof action key
- keeps fallback behavior unchanged when verify output has no action key

## Why this PR uses `tomdps:dev`
The normal upstream `dev -> main` PR (#525) is conflicted because `dev` lost the main ancestry edge when the merge queue squashed the no-file sync PR. The repo guard allows `main` PRs only from a branch named `dev`; this fork branch is named `dev` and is based directly on current `main`, so the release diff is clean and limited to the intended two files.

## Validation
- #524 feature PR CI passed
- #524 merge-group CI passed into upstream dev
- This PR should run the required main CI/install matrix on the clean main-based patch
