### PR TITLE
refactor(run-mode): collapse boolean soup into one canonical RunPlan (#582)

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -189,7 +189,9 @@ function normalizeRunOptions(options) {
   if (options.docker) {
     options.worktree = false;
   }
-  options.autoMerge = Boolean(options.ship);
+  // autoMerge is NOT stored here — it is derived from the run plan (delivery ===
+  // 'ship') at every consumer. Writing it here unconditionally would clobber an
+  // explicit autoMerge intent (e.g. a future `--auto-merge` flag) back to false.
 }
 
 async function runClusterPreflight({ input, options, providerOverride, settings, forceProvider }) {

--- a/lib/detached-startup.js
+++ b/lib/detached-startup.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const lockfile = require('proper-lockfile');
+const { resolveRunPlan } = require('./run-plan');
 
 const DEFAULT_WAIT_TIMEOUT_SECONDS = 180;
 const DEFAULT_WAIT_POLL_MS = 1000;
@@ -116,6 +117,7 @@ async function registerDetachedSetupCluster({
   runOptions = {},
   cwd,
 }) {
+  const plan = resolveRunPlan(runOptions);
   await updateClustersFile(storageDir, (clusters) => {
     clusters[clusterId] = {
       id: clusterId,
@@ -125,13 +127,13 @@ async function registerDetachedSetupCluster({
       setupLogPath: logPath || null,
       setupStartedAt: Date.now(),
       setupStage: 'starting',
-      autoPr: Boolean(runOptions.pr || runOptions.ship),
+      autoPr: plan.delivery !== 'none',
       prOptions: runOptions.prBase
         ? {
             prBase: runOptions.prBase,
             mergeQueue: runOptions.mergeQueue || false,
             closeIssue: runOptions.closeIssue || null,
-            autoMerge: Boolean(runOptions.ship),
+            autoMerge: plan.autoMerge,
             cwd: cwd || null,
           }
         : null,

--- a/lib/run-mode.js
+++ b/lib/run-mode.js
@@ -1,8 +1,15 @@
+const { resolveRunPlan } = require('./run-plan');
+
+// The run-mode label is a VIEW of the canonical plan, never an independent
+// cascade. Deriving it from resolveRunPlan is what keeps the user-facing label
+// and the actual isolation/delivery/autoMerge behavior from drifting apart.
 function resolveRunMode(options) {
-  if (options.ship) return options.docker ? 'ship+docker' : 'ship';
-  if (options.pr) return options.docker ? 'pr+docker' : 'pr';
-  if (options.docker) return 'docker';
-  if (options.worktree) return 'worktree';
+  const { isolation, delivery } = resolveRunPlan(options);
+  const dockerSuffix = isolation === 'docker' ? '+docker' : '';
+  if (delivery === 'ship') return `ship${dockerSuffix}`;
+  if (delivery === 'pr') return `pr${dockerSuffix}`;
+  if (isolation === 'docker') return 'docker';
+  if (isolation === 'worktree') return 'worktree';
   return null;
 }
 

--- a/lib/run-plan.js
+++ b/lib/run-plan.js
@@ -1,0 +1,32 @@
+/**
+ * The single canonical run-mode resolver.
+ *
+ * Every consumer (orchestrator, daemon startup, CLI label) derives isolation,
+ * delivery, and autoMerge from THIS function and nowhere else. The raw
+ * worktree/docker/pr/ship/autoMerge booleans are inputs; the frozen plan is the
+ * one truth. Deriving autoMerge separately (the old `Boolean(ship)` scatter) is
+ * what let `--pr` merge and let the run-mode label drift from behavior.
+ */
+
+function resolveIsolation(options) {
+  if (options.docker) return 'docker';
+  if (options.worktree || options.pr || options.ship) return 'worktree';
+  return 'none';
+}
+
+function resolveDelivery(options) {
+  // Explicit autoMerge (e.g. a future `--auto-merge` flag) is ship-equivalent:
+  // "merge it" implies the ship delivery. This is the ONLY place that intent is
+  // interpreted, so it can never be silently overwritten downstream.
+  if (options.ship || options.autoMerge === true) return 'ship';
+  if (options.pr) return 'pr';
+  return 'none';
+}
+
+function resolveRunPlan(options = {}) {
+  const isolation = resolveIsolation(options);
+  const delivery = resolveDelivery(options);
+  return Object.freeze({ isolation, delivery, autoMerge: delivery === 'ship' });
+}
+
+module.exports = { resolveRunPlan };

--- a/lib/start-cluster.js
+++ b/lib/start-cluster.js
@@ -6,6 +6,7 @@ const { getProvider } = require('../src/providers');
 const { detectProvider } = require('../src/issue-providers');
 const TemplateResolver = require('../src/template-resolver');
 const { resolveRunMode } = require('./run-mode');
+const { resolveRunPlan } = require('./run-plan');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 
@@ -245,7 +246,7 @@ function buildStartOptions({
     isolationImage: firstTruthy(mergedOptions.dockerImage, process.env.ZEROSHOT_DOCKER_IMAGE),
     worktree: anyTruthy(mergedOptions.worktree, process.env.ZEROSHOT_WORKTREE === '1'),
     autoPr: anyTruthy(mergedOptions.pr, process.env.ZEROSHOT_PR === '1'),
-    autoMerge: Boolean(mergedOptions.ship),
+    autoMerge: resolveRunPlan(mergedOptions).autoMerge,
     autoPush: process.env.ZEROSHOT_PUSH === '1',
     modelOverride: optionalValue(modelOverride),
     providerOverride: optionalValue(providerOverride),

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -47,6 +47,7 @@ const configValidator = require('./config-validator');
 const TemplateResolver = require('./template-resolver');
 const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
+const { resolveRunPlan } = require('../lib/run-plan');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
@@ -212,14 +213,11 @@ function applyPushBlockedRepairTriggers(config) {
   }
 }
 
-function resolveAutoMerge(options) {
-  return Boolean(options.ship) || Boolean(options.autoMerge);
-}
-
 function buildPrOptions(options, requiredQualityGates) {
   // autoMerge must always be persisted (even when no other PR fields are set) so that
   // `zeroshot run --pr` (autoMerge=false) vs `--ship` (autoMerge=true) survives resume.
-  const autoMerge = resolveAutoMerge(options);
+  // Derived from the canonical run plan — never recomputed from ship/pr here.
+  const autoMerge = resolveRunPlan(options).autoMerge;
 
   return {
     prBase: options.prBase || null,
@@ -1825,7 +1823,7 @@ class Orchestrator {
       mergeQueue: options.mergeQueue,
       closeIssue: options.closeIssue,
       requiredQualityGates: options.requiredQualityGates,
-      autoMerge: resolveAutoMerge(options),
+      autoMerge: resolveRunPlan(options).autoMerge,
       cwd: options.cwd,
     });
 
@@ -4103,7 +4101,7 @@ Continue from where you left off. Review your previous output to understand what
 
 // Exported for testing (PR options persistence, e.g. autoMerge for --pr vs --ship).
 Orchestrator.buildPrOptions = buildPrOptions;
-Orchestrator.resolveAutoMerge = resolveAutoMerge;
+Orchestrator.resolveRunPlan = resolveRunPlan;
 
 module.exports = Orchestrator;
 module.exports.DuplicateClusterError = DuplicateClusterError;

--- a/tests/git-pusher-pr-mode.test.js
+++ b/tests/git-pusher-pr-mode.test.js
@@ -122,23 +122,25 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
     assert.notStrictEqual(prOptionsForPr, null);
   });
 
-  it('resolveAutoMerge is the single source for the autoMerge decision', function () {
-    assert.strictEqual(Orchestrator.resolveAutoMerge({ ship: true }), true);
-    assert.strictEqual(Orchestrator.resolveAutoMerge({ pr: true }), false);
-    assert.strictEqual(Orchestrator.resolveAutoMerge({ pr: true, autoMerge: true }), true);
+  it('resolveRunPlan is the single source for the autoMerge decision', function () {
+    assert.strictEqual(Orchestrator.resolveRunPlan({ ship: true }).autoMerge, true);
+    assert.strictEqual(Orchestrator.resolveRunPlan({ pr: true }).autoMerge, false);
+    // Explicit autoMerge is ship-equivalent and is NOT clobbered (the old
+    // normalizeRunOptions overwrite bug reset this to false).
+    assert.strictEqual(Orchestrator.resolveRunPlan({ pr: true, autoMerge: true }).autoMerge, true);
   });
 
-  it('buildPrOptions and git-pusher config cannot diverge (both derive from resolveAutoMerge)', function () {
+  it('buildPrOptions and git-pusher config cannot diverge (both derive from resolveRunPlan)', function () {
     const shipOptions = { ship: true };
     const prOptions = { pr: true };
 
     assert.strictEqual(
       Orchestrator.buildPrOptions(shipOptions, []).autoMerge,
-      Orchestrator.resolveAutoMerge(shipOptions)
+      Orchestrator.resolveRunPlan(shipOptions).autoMerge
     );
     assert.strictEqual(
       Orchestrator.buildPrOptions(prOptions, []).autoMerge,
-      Orchestrator.resolveAutoMerge(prOptions)
+      Orchestrator.resolveRunPlan(prOptions).autoMerge
     );
   });
 });

--- a/tests/unit/run-plan.test.js
+++ b/tests/unit/run-plan.test.js
@@ -1,0 +1,120 @@
+/**
+ * Test: resolveRunPlan (the single canonical run-mode resolver)
+ *
+ * Verifies isolation/delivery/autoMerge for every flag combination, and — the
+ * point of #582 — that the run-mode LABEL (resolveRunMode) is a pure view of the
+ * same plan, so the label and the behavior cannot drift.
+ */
+
+const assert = require('assert');
+const { resolveRunPlan } = require('../../lib/run-plan');
+const { resolveRunMode } = require('../../lib/run-mode');
+
+describe('resolveRunPlan', function () {
+  it('resolves {} to no isolation, no delivery', function () {
+    assert.deepStrictEqual(resolveRunPlan({}), {
+      isolation: 'none',
+      delivery: 'none',
+      autoMerge: false,
+    });
+  });
+
+  it('resolves {worktree: true}', function () {
+    assert.deepStrictEqual(resolveRunPlan({ worktree: true }), {
+      isolation: 'worktree',
+      delivery: 'none',
+      autoMerge: false,
+    });
+  });
+
+  it('resolves {docker: true}', function () {
+    assert.deepStrictEqual(resolveRunPlan({ docker: true }), {
+      isolation: 'docker',
+      delivery: 'none',
+      autoMerge: false,
+    });
+  });
+
+  it('resolves {pr: true} to pr delivery, no auto-merge', function () {
+    assert.deepStrictEqual(resolveRunPlan({ pr: true }), {
+      isolation: 'worktree',
+      delivery: 'pr',
+      autoMerge: false,
+    });
+  });
+
+  it('resolves {ship: true} to ship delivery with auto-merge', function () {
+    assert.deepStrictEqual(resolveRunPlan({ ship: true }), {
+      isolation: 'worktree',
+      delivery: 'ship',
+      autoMerge: true,
+    });
+  });
+
+  it('resolves {pr: true, docker: true}', function () {
+    assert.deepStrictEqual(resolveRunPlan({ pr: true, docker: true }), {
+      isolation: 'docker',
+      delivery: 'pr',
+      autoMerge: false,
+    });
+  });
+
+  it('resolves {ship: true, docker: true}', function () {
+    assert.deepStrictEqual(resolveRunPlan({ ship: true, docker: true }), {
+      isolation: 'docker',
+      delivery: 'ship',
+      autoMerge: true,
+    });
+  });
+
+  it('treats an explicit autoMerge as ship-equivalent (future --auto-merge flag)', function () {
+    // Regression for the normalizeRunOptions overwrite bug: an explicit
+    // autoMerge intent must survive, not be reset to false.
+    assert.deepStrictEqual(resolveRunPlan({ pr: true, autoMerge: true }), {
+      isolation: 'worktree',
+      delivery: 'ship',
+      autoMerge: true,
+    });
+  });
+
+  it('returns a frozen object', function () {
+    assert.strictEqual(Object.isFrozen(resolveRunPlan({})), true);
+  });
+
+  it('defaults options to {} when called with no arguments', function () {
+    assert.deepStrictEqual(resolveRunPlan(), {
+      isolation: 'none',
+      delivery: 'none',
+      autoMerge: false,
+    });
+  });
+});
+
+describe('resolveRunMode is a view of resolveRunPlan (cannot drift)', function () {
+  // Expected label derived ONLY from the plan. If resolveRunMode ever grows an
+  // independent cascade again, this binding breaks.
+  function labelFromPlan(options) {
+    const { isolation, delivery } = resolveRunPlan(options);
+    const suffix = isolation === 'docker' ? '+docker' : '';
+    if (delivery === 'ship') return `ship${suffix}`;
+    if (delivery === 'pr') return `pr${suffix}`;
+    if (isolation === 'docker') return 'docker';
+    if (isolation === 'worktree') return 'worktree';
+    return null;
+  }
+
+  it('agrees with the plan across all 16 flag combinations', function () {
+    const flags = ['worktree', 'docker', 'pr', 'ship'];
+    for (let mask = 0; mask < 1 << flags.length; mask++) {
+      const options = {};
+      flags.forEach((f, i) => {
+        if (mask & (1 << i)) options[f] = true;
+      });
+      assert.strictEqual(
+        resolveRunMode(options),
+        labelFromPlan(options),
+        `run-mode label drifted from plan for ${JSON.stringify(options)}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What

Collapses the run-mode boolean soup into one canonical `RunPlan`, resolved once and consumed everywhere. Closes #582.

`autoMerge` was derived in **four** places, **three** different ways, and the user-facing run-mode label was a second independent cascade that could drift from actual behavior. `normalizeRunOptions` also unconditionally overwrote `options.autoMerge`, silently resetting any explicit intent.

## Changes

- **New `lib/run-plan.js`** — single resolver → `Object.freeze({ isolation, delivery, autoMerge })`. `autoMerge` is a derived property of `delivery === 'ship'`. An explicit `autoMerge` (e.g. a future `--auto-merge` flag) is ship-equivalent, so it can't be clobbered.
- **`lib/run-mode.js`** — `resolveRunMode` now derives its label from `resolveRunPlan`. Label and behavior share one producer and cannot drift.
- **`src/orchestrator.js`** — deleted `resolveAutoMerge`; both consumers read `resolveRunPlan(options).autoMerge`. Export is now `Orchestrator.resolveRunPlan`.
- **`lib/start-cluster.js`, `lib/detached-startup.js`** — `autoPr` / `autoMerge` derived from the plan, not recomputed from `ship`/`pr`.
- **`cli/index.js`** — removed the `normalizeRunOptions` `autoMerge` overwrite (the latent-reset bug).

## Behavior

**No change** to `--pr` / `--ship` / `--worktree` / `--docker`. `--pr` still opens a PR and never merges; `--ship` still merges. This is a shape fix, guarded by the existing behavior tests staying green.

## Tests

- `tests/unit/run-plan.test.js` — full truth table, explicit-autoMerge regression, and a **16-combination anti-drift test** binding `resolveRunMode` to `resolveRunPlan`.
- `tests/git-pusher-pr-mode.test.js` — single-source and non-divergence tests rewritten onto `resolveRunPlan`.
- `421 passing` across `tests/unit`; the four PR-mode/run-mode suites green; `eslint` 0 errors.

## Context

Supersedes the leftover half of #579's finding #1 (#580 relocated the derivation into helpers but did not consolidate it). Replaces the stale-based PR #584, which forked before #555/#580 and conflicted with `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
