### PR TITLE
test: harden compose cleanup data-loss guard

### DIFF
--- a/tests/worktree-compose-cleanup.test.js
+++ b/tests/worktree-compose-cleanup.test.js
@@ -1,18 +1,17 @@
 /**
  * Worktree Docker Compose Cleanup Test Suite
  *
- * Regression test for bug where `docker compose down` was never called when
- * cleaning up zeroshot worktrees. Agents could run `docker compose up` inside
- * worktrees, and those containers would keep running after session end,
- * hogging host ports (5433, 6379, 3001, etc.) and blocking the main project.
+ * Regression tests for worktree Docker Compose cleanup.
  *
- * Root cause: removeWorktree() only did `git worktree remove` + `fs.rmSync`,
- * never tore down Docker Compose services. The orchestrator stop() path
- * (Ctrl+C / SIGINT) preserved worktrees entirely, including running containers.
+ * Safety contract:
+ * - automatic cleanup must never pass `--volumes`
+ * - automatic cleanup must never touch a pinned/shared Compose project
+ * - automatic cleanup may only tear down a project explicitly scoped to the
+ *   worktree directory basename
  *
- * Fix:
- * - isolation-manager.js: removeWorktree() now calls `docker compose down` first
- * - orchestrator.js: stop() calls _teardownWorktreeCompose() even when preserving worktree
+ * These tests cover both cleanup entry points:
+ * - IsolationManager.removeWorktree() for completed --pr/--ship cleanup
+ * - Orchestrator._teardownWorktreeCompose() for stop/Ctrl+C cleanup
  */
 
 const assert = require('assert');
@@ -163,6 +162,102 @@ describe('Worktree Docker Compose Cleanup', function () {
           'docker compose should NOT be called when no docker-compose.yml exists'
         );
       } finally {
+        childProcess.spawnSync = origSpawnSync;
+        delete require.cache[require.resolve('../src/isolation-manager')];
+      }
+    });
+
+    it('should skip docker compose down when compose project name is pinned via top-level name', function () {
+      const origSpawnSync = childProcess.spawnSync;
+      const calls = [];
+
+      childProcess.spawnSync = function (command, args, opts) {
+        calls.push({ command, args, cwd: opts?.cwd });
+        if (command === 'git' && args[0] === 'worktree') {
+          return { status: 1, stdout: '', stderr: 'not a git repo' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      };
+
+      try {
+        delete require.cache[require.resolve('../src/isolation-manager')];
+        const IsolationManager = require('../src/isolation-manager');
+        const manager = new IsolationManager();
+
+        const fakeWorktreePath = path.join(tmpDir, 'pinned-name-worktree');
+        fs.mkdirSync(fakeWorktreePath, { recursive: true });
+        fs.writeFileSync(
+          path.join(fakeWorktreePath, 'docker-compose.yml'),
+          'name: myproj\nservices:\n  db:\n    image: postgres\n'
+        );
+
+        manager.worktrees.set('test-pinned-name', {
+          path: fakeWorktreePath,
+          branch: 'zeroshot/test-pinned-name',
+          repoRoot: tmpDir,
+        });
+
+        manager.cleanupWorktreeIsolation('test-pinned-name');
+
+        const composeCall = calls.find(
+          (c) => c.command === 'docker' && Array.isArray(c.args) && c.args[0] === 'compose'
+        );
+        assert.strictEqual(
+          composeCall,
+          undefined,
+          'docker compose down must NOT be invoked when the project name is pinned'
+        );
+      } finally {
+        childProcess.spawnSync = origSpawnSync;
+        delete require.cache[require.resolve('../src/isolation-manager')];
+      }
+    });
+
+    it('should skip docker compose down when COMPOSE_PROJECT_NAME env var is set', function () {
+      const origSpawnSync = childProcess.spawnSync;
+      const origEnv = process.env.COMPOSE_PROJECT_NAME;
+      const calls = [];
+
+      childProcess.spawnSync = function (command, args, opts) {
+        calls.push({ command, args, cwd: opts?.cwd });
+        if (command === 'git' && args[0] === 'worktree') {
+          return { status: 1, stdout: '', stderr: 'not a git repo' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      };
+
+      process.env.COMPOSE_PROJECT_NAME = 'shared-host-project';
+      try {
+        delete require.cache[require.resolve('../src/isolation-manager')];
+        const IsolationManager = require('../src/isolation-manager');
+        const manager = new IsolationManager();
+
+        const fakeWorktreePath = path.join(tmpDir, 'pinned-env-worktree');
+        fs.mkdirSync(fakeWorktreePath, { recursive: true });
+        fs.writeFileSync(path.join(fakeWorktreePath, 'docker-compose.yml'), 'version: "3"');
+
+        manager.worktrees.set('test-pinned-env', {
+          path: fakeWorktreePath,
+          branch: 'zeroshot/test-pinned-env',
+          repoRoot: tmpDir,
+        });
+
+        manager.cleanupWorktreeIsolation('test-pinned-env');
+
+        const composeCall = calls.find(
+          (c) => c.command === 'docker' && Array.isArray(c.args) && c.args[0] === 'compose'
+        );
+        assert.strictEqual(
+          composeCall,
+          undefined,
+          'docker compose down must NOT be invoked when COMPOSE_PROJECT_NAME pins a shared project'
+        );
+      } finally {
+        if (origEnv === undefined) {
+          delete process.env.COMPOSE_PROJECT_NAME;
+        } else {
+          process.env.COMPOSE_PROJECT_NAME = origEnv;
+        }
         childProcess.spawnSync = origSpawnSync;
         delete require.cache[require.resolve('../src/isolation-manager')];
       }


### PR DESCRIPTION
Problem
Worktree cleanup previously deleted host Compose volumes when a repo pinned the Compose project name. The fix is merged, but the completed --pr/--ship cleanup path should directly prove it will not touch pinned/shared projects.

Approach
Add direct IsolationManager.removeWorktree() coverage for the two shared-project cases: top-level compose name and COMPOSE_PROJECT_NAME. Refresh the test header so the data-loss safety contract is explicit for future maintainers.

Verification
<details><summary>Focused test output</summary>

npm test -- tests/compose-utils.test.js tests/worktree-compose-cleanup.test.js

17 passing

</details>

Push hook also ran lint and typecheck. Lint reported existing warnings only.