### PR TITLE
feat(copilot): MCP support + cached per-provider Docker install (+ base-image build fixes)

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -2693,6 +2693,12 @@ taskCmd
     'stream-json'
   )
   .option('--json-schema <schema>', 'JSON schema for structured output')
+  .option(
+    '--mcp-config <config>',
+    'MCP server config for providers that accept an MCP config flag (e.g. Copilot). ' +
+      'Inline JSON string ({"mcpServers":{...}}) or @<path>. Repeatable.',
+    (value, previous) => (previous || []).concat([value])
+  )
   .option('--silent-json-output', 'Log ONLY final structured output')
   .action(async (prompt, options) => {
     try {

--- a/docker/zeroshot-cluster/Dockerfile
+++ b/docker/zeroshot-cluster/Dockerfile
@@ -8,7 +8,9 @@ FROM node:20-slim
 
 # Upgrade npm to fix Arborist isDescendantOf bug (npm 10.x crash on complex peer deps)
 # See: https://github.com/npm/cli/issues/7682
-RUN npm install -g npm@latest
+# Pinned to npm@11 (the latest line that still supports the node:20-slim base); npm@latest (12.x)
+# now requires node >=22 and breaks the build with EBADENGINE.
+RUN npm install -g npm@11
 
 # Version pinning for infrastructure tools
 ARG AWS_CLI_VERSION=2.15.10
@@ -145,6 +147,14 @@ RUN mkdir -p /home/node/.claude /home/node/.config/gh \
 # Create workspace directory with node ownership
 RUN mkdir -p /workspace && chown node:node /workspace
 WORKDIR /workspace
+
+# Install the running provider's CLI as a docker-cached layer (per-provider image variant).
+# Claude is baked in above, so its variant passes an empty PROVIDER_INSTALL and skips this step.
+# Kept last in the root phase so every heavy layer above is shared across all provider images;
+# Docker caches this layer keyed on the install command, so it builds once per provider and is
+# then reused. The command comes from the provider registry (docker.install), never hardcoded.
+ARG PROVIDER_INSTALL=""
+RUN if [ -n "$PROVIDER_INSTALL" ]; then sh -c "$PROVIDER_INSTALL"; fi
 
 # Switch to non-root user (required for --dangerously-skip-permissions)
 USER node

--- a/src/agent-cli-provider/adapters/copilot.ts
+++ b/src/agent-cli-provider/adapters/copilot.ts
@@ -59,6 +59,7 @@ function detectCliFeatures(helpText?: string | null): CopilotCliFeatures {
     supportsAllowAll: supports(help, /--allow-all\b/),
     supportsNoAskUser: supports(help, /--no-ask-user\b/),
     supportsAddDir: supports(help, /--add-dir\b/),
+    supportsMcpConfig: supports(help, /--additional-mcp-config\b/),
     unknown,
   };
 }
@@ -94,6 +95,21 @@ function addAutoApproveArgs(args: string[], options: BuildProviderCommandOptions
   if (features.supportsNoAskUser !== false) args.push('--no-ask-user');
 }
 
+// Copilot consumes MCP servers via the `--additional-mcp-config` CLI flag (each value augments the
+// session config from ~/.copilot/mcp-config.json). Unlike Claude — which reads a `.mcp.json` file
+// overlaid into its config dir — Copilot's config lives under $HOME/.copilot, unreachable by the
+// worktree overlay, so the CLI flag is the only delivery path. Copilot and Claude share the same
+// `{"mcpServers": {...}}` envelope, so entries are forwarded verbatim (inline JSON string or
+// `@<path>`) with no translation.
+function addMcpArgs(args: string[], options: BuildProviderCommandOptions): void {
+  const features = optionFeatures(options);
+  if (!options.mcpConfig || options.mcpConfig.length === 0) return;
+  if (features.supportsMcpConfig === false) return;
+  for (const entry of options.mcpConfig) {
+    args.push('--additional-mcp-config', entry);
+  }
+}
+
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
   const warnings: WarningMetadata[] = unsupportedSessionControlWarnings('copilot', options);
@@ -116,6 +132,15 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
       )
     );
   }
+  if (options.mcpConfig && options.mcpConfig.length > 0 && features.supportsMcpConfig === false) {
+    warnings.push(
+      warning(
+        'copilot',
+        'copilot-mcp-config',
+        'Copilot CLI does not advertise --additional-mcp-config; ignoring the requested MCP server config.'
+      )
+    );
+  }
   return warnings;
 }
 
@@ -129,6 +154,7 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
   addModelArgs(args, options);
   addAddDirArgs(args, options);
   addAutoApproveArgs(args, options);
+  addMcpArgs(args, options);
   args.push('-p', finalContext);
 
   return commandSpec({

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -40,6 +40,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsAllowAll',
   'supportsNoAskUser',
   'supportsAddDir',
+  'supportsMcpConfig',
   'supportsBundledRunner',
   'supportsAcpStdio',
   'supportsPromptImages',
@@ -107,6 +108,25 @@ function optionalBooleanValue(value: unknown, field: string): boolean | undefine
   if (value === undefined) return undefined;
   if (typeof value === 'boolean') return value;
   invalidField(field, `${field} must be a boolean.`);
+}
+
+function optionalMcpConfig(value: unknown): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    invalidField('options.mcpConfig', 'options.mcpConfig must be an array of strings.');
+  }
+  return value.map((item, index) => {
+    if (typeof item !== 'string') {
+      invalidField(`options.mcpConfig[${index}]`, `options.mcpConfig[${index}] must be a string.`);
+    }
+    if (item.trim().length === 0) {
+      invalidField(
+        `options.mcpConfig[${index}]`,
+        `options.mcpConfig[${index}] must be a non-empty string.`
+      );
+    }
+    return item;
+  });
 }
 
 function optionalEnumValue<T extends string>(
@@ -188,6 +208,7 @@ function normalizeBuildOptions(value: Record<string, unknown>): BuildProviderCom
     optionalBooleanValue(value.continueSession, 'options.continueSession')
   );
   addDefined(result, 'cliFeatures', optionalCliFeatures(value.cliFeatures));
