### PR TITLE
feat: add Pi provider engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,9 @@ UX modes:
 - Daemon (`-d`): background, Ctrl+C detaches.
 - Attach (`zeroshot attach`): connect to daemon, Ctrl+C detaches only.
 
-Settings: `defaultProvider`, `providerSettings` (claude/codex/gemini/opencode), legacy `maxModel`, `defaultConfig`, `logLevel`, robustness (`maxRetries`, `backoffBaseMs`, `backoffMaxMs`, `jitterFactor`, `maxRestartAttempts`, `maxTotalRestarts`, `staleWarningsBeforeKill`).
+Settings: `defaultProvider`, `providerSettings` (claude/codex/gemini/opencode/pi), legacy `maxModel`, `defaultConfig`, `logLevel`, robustness (`maxRetries`, `backoffBaseMs`, `backoffMaxMs`, `jitterFactor`, `maxRestartAttempts`, `maxTotalRestarts`, `staleWarningsBeforeKill`).
 
-Provider engines are registry-owned: adding an engine means one entry in `src/agent-cli-provider/provider-registry.ts`, plus the provider-specific adapter and tests. Docker credential mount/env presets and visible preset lists must derive from that registry entry; do not add new provider identity lists or provider preset lists elsewhere.
+Provider engines are registry-owned: adding an engine means one entry in `src/agent-cli-provider/provider-registry.ts`, plus the provider-specific adapter and tests. Docker credential mount/env presets, CLI aliases, visible preset lists, and any nontrivial availability probe rules must derive from that registry entry; do not add new provider identity lists or provider preset lists elsewhere.
 
 ## Architecture
 
@@ -130,7 +130,7 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 
 - Use `modelLevel` (`level1`/`level2`/`level3`) for provider-agnostic configs.
 - Set `provider` per agent or `defaultProvider`/`forceProvider` at cluster level.
-- Provider names use CLI identifiers: `claude`, `codex`, `gemini` (legacy `anthropic`/`openai`/`google` map to these).
+- Provider names use CLI identifiers: `claude`, `codex`, `gemini`, `opencode`, `pi` (legacy `anthropic`/`openai`/`google` map to these).
 - `model` remains a provider-specific escape hatch.
 - Codex/Opencode only: `reasoningEffort` (`low|medium|high|xhigh`).
 

