### PR TITLE
feat: bug: worktree compose teardown -p uses un-normalized basename (may no-op, leaving ports bound)

### DIFF
--- a/lib/compose-utils.js
+++ b/lib/compose-utils.js
@@ -18,6 +18,20 @@ const COMPOSE_FILENAMES = [
 ];
 
 /**
+ * Reproduce Docker Compose's default project-name normalization
+ * (compose-go NormalizeProjectName: lowercase -> keep [a-z0-9_-] -> trim leading '_'/'-').
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function normalizeComposeProjectName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .replace(/^[-_]+/, '');
+}
+
+/**
  * Decide whether it's safe to run `docker compose down` in a worktree, and with what args.
  * Never includes `--volumes` — automatic cleanup must not delete named volumes.
  * Skips teardown entirely when the Compose project name is pinned (top-level `name:`
@@ -75,7 +89,7 @@ function resolveWorktreeComposeTeardown(worktreePath) {
     args: [
       'compose',
       '-p',
-      path.basename(worktreePath),
+      normalizeComposeProjectName(path.basename(worktreePath)),
       'down',
       '--remove-orphans',
       '--timeout',
@@ -84,4 +98,4 @@ function resolveWorktreeComposeTeardown(worktreePath) {
   };
 }
 
-module.exports = { resolveWorktreeComposeTeardown };
+module.exports = { resolveWorktreeComposeTeardown, normalizeComposeProjectName };

--- a/tests/compose-utils.test.js
+++ b/tests/compose-utils.test.js
@@ -15,7 +15,10 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { resolveWorktreeComposeTeardown } = require('../lib/compose-utils');
+const {
+  resolveWorktreeComposeTeardown,
+  normalizeComposeProjectName,
+} = require('../lib/compose-utils');
 
 describe('resolveWorktreeComposeTeardown', function () {
   let tmpDir;
@@ -52,7 +55,23 @@ describe('resolveWorktreeComposeTeardown', function () {
     assert.strictEqual(result.shouldTeardown, true);
     assert.ok(!result.args.includes('--volumes'), 'must never include --volumes');
     assert.ok(result.args.includes('--remove-orphans'));
-    assert.strictEqual(result.args[result.args.indexOf('-p') + 1], path.basename(tmpDir));
+    assert.strictEqual(
+      result.args[result.args.indexOf('-p') + 1],
+      normalizeComposeProjectName(path.basename(tmpDir))
+    );
+  });
+
+  it('normalizes an uppercase/special-char worktree basename to match Docker Compose default project naming', function () {
+    const worktreeDir = path.join(tmpDir, 'My.Worktree!');
+    fs.mkdirSync(worktreeDir);
+    fs.writeFileSync(
+      path.join(worktreeDir, 'docker-compose.yml'),
+      'services:\n  db:\n    image: postgres\n'
+    );
+
+    const result = resolveWorktreeComposeTeardown(worktreeDir);
+    assert.strictEqual(result.shouldTeardown, true);
+    assert.strictEqual(result.args[result.args.indexOf('-p') + 1], 'myworktree');
   });
 
   it('returns shouldTeardown:false when the compose file pins a top-level project name', function () {


### PR DESCRIPTION
Closes #551