### PR TITLE
fix(providers): harden Gemini live smoke failures

### DIFF
--- a/scripts/live-provider-smoke.js
+++ b/scripts/live-provider-smoke.js
@@ -133,6 +133,7 @@ function summarizeResult(envelope) {
       exitCode: result.exitCode,
       signal: result.signal,
       timedOut: result.timedOut,
+      classification: result.classification || null,
       eventCount: events.length,
       lastEventType: last && typeof last === 'object' ? last.type : null,
       text: text.slice(0, 500),

--- a/src/agent-cli-provider/adapters/gemini.ts
+++ b/src/agent-cli-provider/adapters/gemini.ts
@@ -103,7 +103,7 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
   return commandSpec({
     binary: 'gemini',
     args,
-    env: {},
+    env: { GEMINI_CLI_TRUST_WORKSPACE: 'true' },
     ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
     warnings: collectGeminiWarnings(options),
   });
@@ -218,7 +218,14 @@ function classifyError(error: unknown): ErrorClassification {
       /No capacity available/i,
       /quota.?exceeded/i,
     ],
-    [/\bINVALID_ARGUMENT\b/i, /\bPERMISSION_DENIED\b/i, /\bNOT_FOUND\b/i]
+    [
+      /\bINVALID_ARGUMENT\b/i,
+      /\bPERMISSION_DENIED\b/i,
+      /\bNOT_FOUND\b/i,
+      /\bIneligibleTierError\b/i,
+      /\bUNSUPPORTED_CLIENT\b/i,
+      /\bno longer supported\b/i,
+    ]
   );
 }
 

--- a/tests/agent-cli-provider/executable-contract-output.test.js
+++ b/tests/agent-cli-provider/executable-contract-output.test.js
@@ -133,6 +133,24 @@ test('classify-error returns machine-readable category and redacted evidence', (
   assertNoSecret(response.envelope, 'sk-secret');
 });
 
+test('classify-error treats Gemini unsupported-client auth failures as permanent', () => {
+  const response = runExecutable({
+    schemaVersion: 1,
+    command: 'classify-error',
+    provider: 'gemini',
+    error: {
+      message:
+        'IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals. reasonCode: UNSUPPORTED_CLIENT',
+      status: 1,
+    },
+  });
+
+  assert.equal(response.exitCode, 0);
+  assert.equal(response.envelope.ok, true);
+  assert.equal(response.envelope.result.classification.retryable, false);
+  assert.equal(response.envelope.result.classification.kind, 'permanent-pattern');
+});
+
 test('classify-error redacts secret-looking evidence without matching env value', () => {
   const secret = 'sk-live-123456';
   const response = runExecutable({

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -169,6 +169,14 @@ describe('Gemini provider helper builder', function () {
     assert.ok(result.args.includes('--output-format'));
     assert.ok(result.args.includes('stream-json'));
   });
+
+  it('marks headless workspaces trusted for noninteractive Gemini runs', function () {
+    const result = buildCommand('gemini', 'test', {
+      cwd: '/tmp/project',
+    });
+
+    assert.strictEqual(result.env.GEMINI_CLI_TRUST_WORKSPACE, 'true');
+  });
 });
 
 describe('Opencode provider helper builder', function () {


### PR DESCRIPTION
## Summary
- trust noninteractive Gemini workspaces by setting `GEMINI_CLI_TRUST_WORKSPACE=true`
- classify Gemini unsupported-client / `IneligibleTierError` failures as permanent instead of retryable
- include provider error classification in live smoke summaries

## Live smoke evidence
- `claude` live smoke passed
- `codex` live smoke passed
- `opencode` live smoke passed
- `gemini` live smoke now fails as permanent `IneligibleTierError` due external account/client eligibility, not workspace trust or a retryable Zeroshot error
- `pi`, `copilot`, and `kiro` were attempted but the CLIs are not installed on this machine
- `gateway` was attempted but gateway env vars are not configured here

## Verification
- `npm run build:agent-cli-provider && npx mocha tests/provider-cli-builder.test.js --grep 'Gemini provider helper builder' --timeout 120000`\n- `npm run build:agent-cli-provider && node --test tests/agent-cli-provider/executable-contract-output.test.js`\n- `npm run check:agent-cli-provider:ci`\n- `ZEROSHOT_LIVE_PROVIDERS=claude npm run test:providers:live`\n- `ZEROSHOT_LIVE_PROVIDERS=codex npm run test:providers:live`\n- `ZEROSHOT_LIVE_PROVIDERS=opencode npm run test:providers:live`\n- `ZEROSHOT_LIVE_PROVIDERS=gemini npm run test:providers:live` expected external failure: permanent `IneligibleTierError`\n