### PR TITLE
docs(readme): add single-agent vs Zeroshot comparison grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ task --> plan --> implement --> verify --> APPROVED --> done
 
 Bring your own provider and your own backend. Zeroshot orchestrates the agents that write your code; it doesn't store your keys or replace your models.
 
+## How is this different from a single coding agent?
+
+|                             | A single coding agent        | Zeroshot                                                                                    |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------- |
+| Who says it is correct?     | the same agent that wrote it | a separate agent that never saw how it was written                                          |
+| Is the code actually run?   | usually just claimed         | executed against your real tests                                                            |
+| When it fails, you get      | an assertion it is fine      | a reproducible failure                                                                      |
+| When does it stop?          | when it decides it is done   | when the change is verified, or provably is not                                             |
+| Which coding agent runs it? | one, fixed                   | any you already run: Zeroshot is the harness around Claude Code, Codex, Gemini, or OpenCode |
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Adds a scannable "How is this different from a single coding agent?" grid right after How it works, so a skeptical dev grasps the differentiator in seconds.

Honest capability framing (no benchmark claims, fair to single agents), descriptive cells rather than a checkmark scorecard. The last row makes the meta-harness point: Zeroshot is not another agent, it is the harness around whatever coding CLI you already run (Claude Code, Codex, Gemini, or OpenCode).

Question heading is also good for GEO/LLM-quotability. No emoji, no em dashes.