--- a/lib/provider-detection.js
+++ b/lib/provider-detection.js
@@ -36,6 +36,7 @@ function getHelpOutput(command, args = []) {
 
   const attempt = (flag) => {
     const result = spawnSync(command, [...args, flag], { encoding: 'utf8' });
+    if (result.status !== 0) return '';
     const output = `${result.stdout || ''}${result.stderr || ''}`;
     return output.trim();
   };
@@ -50,6 +51,7 @@ function getHelpOutput(command, args = []) {
 function getVersionOutput(command, args = []) {
   if (!commandExists(command)) return '';
   const result = spawnSync(command, [...args, '--version'], { encoding: 'utf8' });
+  if (result.status !== 0) return '';
   const output = `${result.stdout || ''}${result.stderr || ''}`;
   return output.trim();
 }

--- a/src/agent-cli-provider/adapters/pi.ts
+++ b/src/agent-cli-provider/adapters/pi.ts
@@ -1,0 +1,410 @@
+import { appendJsonSchemaPrompt } from '../schema';
+import { contractError } from '../contract-errors';
+import {
+  getArray,
+  getBoolean,
+  getNumber,
+  getOptionalString,
+  getRecord,
+  getString,
+  isRecord,
+  tryParseJson,
+  unknownToMessage,
+} from '../json';
+import {
+  type BuildProviderCommandOptions,
+  type CommandSpec,
+  type ErrorClassification,
+  type LevelModelSpec,
+  type LevelOverrides,
+  type ModelCatalogEntry,
+  type ModelLevel,
+  type OutputEvent,
+  type PiCliFeatures,
+  type ProviderAdapter,
+  type ProviderParserState,
+  type ResolvedModelSpec,
+  type WarningMetadata,
+} from '../types';
+import {
+  classifyBaseProviderError,
+  commandSpec,
+  createParserState,
+  optionFeatures,
+  resolveModelSpecWithConfig,
+  warning,
+} from './common';
+
+const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {};
+
+const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
+  level1: { rank: 1, model: null },
+  level2: { rank: 2, model: null },
+  level3: { rank: 3, model: null },
+};
+
+const IGNORED_EVENT_TYPES = new Set([
+  'session',
+  'agent_start',
+  'agent_end',
+  'turn_start',
+  'queue_update',
+  'compaction_start',
+  'compaction_end',
+  'auto_retry_start',
+  'auto_retry_end',
+]);
+
+function detectCliFeatures(helpText?: string | null): PiCliFeatures {
+  const help = helpText ?? '';
+  const unknown = !help;
+  return {
+    provider: 'pi',
+    supportsJsonMode: unknown ? true : /--mode\b/.test(help) && /\bjson\b/.test(help),
+    supportsModel: unknown ? true : /--model\b/.test(help),
+    supportsNoSession: unknown ? true : /--no-session\b/.test(help),
+    supportsNoExtensions: unknown ? true : /--no-extensions\b/.test(help),
+    supportsNoSkills: unknown ? true : /--no-skills\b/.test(help),
+    supportsNoPromptTemplates: unknown ? true : /--no-prompt-templates\b/.test(help),
+    supportsNoContextFiles: unknown ? true : /--no-context-files\b/.test(help),
+    supportsNoApprove: unknown ? true : /--no-approve\b/.test(help),
+    unknown,
+  };
+}
+
+function addRequiredArgs(args: string[], options: BuildProviderCommandOptions): void {
+  const features = optionFeatures(options);
+  if (features.supportsJsonMode !== false) args.push('--mode', 'json');
+  if (features.supportsNoSession !== false) args.push('--no-session');
+  if (features.supportsNoExtensions !== false) args.push('--no-extensions');
+  if (features.supportsNoSkills !== false) args.push('--no-skills');
+  if (features.supportsNoPromptTemplates !== false) args.push('--no-prompt-templates');
+  if (features.supportsNoContextFiles !== false) args.push('--no-context-files');
+  if (features.supportsNoApprove !== false) args.push('--no-approve');
+}
+
+function addOptionalArgs(args: string[], options: BuildProviderCommandOptions): void {
+  const features = optionFeatures(options);
+  if (options.modelSpec?.model && features.supportsModel !== false) {
+    args.push('--model', options.modelSpec.model);
+  }
+}
+
+function failClosedUnsupportedSessionControl(options: BuildProviderCommandOptions): void {
+  const hasResumeSessionId = options.resumeSessionId !== undefined;
+  if (!hasResumeSessionId && !options.continueSession) return;
+  const field = hasResumeSessionId ? 'options.resumeSessionId' : 'options.continueSession';
+  throw contractError({
+    code: 'invalid-field',
+    field,
+    exitCode: 2,
+    message:
+      'Pi CLI does not support resume/continue session control; fail closed and start a fresh run instead.',
+  });
+}
+
+function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
+  const features = optionFeatures(options);
+  const warnings: WarningMetadata[] = [];
+
+  if (options.jsonSchema) {
+    warnings.push(
+      warning(
+        'pi',
+        'pi-jsonschema',
+        'Pi CLI does not support provider-native JSON schema; appending schema instructions to the prompt.'
+      )
+    );
+  }
+  if (features.supportsJsonMode === false) {
+    warnings.push(
+      warning('pi', 'pi-json-mode', 'Pi CLI does not advertise --mode json; continuing anyway.')
+    );
+  }
+  return warnings;
+}
+
+function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
+  failClosedUnsupportedSessionControl(options);
+  const finalContext = options.jsonSchema
+    ? appendJsonSchemaPrompt(context, options.jsonSchema)
+    : context;
+  const args: string[] = [];
+
+  addRequiredArgs(args, options);
+  addOptionalArgs(args, options);
+  args.push(finalContext);
+
+  return commandSpec({
+    binary: 'pi',
+    args,
+    env: {},
+    ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+    warnings: collectWarnings(options),
+  });
+}
+
+function createPiState(): ProviderParserState {
+  return {
+    ...createParserState('pi'),
+    lastAssistantText: '',
+    lastAssistantThinking: '',
+  };
+}
+
+function assistantSnapshot(message: Record<string, unknown>): { text: string; thinking: string } {
+  if (getString(message, 'role') !== 'assistant') return { text: '', thinking: '' };
+
+  let text = '';
+  let thinking = '';
+  for (const item of getArray(message, 'content')) {
+    if (!isRecord(item)) continue;
+    const type = getString(item, 'type');
+    if (type === 'text') {
+      text += getString(item, 'text') ?? '';
+    } else if (type === 'thinking') {
+      thinking += getString(item, 'thinking') ?? '';
+    }
+  }
+
+  return { text, thinking };
+}
+
+function snapshotDelta(previous: string, current: string): string | null {
+  if (!current) return null;
+  if (previous === current) return null;
+  if (current.startsWith(previous)) return current.slice(previous.length) || null;
+  return current;
+}
+
+function emitAssistantSnapshot(
+  message: Record<string, unknown>,
+  state: ProviderParserState
+): readonly OutputEvent[] {
+  const snapshot = assistantSnapshot(message);
+  const events: OutputEvent[] = [];
+
+  const textDelta = snapshotDelta(state.lastAssistantText ?? '', snapshot.text);
+  if (textDelta) events.push({ type: 'text', text: textDelta });
+  state.lastAssistantText = snapshot.text;
+
+  const thinkingDelta = snapshotDelta(state.lastAssistantThinking ?? '', snapshot.thinking);
+  if (thinkingDelta) events.push({ type: 'thinking', text: thinkingDelta });
+  state.lastAssistantThinking = snapshot.thinking;
+
+  return events;
+}
+
+function parseAssistantEvent(
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): OutputEvent | null {
+  const type = getString(event, 'type');
+  if (type === 'text_delta') {
+    const delta = getString(event, 'delta');
+    if (!delta) return null;
+    state.lastAssistantText += delta;
+    return { type: 'text', text: delta };
+  }
+  if (type === 'thinking_delta') {
+    const delta = getString(event, 'delta');
+    if (!delta) return null;
+    state.lastAssistantThinking += delta;
+    return { type: 'thinking', text: delta };
+  }
+  return null;
+}
+
+function parseToolExecutionStart(
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): OutputEvent {
+  const toolId = getOptionalString(event, 'toolCallId');
+  state.lastToolId = toolId;
+  return {
+    type: 'tool_call',
+    toolName: getOptionalString(event, 'toolName'),
+    toolId,
+    input: event.args ?? {},
+  };
+}
+
+function parseToolExecutionUpdate(
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): OutputEvent | null {
+  const toolId = getOptionalString(event, 'toolCallId') ?? state.lastToolId;
+  if (toolId !== undefined) state.lastToolId = toolId;
+  if (!Object.prototype.hasOwnProperty.call(event, 'partialResult')) return null;
+  return {
+    type: 'tool_result',
+    toolId,
+    content: event.partialResult,
+    isError: false,
+  };
+}
+
+function parseToolExecutionEnd(
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): OutputEvent {
+  const toolId = getOptionalString(event, 'toolCallId') ?? state.lastToolId;
+  return {
+    type: 'tool_result',
+    toolId,
+    content: event.result ?? '',
+    isError: getBoolean(event, 'isError') ?? false,
+  };
+}
+
+function parseTurnEnd(
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): readonly OutputEvent[] {
+  const message = getRecord(event, 'message');
+  const events: OutputEvent[] = [];
+  if (message !== null) {
+    events.push(...emitAssistantSnapshot(message, state));
+  }
+
+  const usage = message ? getRecord(message, 'usage') ?? {} : {};
+  const stopReason = message ? getString(message, 'stopReason') : null;
+  const errorMessage = message ? getString(message, 'errorMessage') : null;
+  const snapshot = message ? assistantSnapshot(message) : { text: '', thinking: '' };
+  const success = stopReason !== 'error' && stopReason !== 'aborted' && !errorMessage;
+  events.push({
+    type: 'result',
+    success,
+    result: success ? snapshot.text || null : null,
+    error: success ? null : (errorMessage ?? stopReason ?? 'Pi turn failed'),
+    inputTokens: getNumber(usage, 'input') ?? 0,
+    outputTokens: getNumber(usage, 'output') ?? 0,
+    cacheReadInputTokens: getNumber(usage, 'cacheRead') ?? 0,
+    cacheCreationInputTokens: getNumber(usage, 'cacheWrite') ?? 0,
+    cost: getRecord(usage, 'cost') ?? null,
+    modelUsage: usage,
+  });
+  return events;
+}
+
+function parseMessageEvent(
+  type: string,
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): readonly OutputEvent[] | OutputEvent | null | undefined {
+  if (type === 'message_start') {
+    const message = getRecord(event, 'message');
+    if (message !== null && getString(message, 'role') === 'assistant') {
+      state.lastAssistantText = '';
+      state.lastAssistantThinking = '';
+    }
+    return null;
+  }
+
+  if (type === 'message_update') {
+    const assistantMessageEvent = getRecord(event, 'assistantMessageEvent');
+    if (assistantMessageEvent !== null) {
+      const assistantEvent = parseAssistantEvent(assistantMessageEvent, state);
+      if (assistantEvent !== null) return assistantEvent;
+    }
+    const message = getRecord(event, 'message');
+    return message === null ? null : emitAssistantSnapshot(message, state);
+  }
+
+  if (type !== 'message_end') return undefined;
+  const message = getRecord(event, 'message');
+  return message === null ? null : emitAssistantSnapshot(message, state);
+}
+
+function parseToolEvent(
+  type: string,
+  event: Record<string, unknown>,
+  state: ProviderParserState
+): OutputEvent | null | undefined {
+  if (type === 'tool_execution_start') return parseToolExecutionStart(event, state);
+  if (type === 'tool_execution_update') return parseToolExecutionUpdate(event, state);
+  if (type === 'tool_execution_end') return parseToolExecutionEnd(event, state);
+  return undefined;
+}
+
+function parseEvent(
+  line: string,
+  state: ProviderParserState
+): readonly OutputEvent[] | OutputEvent | null {
+  const parsed = tryParseJson(line);
+  if (!isRecord(parsed)) return null;
+
+  const type = getString(parsed, 'type');
+  if (type === null || IGNORED_EVENT_TYPES.has(type)) return null;
+
+  const messageEvent = parseMessageEvent(type, parsed, state);
+  if (messageEvent !== undefined) return messageEvent;
+
+  const toolEvent = parseToolEvent(type, parsed, state);
+  if (toolEvent !== undefined) return toolEvent;
+
+  if (type === 'turn_end') return parseTurnEnd(parsed, state);
+  return null;
+}
+
+function resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec {
+  return resolveModelSpecWithConfig({
+    mapping: LEVEL_MAPPING,
+    defaultLevel: 'level2',
+    level,
+    overrides,
+    validateModelId,
+  });
+}
+
+function validateModelId(modelId: string | null | undefined): string | null | undefined {
+  if (modelId === undefined || modelId === null) return modelId;
+  if (typeof modelId !== 'string') {
+    throw new Error(`Invalid model "${unknownToMessage(modelId)}" for provider "pi".`);
+  }
+  return modelId;
+}
+
+function classifyError(error: unknown): ErrorClassification {
+  return classifyBaseProviderError(
+    error,
+    [
+      /\brate(?:[_ -]?limit| limited)\b/i,
+      /\bquota\b/i,
+      /\bresource[_ -]?exhausted\b/i,
+      /\btemporar(?:y|ily)\b/i,
+      /\boverloaded\b/i,
+      /\bservice unavailable\b/i,
+    ],
+    [
+      /\b(cancelled|canceled|aborted|interrupted)\b/i,
+      /\brun\s*\/login\b/i,
+      /\bmissing api key\b/i,
+      /\bno valid authentication\b/i,
+      /\bunknown option\b/i,
+      /\bfailed to load\b/i,
+      /\bcannot find module\b/i,
+      /\bno such file or directory\b/i,
+    ]
+  );
+}
+
+export const piAdapter: ProviderAdapter = {
+  id: 'pi',
+  displayName: 'Pi',
+  binary: 'pi',
+  adapterVersion: '1',
+  credentialEnvKeys: [],
+  modelCatalog: MODEL_CATALOG,
+  levelMapping: LEVEL_MAPPING,
+  defaultLevel: 'level2',
+  defaultMaxLevel: 'level3',
+  defaultMinLevel: 'level1',
+  detectCliFeatures,
+  buildCommand,
+  parseEvent,
+  createParserState: createPiState,
+  resolveModelSpec,
+  validateModelId,
+  classifyError,
+};

