### PR TITLE
fix(agent): use anyOf for quality-gate timestamps so strict AJV accepts them

### DIFF
--- a/src/agent/agent-quality-gate-schema.js
+++ b/src/agent/agent-quality-gate-schema.js
@@ -41,11 +41,11 @@ function buildQualityGateSchema() {
           required: ['command', 'exitCode', 'output'],
         },
         completedAt: {
-          type: ['string', 'number'],
+          anyOf: [{ type: 'string' }, { type: 'number' }],
           description: 'When the gate completed, as an ISO string or numeric timestamp.',
         },
         timestamp: {
-          type: ['string', 'number'],
+          anyOf: [{ type: 'string' }, { type: 'number' }],
           description: 'Alternate completion timestamp, as an ISO string or numeric timestamp.',
         },
         stale: {

--- a/tests/quality-gate-schema.test.js
+++ b/tests/quality-gate-schema.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const Ajv = require('ajv');
+
+const { buildQualityGateSchema } = require('../src/agent/agent-quality-gate-schema');
+
+// Regression for #614: the quality-gate schema is injected into validator agent
+// output schemas and compiled by strict-mode AJV consumers. Union
+// `type: ['string','number']` arrays throw under strict mode
+// ("strict mode: use allowUnionTypes ... (strictTypes)"), which crashed
+// validation before the validator's output could be checked and burned
+// validator retries until runs failed.
+//
+// The prior tests only asserted whether the schema was *injected*, never that it
+// *compiles* under a strict AJV. AJV's default `new Ajv()` only LOGS strictTypes
+// (it does not throw), so a naive test would pass on the buggy schema too — that
+// is exactly the gap that let this ship. These tests compile with the throwing
+// `{ strict: true }` config that reproduces the runtime failure, and the guard
+// below proves that config actually discriminates the bug.
+const STRICT = { strict: true };
+
+describe('quality gate schema (strict AJV compatibility)', function () {
+  it('guard: the strict config throws on a union `type` array (so this test can catch the regression)', function () {
+    const unionSchema = { type: 'object', properties: { t: { type: ['string', 'number'] } } };
+    assert.throws(() => new Ajv(STRICT).compile(unionSchema), /allowUnionTypes|strictTypes/);
+  });
+
+  it('compiles under strict AJV without strictTypes errors', function () {
+    const schema = buildQualityGateSchema();
+    assert.doesNotThrow(() => new Ajv(STRICT).compile(schema));
+  });
+
+  it('accepts a gate with a string completedAt/timestamp', function () {
+    const validate = new Ajv(STRICT).compile(buildQualityGateSchema());
+    const ok = validate([
+      {
+        id: 'ci',
+        status: 'PASS',
+        evidence: { command: 'npm test', exitCode: 0, output: 'ok' },
+        completedAt: '2026-07-09T17:00:00Z',
+        timestamp: '2026-07-09T17:00:00Z',
+      },
+    ]);
+    assert.strictEqual(ok, true, JSON.stringify(validate.errors));
+  });
+
+  it('accepts a gate with a numeric completedAt/timestamp', function () {
+    const validate = new Ajv(STRICT).compile(buildQualityGateSchema());
+    const ok = validate([
+      {
+        id: 'ci',
+        status: 'PASS',
+        evidence: { command: 'npm test', exitCode: 0, output: 'ok' },
+        completedAt: 1752080400000,
+        timestamp: 1752080400000,
+      },
+    ]);
+    assert.strictEqual(ok, true, JSON.stringify(validate.errors));
+  });
+
+  it('still rejects a wrong-typed completedAt (anyOf keeps the type constraint)', function () {
+    const validate = new Ajv(STRICT).compile(buildQualityGateSchema());
+    const ok = validate([
+      {
+        id: 'ci',
+        status: 'PASS',
+        evidence: { command: 'npm test', exitCode: 0, output: 'ok' },
+        completedAt: true,
+      },
+    ]);
+    assert.strictEqual(ok, false);
+  });
+});


### PR DESCRIPTION
Fixes #614.

## Problem

The injected validator quality-gate schema declared `completedAt`/`timestamp` as union `type: ['string', 'number']` arrays. Strict-mode AJV consumers reject union `type` arrays:

```
strict mode: use allowUnionTypes to allow union type keyword
  at "#/properties/qualityGates/items/properties/completedAt" (strictTypes)
```

That threw during validator output validation before the validator's output could be checked, marking the task failed and burning validator retries until ship runs failed. Observed live killing an opcore ship run in validation.

## Fix

Replace the union `type` arrays with `anyOf`, which strict mode accepts with no `allowUnionTypes` flag and keeps the string|number constraint. Instance-agnostic: works regardless of which AJV consumer compiles the schema.

```js
completedAt: { anyOf: [{ type: 'string' }, { type: 'number' }], ... }
timestamp:   { anyOf: [{ type: 'string' }, { type: 'number' }], ... }
```

## Why tests didn't catch it

The prior tests only asserted whether the schema was *injected*, never that it *compiles* under a strict AJV. And AJV's default `new Ajv()` only **logs** `strictTypes` (it does not throw), so a naive compile test would pass on the buggy schema too — that is the exact gap that let this ship.

New `tests/quality-gate-schema.test.js` compiles under `{ strict: true }` (which throws on the union shape) and includes a guard test proving that config actually discriminates the bug, plus string/numeric acceptance and a wrong-type rejection. Verified: the real schema reverted to unions throws the exact `strictTypes` error; the `anyOf` version passes all 5.

## Test

- `node tests/run-tests.js tests/quality-gate-schema.test.js` → 5 passing
- `node tests/run-tests.js tests/required-quality-gates-context.test.js` → 3 passing (no regression)
- `tsc --noEmit` clean (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)