### PR TITLE
test(providers): add live smoke workflow

### DIFF
--- a/.github/workflows/live-provider-smoke.yml
+++ b/.github/workflows/live-provider-smoke.yml
@@ -1,0 +1,183 @@
+name: Live Provider Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      providers:
+        description: Comma-separated providers to test, or all.
+        required: true
+        default: claude,codex,gemini,copilot,gateway
+      timeout_ms:
+        description: Per-provider timeout in milliseconds.
+        required: true
+        default: '120000'
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    if: github.event_name != 'schedule' || vars.ZEROSHOT_LIVE_PROVIDER_SMOKE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      providers: ${{ steps.providers.outputs.providers }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build provider matrix
+        id: providers
+        env:
+          DISPATCH_PROVIDERS: ${{ github.event.inputs.providers }}
+          SCHEDULE_PROVIDERS: ${{ vars.ZEROSHOT_LIVE_PROVIDERS }}
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const requested =
+            process.env.DISPATCH_PROVIDERS ||
+            process.env.SCHEDULE_PROVIDERS ||
+            'claude,codex,gemini,copilot,gateway';
+          const helper = require('./lib/agent-cli-provider');
+          const valid = helper.listProviderAdapters();
+          const selected = [];
+          for (const raw of requested.split(',')) {
+            const item = raw.trim().toLowerCase();
+            if (!item) continue;
+            if (item === 'all') {
+              for (const provider of valid) {
+                if (!selected.includes(provider)) selected.push(provider);
+              }
+              continue;
+            }
+            if (!valid.includes(item)) {
+              throw new Error(`Unknown live provider "${raw}". Valid: ${valid.join(', ')}, all`);
+            }
+            if (!selected.includes(item)) selected.push(item);
+          }
+          if (selected.length === 0) {
+            throw new Error('No live providers selected.');
+          }
+          console.log(`providers=${JSON.stringify(selected.map((provider) => ({ provider })))}`);
+          NODE
+
+  live-smoke:
+    needs: matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.matrix.outputs.providers) }}
+    env:
+      ZEROSHOT_LIVE_TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '120000' }}
+      ANTHROPIC_API_KEY: ${{ secrets.ZEROSHOT_LIVE_ANTHROPIC_API_KEY || secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_API_KEY: ${{ secrets.ZEROSHOT_LIVE_CLAUDE_API_KEY || secrets.CLAUDE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.ZEROSHOT_LIVE_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+      CODEX_API_KEY: ${{ secrets.ZEROSHOT_LIVE_CODEX_API_KEY || secrets.CODEX_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.ZEROSHOT_LIVE_GEMINI_API_KEY || secrets.GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.ZEROSHOT_LIVE_GOOGLE_API_KEY || secrets.GOOGLE_API_KEY }}
+      OPENCODE_API_KEY: ${{ secrets.ZEROSHOT_LIVE_OPENCODE_API_KEY || secrets.OPENCODE_API_KEY }}
+      KIRO_API_KEY: ${{ secrets.ZEROSHOT_LIVE_KIRO_API_KEY || secrets.KIRO_API_KEY }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.ZEROSHOT_LIVE_COPILOT_GITHUB_TOKEN || secrets.COPILOT_GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.ZEROSHOT_LIVE_GH_TOKEN || secrets.GH_TOKEN }}
+      ZEROSHOT_LIVE_GATEWAY_BASE_URL: ${{ secrets.ZEROSHOT_LIVE_GATEWAY_BASE_URL || vars.ZEROSHOT_LIVE_GATEWAY_BASE_URL }}
+      ZEROSHOT_LIVE_GATEWAY_API_KEY: ${{ secrets.ZEROSHOT_LIVE_GATEWAY_API_KEY }}
+      ZEROSHOT_LIVE_GATEWAY_MODEL: ${{ secrets.ZEROSHOT_LIVE_GATEWAY_MODEL || vars.ZEROSHOT_LIVE_GATEWAY_MODEL }}
+      ZEROSHOT_LIVE_GATEWAY_HEADERS_JSON: ${{ secrets.ZEROSHOT_LIVE_GATEWAY_HEADERS_JSON }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install provider CLI
+        run: |
+          case "${{ matrix.provider }}" in
+            claude)
+              npm install -g @anthropic-ai/claude-code
+              ;;
+            codex)
+              npm install -g @openai/codex
+              ;;
+            gemini)
+              npm install -g @google/gemini-cli
+              ;;
+            pi)
+              npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.3
+              ;;
+            copilot)
+              npm install -g @github/copilot
+              ;;
+            gateway)
+              ;;
+            opencode)
+              command -v opencode >/dev/null 2>&1 || {
+                echo "::error::opencode is not installed on this runner. Use a self-hosted runner with opencode installed and authenticated."
+                exit 1
+              }
+              ;;
+            kiro)
+              command -v kiro-cli >/dev/null 2>&1 || {
+                echo "::error::kiro-cli is not installed on this runner. Use a self-hosted runner with kiro-cli installed and authenticated."
+                exit 1
+              }
+              ;;
+            *)
+              echo "::error::Unsupported provider ${{ matrix.provider }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify live prerequisites
+        run: |
+          case "${{ matrix.provider }}" in
+            claude)
+              test -n "$ANTHROPIC_API_KEY$CLAUDE_API_KEY" || {
+                echo "::error::claude live smoke requires ZEROSHOT_LIVE_ANTHROPIC_API_KEY, ANTHROPIC_API_KEY, ZEROSHOT_LIVE_CLAUDE_API_KEY, or CLAUDE_API_KEY."
+                exit 1
+              }
+              ;;
+            codex)
+              test -n "$OPENAI_API_KEY$CODEX_API_KEY" || {
+                echo "::error::codex live smoke requires ZEROSHOT_LIVE_OPENAI_API_KEY, OPENAI_API_KEY, ZEROSHOT_LIVE_CODEX_API_KEY, or CODEX_API_KEY."
+                exit 1
+              }
+              ;;
+            gemini)
+              test -n "$GEMINI_API_KEY$GOOGLE_API_KEY" || {
+                echo "::error::gemini live smoke requires ZEROSHOT_LIVE_GEMINI_API_KEY, GEMINI_API_KEY, ZEROSHOT_LIVE_GOOGLE_API_KEY, or GOOGLE_API_KEY."
+                exit 1
+              }
+              ;;
+            copilot)
+              test -n "$COPILOT_GITHUB_TOKEN$GH_TOKEN" || {
+                echo "::error::copilot live smoke requires ZEROSHOT_LIVE_COPILOT_GITHUB_TOKEN, COPILOT_GITHUB_TOKEN, ZEROSHOT_LIVE_GH_TOKEN, or GH_TOKEN."
+                exit 1
+              }
+              ;;
+            gateway)
+              test -n "$ZEROSHOT_LIVE_GATEWAY_BASE_URL" &&
+                test -n "$ZEROSHOT_LIVE_GATEWAY_API_KEY" &&
+                test -n "$ZEROSHOT_LIVE_GATEWAY_MODEL" || {
+                  echo "::error::gateway live smoke requires ZEROSHOT_LIVE_GATEWAY_BASE_URL, ZEROSHOT_LIVE_GATEWAY_API_KEY, and ZEROSHOT_LIVE_GATEWAY_MODEL."
+                  exit 1
+                }
+              ;;
+            kiro)
+              test -n "$KIRO_API_KEY" || {
+                echo "::error::kiro live smoke requires ZEROSHOT_LIVE_KIRO_API_KEY or KIRO_API_KEY."
+                exit 1
+              }
+              ;;
+          esac
+
+      - name: Run live provider smoke
+        env:
+          ZEROSHOT_LIVE_PROVIDERS: ${{ matrix.provider }}
+        run: npm run test:providers:live

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,13 +8,16 @@ Zeroshot supports two provider shapes:
 
 ## Supported Providers
 
