### PR TITLE
fix(providers): clamp model level to min/max guardrails instead of throwing (#162)

### DIFF
--- a/src/providers/base-provider.js
+++ b/src/providers/base-provider.js
@@ -248,16 +248,17 @@ class BaseProvider {
       );
     }
 
+    // minLevel/maxLevel are the user's floor/ceiling cost guardrails, not a hard
+    // constraint on template-pinned levels. Clamp an out-of-range level into range
+    // rather than throwing: rejecting made a single-level clamp (min === max)
+    // unusable with any template that pins a different level, and broke read-only
+    // commands like `zeroshot logs` that resolve model specs for display (#162).
     if (maxLevel && rank(level) > rank(maxLevel)) {
-      throw new Error(
-        `Level "${level}" exceeds maxLevel "${maxLevel}" for provider "${this.name}"`
-      );
+      return maxLevel;
     }
 
     if (minLevel && rank(level) < rank(minLevel)) {
-      throw new Error(
-        `Level "${level}" is below minLevel "${minLevel}" for provider "${this.name}"`
-      );
+      return minLevel;
     }
 
     return level;

--- a/tests/provider-level-clamp.test.js
+++ b/tests/provider-level-clamp.test.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const { getProvider } = require('../src/providers');
+
+// Regression coverage for #162: `zeroshot logs` (and any model-spec resolution)
+// crashed with `Level "level1" is below minLevel "level3"` when a provider's
+// min/max level guardrails were clamped to a single level. minLevel/maxLevel are
+// the user's floor/ceiling cost guardrails, so an out-of-range template-pinned
+// level must clamp into range instead of throwing.
+describe('base provider validateLevel clamping (#162)', function () {
+  const provider = getProvider('claude');
+
+  it('clamps a below-floor level up to minLevel', function () {
+    assert.strictEqual(provider.validateLevel('level1', 'level3', 'level3'), 'level3');
+    assert.strictEqual(provider.validateLevel('level1', 'level2', 'level3'), 'level2');
+  });
+
+  it('clamps an above-ceiling level down to maxLevel', function () {
+    assert.strictEqual(provider.validateLevel('level3', 'level1', 'level1'), 'level1');
+    assert.strictEqual(provider.validateLevel('level3', 'level1', 'level2'), 'level2');
+  });
+
+  it('single-level clamp (min === max) forces that level for any input', function () {
+    for (const level of ['level1', 'level2', 'level3']) {
+      assert.strictEqual(provider.validateLevel(level, 'level2', 'level2'), 'level2');
+    }
+  });
+
+  it('returns an in-range level unchanged', function () {
+    assert.strictEqual(provider.validateLevel('level2', 'level1', 'level3'), 'level2');
+  });
+
+  it('still throws on an unknown level key', function () {
+    assert.throws(() => provider.validateLevel('level9', 'level1', 'level3'), /Invalid level/);
+  });
+
+  it('still throws when minLevel exceeds maxLevel (genuine misconfiguration)', function () {
+    assert.throws(
+      () => provider.validateLevel('level2', 'level3', 'level1'),
+      /minLevel "level3" exceeds maxLevel "level1"/
+    );
+  });
+});


### PR DESCRIPTION
## Problem
`zeroshot logs <cluster>` crashed with `Level "level1" is below minLevel "level3" for provider "claude"` when the claude provider was clamped to a single level (min=max=level3). Stock templates pin agents at level1/level2, and read-only commands resolve model specs for display, so the guardrail turned into a hard crash.

## Root cause
`base-provider.js#validateLevel` **threw** when a template-pinned level fell outside [minLevel, maxLevel]. But those are the user's floor/ceiling cost guardrails, not hard constraints.

## Fix
Clamp an out-of-range level into [minLevel, maxLevel] (below floor → minLevel, above ceiling → maxLevel). Invalid level keys and minLevel > maxLevel still throw. Left config-validator strict (it validates user-entered settings coherence).

## Tests
New `tests/provider-level-clamp.test.js` (6 cases). Adjacent settings suites pass; lint clean.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)