### PR TITLE
fix: enforce review-mode PR safety and package hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "cli/",
     "task-lib/",
     "cluster-templates/",
-    "hooks/",
+    "cluster-hooks/",
     "docker/",
     "scripts/",
     "README.md",

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -118,7 +118,7 @@ function buildClaudeEnv(modelSpec, options = {}) {
     env.ANTHROPIC_MODEL = modelSpec.model;
   }
 
-  // Activate AskUserQuestion blocking hook (see hooks/block-ask-user-question.py)
+  // Activate AskUserQuestion blocking hook (see cluster-hooks/block-ask-user-question.py)
   env.ZEROSHOT_BLOCK_ASK_USER = '1';
 
   return env;
@@ -446,7 +446,7 @@ function ensureAskUserQuestionHook(targetClaudeDir = null) {
   }
 
   // Copy hook script if not present or outdated
-  const hookScriptSrc = path.join(__dirname, '..', '..', 'hooks', hookScriptName);
+  const hookScriptSrc = path.join(__dirname, '..', '..', 'cluster-hooks', hookScriptName);
   if (fs.existsSync(hookScriptSrc)) {
     // Always copy to ensure latest version
     fs.copyFileSync(hookScriptSrc, hookScriptDst);
@@ -524,7 +524,7 @@ function ensureDangerousGitHook(targetClaudeDir = null) {
   }
 
   // Copy hook script if not present or outdated
-  const hookScriptSrc = path.join(__dirname, '..', '..', 'hooks', hookScriptName);
+  const hookScriptSrc = path.join(__dirname, '..', '..', 'cluster-hooks', hookScriptName);
   if (fs.existsSync(hookScriptSrc)) {
     // Always copy to ensure latest version
     fs.copyFileSync(hookScriptSrc, hookScriptDst);

--- a/src/agent/pr-verification.js
+++ b/src/agent/pr-verification.js
@@ -627,6 +627,13 @@ async function verifyPullRequest({ result, agent, autoMerge }) {
   if (!requireMerge) {
     // --pr mode: the PR/MR was created and verified to exist. It's left OPEN for human
     // review - do NOT poll for merge or treat an unmerged PR as a failure.
+    if (adapter.isMerged(prData)) {
+      throw new Error(
+        `VERIFICATION FAILED: ${adapter.itemName} #${prData.number} is already merged, ` +
+          'but this run was started in review mode (autoMerge=false).'
+      );
+    }
+
     agent._log(
       `✅ VERIFICATION PASSED: ${adapter.itemName} #${prData.number} created (open for human review)`
     );

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -1042,7 +1042,7 @@ class IsolationManager {
     provisionClaudeCredentials({ sourceDir, destDir: configDir });
 
     // Copy hook script to block AskUserQuestion (CRITICAL for autonomous execution)
-    const hookScriptSrc = path.join(__dirname, '..', 'hooks', 'block-ask-user-question.py');
+    const hookScriptSrc = path.join(__dirname, '..', 'cluster-hooks', 'block-ask-user-question.py');
     const hookScriptDst = path.join(hooksDir, 'block-ask-user-question.py');
     if (fs.existsSync(hookScriptSrc)) {
       fs.copyFileSync(hookScriptSrc, hookScriptDst);

--- a/tests/git-pusher-pr-mode.test.js
+++ b/tests/git-pusher-pr-mode.test.js
@@ -11,6 +11,7 @@ const assert = require('node:assert');
 const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
+const { execSync } = require('node:child_process');
 
 const { generateGitPusherAgent } = require('../src/agents/git-pusher-template');
 const Orchestrator = require('../src/orchestrator');
@@ -23,6 +24,13 @@ function withTmpCwd(fn) {
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+}
+
+function writeRepoSettings(cwd, settings) {
+  execSync('git init', { cwd, stdio: 'ignore' });
+  const settingsDir = path.join(cwd, '.zeroshot');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(settings, null, 2));
 }
 
 describe('git-pusher --pr vs --ship (autoMerge)', function () {
@@ -73,6 +81,32 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
       const agentConfig = generateGitPusherAgent('github', { cwd });
       assert.strictEqual(agentConfig.hooks.onComplete.config.autoMerge, false);
       assert(!/gh pr merge/i.test(agentConfig.prompt));
+    });
+  });
+
+  it('--pr review mode overrides repo github.autoMerge=true', function () {
+    withTmpCwd((cwd) => {
+      writeRepoSettings(cwd, { github: { autoMerge: true } });
+
+      const agentConfig = generateGitPusherAgent('github', { autoMerge: false, cwd });
+
+      assert.strictEqual(agentConfig.hooks.onComplete.config.autoMerge, false);
+      assert(!/gh pr merge/i.test(agentConfig.prompt), '--pr must not inherit repo auto-merge');
+      assert(
+        /Do NOT merge the PR/i.test(agentConfig.prompt),
+        '--pr must remain a human-review prompt even when repo settings enable auto-merge'
+      );
+    });
+  });
+
+  it('repo github.autoMerge=true only applies when the caller has not selected --pr', function () {
+    withTmpCwd((cwd) => {
+      writeRepoSettings(cwd, { github: { autoMerge: true } });
+
+      const agentConfig = generateGitPusherAgent('github', { cwd });
+
+      assert.strictEqual(agentConfig.hooks.onComplete.config.autoMerge, true);
+      assert(/gh pr merge/i.test(agentConfig.prompt));
     });
   });
 

--- a/tests/package-smoke.test.js
+++ b/tests/package-smoke.test.js
@@ -1,0 +1,61 @@
+/**
+ * Packaging smoke tests for the npm artifact.
+ *
+ * These run `npm pack --dry-run --json` so they validate the publish file list
+ * without relying on the network or installing dependencies.
+ */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..');
+
+function runNpmPackDryRun() {
+  const result = spawnSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+      npm_config_loglevel: 'silent',
+    },
+  });
+
+  assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  const parsed = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(parsed) && parsed.length === 1, 'expected one packed artifact entry');
+  return parsed[0];
+}
+
+describe('npm package smoke', function () {
+  this.timeout(30000);
+
+  it('publishes the CLI bin and first-run/auth/runtime support files', function () {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    const pack = runNpmPackDryRun();
+    const files = new Set(pack.files.map((file) => file.path));
+
+    assert.strictEqual(pkg.bin.zeroshot, './cli/index.js');
+    assert.strictEqual(
+      pkg.bin['zeroshot-agent-provider'],
+      './lib/agent-cli-provider/executable.js'
+    );
+
+    for (const requiredFile of [
+      'cli/index.js',
+      'lib/start-cluster.js',
+      'lib/path-check.js',
+      'scripts/check-path.js',
+      'src/claude-credentials.js',
+      'src/worktree-claude-config.js',
+      'src/agent/pr-verification.js',
+      'src/agents/git-pusher-template.js',
+      'cluster-hooks/block-ask-user-question.py',
+      'cluster-hooks/block-dangerous-git.py',
+    ]) {
+      assert.ok(files.has(requiredFile), `npm package must include ${requiredFile}`);
+    }
+  });
+});