-| Provider | CLI         | Install                                    |
-| -------- | ----------- | ------------------------------------------ |
-| Claude   | Claude Code | `npm install -g @anthropic-ai/claude-code` |
-| Codex    | Codex       | `npm install -g @openai/codex`             |
-| Gateway  | Bundled     | No external CLI required                   |
-| Gemini   | Gemini      | `npm install -g @google/gemini-cli`        |
-| Opencode | Opencode    | See https://opencode.ai                    |
+| Provider | CLI         | Install                                                                  |
+| -------- | ----------- | ------------------------------------------------------------------------ |
+| Claude   | Claude Code | `npm install -g @anthropic-ai/claude-code`                               |
+| Codex    | Codex       | `npm install -g @openai/codex`                                           |
+| Gateway  | Bundled     | No external CLI required                                                 |
+| Gemini   | Gemini      | `npm install -g @google/gemini-cli`                                      |
+| Opencode | Opencode    | See https://opencode.ai                                                  |
+| Pi       | Pi          | `npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.3` |
+| Kiro     | Kiro        | See https://kiro.dev/docs/cli/                                           |
+| Copilot  | Copilot     | `npm install -g @github/copilot`                                         |
 
 ## Selecting a Provider
 
@@ -131,6 +134,8 @@ the real installed CLI or a real gateway endpoint, run the opt-in live smoke
 command:
 
 ```bash
+ZEROSHOT_LIVE_PROVIDERS=all npm run test:providers:live
+ZEROSHOT_LIVE_PROVIDERS=claude,codex,gemini npm run test:providers:live
 ZEROSHOT_LIVE_PROVIDERS=pi npm run test:providers:live
 ZEROSHOT_LIVE_PROVIDERS=copilot npm run test:providers:live
 ```