--- a/src/agent-cli-provider/contract-actions.ts
+++ b/src/agent-cli-provider/contract-actions.ts
@@ -15,7 +15,7 @@ import {
   schemaMode,
   type RequestData,
 } from './contract-support';
-import { detectRuntimeProviderCliFeatures } from './single-agent-runtime';
+import { probeRuntimeProviderCli } from './single-agent-runtime';
 import { getNumber, getRecord, getString, isRecord, unknownToMessage } from './json';
 import type { ErrorClassification } from './types';
 import type { ProcessRunner } from './process-runner';
@@ -42,8 +42,11 @@ function runBuildCommand(request: RequestData): ContractEnvelope {
 function runProbe(request: RequestData): ContractEnvelope {
   const adapter = adapterForProvider(request.provider);
   const helpText = typeof request.raw.helpText === 'string' ? request.raw.helpText : null;
+  const runtimeProbe = helpText === null ? probeRuntimeProviderCli(adapter.id) : null;
   const capabilities =
-    helpText === null ? detectRuntimeProviderCliFeatures(adapter.id) : adapter.detectCliFeatures(helpText);
+    runtimeProbe === null
+      ? adapter.detectCliFeatures(helpText)
+      : runtimeProbe.capabilities;
   return successEnvelope({
     command: request.command ?? 'probe',
     adapter,
@@ -56,6 +59,9 @@ function runProbe(request: RequestData): ContractEnvelope {
       },
       contractVersion: providerExecutableSchemaVersion,
       adapterVersion: adapter.adapterVersion,
+      available: runtimeProbe?.available ?? true,
+      helpText: runtimeProbe?.helpText ?? helpText,
+      versionText: runtimeProbe?.versionText ?? null,
       capabilities,
       credentials: adapter.credentialEnvKeys.map((key) => ({
         key,

--- a/src/agent-cli-provider/contract-invoke.ts
+++ b/src/agent-cli-provider/contract-invoke.ts
@@ -62,7 +62,7 @@ export async function runInvoke(
       { name: 'stderr', value: result.stderr },
     ],
   });
-  const classification = providerFailureClassification(adapter, result);
+  const classification = providerFailureClassification(adapter, result, parsed.events);
   return successEnvelope({
     command: request.command ?? 'invoke',
     adapter,

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -28,6 +28,13 @@ const CLI_FEATURE_FIELDS = [
   'supportsConfigOverride',
   'supportsSkipGitRepoCheck',
   'supportsVariant',
+  'supportsJsonMode',
+  'supportsNoSession',
+  'supportsNoExtensions',
+  'supportsNoSkills',
+  'supportsNoPromptTemplates',
+  'supportsNoContextFiles',
+  'supportsNoApprove',
   'unknown',
 ] as const;
 

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -35,7 +35,9 @@ export {
 export {
   detectRuntimeProviderCliFeatures,
   prepareSingleAgentProviderCommand,
+  probeRuntimeProviderCli,
   type PreparedSingleAgentProviderCommand,
+  type RuntimeProviderProbe,
   type SingleAgentProviderCommandInput,
 } from './single-agent-runtime';
 export {
@@ -72,6 +74,7 @@ export type {
   OpencodeCliFeatures,
   OutputEvent,
   OutputFormat,
+  PiCliFeatures,
   ProviderAdapter,
   ProviderCapabilities,
   ProviderCapabilityState,

--- a/src/agent-cli-provider/invoke-evidence.ts
+++ b/src/agent-cli-provider/invoke-evidence.ts
@@ -1,17 +1,38 @@
 import { classifyProviderError } from './adapters';
 import type { ProcessResult } from './process-runner';
-import type { ErrorClassification, ProviderAdapter } from './types';
+import type { ErrorClassification, OutputEvent, ProviderAdapter, ResultEvent } from './types';
+
+function isFailedResultEvent(event: OutputEvent): event is ResultEvent {
+  return event.type === 'result' && event.success === false;
+}
+
+function classifyParsedFailure(
+  adapter: ProviderAdapter,
+  events: readonly OutputEvent[]
+): ErrorClassification | null {
+  const failedResult = [...events].reverse().find(isFailedResultEvent);
+  if (failedResult === undefined) return null;
+  return classifyProviderError(adapter.id, {
+    message:
+      typeof failedResult.error === 'string' && failedResult.error.trim()
+        ? failedResult.error
+        : 'Provider reported a failed result event.',
+  });
+}
 
 export function providerFailureClassification(
   adapter: ProviderAdapter,
-  result: ProcessResult
+  result: ProcessResult,
+  events: readonly OutputEvent[] = []
 ): ErrorClassification | null {
   if (result.timedOut) {
     return classifyProviderError(adapter.id, {
       message: `Provider timed out after ${result.timeoutMs ?? 'unknown'}ms`,
     });
   }
-  if (result.exitCode === 0 && result.signal === null) return null;
+  if (result.exitCode === 0 && result.signal === null) {
+    return classifyParsedFailure(adapter, events);
+  }
   return classifyProviderError(adapter.id, {
     message: result.stderr || result.stdout || `Provider exited with code ${result.exitCode ?? ''}`,
   });

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -2,6 +2,7 @@ import { claudeAdapter } from './adapters/claude';
 import { codexAdapter } from './adapters/codex';
 import { geminiAdapter } from './adapters/gemini';
 import { opencodeAdapter } from './adapters/opencode';
+import { piAdapter } from './adapters/pi';
 import { resolveClaudeCommand } from './claude-command';
 import type { ModelLevel, ProviderAdapter } from './types';
 
@@ -56,6 +57,7 @@ export interface ProviderRegistryEntry {
   readonly credentialPaths: readonly string[];
   readonly credentialEnvKeys: readonly string[];
   readonly settingsFields: readonly string[];
+  readonly availabilityProbe?: 'command' | 'help-or-version';
   readonly capabilities: ProviderCapabilities;
   readonly docs: ProviderDocsMetadata;
   readonly docker: ProviderDockerMetadata;
@@ -225,6 +227,44 @@ export const providerRegistry = [
       max: opencodeAdapter.defaultMaxLevel,
     },
     adapter: opencodeAdapter,
+  },
+  {
+    id: 'pi',
+    aliases: [],
+    displayName: 'Pi',
+    binary: 'pi',
+    command: { kind: 'fixed', command: 'pi', args: [] },
+    installInstructions:
+      'npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.3',
+    authInstructions: 'pi\n/login',
+    credentialPaths: ['~/.pi'],
+    credentialEnvKeys: piAdapter.credentialEnvKeys,
+    settingsFields: [],
+    availabilityProbe: 'help-or-version',
+    capabilities: {
+      ...STANDARD_CAPABILITIES,
+      mcpServers: false,
+      jsonSchema: false,
+      reasoningEffort: false,
+    },
+    docs: {
+      label: 'Pi',
+      setupHeading: 'Pi Setup',
+    },
+    docker: {
+      mount: {
+        host: '~/.pi',
+        container: '$HOME/.pi',
+        readonly: true,
+      },
+      envPassthrough: [],
+    },
+    defaultLevels: {
+      min: piAdapter.defaultMinLevel,
+      default: piAdapter.defaultLevel,
+      max: piAdapter.defaultMaxLevel,
+    },
+    adapter: piAdapter,
   },
 ] as const satisfies readonly ProviderRegistryEntry[];
 

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -1,6 +1,10 @@
 import { getProviderAdapter } from './adapters';
 import { isRecord } from './json';
-import { resolveProviderCommand } from './provider-registry';
+import {
+  getProviderRegistryEntry,
+  resolveProviderCommand,
+  supportsProviderCapability,
+} from './provider-registry';
 import type {
   BuildProviderCommandOptions,
   CliFeatureOverrides,
@@ -39,6 +43,13 @@ export interface PreparedSingleAgentProviderCommand {
   readonly cliFeatures: CliFeatureOverrides;
 }
 
+export interface RuntimeProviderProbe {
+  readonly available: boolean;
+  readonly helpText: string;
+  readonly versionText: string;
+  readonly capabilities: ProviderCliFeatures;
+}
+
 type MutableModelSpec = {
   level?: ModelLevel;
   model?: string | null;
@@ -54,7 +65,9 @@ const claudeAuthModule: unknown = require('../../lib/settings/claude-auth');
 
 const loadSettingsFn = moduleFunction(settingsModule, 'loadSettings');
 const getClaudeCommandFn = moduleFunction(settingsModule, 'getClaudeCommand');
+const commandExistsFn = moduleFunction(providerDetectionModule, 'commandExists');
 const getHelpOutputFn = moduleFunction(providerDetectionModule, 'getHelpOutput');
+const getVersionOutputFn = moduleFunction(providerDetectionModule, 'getVersionOutput');
 const resolveClaudeAuthFn = moduleFunction(claudeAuthModule, 'resolveClaudeAuth');
 
 export function prepareSingleAgentProviderCommand(
@@ -76,10 +89,32 @@ export function prepareSingleAgentProviderCommand(
 }
 
 export function detectRuntimeProviderCliFeatures(provider: string): ProviderCliFeatures {
+  return probeRuntimeProviderCli(provider).capabilities;
+}
+
+export function probeRuntimeProviderCli(provider: string): RuntimeProviderProbe {
   const adapter = getProviderAdapter(provider);
   const helpCommand = runtimeHelpCommand(adapter.id);
-  const helpText = stringResult(getHelpOutputFn(helpCommand.command, helpCommand.args));
-  return adapter.detectCliFeatures(helpText);
+  const commandAvailable = booleanResult(commandExistsFn(helpCommand.command));
+  if (!commandAvailable) {
+    return {
+      available: false,
+      helpText: '',
+      versionText: '',
+      capabilities: adapter.detectCliFeatures(''),
+    };
+  }
+
+  const helpText = stringResult(getHelpOutputFn(helpCommand.command, helpCommand.args)).trim();
+  const versionText = stringResult(getVersionOutputFn(helpCommand.command, helpCommand.args)).trim();
+  const availabilityProbe = getProviderRegistryEntry(adapter.id).availabilityProbe ?? 'command';
+
+  return {
+    available: availabilityProbe === 'help-or-version' ? Boolean(helpText || versionText) : true,
+    helpText,
+    versionText,
+    capabilities: adapter.detectCliFeatures(helpText),
+  };
 }
 
 function buildRuntimeOptions(
@@ -94,6 +129,12 @@ function buildRuntimeOptions(
     modelSpec: resolveRuntimeModelSpec(adapter, baseOptions.modelSpec, providerSettings),
     cliFeatures,
   };
+  if (baseOptions.jsonSchema && !supportsProviderCapability(adapter.id, 'jsonSchema')) {
+    if (!shouldIncludeAuthEnv(baseOptions, authEnv)) {
+      return { ...resolved, strictSchema: false };
+    }
+    return { ...resolved, authEnv, strictSchema: false };
+  }
   if (!shouldIncludeAuthEnv(baseOptions, authEnv)) return resolved;
   return { ...resolved, authEnv };
 }
@@ -305,4 +346,9 @@ function stringArray(value: unknown, field: string): readonly string[] {
 function stringResult(value: unknown): string {
   if (typeof value === 'string') return value;
   throw new Error('Provider help output must be a string.');
+}
+
+function booleanResult(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  throw new Error('Provider availability probe must return a boolean.');
 }

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -102,11 +102,24 @@ export interface OpencodeCliFeatures extends BaseCliFeatures {
   readonly supportsAutoApprove: false;
 }
 
+export interface PiCliFeatures extends BaseCliFeatures {
+  readonly provider: 'pi';
+  readonly supportsJsonMode: boolean;
+  readonly supportsModel: boolean;
+  readonly supportsNoSession: boolean;
+  readonly supportsNoExtensions: boolean;
+  readonly supportsNoSkills: boolean;
+  readonly supportsNoPromptTemplates: boolean;
+  readonly supportsNoContextFiles: boolean;
+  readonly supportsNoApprove: boolean;
+}
+
 export type ProviderCliFeatures =
   | ClaudeCliFeatures
   | CodexCliFeatures
   | GeminiCliFeatures
-  | OpencodeCliFeatures;
+  | OpencodeCliFeatures
+  | PiCliFeatures;
 
 export interface CliFeatureOverrides {
   readonly supportsOutputFormat?: boolean;
@@ -123,6 +136,13 @@ export interface CliFeatureOverrides {
   readonly supportsConfigOverride?: boolean;
   readonly supportsSkipGitRepoCheck?: boolean;
   readonly supportsVariant?: boolean;
+  readonly supportsJsonMode?: boolean;
+  readonly supportsNoSession?: boolean;
+  readonly supportsNoExtensions?: boolean;
+  readonly supportsNoSkills?: boolean;
+  readonly supportsNoPromptTemplates?: boolean;
+  readonly supportsNoContextFiles?: boolean;
+  readonly supportsNoApprove?: boolean;
   readonly unknown?: boolean;
 }
 
@@ -212,8 +232,10 @@ export type OutputEvent = TextEvent | ThinkingEvent | ToolCallEvent | ToolResult
 export type ProviderParseResult = OutputEvent | readonly OutputEvent[] | null;
 
 export interface ProviderParserState {
-  provider: ProviderId;
+  readonly provider: ProviderId;
   lastToolId: string | null | undefined;
+  lastAssistantText?: string;
+  lastAssistantThinking?: string;
 }
 
 export type ErrorClassificationKind =

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -442,12 +442,30 @@ function validateRegistryCliProvider(providerName) {
   const metadata = getProviderMetadata(providerName);
   const { command } = resolveProviderCommand(providerName);
   const installSteps = metadata.installInstructions.split('\n').filter(Boolean);
-  return validateCliProvider(
-    command,
-    `${metadata.displayName} CLI not available`,
-    `Command "${command}" not installed`,
-    [...installSteps, `Then run: ${command} --version`]
-  );
+  if (!commandExists(command)) {
+    return validateCliProvider(
+      command,
+      `${metadata.displayName} CLI not available`,
+      `Command "${command}" not installed`,
+      [...installSteps, `Then run: ${command} --version`]
+    );
+  }
+
+  const { getProvider } = require('./providers');
+  if (getProvider(providerName).isAvailable()) {
+    return { errors: [], warnings: [] };
+  }
+
+  return {
+    errors: [
+      formatError(
+        `${metadata.displayName} CLI not available`,
+        `Command "${command}" is installed but did not produce usable --help/--version output`,
+        [...installSteps, `Then run: ${command} --version`]
+      ),
+    ],
+    warnings: [],
+  };
 }
 
 function validateGhRequirement() {

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -34,7 +34,8 @@ class RuntimeProvider extends BaseProvider {
 
   isAvailable() {
     const { command } = resolveProviderCommand(this.name);
-    return commandExists(command);
+    if (!commandExists(command)) return false;
+    return helper.probeRuntimeProviderCli(this.name).available;
   }
 
   getCliPath() {

--- a/tests/agent-cli-provider/architecture.test.js
+++ b/tests/agent-cli-provider/architecture.test.js
@@ -26,6 +26,7 @@ const providerPolicyNames = [
   'codex',
   'gemini',
   'opencode',
+  'pi',
   'anthropic',
   'openai',
   'google',
@@ -175,7 +176,7 @@ test('docker preset surfaces derive provider entries from registry', () => {
   assert.match(dockerSource, /listProviderMetadata\(\)/);
   assert.doesNotMatch(
     dockerSource,
-    /claude:\s*\{[\s\S]*codex:\s*\{[\s\S]*gemini:\s*\{[\s\S]*opencode:\s*\{/m
+    /claude:\s*\{[\s\S]*codex:\s*\{[\s\S]*gemini:\s*\{[\s\S]*opencode:\s*\{[\s\S]*pi:\s*\{/m
   );
   assert.match(cliSource, /Object\.keys\(MOUNT_PRESETS\)\.join\(', '\)/);
 });

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const {
   assertNoSecret,
   fakeCodexScript,
+  fakePiScript,
   runExecutable,
   withFakeProviderCli,
   withTempEnv,
@@ -185,6 +186,172 @@ process.exit(17);
   );
 });
 
+test('build-command uses Pi JSON mode with discovery disabled and schema prompt fallback', () => {
+  const response = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'pi',
+    context: 'Return JSON.',
+    options: {
+      outputFormat: 'json',
+      cwd: '/tmp/worktree',
+      jsonSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+      modelSpec: { model: 'openai/gpt-5.5' },
+      cliFeatures: {
+        supportsJsonMode: true,
+        supportsNoSession: true,
+        supportsNoExtensions: true,
+        supportsNoSkills: true,
+        supportsNoPromptTemplates: true,
+        supportsNoContextFiles: true,
+        supportsNoApprove: true,
+        supportsModel: true,
+      },
+    },
+  });
+
+  const { commandSpec } = response.envelope.result;
+  assert.equal(response.exitCode, 0);
+  assert.equal(response.envelope.ok, true);
+  assert.equal(response.envelope.result.schemaMode, 'prompt');
+  assert.equal(commandSpec.binary, 'pi');
+  assert.equal(commandSpec.cwd, '/tmp/worktree');
+  assert.deepEqual(commandSpec.args.slice(0, 11), [
+    '--mode',
+    'json',
+    '--no-session',
+    '--no-extensions',
+    '--no-skills',
+    '--no-prompt-templates',
+    '--no-context-files',
+    '--no-approve',
+    '--model',
+    'openai/gpt-5.5',
+    commandSpec.args.at(-1),
+  ]);
+  assert.ok(commandSpec.args.at(-1).includes('## OUTPUT FORMAT (CRITICAL - REQUIRED)'));
+  assert.ok(response.envelope.warnings.some((warning) => warning.code === 'pi-jsonschema'));
+});
+
+test('build-command rejects Pi resume/continue session control requests', () => {
+  const resumed = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'pi',
+    context: 'Return JSON.',
+    options: {
+      resumeSessionId: 'ignored-session',
+      cliFeatures: {
+        supportsJsonMode: true,
+      },
+    },
+  });
+
+  assert.equal(resumed.exitCode, 2);
+  assert.equal(resumed.envelope.ok, false);
+  assert.equal(resumed.envelope.error.code, 'invalid-field');
+  assert.equal(resumed.envelope.error.field, 'options.resumeSessionId');
+
+  const emptyResumed = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'pi',
+    context: 'Return JSON.',
+    options: {
+      resumeSessionId: '',
+      cliFeatures: {
+        supportsJsonMode: true,
+      },
+    },
+  });
+
+  assert.equal(emptyResumed.exitCode, 2);
+  assert.equal(emptyResumed.envelope.ok, false);
+  assert.equal(emptyResumed.envelope.error.code, 'invalid-field');
+  assert.equal(emptyResumed.envelope.error.field, 'options.resumeSessionId');
+
+  const continued = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'pi',
+    context: 'Return JSON.',
+    options: {
+      continueSession: true,
+      cliFeatures: {
+        supportsJsonMode: true,
+      },
+    },
+  });
+
+  assert.equal(continued.exitCode, 2);
+  assert.equal(continued.envelope.ok, false);
+  assert.equal(continued.envelope.error.code, 'invalid-field');
+  assert.equal(continued.envelope.error.field, 'options.continueSession');
+});
+
+test('build-command ignores undefined Pi resumeSessionId values', () => {
+  const response = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'pi',
+    context: 'Return JSON.',
+    options: {
+      resumeSessionId: undefined,
+      cliFeatures: {
+        supportsJsonMode: true,
+      },
+    },
+  });
+
+  assert.equal(response.exitCode, 0);
+  assert.equal(response.envelope.ok, true);
+  assert.equal(response.envelope.result.commandSpec.binary, 'pi');
+  assert.equal(response.envelope.result.commandSpec.args.at(-1), 'Return JSON.');
+});
+
+test('build-command keeps Pi JSON-mode args when only version probe returns output', () => {
+  withFakeProviderCli(
+    'pi',
+    fakePiScript(`
+if (process.argv.includes('--help')) {
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('0.80.3\\n');
+  process.exit(0);
+}
+process.stderr.write('unknown option -h\\n');
+process.exit(1);
+`),
+    () => {
+      const response = runExecutable({
+        schemaVersion: 1,
+        command: 'build-command',
+        provider: 'pi',
+        context: 'Return JSON.',
+        options: {
+          outputFormat: 'json',
+        },
+      });
+
+      const args = response.envelope.result.commandSpec.args;
+      assert.equal(response.exitCode, 0);
+      assert.equal(response.envelope.ok, true);
+      assert.deepEqual(args.slice(0, 8), [
+        '--mode',
+        'json',
+        '--no-session',
+        '--no-extensions',
+        '--no-skills',
+        '--no-prompt-templates',
+        '--no-context-files',
+        '--no-approve',
+      ]);
+      assert.equal(args.at(-1), 'Return JSON.');
+    }
+  );
+});
+
 test('build-command resolves Codex settings default level and model overrides', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-provider-settings-'));
   const settingsFile = path.join(tempDir, 'settings.json');
@@ -289,6 +456,38 @@ process.exit(17);
       assert.equal(response.envelope.result.capabilities.supportsJson, true);
       assert.equal(response.envelope.result.capabilities.supportsOutputSchema, false);
       assert.equal(response.envelope.result.capabilities.unknown, false);
+    }
+  );
+});
+
+test('probe requires Pi help or version output when helpText is not supplied', () => {
+  withFakeProviderCli(
+    'pi',
+    fakePiScript(`
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: pi --mode json --no-session --no-extensions --no-skills --no-prompt-templates --no-context-files --no-approve --model\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('0.80.3\\n');
+  process.exit(0);
+}
+process.exit(17);
+`),
+    () => {
+      const response = runExecutable({
+        schemaVersion: 1,
+        command: 'probe',
+        provider: 'pi',
+      });
+
+      assert.equal(response.exitCode, 0);
+      assert.equal(response.envelope.ok, true);
+      assert.equal(response.envelope.result.available, true);
+      assert.equal(response.envelope.result.provider.id, 'pi');
+      assert.equal(response.envelope.result.capabilities.supportsJsonMode, true);
+      assert.equal(response.envelope.result.capabilities.supportsNoApprove, true);
+      assert.equal(response.envelope.result.versionText, '0.80.3');
     }
   );
 });

--- a/tests/agent-cli-provider/executable-contract-helpers.cjs
+++ b/tests/agent-cli-provider/executable-contract-helpers.cjs
@@ -103,6 +103,10 @@ function fakeCodexScript(body) {
   return `#!/usr/bin/env node\n${body}\n`;
 }
 
+function fakePiScript(body) {
+  return `#!/usr/bin/env node\n${body}\n`;
+}
+
 function invokeCodexSchemaRequest(overrides = {}) {
   return {
     schemaVersion: 1,
@@ -119,6 +123,7 @@ module.exports = {
   codexSchemaOptions,
   invokeCodexSchemaRequest,
   fakeCodexScript,
+  fakePiScript,
   repoRoot,
   runExecutable,
   runProviderExecutable,

--- a/tests/agent-cli-provider/executable-contract-invoke.test.js
+++ b/tests/agent-cli-provider/executable-contract-invoke.test.js
@@ -1,14 +1,18 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { test } = require('node:test');
 const {
   assertNoSecret,
   fakeCodexScript,
+  fakePiScript,
   invokeCodexSchemaRequest,
   runExecutable,
   runProviderExecutable,
   runnerResult,
   withFakeProviderCli,
+  withTempEnv,
 } = require('./executable-contract-helpers.cjs');
 
 test('invoke returns redacted terminal evidence, parsed events, status, timing, and cleanup', async () => {
@@ -212,4 +216,103 @@ process.stdin.resume();
       assert.ok(response.envelope.result.commandSpec.args.includes('--json'));
     }
   );
+});
+
+test('invoke runs Pi in the requested worktree cwd and normalizes streamed JSONL', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-pi-worktree-'));
+  const fixturePath = path.join(__dirname, '..', 'fixtures', 'pi', 'tool.jsonl');
+
+  try {
+    withFakeProviderCli(
+      'pi',
+      fakePiScript(`
+const fs = require('node:fs');
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: pi --mode json --no-session --no-extensions --no-skills --no-prompt-templates --no-context-files --no-approve --model\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+process.stdout.write('0.80.3\\n');
+  process.exit(0);
+}
+if (fs.realpathSync(process.cwd()) !== process.env.PI_EXPECT_CWD) {
+  process.stderr.write(\`cwd mismatch: \${process.cwd()}\`);
+  process.exit(19);
+}
+process.stdout.write(fs.readFileSync(process.env.PI_FIXTURE, 'utf8'));
+`),
+      () =>
+        withTempEnv(
+          {
+            PI_EXPECT_CWD: fs.realpathSync(tempDir),
+            PI_FIXTURE: fixturePath,
+          },
+          () => {
+            const response = runExecutable({
+              schemaVersion: 1,
+              command: 'invoke',
+              provider: 'pi',
+              context: 'Run one tool.',
+              options: {
+                cwd: tempDir,
+                outputFormat: 'json',
+                modelSpec: { model: 'openai/gpt-5.5' },
+              },
+              timeoutMs: 300,
+            });
+
+            assert.equal(response.exitCode, 0);
+            assert.equal(response.envelope.ok, true);
+            assert.equal(response.envelope.result.exitCode, 0);
+            assert.equal(response.envelope.result.commandSpec.cwd, tempDir);
+            assert.deepEqual(response.envelope.result.commandSpec.args.slice(0, 10), [
+              '--mode',
+              'json',
+              '--no-session',
+              '--no-extensions',
+              '--no-skills',
+              '--no-prompt-templates',
+              '--no-context-files',
+              '--no-approve',
+              '--model',
+              'openai/gpt-5.5',
+            ]);
+            assert.equal(response.envelope.result.events[0].type, 'tool_call');
+            assert.equal(response.envelope.result.events.at(-1).type, 'result');
+          }
+        )
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('invoke classifies Pi in-band turn_end failures even when the process exits 0', async () => {
+  const fixturePath = path.join(__dirname, '..', 'fixtures', 'pi', 'auth-failure.jsonl');
+  const response = await runProviderExecutable(
+    {
+      schemaVersion: 1,
+      command: 'invoke',
+      provider: 'pi',
+      context: 'Authenticate.',
+      options: {
+        outputFormat: 'json',
+      },
+    },
+    {
+      runner: () =>
+        runnerResult({
+          stdout: fs.readFileSync(fixturePath, 'utf8'),
+          exitCode: 0,
+          signal: null,
+        }),
+    }
+  );
+
+  assert.equal(response.exitCode, 0);
+  assert.equal(response.envelope.ok, true);
+  assert.equal(response.envelope.result.events.at(-1).type, 'result');
+  assert.equal(response.envelope.result.events.at(-1).error, 'authentication required: run /login');
+  assert.equal(response.envelope.result.classification.retryable, false);
+  assert.equal(response.envelope.result.classification.kind, 'permanent-pattern');
 });

--- a/tests/agent-cli-provider/executable-contract-output.test.js
+++ b/tests/agent-cli-provider/executable-contract-output.test.js
@@ -1,10 +1,16 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const { test } = require('node:test');
 const {
   assertNoSecret,
   runExecutable,
   runProviderExecutable,
 } = require('./executable-contract-helpers.cjs');
+
+function piFixture(name) {
+  return fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'pi', name), 'utf8');
+}
 
 test('parse-output returns normalized events and parser diagnostics', () => {
   const stdout = [
@@ -220,5 +226,115 @@ test('parse-output reports parser-error diagnostics when provider parser throws'
     assert.match(response.envelope.result.diagnostics[0].message, /adapter parser crashed/);
   } finally {
     adapters.parseProviderChunk = originalParseProviderChunk;
+  }
+});
+
+test('parse-output normalizes Pi JSON fixtures without duplicate snapshot text', () => {
+  const textResponse = runExecutable({
+    schemaVersion: 1,
+    command: 'parse-output',
+    provider: 'pi',
+    stdout: piFixture('text.jsonl'),
+  });
+
+  assert.equal(textResponse.exitCode, 0);
+  assert.equal(textResponse.envelope.ok, true);
+  assert.deepEqual(textResponse.envelope.result.events, [
+    { type: 'text', text: 'Hello from Pi' },
+    {
+      type: 'result',
+      success: true,
+      result: 'Hello from Pi',
+      error: null,
+      inputTokens: 7,
+      outputTokens: 3,
+      cacheReadInputTokens: 1,
+      cacheCreationInputTokens: 0,
+      cost: null,
+      modelUsage: { input: 7, output: 3, cacheRead: 1, cacheWrite: 0 },
+    },
+  ]);
+
+  const toolResponse = runExecutable({
+    schemaVersion: 1,
+    command: 'parse-output',
+    provider: 'pi',
+    stdout: piFixture('tool.jsonl'),
+  });
+
+  assert.equal(toolResponse.exitCode, 0);
+  assert.equal(toolResponse.envelope.ok, true);
+  assert.deepEqual(toolResponse.envelope.result.events, [
+    { type: 'tool_call', toolName: 'bash', toolId: 'tool-1', input: { command: 'pwd' } },
+    { type: 'tool_result', toolId: 'tool-1', content: 'line1', isError: false },
+    { type: 'tool_result', toolId: 'tool-1', content: 'line1\n/tmp/pi', isError: false },
+    { type: 'text', text: 'done' },
+    {
+      type: 'result',
+      success: true,
+      result: 'done',
+      error: null,
+      inputTokens: 9,
+      outputTokens: 4,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cost: null,
+      modelUsage: { input: 9, output: 4, cacheRead: 0, cacheWrite: 0 },
+    },
+  ]);
+});
+
+test('parse-output handles Pi failure and empty fixtures', () => {
+  for (const [name, expectedError] of [
+    ['command-failure.jsonl', 'Unknown option --bogus'],
+    ['auth-failure.jsonl', 'authentication required: run /login'],
+    ['rate-limit.jsonl', 'rate limit exceeded; retry later'],
+    ['cancelled.jsonl', 'cancelled by user'],
+  ]) {
+    const response = runExecutable({
+      schemaVersion: 1,
+      command: 'parse-output',
+      provider: 'pi',
+      stdout: piFixture(name),
+    });
+
+    const lastEvent = response.envelope.result.events.at(-1);
+    assert.equal(response.exitCode, 0);
+    assert.equal(response.envelope.ok, true);
+    assert.equal(lastEvent.type, 'result');
+    assert.equal(lastEvent.success, false);
+    assert.equal(lastEvent.error, expectedError);
+  }
+
+  const emptyResponse = runExecutable({
+    schemaVersion: 1,
+    command: 'parse-output',
+    provider: 'pi',
+    stdout: piFixture('empty.jsonl'),
+  });
+
+  assert.equal(emptyResponse.exitCode, 0);
+  assert.equal(emptyResponse.envelope.ok, true);
+  assert.deepEqual(emptyResponse.envelope.result.events, []);
+});
+
+test('classify-error maps Pi auth, rate-limit, cancellation, and command failures', () => {
+  for (const [message, expectedCategory, expectedRetryable] of [
+    ['authentication required: run /login', 'auth', false],
+    ['rate limit exceeded; retry later', 'rate-limit', true],
+    ['cancelled by user', 'permanent', false],
+    ['Unknown option --bogus', 'permanent', false],
+  ]) {
+    const response = runExecutable({
+      schemaVersion: 1,
+      command: 'classify-error',
+      provider: 'pi',
+      error: { message },
+    });
+
+    assert.equal(response.exitCode, 0);
+    assert.equal(response.envelope.ok, true);
+    assert.equal(response.envelope.result.category, expectedCategory);
+    assert.equal(response.envelope.result.classification.retryable, expectedRetryable);
   }
 });

--- a/tests/agent-cli-provider/executable-contract-request-errors.test.js
+++ b/tests/agent-cli-provider/executable-contract-request-errors.test.js
@@ -57,7 +57,7 @@ test('unknown provider returns structured provider error envelope', () => {
   assert.equal(response.envelope.error.code, 'unknown-provider');
   assert.equal(
     response.envelope.error.message,
-    'Unknown provider: unknown. Valid: claude, codex, gemini, opencode'
+    'Unknown provider: unknown. Valid: claude, codex, gemini, opencode, pi'
   );
 });
 

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -128,6 +128,25 @@ test('runtime Opencode command facade delegates to helper', () => {
   });
 });
 
+test('runtime Pi command facade delegates to helper', () => {
+  assertRuntimeCommandParity('pi', 'pi context', {
+    outputFormat: 'json',
+    jsonSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+    cwd: '/tmp/project',
+    modelSpec: { level: 'level2', model: 'openai/gpt-5.5' },
+    cliFeatures: {
+      supportsJsonMode: true,
+      supportsNoSession: true,
+      supportsNoExtensions: true,
+      supportsNoSkills: true,
+      supportsNoPromptTemplates: true,
+      supportsNoContextFiles: true,
+      supportsNoApprove: true,
+      supportsModel: true,
+    },
+  });
+});
+
 test('Codex helper exposes strict schema cleanup metadata through runtime facade', () => {
   const actual = runtimeProviders.getProvider('codex').buildCommand('schema context', {
     outputFormat: 'json',
@@ -162,6 +181,14 @@ test('model resolution and invalid-model permanence match helper', () => {
       helper.resolveModelSpec(provider, 'level2', { level2: { model: '' } }),
       current.resolveModelSpec('level2', { level2: { model: '' } })
     );
+
+    if (provider === 'pi') {
+      assert.deepEqual(
+        helper.resolveModelSpec(provider, 'level2', { level2: { model: 'invalid' } }),
+        current.resolveModelSpec('level2', { level2: { model: 'invalid' } })
+      );
+      continue;
+    }
 
     assert.throws(
       () => helper.resolveModelSpec(provider, 'level2', { level2: { model: 'invalid' } }),
@@ -203,6 +230,7 @@ test('parser output from runtime facade matches helper fixtures', () => {
   for (const [provider, files] of [
     ['codex', ['text.jsonl', 'tool.jsonl']],
     ['gemini', ['text.jsonl', 'tool.jsonl']],
+    ['pi', ['text.jsonl', 'tool.jsonl', 'command-failure.jsonl']],
   ]) {
     for (const file of files) {
       const chunk = fixture(provider, file);
@@ -299,6 +327,14 @@ test('feature probing is deterministic from injected help text', () => {
   assert.equal(
     helper.getProviderAdapter('opencode').detectCliFeatures('opencode run --format').supportsCwd,
     false
+  );
+  assert.equal(
+    helper
+      .getProviderAdapter('pi')
+      .detectCliFeatures(
+        'pi --mode json --no-session --no-extensions --no-skills --no-prompt-templates --no-context-files --no-approve --model'
+      ).supportsNoApprove,
+    true
   );
 });
 

--- a/tests/agent-cli-provider/providers-command-parity.test.js
+++ b/tests/agent-cli-provider/providers-command-parity.test.js
@@ -47,6 +47,7 @@ test('providers command renders rows from registry-backed runtime metadata', asy
       codex: { defaultLevel: 'level3', levelOverrides: {} },
       gemini: { defaultLevel: 'level2', levelOverrides: {} },
       opencode: { defaultLevel: 'level2', levelOverrides: {} },
+      pi: { defaultLevel: 'level2', levelOverrides: {} },
     },
   };
   const detected = Object.fromEntries(

--- a/tests/agent-cli-provider/strict-lane.test.ts
+++ b/tests/agent-cli-provider/strict-lane.test.ts
@@ -31,7 +31,7 @@ test('provider helper metadata documents package and build output', (): void => 
 
 test('provider helper public API exposes typed provider adapters', (): void => {
   const providerIds: readonly ProviderId[] = listProviderAdapters();
-  assert.deepEqual(providerIds, ['claude', 'codex', 'gemini', 'opencode']);
+  assert.deepEqual(providerIds, ['claude', 'codex', 'gemini', 'opencode', 'pi']);
 
   const adapter = getProviderAdapter('openai');
   assert.equal(adapter.id, 'codex');

--- a/tests/fixtures/pi/auth-failure.jsonl
+++ b/tests/fixtures/pi/auth-failure.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","version":3,"id":"pi-auth-failure","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"auth failed"}],"usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"error","errorMessage":"authentication required: run /login"},"toolResults":[]}

--- a/tests/fixtures/pi/cancelled.jsonl
+++ b/tests/fixtures/pi/cancelled.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","version":3,"id":"pi-cancelled","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"stopped"}],"usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"aborted","errorMessage":"cancelled by user"},"toolResults":[]}

--- a/tests/fixtures/pi/command-failure.jsonl
+++ b/tests/fixtures/pi/command-failure.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"pi-command-failure","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"tool_execution_start","toolCallId":"tool-err","toolName":"bash","args":{"command":"pi --bogus"}}
+{"type":"tool_execution_end","toolCallId":"tool-err","toolName":"bash","result":"Unknown option --bogus","isError":true}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"command failed"}],"usage":{"input":3,"output":2,"cacheRead":0,"cacheWrite":0},"stopReason":"error","errorMessage":"Unknown option --bogus"},"toolResults":[]}

--- a/tests/fixtures/pi/empty.jsonl
+++ b/tests/fixtures/pi/empty.jsonl
@@ -1,0 +1,1 @@
+{"type":"session","version":3,"id":"pi-empty","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}

--- a/tests/fixtures/pi/rate-limit.jsonl
+++ b/tests/fixtures/pi/rate-limit.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","version":3,"id":"pi-rate-limit","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"slow down"}],"usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0},"stopReason":"error","errorMessage":"rate limit exceeded; retry later"},"toolResults":[]}

--- a/tests/fixtures/pi/text.jsonl
+++ b/tests/fixtures/pi/text.jsonl
@@ -1,0 +1,8 @@
+{"type":"session","version":3,"id":"pi-text","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","content":[]}}
+{"type":"message_update","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Pi"}]},"assistantMessageEvent":{"type":"text_delta","delta":"Hello from Pi"}}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Pi"}],"usage":{"input":7,"output":3,"cacheRead":1,"cacheWrite":0},"stopReason":"stop"}}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"Hello from Pi"}],"usage":{"input":7,"output":3,"cacheRead":1,"cacheWrite":0},"stopReason":"stop"},"toolResults":[]}
+{"type":"agent_end","messages":[]}

--- a/tests/fixtures/pi/tool.jsonl
+++ b/tests/fixtures/pi/tool.jsonl
@@ -1,0 +1,10 @@
+{"type":"session","version":3,"id":"pi-tool","timestamp":"2026-07-09T00:00:00.000Z","cwd":"/tmp/pi"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"tool_execution_start","toolCallId":"tool-1","toolName":"bash","args":{"command":"pwd"}}
+{"type":"tool_execution_update","toolCallId":"tool-1","toolName":"bash","args":{"command":"pwd"},"partialResult":"line1"}
+{"type":"tool_execution_end","toolCallId":"tool-1","toolName":"bash","result":"line1\n/tmp/pi","isError":false}
+{"type":"message_start","message":{"role":"assistant","content":[]}}
+{"type":"message_update","message":{"role":"assistant","content":[{"type":"text","text":"done"}]},"assistantMessageEvent":{"type":"text_delta","delta":"done"}}
+{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"usage":{"input":9,"output":4,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"},"toolResults":[]}
+{"type":"agent_end","messages":[]}

--- a/tests/preflight.test.js
+++ b/tests/preflight.test.js
@@ -392,6 +392,39 @@ function defineRunPreflightTests() {
       }
     });
 
+    it('should fail Pi preflight when the command exists but help/version probing fails', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preflight-pi-'));
+      const originalPath = process.env.PATH;
+      const piPath = path.join(tempDir, 'pi');
+
+      fs.writeFileSync(
+        piPath,
+        '#!/usr/bin/env node\nif (process.argv.includes("--help") || process.argv.includes("--version")) process.exit(9);\nprocess.exit(0);\n',
+        { mode: 0o755 }
+      );
+      process.env.PATH = `${tempDir}${path.delimiter}${originalPath || ''}`;
+
+      try {
+        const result = await runPreflight({
+          requireGh: false,
+          requireDocker: false,
+          quiet: true,
+          provider: 'pi',
+        });
+
+        expect(result.valid).to.be.false;
+        expect(result.errors.join('')).to.include(
+          'Command "pi" is installed but did not produce usable --help/--version output'
+        );
+        expect(result.errors.join('')).to.include(
+          'npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.3'
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('should not require Claude auth when CLI is installed', async function () {
       try {
         execSync(`${whichCmd} claude`, { stdio: 'pipe' });

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -250,6 +250,26 @@ describe('Opencode provider helper builder', function () {
   });
 });
 
+describe('Pi provider helper builder', function () {
+  it('fails closed when resume or continue session control is requested', function () {
+    assert.throws(
+      () =>
+        buildCommand('pi', 'test context', {
+          resumeSessionId: 'session-123',
+        }),
+      /does not support resume\/continue session control/
+    );
+
+    assert.throws(
+      () =>
+        buildCommand('pi', 'test context', {
+          continueSession: true,
+        }),
+      /does not support resume\/continue session control/
+    );
+  });
+});
+
 describe('Claude provider helper builder', function () {
   const originalEnv = process.env.ZEROSHOT_CLAUDE_COMMAND;
 

--- a/tests/providers/detection.test.js
+++ b/tests/providers/detection.test.js
@@ -1,4 +1,7 @@
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const {
   commandExists,
   getCommandPath,
@@ -26,5 +29,23 @@ describe('Provider CLI detection', () => {
     assert.ok(typeof help === 'string');
     assert.ok(typeof version === 'string');
     assert.ok(version.length > 0);
+  });
+
+  it('ignores failing fallback help/version probes', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-detect-'));
+    const cliPath = path.join(tempDir, 'pi');
+
+    fs.writeFileSync(
+      cliPath,
+      '#!/usr/bin/env node\nif (process.argv.includes("--help")) process.exit(0);\nif (process.argv.includes("--version")) { process.stdout.write("0.80.3\\n"); process.exit(0); }\nprocess.stderr.write("unknown option -h\\n"); process.exit(1);\n',
+      { mode: 0o755 }
+    );
+
+    try {
+      assert.strictEqual(getHelpOutput(cliPath), '');
+      assert.strictEqual(getVersionOutput(cliPath), '0.80.3');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/cli-invalid-command.test.js
+++ b/tests/unit/cli-invalid-command.test.js
@@ -42,6 +42,7 @@ describe('CLI Invalid Command Handling', function () {
       'claude',
       'gemini',
       'opencode',
+      'pi',
       'attach',
       'agents',
       'config',
@@ -126,6 +127,10 @@ describe('CLI Invalid Command Handling', function () {
 
     it('should not prepend run for "opencode" command', function () {
       assert.strictEqual(shouldPrependRun(['opencode']), false);
+    });
+
+    it('should not prepend run for "pi" command', function () {
+      assert.strictEqual(shouldPrependRun(['pi']), false);
     });
   });
 


### PR DESCRIPTION
## Summary
- add the registry-backed Pi provider adapter with JSON-mode args, disabled discovery/session controls, conservative capabilities, and help/version probing
- normalize Pi JSONL text/tool/result events and classify in-band failure result events
- add Pi fixtures and provider-helper/preflight/parity regressions

## Verification
- npm run build:agent-cli-provider
- npm run typecheck:agent-cli-provider
- npm run test:agent-cli-provider
- npm run check:agent-cli-provider
- npx mocha tests/preflight.test.js tests/unit/cli-invalid-command.test.js --timeout 120000

Closes #595