### PR TITLE
fix(release): commit published package metadata

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,10 +3,18 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         "npmPublish": true
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-open-engine/zeroshot",
-  "version": "5.4.0",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-open-engine/zeroshot",
-      "version": "5.4.0",
+      "version": "6.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-open-engine/zeroshot",
-  "version": "5.4.0",
+  "version": "6.4.0",
   "description": "Multi-agent orchestration engine for Claude, Codex, and Gemini",
   "main": "src/orchestrator.js",
   "bin": {


### PR DESCRIPTION
## Summary
- align source package metadata with the published 6.4.0 package
- add semantic-release changelog/git prepare steps so future release tags include bumped package metadata

## Verification
- node -p "require('./package.json').version + ' ' + require('./package-lock.json').version + ' ' + require('./package-lock.json').packages[''].version"
- npx mocha tests/package-smoke.test.js --timeout 30000
- npm run typecheck
- npx semantic-release --dry-run (loads new plugins; stops locally on missing NPM_TOKEN/GITHUB_TOKEN, expected outside CI)