### PR TITLE
fix: worktree/PR cleanup runs docker compose down --volumes against host's Compose project (data loss)

### DIFF
--- a/lib/compose-utils.js
+++ b/lib/compose-utils.js
@@ -1,0 +1,87 @@
+/**
+ * Docker Compose teardown resolution for worktree cleanup.
+ *
+ * Zeroshot never runs `docker compose up` — any compose file found in a worktree
+ * belongs to the target repo, not to zeroshot. Tearing it down is only safe when
+ * the resolved Compose project name is scoped to the worktree directory itself
+ * (i.e. nothing pins it to the host's real, possibly-already-running project).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const COMPOSE_FILENAMES = [
+  'docker-compose.yml',
+  'docker-compose.yaml',
+  'compose.yml',
+  'compose.yaml',
+];
+
+/**
+ * Decide whether it's safe to run `docker compose down` in a worktree, and with what args.
+ * Never includes `--volumes` — automatic cleanup must not delete named volumes.
+ * Skips teardown entirely when the Compose project name is pinned (top-level `name:`
+ * in the compose file, or `COMPOSE_PROJECT_NAME` env var), since that resolves to a
+ * shared/host project zeroshot did not create.
+ *
+ * @param {string} worktreePath - Path to the worktree directory
+ * @returns {{ shouldTeardown: boolean, reason?: string, composePath?: string, args?: string[] }}
+ */
+function resolveWorktreeComposeTeardown(worktreePath) {
+  let composePath = null;
+  for (const filename of COMPOSE_FILENAMES) {
+    const candidate = path.join(worktreePath, filename);
+    if (fs.existsSync(candidate)) {
+      composePath = candidate;
+      break;
+    }
+  }
+
+  if (!composePath) {
+    return { shouldTeardown: false, reason: 'no compose file' };
+  }
+
+  if (
+    typeof process.env.COMPOSE_PROJECT_NAME === 'string' &&
+    process.env.COMPOSE_PROJECT_NAME.trim() !== ''
+  ) {
+    return {
+      shouldTeardown: false,
+      reason: 'pinned compose project name (shared host project)',
+      composePath,
+    };
+  }
+
+  try {
+    const yaml = require('js-yaml');
+    const contents = fs.readFileSync(composePath, 'utf8');
+    const parsed = yaml.load(contents);
+    if (parsed && typeof parsed === 'object' && parsed.name) {
+      return {
+        shouldTeardown: false,
+        reason: 'pinned compose project name (shared host project)',
+        composePath,
+      };
+    }
+  } catch {
+    // Fail safe: if the compose file can't be read/parsed, we cannot confirm project
+    // identity is worktree-scoped, so never tear down.
+    return { shouldTeardown: false, reason: 'compose file unreadable or unparsable', composePath };
+  }
+
+  return {
+    shouldTeardown: true,
+    composePath,
+    args: [
+      'compose',
+      '-p',
+      path.basename(worktreePath),
+      'down',
+      '--remove-orphans',
+      '--timeout',
+      '10',
+    ],
+  };
+}
+
+module.exports = { resolveWorktreeComposeTeardown };

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -1651,10 +1651,14 @@ class IsolationManager {
     // Tear down any Docker Compose services that may have been started in this worktree.
     // Without this, containers keep running with host port mappings after the worktree is deleted,
     // blocking port allocation for the main project or other worktrees.
-    const composePath = path.join(worktreeInfo.path, 'docker-compose.yml');
-    if (fs.existsSync(composePath)) {
+    // NEVER pass --volumes (irreversible data loss) and NEVER tear down a pinned/shared
+    // Compose project — only a project scoped to the worktree directory basename, which is
+    // the only kind zeroshot could itself have created, is touched.
+    const { resolveWorktreeComposeTeardown } = require('../lib/compose-utils');
+    const teardown = resolveWorktreeComposeTeardown(worktreeInfo.path);
+    if (teardown.shouldTeardown) {
       try {
-        runSync('docker', ['compose', 'down', '--remove-orphans', '--volumes', '--timeout', '10'], {
+        runSync('docker', teardown.args, {
           cwd: worktreeInfo.path,
           encoding: 'utf8',
           stdio: 'pipe',

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1908,22 +1908,29 @@ class Orchestrator {
    * @private
    */
   _teardownWorktreeCompose(worktreePath) {
-    const composePath = path.join(worktreePath, 'docker-compose.yml');
-    if (!fs.existsSync(composePath)) return;
+    // NEVER pass --volumes (irreversible data loss) and NEVER tear down a pinned/shared
+    // Compose project — only a project scoped to the worktree directory basename, which is
+    // the only kind zeroshot could itself have created, is touched.
+    const { resolveWorktreeComposeTeardown } = require('../lib/compose-utils');
+    const teardown = resolveWorktreeComposeTeardown(worktreePath);
+    if (!teardown.shouldTeardown) {
+      if (teardown.composePath) {
+        this._log(
+          `[Orchestrator] Skipping Docker Compose teardown in ${worktreePath}: ${teardown.reason}`
+        );
+      }
+      return;
+    }
 
     try {
       this._log(`[Orchestrator] Tearing down Docker Compose services in ${worktreePath}...`);
       const { spawnSync } = require('child_process');
-      const result = spawnSync(
-        'docker',
-        ['compose', 'down', '--remove-orphans', '--volumes', '--timeout', '10'],
-        {
-          cwd: worktreePath,
-          encoding: 'utf8',
-          stdio: 'pipe',
-          timeout: 30000,
-        }
-      );
+      const result = spawnSync('docker', teardown.args, {
+        cwd: worktreePath,
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 30000,
+      });
       if (result.status !== 0 || result.error) {
         const detail = result.error?.message || result.stderr || 'no stderr';
         throw new Error(`Docker Compose teardown failed in ${worktreePath}: ${detail}`);

--- a/tests/compose-utils.test.js
+++ b/tests/compose-utils.test.js
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for lib/compose-utils.js — resolveWorktreeComposeTeardown()
+ *
+ * Bug (issue #543): worktree/PR cleanup ran `docker compose down --remove-orphans --volumes`
+ * unconditionally. When the target repo's compose file (or COMPOSE_PROJECT_NAME) pinned a
+ * project name, Compose resolved to the user's real, already-running project and --volumes
+ * permanently deleted its named volumes.
+ *
+ * These tests would FAIL against the original behavior (which always returned a teardown
+ * command including --volumes, regardless of project-name pinning) and PASS against the fix.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { resolveWorktreeComposeTeardown } = require('../lib/compose-utils');
+
+describe('resolveWorktreeComposeTeardown', function () {
+  let tmpDir;
+  let origComposeProjectName;
+
+  beforeEach(function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-compose-utils-'));
+    origComposeProjectName = process.env.COMPOSE_PROJECT_NAME;
+    delete process.env.COMPOSE_PROJECT_NAME;
+  });
+
+  afterEach(function () {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (origComposeProjectName === undefined) {
+      delete process.env.COMPOSE_PROJECT_NAME;
+    } else {
+      process.env.COMPOSE_PROJECT_NAME = origComposeProjectName;
+    }
+  });
+
+  it('returns shouldTeardown:false when no compose file exists', function () {
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, false);
+    assert.strictEqual(result.reason, 'no compose file');
+  });
+
+  it('returns shouldTeardown:true with no --volumes for an unpinned compose file', function () {
+    fs.writeFileSync(
+      path.join(tmpDir, 'docker-compose.yml'),
+      'services:\n  db:\n    image: postgres\n'
+    );
+
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, true);
+    assert.ok(!result.args.includes('--volumes'), 'must never include --volumes');
+    assert.ok(result.args.includes('--remove-orphans'));
+    assert.strictEqual(result.args[result.args.indexOf('-p') + 1], path.basename(tmpDir));
+  });
+
+  it('returns shouldTeardown:false when the compose file pins a top-level project name', function () {
+    fs.writeFileSync(
+      path.join(tmpDir, 'docker-compose.yml'),
+      'name: myproj\nservices:\n  db:\n    image: postgres\n'
+    );
+
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, false);
+    assert.strictEqual(result.reason, 'pinned compose project name (shared host project)');
+  });
+
+  it('returns shouldTeardown:false when COMPOSE_PROJECT_NAME env var is set', function () {
+    fs.writeFileSync(
+      path.join(tmpDir, 'docker-compose.yml'),
+      'services:\n  db:\n    image: postgres\n'
+    );
+    process.env.COMPOSE_PROJECT_NAME = 'shared-host-project';
+
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, false);
+    assert.strictEqual(result.reason, 'pinned compose project name (shared host project)');
+  });
+
+  it('finds alternate compose filenames (compose.yaml)', function () {
+    fs.writeFileSync(path.join(tmpDir, 'compose.yaml'), 'services:\n  db:\n    image: postgres\n');
+
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, true);
+    assert.ok(result.composePath.endsWith('compose.yaml'));
+  });
+
+  it('fails safe (shouldTeardown:false) when the compose file is malformed YAML', function () {
+    fs.writeFileSync(path.join(tmpDir, 'docker-compose.yml'), ':\n  - this is not: valid: yaml: [');
+
+    const result = resolveWorktreeComposeTeardown(tmpDir);
+    assert.strictEqual(result.shouldTeardown, false);
+  });
+});

--- a/tests/worktree-compose-cleanup.test.js
+++ b/tests/worktree-compose-cleanup.test.js
@@ -26,7 +26,7 @@ function isComposeDownCall(call) {
     call.command === 'docker' &&
     Array.isArray(call.args) &&
     call.args[0] === 'compose' &&
-    call.args[1] === 'down'
+    call.args.includes('down')
   );
 }
 
@@ -34,13 +34,23 @@ describe('Worktree Docker Compose Cleanup', function () {
   this.timeout(10000);
 
   let tmpDir;
+  let origComposeProjectName;
 
   beforeEach(function () {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-compose-cleanup-'));
+    // Isolate from any host-level COMPOSE_PROJECT_NAME (e.g. this repo's own dev setup
+    // may export one) so unpinned-project tests reflect the worktree-basename default.
+    origComposeProjectName = process.env.COMPOSE_PROJECT_NAME;
+    delete process.env.COMPOSE_PROJECT_NAME;
   });
 
   afterEach(function () {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (origComposeProjectName === undefined) {
+      delete process.env.COMPOSE_PROJECT_NAME;
+    } else {
+      process.env.COMPOSE_PROJECT_NAME = origComposeProjectName;
+    }
   });
 
   describe('IsolationManager.removeWorktree', function () {
@@ -89,8 +99,13 @@ describe('Worktree Docker Compose Cleanup', function () {
           'docker compose down should use --remove-orphans'
         );
         assert.ok(
-          composeDownCall.args.includes('--volumes'),
-          'docker compose down should use --volumes to free disk'
+          !composeDownCall.args.includes('--volumes'),
+          'docker compose down must NEVER use --volumes (irreversible data loss on shared projects)'
+        );
+        assert.ok(
+          composeDownCall.args.includes('-p') &&
+            composeDownCall.args[composeDownCall.args.indexOf('-p') + 1] === 'test-worktree',
+          'docker compose down should pin the project to the worktree directory basename'
         );
 
         // Verify ordering: compose down appears before git worktree remove
@@ -223,7 +238,72 @@ describe('Worktree Docker Compose Cleanup', function () {
       assert.ok(composeCall, '_teardownWorktreeCompose should call docker compose down');
       assert.strictEqual(composeCall.cwd, fakeWorktreePath);
       assert.ok(composeCall.args.includes('--remove-orphans'));
-      assert.ok(composeCall.args.includes('--volumes'));
+      assert.ok(
+        !composeCall.args.includes('--volumes'),
+        'docker compose down must NEVER use --volumes (irreversible data loss on shared projects)'
+      );
+      assert.ok(
+        composeCall.args.includes('-p') &&
+          composeCall.args[composeCall.args.indexOf('-p') + 1] === 'stop-test-worktree',
+        'docker compose down should pin the project to the worktree directory basename'
+      );
+    });
+
+    it('should skip docker compose down when compose project name is pinned via top-level name', function () {
+      const Orchestrator = require('../src/orchestrator');
+      const orchestrator = new Orchestrator({ dataDir: tmpDir });
+
+      const fakeWorktreePath = path.join(tmpDir, 'pinned-name-worktree');
+      fs.mkdirSync(fakeWorktreePath, { recursive: true });
+      fs.writeFileSync(
+        path.join(fakeWorktreePath, 'docker-compose.yml'),
+        'name: myproj\nservices:\n  db:\n    image: postgres\n'
+      );
+
+      const calls = [];
+      childProcess.spawnSync = function (command, args, opts) {
+        calls.push({ command, args, cwd: opts?.cwd });
+        return { status: 0, stdout: '', stderr: '' };
+      };
+
+      orchestrator._teardownWorktreeCompose(fakeWorktreePath);
+      assert.strictEqual(
+        calls.length,
+        0,
+        'docker compose down must NOT be invoked when the project name is pinned (shared host project)'
+      );
+    });
+
+    it('should skip docker compose down when COMPOSE_PROJECT_NAME env var is set', function () {
+      const Orchestrator = require('../src/orchestrator');
+      const orchestrator = new Orchestrator({ dataDir: tmpDir });
+
+      const fakeWorktreePath = path.join(tmpDir, 'pinned-env-worktree');
+      fs.mkdirSync(fakeWorktreePath, { recursive: true });
+      fs.writeFileSync(path.join(fakeWorktreePath, 'docker-compose.yml'), 'version: "3"');
+
+      const calls = [];
+      childProcess.spawnSync = function (command, args, opts) {
+        calls.push({ command, args, cwd: opts?.cwd });
+        return { status: 0, stdout: '', stderr: '' };
+      };
+
+      const origEnv = process.env.COMPOSE_PROJECT_NAME;
+      process.env.COMPOSE_PROJECT_NAME = 'shared-host-project';
+      try {
+        orchestrator._teardownWorktreeCompose(fakeWorktreePath);
+        assert.strictEqual(
+          calls.length,
+          0,
+          'docker compose down must NOT be invoked when COMPOSE_PROJECT_NAME pins a shared project'
+        );
+      } finally {
+        if (origEnv === undefined) {
+          delete process.env.COMPOSE_PROJECT_NAME;
+        } else {
+          process.env.COMPOSE_PROJECT_NAME = origEnv;
+        }
+      }
     });
 
     it('should skip when no docker-compose.yml exists', function () {


### PR DESCRIPTION
Closes #543

## Summary
- `docker compose down` was capable of running with `--volumes` against the host's live Compose project when project-name resolution collided or was left unpinned, causing data loss.
- Teardown is now skipped entirely when the Compose project name is pinned (top-level `name:` in the compose file, or `COMPOSE_PROJECT_NAME` env var).
- `--volumes` is no longer passed anywhere in `src`/`lib`.

## Test plan
- Full test suite: 1263 passing
- Targeted new/updated test files: 14/14 passing
- Manual invocation of `resolveWorktreeComposeTeardown` against pinned/unpinned/env-pinned compose files reproducing the original scenario
- Lint: 0 errors