### PR TITLE
fix: prefer opencode dir for worktrees

### DIFF
--- a/src/agent-cli-provider/adapters/opencode.ts
+++ b/src/agent-cli-provider/adapters/opencode.ts
@@ -84,6 +84,7 @@ function detectCliFeatures(helpText?: string | null): OpencodeCliFeatures {
     supportsJson: unknown ? true : /--format\b/.test(help),
     supportsModel: unknown ? true : /--model\b/.test(help),
     supportsVariant: unknown ? true : /--variant\b/.test(help),
+    supportsDir: unknown ? false : /--dir\b/.test(help),
     supportsCwd: unknown ? false : /--cwd\b/.test(help),
     supportsAutoApprove: false,
     unknown,
@@ -107,7 +108,9 @@ function addOpencodeOptionalArgs(args: string[], options: BuildProviderCommandOp
     args.push('--variant', options.modelSpec.reasoningEffort);
   }
 
-  if (options.cwd && features.supportsCwd) {
+  if (options.cwd && features.supportsDir) {
+    args.push('--dir', options.cwd);
+  } else if (options.cwd && features.supportsCwd) {
     args.push('--cwd', options.cwd);
   }
 }

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -23,6 +23,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsModel',
   'supportsJson',
   'supportsOutputSchema',
+  'supportsDir',
   'supportsCwd',
   'supportsConfigOverride',
   'supportsSkipGitRepoCheck',

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -76,6 +76,7 @@ export interface OpencodeCliFeatures extends BaseCliFeatures {
   readonly supportsJson: boolean;
   readonly supportsModel: boolean;
   readonly supportsVariant: boolean;
+  readonly supportsDir: boolean;
   readonly supportsCwd: boolean;
   readonly supportsAutoApprove: false;
 }
@@ -96,6 +97,7 @@ export interface CliFeatureOverrides {
   readonly supportsModel?: boolean;
   readonly supportsJson?: boolean;
   readonly supportsOutputSchema?: boolean;
+  readonly supportsDir?: boolean;
   readonly supportsCwd?: boolean;
   readonly supportsConfigOverride?: boolean;
   readonly supportsSkipGitRepoCheck?: boolean;

--- a/tests/agent-cli-provider/executable-contract-option-validation.test.js
+++ b/tests/agent-cli-provider/executable-contract-option-validation.test.js
@@ -30,6 +30,11 @@ const invalidNestedOptionCases = [
     options: { cliFeatures: { supportsCwd: 'true' } },
     field: 'options.cliFeatures.supportsCwd',
   },
+  {
+    name: 'cliFeatures supportsDir boolean',
+    options: { cliFeatures: { supportsDir: 'true' } },
+    field: 'options.cliFeatures.supportsDir',
+  },
   { name: 'modelSpec object', options: { modelSpec: 'level2' }, field: 'options.modelSpec' },
   {
     name: 'modelSpec level enum',

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -115,6 +115,7 @@ test('runtime Opencode command facade delegates to helper', () => {
     cliFeatures: {
       supportsJson: true,
       supportsVariant: true,
+      supportsDir: true,
       supportsCwd: true,
     },
   });
@@ -285,7 +286,11 @@ test('feature probing is deterministic from injected help text', () => {
   assert.equal(
     helper
       .getProviderAdapter('opencode')
-      .detectCliFeatures('opencode run --format --model --variant').supportsCwd,
+      .detectCliFeatures('opencode run --format --model --variant --dir --cwd').supportsDir,
+    true
+  );
+  assert.equal(
+    helper.getProviderAdapter('opencode').detectCliFeatures('opencode run --format').supportsCwd,
     false
   );
 });

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -226,6 +226,28 @@ describe('Opencode provider helper builder', function () {
     assert.ok(result.args.includes('--variant'));
     assert.ok(result.args.includes('high'));
   });
+
+  it('prefers --dir over --cwd when opencode supports both', function () {
+    const result = buildCommand('opencode', 'test', {
+      cwd: '/tmp/worktree',
+      cliFeatures: { supportsDir: true, supportsCwd: true },
+    });
+
+    assert.ok(result.args.includes('--dir'));
+    assert.ok(!result.args.includes('--cwd'));
+    assert.deepStrictEqual(result.args.slice(1, 3), ['--dir', '/tmp/worktree']);
+  });
+
+  it('falls back to --cwd when opencode does not support --dir', function () {
+    const result = buildCommand('opencode', 'test', {
+      cwd: '/tmp/worktree',
+      cliFeatures: { supportsDir: false, supportsCwd: true },
+    });
+
+    assert.ok(!result.args.includes('--dir'));
+    assert.ok(result.args.includes('--cwd'));
+    assert.deepStrictEqual(result.args.slice(1, 3), ['--cwd', '/tmp/worktree']);
+  });
 });
 
 describe('Claude provider helper builder', function () {


### PR DESCRIPTION
Fixes #530.\n\n## Summary\n- detect opencode --dir support as supportsDir\n- prefer --dir <cwd> over --cwd <cwd> so worktree runs stay rooted in the isolated worktree\n- keep --cwd fallback for older opencode CLIs\n\n## Verification\n- npm run build:agent-cli-provider\n- npx mocha tests/provider-cli-builder.test.js\n- node --test tests/agent-cli-provider/parity.test.js tests/agent-cli-provider/executable-contract-option-validation.test.js\n- npm run typecheck:agent-cli-provider\n- npx eslint src/agent-cli-provider/adapters/opencode.ts src/agent-cli-provider/contract-options.ts src/agent-cli-provider/types.ts tests/agent-cli-provider/parity.test.js tests/agent-cli-provider/executable-contract-option-validation.test.js tests/provider-cli-builder.test.js\n- git push pre-push hook: npm run lint (0 errors, existing warnings) and tsc --noEmit