--- a/tests/unit/cli-stdin-input.test.js
+++ b/tests/unit/cli-stdin-input.test.js
@@ -6,6 +6,8 @@
  */
 
 const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
 const { Readable } = require('stream');
 const {
   isStdinInput,
@@ -14,6 +16,8 @@ const {
   decodeStdinEnv,
   buildTextInput,
 } = require('../../lib/start-cluster');
+
+const repoRoot = path.join(__dirname, '..', '..');
 
 describe('CLI stdin task input', function () {
   describe('isStdinInput', function () {
@@ -55,5 +59,33 @@ describe('CLI stdin task input', function () {
       const result = buildTextInput(decodeStdinEnv(encodeStdinEnv(text)));
       assert.deepStrictEqual(result, { text });
     });
+  });
+
+  it('preserves piped stdin through a real Node process boundary', function () {
+    const taskBody = [
+      '# Task',
+      '',
+      'Update `BrandContext.writingStyle` without evaluating $(shell) syntax.',
+    ].join('\n');
+    const script = `
+      const { readStdinText, buildTextInput } = require(${JSON.stringify(
+        path.join(repoRoot, 'lib/start-cluster')
+      )});
+      readStdinText()
+        .then((text) => process.stdout.write(JSON.stringify(buildTextInput(text))))
+        .catch((error) => {
+          console.error(error.stack || error.message);
+          process.exit(1);
+        });
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], {
+      cwd: repoRoot,
+      input: taskBody,
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { text: taskBody });
   });
 });

--- a/tests/unit/git-safety-hook.test.js
+++ b/tests/unit/git-safety-hook.test.js
@@ -18,8 +18,8 @@ const { execFileSync, spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-// Path to the hook script
-const HOOK_PATH = path.join(__dirname, '../../hooks/block-dangerous-git.py');
+// Path to the hook script used by runtime packaging/copy logic.
+const HOOK_PATH = path.join(__dirname, '../../cluster-hooks/block-dangerous-git.py');
 
 function resolvePython() {
   const candidates = [process.env.PYTHON, '/usr/bin/python3', 'python3', 'python'].filter(Boolean);

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -2,14 +2,36 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const sinon = require('sinon');
 
 const { prepareClaudeConfigDir } = require('../../src/worktree-claude-config');
+const safeExec = require('../../src/lib/safe-exec');
+
+function withPlatform(value, fn) {
+  const original = Object.getOwnPropertyDescriptor(os, 'platform');
+  Object.defineProperty(os, 'platform', { value: () => value, configurable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(os, 'platform', original);
+  }
+}
+
+function loadWorktreeClaudeConfigWithStubbedCredentials(execSyncStub) {
+  sinon.stub(safeExec, 'execSync').callsFake(execSyncStub);
+  delete require.cache[require.resolve('../../src/claude-credentials')];
+  delete require.cache[require.resolve('../../src/worktree-claude-config')];
+  return require('../../src/worktree-claude-config');
+}
 
 describe('worktree-claude-config', function () {
   /** @type {string[]} */
   let tempDirs = [];
 
   afterEach(function () {
+    sinon.restore();
+    delete require.cache[require.resolve('../../src/claude-credentials')];
+    delete require.cache[require.resolve('../../src/worktree-claude-config')];
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -116,5 +138,42 @@ describe('worktree-claude-config', function () {
 
     const mergedMcp = JSON.parse(fs.readFileSync(path.join(overlayDir, '.mcp.json'), 'utf8'));
     assert.deepStrictEqual(Object.keys(mergedMcp.mcpServers).sort(), ['repo', 'shared']);
+  });
+
+  it('materializes macOS Keychain credentials into the isolated overlay config dir', function () {
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));
+    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-source-no-creds-'));
+    tempDirs.push(worktreeRoot, sourceDir);
+
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
+    fs.mkdirSync(path.join(worktreeRoot, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(worktreeRoot, '.claude', 'settings.json'), '{}\n', 'utf8');
+
+    const keychainJson = '{"claudeAiOauth":{"accessToken":"keychain-token"}}';
+    const { prepareClaudeConfigDir: prepareWithStubbedKeychain } =
+      loadWorktreeClaudeConfigWithStubbedCredentials((command) => {
+        assert.strictEqual(
+          command,
+          'security find-generic-password -s "Claude Code-credentials" -w'
+        );
+        return `${keychainJson}\n`;
+      });
+
+    const overlayDir = withPlatform('darwin', () =>
+      prepareWithStubbedKeychain({ worktreePath: worktreeRoot, sourceDir })
+    );
+    tempDirs.push(overlayDir);
+
+    assert.ok(overlayDir, 'expected an overlay config dir');
+    assert.strictEqual(
+      fs.readFileSync(path.join(overlayDir, '.credentials.json'), 'utf8'),
+      keychainJson,
+      'isolated CLAUDE_CONFIG_DIR must receive materialized Keychain credentials'
+    );
+    assert.strictEqual(
+      fs.statSync(path.join(overlayDir, '.credentials.json')).mode & 0o777,
+      0o600,
+      'materialized credentials should be owner-readable only'
+    );
   });
 });

--- a/tests/verify-github-pr-hook.test.js
+++ b/tests/verify-github-pr-hook.test.js
@@ -614,6 +614,39 @@ describe('verify_pull_request hook action', () => {
       assert.strictEqual(callCount, 1, `Expected exactly 1 gh call (got ${callCount})`);
     });
 
+    it('treats PR existence as success even if review-mode agent output claims merged:true', async function () {
+      const agent = createMockAgent();
+      const hook = { action: 'verify_pull_request', config: { autoMerge: false } };
+      const result = {
+        output: JSON.stringify({
+          pr_url: 'https://github.com/org/repo/pull/124',
+          pr_number: 124,
+          merged: true,
+        }),
+      };
+
+      let callCount = 0;
+      mockSpawnSyncFn = () => {
+        callCount++;
+        return spawnSuccess(
+          JSON.stringify({
+            number: 124,
+            state: 'OPEN',
+            mergedAt: null,
+            url: 'https://github.com/org/repo/pull/124',
+          })
+        );
+      };
+
+      await executeHook({ hook, agent, result });
+
+      assert.strictEqual(agent.lastPublished.topic, 'CLUSTER_COMPLETE');
+      assert.strictEqual(agent.lastPublished.content.data.reason, 'git-pusher-complete-verified');
+      assert.strictEqual(agent.lastPublished.content.data.pr_number, 124);
+      assert.strictEqual(agent.lastPublished.content.data.merged, false);
+      assert.strictEqual(callCount, 1, `Expected exactly 1 gh call (got ${callCount})`);
+    });
+
     it('still throws when the PR does not exist (hallucination check still applies)', async function () {
       const agent = createMockAgent();
       const hook = { action: 'verify_pull_request', config: { autoMerge: false } };

--- a/tests/verify-github-pr-hook.test.js
+++ b/tests/verify-github-pr-hook.test.js
@@ -647,6 +647,34 @@ describe('verify_pull_request hook action', () => {
       assert.strictEqual(callCount, 1, `Expected exactly 1 gh call (got ${callCount})`);
     });
 
+    it('fails review mode when GitHub reports the PR is already merged', async function () {
+      const agent = createMockAgent();
+      const hook = { action: 'verify_pull_request', config: { autoMerge: false } };
+      const result = {
+        output: JSON.stringify({
+          pr_url: 'https://github.com/org/repo/pull/125',
+          pr_number: 125,
+          merged: false,
+        }),
+      };
+
+      mockSpawnSyncFn = () =>
+        spawnSuccess(
+          JSON.stringify({
+            number: 125,
+            state: 'MERGED',
+            mergedAt: '2026-07-08T20:00:00Z',
+            url: 'https://github.com/org/repo/pull/125',
+          })
+        );
+
+      await assert.rejects(
+        () => executeHook({ hook, agent, result }),
+        /already merged.*review mode \(autoMerge=false\)/i
+      );
+      assert.strictEqual(agent.lastPublished, null, 'merged review-mode PR must not complete');
+    });
+
     it('still throws when the PR does not exist (hallucination check still applies)', async function () {
       const agent = createMockAgent();
       const hook = { action: 'verify_pull_request', config: { autoMerge: false } };


### PR DESCRIPTION
Fix review-mode PR safety and package the hook scripts that isolated agents need at runtime.

Problem:
- `--pr` review mode had tests for prompt text, but not enough release-grade coverage around repo `github.autoMerge=true`, over-eager agent output, and package contents.
- `npm pack --dry-run` exposed a real packaging/runtime mismatch: runtime copied hooks from `hooks/`, while the tracked scripts live in `cluster-hooks/`, so packaged installs could miss the AskUserQuestion and dangerous-git hook scripts.

Approach:
- Treat a merged PR as a verification failure when `autoMerge=false`; review mode means the PR must be left open for human review.
- Copy hook scripts from `cluster-hooks/` and publish that directory in the npm package.
- Add package smoke, stdin process-boundary, Keychain overlay, PR-mode precedence, and hook verification coverage.

Verification:
- `npm test` → 1390 passing, 16 pending; known better-sqlite3 cleanup crash ignored by the repo test wrapper.
- `npm run check:agent-cli-provider:ci` → 58 passing.
- `npm run lint` → 0 errors, existing warnings only.
- Packed tarball install smoke: installed from `npm pack` into a temp prefix, ran `zeroshot --help`, `zeroshot run --help`, and verified the PATH warning export line.
- macOS Keychain smoke: materialized Claude OAuth credentials into a temp isolated config with mode `600` without printing secrets.