+  addDefined(result, 'mcpConfig', optionalMcpConfig(value.mcpConfig));
   addDefined(
     result,
     'strictSchema',

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -60,6 +60,10 @@ export interface ProviderDockerMetadata {
   readonly envPassthrough: readonly string[];
   // False when the mounted dir doesn't hold the secret (auth is via an envPassthrough token).
   readonly credentialInMount?: boolean;
+  // Shell command that installs this provider's CLI inside the Debian-based cluster image, run as
+  // a docker-cached build layer for the per-provider image variant. Omit for providers already
+  // baked into the base image (e.g. Claude) or not installable via a single command.
+  readonly install?: string;
 }
 
 export interface ProviderRegistryEntry {
@@ -204,6 +208,7 @@ export const providerRegistry = [
         container: '$HOME/.config/codex',
         readonly: true,
       },
+      install: 'npm install -g @openai/codex',
       envPassthrough: [],
     },
     defaultLevels: {
@@ -280,6 +285,7 @@ export const providerRegistry = [
         container: '$HOME/.config/gemini',
         readonly: true,
       },
+      install: 'npm install -g @google/gemini-cli',
       envPassthrough: [],
     },
     defaultLevels: {
@@ -433,6 +439,7 @@ export const providerRegistry = [
         container: '$HOME/.copilot',
         readonly: true,
       },
+      install: 'npm install -g @github/copilot',
       envPassthrough: ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'],
       credentialInMount: false, // token is in the OS keychain, not ~/.copilot
     },

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -415,10 +415,11 @@ export const providerRegistry = [
     credentialEnvKeys: copilotAdapter.credentialEnvKeys,
     settingsFields: [],
     availabilityProbe: 'help-or-version',
-    // No MCP passthrough; no native output-schema or reasoning-effort flag.
+    // MCP servers pass through via the `--additional-mcp-config` CLI flag (see copilot adapter
+    // addMcpArgs). No native output-schema or reasoning-effort flag.
     capabilities: {
       ...STANDARD_CAPABILITIES,
-      mcpServers: false,
+      mcpServers: true,
       jsonSchema: false,
       reasoningEffort: false,
     },

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -145,6 +145,7 @@ export interface CopilotCliFeatures extends BaseCliFeatures {
   readonly supportsAllowAll: boolean;
   readonly supportsNoAskUser: boolean;
   readonly supportsAddDir: boolean;
+  readonly supportsMcpConfig: boolean;
 }
 
 export interface GatewayCliFeatures extends BaseCliFeatures {
@@ -203,6 +204,7 @@ export interface CliFeatureOverrides {
   readonly supportsAllowAll?: boolean;
   readonly supportsNoAskUser?: boolean;
   readonly supportsAddDir?: boolean;
+  readonly supportsMcpConfig?: boolean;
   readonly supportsBundledRunner?: boolean;
   readonly supportsAcpStdio?: boolean;
   readonly supportsPromptImages?: boolean;
@@ -260,6 +262,11 @@ export interface BuildProviderCommandOptions {
   readonly authEnv?: Readonly<Record<string, string>>;
   readonly strictSchema?: boolean;
   readonly gateway?: GatewayBuildOptions;
+  // MCP server configs forwarded to providers that accept an MCP config CLI flag (currently
+  // Copilot's `--additional-mcp-config`). Each entry is an inline JSON string (the standard
+  // `{"mcpServers": {...}}` envelope) or an `@<path>` file reference; adapters emit one flag per
+  // entry. Providers whose adapter models no MCP flag ignore this field.
+  readonly mcpConfig?: readonly string[];
 }
 
 export interface TextEvent {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -61,10 +61,6 @@ async function createValidatorIsolation(agent, isolationConfig) {
 
   const cluster = agent.cluster || {};
   const workDir = agent.config?.cwd || cluster.worktree?.path || cluster.cwd || process.cwd();
-  const image = isolationConfig.image;
-  await IsolationManager.ensureImage(image);
-
-  const manager = new IsolationManager({ image });
   const providerName = normalizeProviderName(
     (agent._resolveProvider && agent._resolveProvider()) ||
       cluster.config?.forceProvider ||
@@ -72,6 +68,11 @@ async function createValidatorIsolation(agent, isolationConfig) {
       loadSettings().defaultProvider ||
       'claude'
   );
+  // Run validators on the provider's image variant (installs its CLI as a Docker-cached layer).
+  const image = IsolationManager.imageForProvider(providerName, isolationConfig.image);
+  await IsolationManager.ensureImage(image, true, IsolationManager.providerBuildArgs(providerName));
+
+  const manager = new IsolationManager({ image });
 
   const isolationClusterId = `${cluster.id}-validators`;
   const containerId = await manager.createContainer(isolationClusterId, {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -14,12 +14,15 @@ const { spawn, spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { parseProviderChunk } = require('../providers');
+const { parseProviderChunk, getProvider } = require('../providers');
 const { getTask } = require('../../task-lib/store.js');
 const { loadSettings } = require('../../lib/settings.js');
 const { resolveClaudeAuth } = require('../../lib/settings/claude-auth.js');
 const { prependWorktreeToolBinToEnv } = require('../worktree-tooling-env.js');
-const { prepareClaudeConfigDir } = require('../worktree-claude-config.js');
+const {
+  prepareClaudeConfigDir,
+  resolveRepoMcpConfigPath,
+} = require('../worktree-claude-config.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
@@ -733,7 +736,43 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
     args.push('--json-schema', schema);
   }
 
+  // MCP servers: providers whose CLI accepts an MCP config flag (e.g. Copilot's
+  // --additional-mcp-config) cannot use the Claude config-dir overlay, so forward the repo's
+  // `.mcp.json` (the same MCP source Claude consumes) inline via `--mcp-config`.
+  for (const mcpArg of resolveMcpConfigArgs(agent, providerName)) {
+    args.push(mcpArg);
+  }
+
   return args;
+}
+
+/**
+ * Build the `--mcp-config` args for a task-run invocation, or [] when they don't apply.
+ *
+ * Only providers whose adapter models an MCP config CLI flag receive it — Claude consumes MCP via
+ * the config-dir `.mcp.json` overlay (see prepareClaudeConfigDir) and needs no flag. The repo
+ * `.mcp.json` content is inlined (not passed as an @<path> reference) so the identical value works
+ * under local, worktree, and Docker isolation without host/container path translation.
+ */
+function resolveMcpConfigArgs(agent, providerName) {
+  if (!providerModelsMcpConfigFlag(providerName)) return [];
+
+  const mcpPath = resolveRepoMcpConfigPath({
+    cwd: agent.config?.cwd || process.cwd(),
+    worktreePath: agent.worktree?.path || null,
+  });
+  if (!mcpPath) return [];
+
+  const content = fs.readFileSync(mcpPath, 'utf8').trim();
+  if (content.length === 0) return [];
+
+  return ['--mcp-config', content];
+}
+
+/** True when the provider's adapter models an MCP config CLI flag (currently only Copilot). */
+function providerModelsMcpConfigFlag(providerName) {
+  const adapter = getProvider(providerName).adapter;
+  return 'supportsMcpConfig' in adapter.detectCliFeatures('');
 }
 
 function maybeLogStreamJsonNotice(agent, runOutputFormat) {

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -103,6 +103,24 @@ function resolveWorktreeSetupTimeoutMs(repoSettings = {}, options = {}) {
 
 const DEFAULT_IMAGE = 'zeroshot-cluster-base';
 
+/**
+ * Shell command that installs a provider's CLI inside the cluster image, or null when the
+ * provider is baked into the base image (e.g. Claude) or has no single-command installer.
+ * Sourced from the provider registry (docker.install) so nothing here is provider-specific.
+ * @param {string} providerName
+ * @returns {string|null}
+ */
+function providerDockerInstall(providerName) {
+  if (!providerName) return null;
+  try {
+    const metadata = getProviderMetadata(providerName);
+    const install = metadata && metadata.docker && metadata.docker.install;
+    return typeof install === 'string' && install.trim() ? install.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 class IsolationManager {
   constructor(options = {}) {
     this.image = options.image || DEFAULT_IMAGE;
@@ -1278,18 +1296,51 @@ class IsolationManager {
   }
 
   /**
+   * Resolve the cluster image tag for a provider. Providers baked into the base image (e.g.
+   * Claude) run on the base image directly; providers with a `docker.install` command get a
+   * per-provider image variant `<baseImage>-<providerId>` whose install step is a Docker-cached
+   * layer (built once, reused thereafter).
+   * @param {string} providerName
+   * @param {string} [baseImage]
+   * @returns {string}
+   */
+  static imageForProvider(providerName, baseImage = DEFAULT_IMAGE) {
+    if (!providerDockerInstall(providerName)) {
+      return baseImage;
+    }
+    return `${baseImage}-${normalizeProviderName(providerName)}`;
+  }
+
+  /**
+   * Docker `--build-arg` values that install a provider's CLI into its image variant, or [] when
+   * the provider is baked into the base image or has no installer.
+   * @param {string} providerName
+   * @returns {string[]}
+   */
+  static providerBuildArgs(providerName) {
+    const install = providerDockerInstall(providerName);
+    return install ? [`PROVIDER_INSTALL=${install}`] : [];
+  }
+
+  /**
    * Build the Docker image with retry logic
    * @param {string} [image] - Image name to build
    * @param {number} [maxRetries=3] - Maximum retry attempts
    * @returns {Promise<void>}
    */
-  static async buildImage(image = DEFAULT_IMAGE, maxRetries = 3) {
+  static async buildImage(image = DEFAULT_IMAGE, maxRetries = 3, buildArgs = []) {
     // Repository root is one level up from src/
     const repoRoot = path.join(__dirname, '..');
     const dockerfilePath = path.join(repoRoot, 'docker', 'zeroshot-cluster', 'Dockerfile');
 
     if (!fs.existsSync(dockerfilePath)) {
       throw new Error(`Dockerfile not found at ${dockerfilePath}`);
+    }
+
+    // Each buildArg becomes a `--build-arg KEY=VALUE` pair (e.g. the per-provider install command).
+    const buildArgFlags = [];
+    for (const arg of buildArgs) {
+      buildArgFlags.push('--build-arg', arg);
     }
 
     console.log(`[IsolationManager] Building Docker image '${image}'...`);
@@ -1300,11 +1351,15 @@ class IsolationManager {
       try {
         // CRITICAL: Run from repo root so build context includes package.json and src/
         // Use -f flag to specify Dockerfile location
-        runSync('docker', ['build', '-f', 'docker/zeroshot-cluster/Dockerfile', '-t', image, '.'], {
-          cwd: repoRoot,
-          encoding: 'utf8',
-          stdio: 'inherit',
-        });
+        runSync(
+          'docker',
+          ['build', '-f', 'docker/zeroshot-cluster/Dockerfile', ...buildArgFlags, '-t', image, '.'],
+          {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            stdio: 'inherit',
+          }
+        );
 
         console.log(`[IsolationManager] ✓ Image '${image}' built successfully`);
         return;
@@ -1331,7 +1386,7 @@ class IsolationManager {
    * @param {boolean} [autoBuild=true] - Auto-build if missing
    * @returns {Promise<void>}
    */
-  static async ensureImage(image = DEFAULT_IMAGE, autoBuild = true) {
+  static async ensureImage(image = DEFAULT_IMAGE, autoBuild = true, buildArgs = []) {
     if (this.imageExists(image)) {
       return;
     }
@@ -1344,7 +1399,7 @@ class IsolationManager {
     }
 
     console.log(`[IsolationManager] Image '${image}' not found, building automatically...`);
-    await this.buildImage(image);
+    await this.buildImage(image, 3, buildArgs);
   }
 
   /**

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -1358,6 +1358,9 @@ class IsolationManager {
             cwd: repoRoot,
             encoding: 'utf8',
             stdio: 'inherit',
+            // No timeout: image builds legitimately take many minutes (apt, tool downloads,
+            // provider install). runSync's 30s default would kill every build (ETIMEDOUT).
+            timeout: 0,
           }
         );
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1138,11 +1138,12 @@ class Orchestrator {
     const messageBus = new MessageBus(ledger);
 
     // Handle isolation mode (Docker container OR git worktree)
-    const { isolationManager, containerId, worktreeInfo } = await this._initializeIsolation(
-      options,
-      config,
-      clusterId
-    );
+    const {
+      isolationManager,
+      containerId,
+      worktreeInfo,
+      image: resolvedIsolationImage,
+    } = await this._initializeIsolation(options, config, clusterId);
     let requiredQualityGates = resolveClusterRequiredQualityGates(config, options);
     let commandProofs = resolveClusterCommandProofs(config, options);
     options.requiredQualityGates = requiredQualityGates;
@@ -1188,7 +1189,9 @@ class Orchestrator {
         ? {
             enabled: true,
             containerId,
-            image: options.isolationImage || 'zeroshot-cluster-base',
+            // Provider-specific image variant (resolved in _initializeIsolation) so resume
+            // recreates the container on the same image that has the provider CLI installed.
+            image: resolvedIsolationImage || options.isolationImage || 'zeroshot-cluster-base',
             manager: isolationManager,
             workDir: options.cwd || process.cwd(), // Persisted for resume
           }
@@ -1729,20 +1732,30 @@ class Orchestrator {
     let isolationManager = null;
     let containerId = null;
     let worktreeInfo = null;
+    let isolationImage = null;
 
     if (options.isolation) {
       if (!IsolationManager.isDockerAvailable()) {
         throw new Error('Docker is not available. Install Docker to use --docker mode.');
       }
 
-      const image = options.isolationImage || 'zeroshot-cluster-base';
-      await IsolationManager.ensureImage(image);
+      // Resolve the provider first so the cluster runs on that provider's image variant, which
+      // installs the provider CLI as a Docker-cached layer. Providers baked into the base image
+      // (e.g. Claude) resolve back to the base image unchanged.
+      const providerName = this._resolveClusterProvider(config);
+      const baseImage = options.isolationImage || 'zeroshot-cluster-base';
+      const image = IsolationManager.imageForProvider(providerName, baseImage);
+      await IsolationManager.ensureImage(
+        image,
+        true,
+        IsolationManager.providerBuildArgs(providerName)
+      );
+      isolationImage = image;
 
       isolationManager = new IsolationManager({ image });
       this._log(`[Orchestrator] Starting cluster in isolation mode (image: ${image})`);
 
       const workDir = options.cwd || process.cwd();
-      const providerName = this._resolveClusterProvider(config);
       containerId = await isolationManager.createContainer(clusterId, {
         workDir,
         image,
@@ -1770,7 +1783,7 @@ class Orchestrator {
       this._log(`[Orchestrator] Branch: ${worktreeInfo.branch}`);
     }
 
-    return { isolationManager, containerId, worktreeInfo };
+    return { isolationManager, containerId, worktreeInfo, image: isolationImage };
   }
 
   _applyAutoPrConfig(config, inputData, options) {

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -119,6 +119,23 @@ function prepareClaudeConfigDir(options = {}) {
   return overlayDir;
 }
 
+/**
+ * Resolve the repo's `.mcp.json` path (the same MCP-server source Claude consumes via
+ * prepareClaudeConfigDir) for a given worktree/cwd, or null if none exists. Reused by providers
+ * that consume MCP servers through a CLI flag instead of the Claude config-dir overlay (e.g.
+ * Copilot's `--additional-mcp-config`), so both providers share one MCP config surface.
+ */
+function resolveRepoMcpConfigPath(options = {}) {
+  const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
+  if (!worktreeRoot) {
+    return null;
+  }
+
+  const mcpPath = path.join(worktreeRoot, CLAUDE_DIRNAME, MCP_BASENAME);
+  return fs.existsSync(mcpPath) ? mcpPath : null;
+}
+
 module.exports = {
   prepareClaudeConfigDir,
+  resolveRepoMcpConfigPath,
 };

--- a/task-lib/commands/run.js
+++ b/task-lib/commands/run.js
@@ -38,6 +38,7 @@ export async function runTask(prompt, options = {}) {
     continue: options.continue,
     outputFormat,
     jsonSchema,
+    mcpConfig: options.mcpConfig,
     silentJsonOutput,
   });
 

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -80,9 +80,16 @@ function buildProviderOptions(options, outputFormat, jsonSchema, cwd) {
     cwd,
     autoApprove: true,
     ...modelSpecOption(options),
+    ...mcpConfigOption(options),
     ...(options.resume ? { resumeSessionId: options.resume } : {}),
     ...(options.continue ? { continueSession: true } : {}),
   };
+}
+
+function mcpConfigOption(options) {
+  const entries = options.mcpConfig;
+  if (!Array.isArray(entries) || entries.length === 0) return {};
+  return { mcpConfig: entries };
 }
 
 function modelSpecOption(options) {

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -249,9 +249,14 @@ test('build-command returns bundled gateway runner specs with redacted config en
   assert.equal(response.envelope.provider, 'gateway');
   assert.equal(response.envelope.result.commandSpec.binary, process.execPath);
   assert.match(response.envelope.result.commandSpec.args[0], /gateway-runner\.js$/);
-  assert.equal(response.envelope.result.commandSpec.env.ZEROSHOT_GATEWAY_REQUEST.includes(secret), false);
   assert.equal(
-    response.envelope.result.commandSpec.env.ZEROSHOT_GATEWAY_REQUEST.includes('custom-header-secret-42'),
+    response.envelope.result.commandSpec.env.ZEROSHOT_GATEWAY_REQUEST.includes(secret),
+    false
+  );
+  assert.equal(
+    response.envelope.result.commandSpec.env.ZEROSHOT_GATEWAY_REQUEST.includes(
+      'custom-header-secret-42'
+    ),
     false
   );
   assertNoSecret(response.envelope, secret);
@@ -830,6 +835,79 @@ process.exit(1);
       assert.deepEqual(args.slice(0, 2), ['--output-format', 'json']);
       assert.equal(args.at(-2), '-p');
       assert.equal(args.at(-1), 'Return JSON.');
+    }
+  );
+});
+
+test('build-command emits one Copilot --additional-mcp-config flag per mcpConfig entry', () => {
+  const response = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'copilot',
+    context: 'Do work.',
+    options: {
+      autoApprove: true,
+      mcpConfig: ['{"mcpServers":{"a":{"command":"a-bin"}}}', '@/tmp/servers.json'],
+      cliFeatures: {
+        supportsAllowAll: true,
+        supportsNoAskUser: true,
+        supportsMcpConfig: true,
+      },
+    },
+  });
+
+  const { commandSpec } = response.envelope.result;
+  assert.equal(response.exitCode, 0);
+  assert.equal(response.envelope.ok, true);
+  assert.deepEqual(commandSpec.args, [
+    '--allow-all',
+    '--no-ask-user',
+    '--additional-mcp-config',
+    '{"mcpServers":{"a":{"command":"a-bin"}}}',
+    '--additional-mcp-config',
+    '@/tmp/servers.json',
+    '-p',
+    'Do work.',
+  ]);
+  assert.equal(
+    response.envelope.warnings.some((warning) => warning.code === 'copilot-mcp-config'),
+    false
+  );
+});
+
+test('build-command gates Copilot MCP config on feature detection and warns when unsupported', () => {
+  withFakeProviderCli(
+    'copilot',
+    fakeCopilotScript(`
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: copilot -p <prompt> --output-format json --model <m> --allow-all --no-ask-user --add-dir <dir>\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('1.0.0\\n');
+  process.exit(0);
+}
+process.exit(0);
+`),
+    () => {
+      const response = runExecutable({
+        schemaVersion: 1,
+        command: 'build-command',
+        provider: 'copilot',
+        context: 'Do work.',
+        options: {
+          mcpConfig: ['{"mcpServers":{"a":{"command":"a-bin"}}}'],
+        },
+      });
+
+      const { commandSpec } = response.envelope.result;
+      assert.equal(response.exitCode, 0);
+      assert.equal(response.envelope.ok, true);
+      assert.equal(commandSpec.args.includes('--additional-mcp-config'), false);
+      assert.ok(
+        response.envelope.warnings.some((warning) => warning.code === 'copilot-mcp-config'),
+        'expected a copilot-mcp-config warning when the CLI lacks --additional-mcp-config'
+      );
     }
   );
 });

--- a/tests/agent-cli-provider/executable-contract-option-validation.test.js
+++ b/tests/agent-cli-provider/executable-contract-option-validation.test.js
@@ -52,6 +52,21 @@ const invalidNestedOptionCases = [
     field: 'options.modelSpec.reasoningEffort',
   },
   {
+    name: 'mcpConfig array',
+    options: { mcpConfig: '{"mcpServers":{}}' },
+    field: 'options.mcpConfig',
+  },
+  {
+    name: 'mcpConfig entry type',
+    options: { mcpConfig: [123] },
+    field: 'options.mcpConfig[0]',
+  },
+  {
+    name: 'mcpConfig entry empty',
+    options: { mcpConfig: ['   '] },
+    field: 'options.mcpConfig[0]',
+  },
+  {
     name: 'gateway object',
     options: { gateway: 'http://localhost:11434' },
     field: 'options.gateway',

--- a/tests/e2e/copilot-provider.test.js
+++ b/tests/e2e/copilot-provider.test.js
@@ -16,6 +16,7 @@ const assert = require('node:assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { spawnSync } = require('node:child_process');
 
 const {
   setupE2ERepo,
@@ -35,6 +36,21 @@ function installFakeCopilot(binDir) {
   const shim = path.join(binDir, 'copilot');
   fs.writeFileSync(shim, `#!/bin/sh\nexec node "${FAKE_COPILOT}" "$@"\n`, { mode: 0o755 });
   fs.chmodSync(shim, 0o755);
+}
+
+function gitCommitFile(repoDir, relPath, content, message) {
+  const absPath = path.join(repoDir, relPath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+  for (const args of [
+    ['add', relPath],
+    ['commit', '-m', message],
+  ]) {
+    const result = spawnSync('git', args, { cwd: repoDir, encoding: 'utf8' });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+    }
+  }
 }
 
 describe('e2e: copilot provider', function () {
@@ -95,6 +111,55 @@ describe('e2e: copilot provider', function () {
     assert.ok(
       completions.length >= 1,
       'expected a TASK_COMPLETE message from the worker onComplete hook'
+    );
+
+    fs.rmSync(issueDir, { recursive: true, force: true });
+  });
+
+  it('forwards the repo .mcp.json to copilot as --additional-mcp-config', async function () {
+    // The repo's `.claude/.mcp.json` (the same MCP source Claude consumes) must be committed so it
+    // lands in the HEAD-based worktree the worker runs in.
+    const mcpJson = JSON.stringify({
+      mcpServers: { demo: { command: 'demo-mcp-bin', args: ['--stdio'] } },
+    });
+    gitCommitFile(env.repoDir, path.join('.claude', '.mcp.json'), mcpJson, 'Add MCP config');
+
+    const issueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-e2e-issue-'));
+    const issuePath = path.join(issueDir, 'feature.md');
+    fs.writeFileSync(issuePath, '# Add feature\n\nDo X.\n');
+
+    const clusterId = 'e2e-copilot-mcp';
+    const result = runZeroshot(
+      env,
+      ['run', issuePath, '--worktree', '--provider', 'copilot', '--config', CONFIG_PATH],
+      { ZEROSHOT_CLUSTER_ID: clusterId }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `zeroshot run exited ${result.status}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+    );
+
+    const cluster = await waitForClusterState(env, clusterId, ['stopped', 'killed']);
+    assert.strictEqual(cluster.state, 'stopped', 'cluster should stop cleanly');
+
+    // The fake copilot records the exact argv it was spawned with, into the worktree cwd.
+    const worktreeDir = worktreePath(env, clusterId);
+    const argvLog = path.join(worktreeDir, 'copilot-received-argv.json');
+    assert.ok(fs.existsSync(argvLog), `expected ${argvLog} to exist`);
+
+    const argv = JSON.parse(fs.readFileSync(argvLog, 'utf8'));
+    const flagIndex = argv.indexOf('--additional-mcp-config');
+    assert.ok(
+      flagIndex >= 0,
+      `expected copilot to receive --additional-mcp-config; got argv: ${JSON.stringify(argv)}`
+    );
+    // The repo .mcp.json content is inlined verbatim as the flag value (no @path, no translation).
+    assert.strictEqual(
+      argv[flagIndex + 1],
+      mcpJson,
+      'the inlined MCP config value must equal the repo .mcp.json content'
     );
 
     fs.rmSync(issueDir, { recursive: true, force: true });

--- a/tests/e2e/fixtures/fake-copilot.js
+++ b/tests/e2e/fixtures/fake-copilot.js
@@ -33,6 +33,7 @@ const USAGE = [
   '  --allow-all                Enable all permissions',
   '  --no-ask-user              Disable the ask_user tool',
   '  --add-dir <directory>      Add a directory to the allowed list',
+  '  --additional-mcp-config <json>  JSON string or @file MCP config (repeatable)',
 ].join('\n');
 
 function emit(event) {
@@ -67,6 +68,11 @@ function main() {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, content);
   process.stderr.write(`fake-copilot: wrote ${target} (prompt="${promptValue(argv)}")\n`);
+
+  // Record the exact argv this run received so the MCP e2e can assert that
+  // `--additional-mcp-config <config>` was forwarded through the whole stack.
+  const argvLog = path.resolve(process.cwd(), 'copilot-received-argv.json');
+  fs.writeFileSync(argvLog, JSON.stringify(argv));
 
   // Emit the real Copilot `--output-format json` JSONL shape (verified against copilot v1.0.69):
   // dot-namespaced types, payload under `data`, success derived from the terminal `exitCode`.

--- a/tests/integration/copilot-mcp-docker.test.js
+++ b/tests/integration/copilot-mcp-docker.test.js
@@ -1,0 +1,153 @@
+/**
+ * Focused Docker-isolation proof for Copilot MCP config.
+ *
+ * The heavyweight `zeroshot run --docker` path (tests/integration/e2e-isolation-and-auto.test.sh)
+ * needs the real `zeroshot-cluster-base` image plus live Claude/Copilot credentials — none are
+ * available offline, and COPILOT_GITHUB_TOKEN is unset, so a live Copilot API call is impossible.
+ *
+ * This proves the Docker-specific piece for the MCP feature: the copilot adapter's inlined
+ * `--additional-mcp-config <json>` argument survives the container boundary intact. It builds the
+ * REAL copilot argv on the host with the compiled adapter (reading the repo `.mcp.json`, exactly as
+ * the agent spawn path does), then delivers it into a container via `docker exec -i <container>
+ * <command>` — the exact mechanism IsolationManager.spawnInContainer uses. A fake `copilot` inside
+ * the container records the argv it received; the host asserts the inlined config arrived unchanged.
+ *
+ * Fully offline: no zeroshot-cluster-base image, no credentials, no Copilot API call.
+ *
+ * REQUIRES: Docker installed and running, and the node:20-slim image already pulled. SKIPS
+ * otherwise (or under CI) — the base image pull is left to the environment to avoid slow network
+ * pulls inside a test hook.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const IsolationManager = require('../../src/isolation-manager');
+const { prepareSingleAgentProviderCommand } = require('../../task-lib/provider-helper-runtime.js');
+
+const IMAGE = 'node:20-slim';
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const FAKE_COPILOT = path.join(REPO_ROOT, 'tests', 'e2e', 'fixtures', 'fake-copilot.js');
+const MCP_JSON = JSON.stringify({
+  mcpServers: { demo: { command: 'demo-mcp-bin', args: ['--stdio'] } },
+});
+
+function dockerCli(args, opts = {}) {
+  return spawnSync('docker', args, { encoding: 'utf8', ...opts });
+}
+
+function imagePresent(image) {
+  return dockerCli(['image', 'inspect', image]).status === 0;
+}
+
+describe('copilot MCP config under Docker isolation', function () {
+  this.timeout(120000);
+
+  let ctxDir;
+  let container;
+  let hostArgs;
+
+  before(function () {
+    if (process.env.CI || !IsolationManager.isDockerAvailable() || !imagePresent(IMAGE)) {
+      this.skip();
+    }
+  });
+
+  beforeEach(function () {
+    ctxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-copilot-mcp-docker-'));
+    fs.writeFileSync(path.join(ctxDir, '.mcp.json'), MCP_JSON);
+    fs.copyFileSync(FAKE_COPILOT, path.join(ctxDir, 'fake-copilot.js'));
+    const shim = path.join(ctxDir, 'copilot');
+    fs.writeFileSync(shim, '#!/bin/sh\nexec node "$(dirname "$0")/fake-copilot.js" "$@"\n', {
+      mode: 0o755,
+    });
+    fs.chmodSync(shim, 0o755);
+
+    // Build the copilot argv on the host exactly as the agent spawn path does: the repo .mcp.json
+    // content is inlined into options.mcpConfig, and the copilot adapter emits it verbatim.
+    const content = fs.readFileSync(path.join(ctxDir, '.mcp.json'), 'utf8').trim();
+    const prepared = prepareSingleAgentProviderCommand({
+      provider: 'copilot',
+      context: 'do the work',
+      options: {
+        autoApprove: true,
+        outputFormat: 'json',
+        cwd: '/app',
+        mcpConfig: [content],
+        cliFeatures: {
+          supportsJsonOutput: true,
+          supportsAllowAll: true,
+          supportsNoAskUser: true,
+          supportsAddDir: true,
+          supportsMcpConfig: true,
+        },
+      },
+    });
+    hostArgs = prepared.commandSpec.args;
+    container = null;
+  });
+
+  afterEach(function () {
+    if (container) {
+      dockerCli(['rm', '-f', container], { stdio: 'pipe' });
+      container = null;
+    }
+    if (ctxDir) {
+      fs.rmSync(ctxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('delivers --additional-mcp-config to copilot intact through docker exec', function () {
+    // Sanity: the host-built argv must carry the inlined MCP config (else the container proof is
+    // vacuous).
+    const hostFlag = hostArgs.indexOf('--additional-mcp-config');
+    assert.ok(
+      hostFlag >= 0 && hostArgs[hostFlag + 1] === MCP_JSON,
+      'adapter did not emit MCP flag'
+    );
+
+    const run = dockerCli(['run', '-d', IMAGE, 'tail', '-f', '/dev/null']);
+    assert.strictEqual(run.status, 0, `docker run failed: ${run.stderr}`);
+    container = run.stdout.trim();
+
+    assert.strictEqual(dockerCli(['exec', container, 'mkdir', '-p', '/app']).status, 0);
+    const cp = dockerCli(['cp', `${ctxDir}/.`, `${container}:/app`]);
+    assert.strictEqual(cp.status, 0, `docker cp failed: ${cp.stderr}`);
+    dockerCli(['exec', container, 'chmod', '+x', '/app/copilot']);
+
+    // Mirror IsolationManager.spawnInContainer: `docker exec -i <container> <command>` with the
+    // provider argv the host built. -w /app makes the fake copilot record argv under /app.
+    const exec = dockerCli([
+      'exec',
+      '-i',
+      '-w',
+      '/app',
+      '-e',
+      'PATH=/app:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      container,
+      'copilot',
+      ...hostArgs,
+    ]);
+    assert.strictEqual(
+      exec.status,
+      0,
+      `copilot failed inside container:\nSTDOUT:\n${exec.stdout}\nSTDERR:\n${exec.stderr}`
+    );
+
+    const out = dockerCli(['exec', container, 'cat', '/app/copilot-received-argv.json']);
+    assert.strictEqual(out.status, 0, `could not read recorded argv: ${out.stderr}`);
+    const argv = JSON.parse(out.stdout);
+
+    // The argv the fake copilot received inside the container must match what the host sent, with
+    // the inlined MCP config unchanged.
+    assert.deepStrictEqual(argv, hostArgs, 'argv mutated crossing the container boundary');
+    const flagIndex = argv.indexOf('--additional-mcp-config');
+    assert.ok(
+      flagIndex >= 0,
+      `no --additional-mcp-config in container argv: ${JSON.stringify(argv)}`
+    );
+    assert.strictEqual(argv[flagIndex + 1], MCP_JSON);
+  });
+});

--- a/tests/unit/docker-image-cacerts.test.js
+++ b/tests/unit/docker-image-cacerts.test.js
@@ -1,0 +1,66 @@
+/**
+ * Test: Docker base image keeps CA certificates
+ *
+ * Regression guard for a hard-to-diagnose failure mode.
+ *
+ * The GitHub Copilot CLI (and other Rust-based provider CLIs) use the *system* CA certificate
+ * store for HTTPS, not a bundled one. If `ca-certificates` is missing from the cluster image,
+ * copilot authentication fails with a cryptic error that looks like a network problem:
+ *
+ *   Failed to fetch PAT user login: network fetch failed: request failed: builder error
+ *   (~/.copilot/logs) No CA certificates were loaded from the system
+ *
+ * ...even when COPILOT_GITHUB_TOKEN is valid and general egress works (Node's own fetch keeps
+ * working because Node bundles its own CAs, which makes this doubly confusing to debug).
+ *
+ * The base image is derived from `node:20-slim`, which does NOT ship system CA certificates,
+ * so the Dockerfile must install them explicitly. This test fails loudly if that line is ever
+ * removed, so the breakage is caught at review time instead of inside a container.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const DOCKERFILE_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'docker',
+  'zeroshot-cluster',
+  'Dockerfile'
+);
+
+describe('Docker cluster image: CA certificates', function () {
+  let dockerfile;
+
+  before(function () {
+    dockerfile = fs.readFileSync(DOCKERFILE_PATH, 'utf8');
+  });
+
+  it('installs ca-certificates (required for copilot/Rust CLI HTTPS auth)', function () {
+    // Strip comment lines so a mention in a comment can never satisfy the guard.
+    const instructions = dockerfile
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('#'))
+      .join('\n');
+
+    assert.match(
+      instructions,
+      /\bca-certificates\b/,
+      'docker/zeroshot-cluster/Dockerfile must install the `ca-certificates` package. ' +
+        'Without it, the Copilot CLI (Rust) cannot load system CA certs and authentication ' +
+        'fails with a misleading "network fetch failed: builder error". Do not remove it.'
+    );
+  });
+
+  it('derives from node:20-slim, which is why ca-certificates must be explicit', function () {
+    // If the base image ever changes to one that bundles system CA certs, this test documents
+    // the assumption behind the guard above (slim images ship no system CA store).
+    assert.match(
+      dockerfile,
+      /^FROM\s+node:\d+-slim/m,
+      'Base image is expected to be a slim node image (no system CA certs by default).'
+    );
+  });
+});

--- a/tests/unit/provider-docker-image.test.js
+++ b/tests/unit/provider-docker-image.test.js
@@ -1,0 +1,99 @@
+/**
+ * Test: per-provider Docker image selection
+ *
+ * Providers whose CLI is not baked into the base image (copilot, codex, gemini) run on a
+ * per-provider image variant `<base>-<provider>` whose CLI install is a Docker-cached build
+ * layer. Providers baked into the base image (claude) — or with no single-command installer
+ * (opencode) — run on the base image directly.
+ *
+ * The install command is sourced from the provider registry (docker.install), never hardcoded
+ * here, so this stays general-purpose across current and future providers.
+ */
+
+const assert = require('assert');
+const IsolationManager = require('../../src/isolation-manager');
+const { getProviderMetadata } = require('../../lib/provider-names');
+
+describe('IsolationManager: per-provider image selection', function () {
+  describe('imageForProvider', function () {
+    it('returns the base image for a provider baked into it (claude)', function () {
+      assert.strictEqual(IsolationManager.imageForProvider('claude'), 'zeroshot-cluster-base');
+    });
+
+    it('returns a per-provider variant for a provider with docker.install (copilot)', function () {
+      assert.strictEqual(
+        IsolationManager.imageForProvider('copilot'),
+        'zeroshot-cluster-base-copilot'
+      );
+    });
+
+    it('returns a per-provider variant for codex', function () {
+      assert.strictEqual(IsolationManager.imageForProvider('codex'), 'zeroshot-cluster-base-codex');
+    });
+
+    it('honors a custom base image when building the variant name', function () {
+      assert.strictEqual(
+        IsolationManager.imageForProvider('copilot', 'my-base'),
+        'my-base-copilot'
+      );
+    });
+
+    it('normalizes provider aliases to the canonical image (no duplicate per alias)', function () {
+      // `openai` is an alias of `codex`; both must resolve to the same variant image so we don't
+      // build a redundant `-openai` image alongside `-codex`.
+      assert.strictEqual(
+        IsolationManager.imageForProvider('openai'),
+        IsolationManager.imageForProvider('codex')
+      );
+      assert.strictEqual(
+        IsolationManager.imageForProvider('openai'),
+        'zeroshot-cluster-base-codex'
+      );
+    });
+
+    it('falls back to the base image for a provider with no docker.install (opencode)', function () {
+      assert.strictEqual(IsolationManager.imageForProvider('opencode'), 'zeroshot-cluster-base');
+    });
+  });
+
+  describe('providerBuildArgs', function () {
+    it('returns no build args for a baked-in provider (claude)', function () {
+      assert.deepStrictEqual(IsolationManager.providerBuildArgs('claude'), []);
+    });
+
+    it('emits PROVIDER_INSTALL for copilot from the registry command', function () {
+      assert.deepStrictEqual(IsolationManager.providerBuildArgs('copilot'), [
+        'PROVIDER_INSTALL=npm install -g @github/copilot',
+      ]);
+    });
+
+    it('emits PROVIDER_INSTALL for codex from the registry command', function () {
+      assert.deepStrictEqual(IsolationManager.providerBuildArgs('codex'), [
+        'PROVIDER_INSTALL=npm install -g @openai/codex',
+      ]);
+    });
+
+    it('matches the value the registry advertises (no hardcoded drift)', function () {
+      const registryInstall = getProviderMetadata('copilot').docker.install;
+      assert.deepStrictEqual(IsolationManager.providerBuildArgs('copilot'), [
+        `PROVIDER_INSTALL=${registryInstall}`,
+      ]);
+    });
+  });
+
+  describe('registry docker.install', function () {
+    it('is set for npm-installable providers and absent for baked-in claude', function () {
+      assert.ok(
+        getProviderMetadata('copilot').docker.install,
+        'copilot should have docker.install'
+      );
+      assert.ok(getProviderMetadata('codex').docker.install, 'codex should have docker.install');
+      assert.ok(getProviderMetadata('gemini').docker.install, 'gemini should have docker.install');
+      assert.strictEqual(
+        getProviderMetadata('claude').docker.install,
+        undefined,
+        'claude is baked into the base image and must not declare docker.install'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Four related changes for the Copilot provider and Docker isolation mode:

1. **Copilot MCP support** — the copilot adapter now emits `--additional-mcp-config`, so MCP servers configured for a run reach Copilot.
2. **Cached per-provider Docker install** — the running provider's CLI is installed into a per-provider image variant as a Docker-cached layer, so `--docker --provider <p>` actually has the provider CLI available.
3. **ca-certificates regression guard** — a unit test that keeps the cluster image buildable for Copilot's auth.
4. **Two pre-existing build-blocking fixes** — the base image could not be built at all before this; both are fixed here so Docker mode works end-to-end.

## Details

### 1. Copilot MCP (`--additional-mcp-config`)
- New validated `mcpConfig` field on `BuildProviderCommandOptions` (array of JSON strings / `@file`), normalized in `contract-options`.
- `copilot.ts` emits one `--additional-mcp-config` per entry, gated on feature detection (`supportsMcpConfig` from `--additional-mcp-config` in help), with a warning when unsupported.
- Threaded end-to-end via **two** paths: (a) CLI `--mcp-config` → runner → adapter; (b) orchestrator agent spawn reads the repo `.claude/.mcp.json` (the same source Claude uses), **inlines** it (so the value survives host→container translation), and forwards it. Registry flips copilot `mcpServers: true`.
- Copilot consumes MCP only from its own config locations, not the worktree overlay, so the CLI-flag approach is the correct fit (unlike Claude's `.mcp.json` convention).

### 2. Cached per-provider Docker install
- Docker mode previously baked **only** the Claude CLI into `zeroshot-cluster-base`; copilot/codex/gemini were never installed, so `--docker --provider <p>` failed with "command not found".
- Now: a per-provider image variant `zeroshot-cluster-base-<provider>` = base + a single `RUN <install>` layer, driven by a new **registry** field `docker.install` (no hardcoded provider names in logic). Claude stays baked (variant = base); installer-less providers fall back to the base image.
- `IsolationManager.imageForProvider` / `providerBuildArgs` resolve the image + `--build-arg`; threaded through `orchestrator._initializeIsolation` and validator isolation, and **persisted for resume** (the resolved variant, not the base, is stored in `cluster.isolation.image`).
- The `ARG PROVIDER_INSTALL` sits after all heavy layers, so the base layers stay shared/Docker-cached across variants — building a second provider variant reuses the whole base and only runs its install layer (~70s vs a full build).

### 3. ca-certificates guard
- Copilot's Rust HTTP client uses the **system** CA store (Node bundles its own, so `fetch` works but copilot doesn't). On the `node:20-slim` base, a missing `ca-certificates` makes auth fail with a cryptic `network fetch failed: builder error`. A unit test keeps the Dockerfile line from being silently dropped.

### 4. Pre-existing build-blocking fixes
- `RUN npm install -g npm@latest` now pulls npm 12, which requires node ≥22 and fails `EBADENGINE` on `node:20-slim` → pinned to `npm@11`.
- `buildImage` inherited `runSync`'s 30s default timeout, killing every heavy image build with `ETIMEDOUT` → `timeout: 0` for the build subprocess.

## Testing
- `check:agent-cli-provider:ci` 127/127 · new unit tests (image selection + ca-certs guard) 13/13 · `test:e2e` 7/7 (incl. asserting the exact inlined `--additional-mcp-config` argv) · `copilot-mcp-docker` integration 1/1 · full unit suite 1490 passing (4 failing are pre-existing node-pty/better-sqlite3 environment issues).
- Real image builds verified: `zeroshot-cluster-base` (claude), `-copilot` (copilot 1.0.70), `-codex` (codex 0.144.1); base-layer caching confirmed.
- Live: copilot in the real image authenticates via `COPILOT_GITHUB_TOKEN` and completes the MCP handshake through `--additional-mcp-config` (the model turn itself was gated by an exhausted Copilot quota, not code).
- Regression: claude still uses the unchanged base image; codex docker was previously broken (not installed) and is now fixed; `claude -p` / `codex exec` work non-docker.

## Reviewer notes (minor, non-blocking follow-ups)
- Validators use `DEFAULT_VALIDATOR_IMAGE`, so a custom `--docker-image` would diverge between main container and validators (pre-existing — validators already ignored `--docker-image`).
- `buildImage` always builds from the repo Dockerfile regardless of tag (pre-existing).
- `timeout: 0` removes the build ceiling entirely (deliberate, to avoid re-introducing the killed-slow-build bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