@@ -149,3 +154,33 @@ The live command invokes the provider through Zeroshot's executable provider
 contract and requires the provider to return the sentinel
 `ZEROSHOT_LIVE_SMOKE_OK`. It is not part of CI because it may require local
 auth, network access, and paid API calls.
+
+### GitHub Actions Live Smoke
+
+Use the `Live Provider Smoke` workflow for release-gating real providers. It is
+manual by default and scheduled only when the repository variable
+`ZEROSHOT_LIVE_PROVIDER_SMOKE_ENABLED` is set to `true`.
+
+Recommended release gate:
+
+```text
+claude,codex,gemini,copilot,gateway
+```
+
+Run `all` only on a runner that also has Opencode, Pi, and Kiro installed and
+authenticated. The workflow fails selected providers when the executable or
+required credential is missing; it does not convert missing live coverage into a
+passing skip.
+
+Credential names:
+
+| Provider | Required CI credential                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------ |
+| Claude   | `ZEROSHOT_LIVE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY`                                         |
+| Codex    | `ZEROSHOT_LIVE_OPENAI_API_KEY` or `OPENAI_API_KEY`                                               |
+| Gemini   | `ZEROSHOT_LIVE_GEMINI_API_KEY` / `ZEROSHOT_LIVE_GOOGLE_API_KEY`                                  |
+| Copilot  | `ZEROSHOT_LIVE_COPILOT_GITHUB_TOKEN`                                                             |
+| Gateway  | `ZEROSHOT_LIVE_GATEWAY_BASE_URL`, `ZEROSHOT_LIVE_GATEWAY_API_KEY`, `ZEROSHOT_LIVE_GATEWAY_MODEL` |
+| Kiro     | `ZEROSHOT_LIVE_KIRO_API_KEY` plus a runner with `kiro-cli` installed                             |
+| Pi       | A runner with `pi` installed and authenticated                                                   |
+| Opencode | A runner with `opencode` installed and authenticated                                             |

--- a/scripts/live-provider-smoke.js
+++ b/scripts/live-provider-smoke.js
@@ -21,6 +21,8 @@ function usage() {
     'Live provider smoke requires explicit provider selection.',
     '',
     'Examples:',
+    '  ZEROSHOT_LIVE_PROVIDERS=all npm run test:providers:live',
+    '  ZEROSHOT_LIVE_PROVIDERS=claude,codex,gemini npm run test:providers:live',
     '  ZEROSHOT_LIVE_PROVIDERS=pi npm run test:providers:live',
     '  ZEROSHOT_LIVE_PROVIDERS=copilot npm run test:providers:live',
     '  ZEROSHOT_LIVE_PROVIDERS=gateway \\',
@@ -42,12 +44,21 @@ function parseProviders() {
   }
 
   const providers = [];
+  const allProviders = helper.listProviderAdapters();
   for (const item of raw.split(',')) {
-    const normalized = helper.normalizeProviderName(item.trim());
+    const trimmed = item.trim();
+    if (trimmed.toLowerCase() === 'all') {
+      for (const provider of allProviders) {
+        if (!providers.includes(provider)) providers.push(provider);
+      }
+      continue;
+    }
+
+    const normalized = helper.normalizeProviderName(trimmed);
     if (!normalized) continue;
-    if (!helper.listProviderAdapters().includes(normalized)) {
+    if (!allProviders.includes(normalized)) {
       throw new Error(
-        `Unknown provider "${item}". Valid providers: ${helper.listProviderAdapters().join(', ')}`
+        `Unknown provider "${item}". Valid providers: ${allProviders.join(', ')}, all`
       );
     }
     if (!providers.includes(normalized)) providers.push(normalized);


### PR DESCRIPTION
## Summary
- add a manual/opt-in scheduled `Live Provider Smoke` workflow for real provider CLI/gateway checks
- let `ZEROSHOT_LIVE_PROVIDERS=all` expand from the provider registry
- document release-gate provider smoke usage, required secrets, and self-hosted-runner requirements

## Why
The normal CI suite proves the provider contract with fixtures and fake providers. It does not prove real installed CLIs or gateway credentials work. This workflow creates an explicit live gate: selected providers fail if their CLI or credential is missing.

## Verification
- `npx prettier --check .github/workflows/live-provider-smoke.yml docs/providers.md scripts/live-provider-smoke.js`
- registry matrix parse check for `all` -> all provider ids
- `npm run check:agent-cli-provider:ci`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/live-provider-smoke.yml"); puts "yaml ok"'`\n\n## Notes\nThis does not claim every provider has now passed live smoke. It adds the release gate needed to run those tests with real secrets/runners. Earlier local live smoke passed for Claude, Codex, and Opencode; Gemini reached a real permanent account/client eligibility failure; Pi, Copilot, Kiro, and Gateway still require installed CLIs and/or configured credentials/endpoints.\n