### PR TITLE
fix(release): avoid default delivery merge conflict

### DIFF
--- a/lib/start-cluster.js
+++ b/lib/start-cluster.js
@@ -212,8 +212,6 @@ function resolveEffectiveRunPlan(mergedOptions, settings) {
       settings.defaultDocker
     ),
     worktree: anyTruthy(mergedOptions.worktree, process.env.ZEROSHOT_WORKTREE === '1'),
-    pr: anyTruthy(mergedOptions.pr, settings.defaultDelivery === 'pr'),
-    ship: anyTruthy(mergedOptions.ship, settings.defaultDelivery === 'ship'),
   });
 }
 
@@ -297,6 +295,16 @@ function resolveConfigOrThrow({
   return loadClusterConfig(orchestrator, resolvedPath, settings, providerOverride);
 }
 
+function applyDefaultDeliveryOptions(options, settings) {
+  if (settings.defaultDelivery === 'pr') {
+    return { ...options, pr: true };
+  }
+  if (settings.defaultDelivery === 'ship') {
+    return { ...options, ship: true };
+  }
+  return options;
+}
+
 function startClusterWithInput(args, input) {
   const { orchestrator, config, configPath, configName, settings, providerOverride } = args;
   if (!orchestrator) {
@@ -312,7 +320,7 @@ function startClusterWithInput(args, input) {
   });
   const startOptions = buildStartOptions({
     clusterId: args.clusterId,
-    options: args.options || {},
+    options: applyDefaultDeliveryOptions(args.options || {}, settings),
     settings,
     providerOverride,
     modelOverride: args.modelOverride,

--- a/tests/unit/setup-apply.test.js
+++ b/tests/unit/setup-apply.test.js
@@ -7,7 +7,7 @@
  * - Writes confined to global settings, .zeroshot/settings.json, and the undo journal
  * - Dead settings keys (no consumer) are refused, not written
  * - No secret-shaped path is ever written
- * - defaultDelivery=ship requires explicit opt-in and is then live in resolveEffectiveRunPlan
+ * - defaultDelivery=ship requires explicit opt-in and is then live in startClusterFromText
  * - github issue-source hint prints a login command instead of storing anything
  */
 
@@ -185,7 +185,7 @@ describe('setup-apply', function () {
     assert.ok(!fs.existsSync(TEST_SETTINGS_FILE));
   });
 
-  it('stores defaultDelivery=ship with --allow-risky-defaults and it is live in resolveEffectiveRunPlan', function () {
+  it('stores defaultDelivery=ship with --allow-risky-defaults and it is live in startClusterFromText', function () {
     const decisions = decisionsFile({ defaultDelivery: 'ship' });
     const results = applyModule.applyDecisions({
       decisionsPath: decisions,
@@ -197,9 +197,21 @@ describe('setup-apply', function () {
     const settings = settingsModule.loadSettings();
     assert.strictEqual(settings.defaultDelivery, 'ship');
 
-    const plan = startClusterModule.resolveEffectiveRunPlan({}, settings);
-    assert.strictEqual(plan.delivery, 'ship');
-    assert.strictEqual(plan.autoMerge, true);
+    const startOptions = startClusterModule.startClusterFromText({
+      orchestrator: {
+        start(_config, _input, options) {
+          return options;
+        },
+      },
+      config: { agents: [] },
+      clusterId: 'c1',
+      text: 'hello',
+      options: {},
+      settings,
+    });
+    assert.strictEqual(startOptions.autoPr, true);
+    assert.strictEqual(startOptions.autoMerge, true);
+    assert.strictEqual(startOptions.worktree, true);
   });
 
   it('confines writes to global settings, repo .zeroshot/settings.json, and the undo journal', function () {

--- a/tests/unit/start-cluster-config.test.js
+++ b/tests/unit/start-cluster-config.test.js
@@ -1,10 +1,6 @@
 const assert = require('assert');
 
-const {
-  loadClusterConfig,
-  buildStartOptions,
-  resolveEffectiveRunPlan,
-} = require('../../lib/start-cluster');
+const { loadClusterConfig, buildStartOptions } = require('../../lib/start-cluster');
 
 function createOrchestrator(config) {
   const calls = { loadConfig: [] };
@@ -109,45 +105,6 @@ describe('buildStartOptions() isolation (single producer via run plan)', functio
     const result = buildStartOptions({ clusterId: 'c1', options: {}, settings: {} });
     assert.strictEqual(result.isolation, false);
     assert.strictEqual(result.worktree, false);
-  });
-});
-
-describe('resolveEffectiveRunPlan() settings.defaultDelivery (issue #606)', function () {
-  it('folds settings.defaultDelivery=ship into delivery + autoMerge', function () {
-    const plan = resolveEffectiveRunPlan({}, { defaultDelivery: 'ship' });
-    assert.strictEqual(plan.delivery, 'ship');
-    assert.strictEqual(plan.autoMerge, true);
-    // ship-equivalent delivery also implies worktree isolation, same as --ship.
-    assert.strictEqual(plan.isolation, 'worktree');
-  });
-
-  it('folds settings.defaultDelivery=pr into delivery without autoMerge', function () {
-    const plan = resolveEffectiveRunPlan({}, { defaultDelivery: 'pr' });
-    assert.strictEqual(plan.delivery, 'pr');
-    assert.strictEqual(plan.autoMerge, false);
-    assert.strictEqual(plan.isolation, 'worktree');
-  });
-
-  it('defaults to delivery=none when settings.defaultDelivery is unset', function () {
-    const plan = resolveEffectiveRunPlan({}, {});
-    assert.strictEqual(plan.delivery, 'none');
-    assert.strictEqual(plan.autoMerge, false);
-  });
-
-  it('a CLI --pr flag still wins when settings.defaultDelivery=none', function () {
-    const plan = resolveEffectiveRunPlan({ pr: true }, { defaultDelivery: 'none' });
-    assert.strictEqual(plan.delivery, 'pr');
-  });
-
-  it('buildStartOptions folds settings.defaultDelivery into autoPr/autoMerge', function () {
-    const result = buildStartOptions({
-      clusterId: 'c1',
-      options: {},
-      settings: { defaultDelivery: 'ship' },
-    });
-    assert.strictEqual(result.autoPr, true);
-    assert.strictEqual(result.autoMerge, true);
-    assert.strictEqual(result.worktree, true);
   });
 });
 

--- a/tests/unit/start-cluster-default-delivery.test.js
+++ b/tests/unit/start-cluster-default-delivery.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+
+const { resolveEffectiveRunPlan, startClusterFromText } = require('../../lib/start-cluster');
+
+function captureStartOptions(settings) {
+  const config = { agents: [] };
+  const orchestrator = {
+    start(_config, _input, startOptions) {
+      return startOptions;
+    },
+  };
+  return startClusterFromText({
+    orchestrator,
+    config,
+    clusterId: 'c1',
+    text: 'hello',
+    options: {},
+    settings,
+  });
+}
+
+describe('resolveEffectiveRunPlan() settings.defaultDelivery (issue #606)', function () {
+  it('folds merged defaultDelivery=ship into delivery + autoMerge', function () {
+    const plan = resolveEffectiveRunPlan({ ship: true }, {});
+    assert.strictEqual(plan.delivery, 'ship');
+    assert.strictEqual(plan.autoMerge, true);
+    assert.strictEqual(plan.isolation, 'worktree');
+  });
+
+  it('folds merged defaultDelivery=pr into delivery without autoMerge', function () {
+    const plan = resolveEffectiveRunPlan({ pr: true }, {});
+    assert.strictEqual(plan.delivery, 'pr');
+    assert.strictEqual(plan.autoMerge, false);
+    assert.strictEqual(plan.isolation, 'worktree');
+  });
+
+  it('defaults to delivery=none when settings.defaultDelivery is unset', function () {
+    const plan = resolveEffectiveRunPlan({}, {});
+    assert.strictEqual(plan.delivery, 'none');
+    assert.strictEqual(plan.autoMerge, false);
+  });
+
+  it('a CLI --pr flag still wins when settings.defaultDelivery=none', function () {
+    const plan = resolveEffectiveRunPlan({ pr: true }, { defaultDelivery: 'none' });
+    assert.strictEqual(plan.delivery, 'pr');
+  });
+
+  it('startClusterFromText folds settings.defaultDelivery into autoPr/autoMerge', function () {
+    const result = captureStartOptions({ defaultDelivery: 'ship' });
+    assert.strictEqual(result.autoPr, true);
+    assert.strictEqual(result.autoMerge, true);
+    assert.strictEqual(result.worktree, true);
+  });
+});


### PR DESCRIPTION
## Summary
- moves defaultDelivery application out of the release-conflicting buildStartOptions hunk and into the production start path
- moves defaultDelivery regression coverage into a separate test file
- keeps behavior: defaultDelivery=ship still produces worktree + autoMerge on start

## Verification
- node tests/run-tests.js tests/unit/start-cluster-config.test.js tests/unit/start-cluster-default-delivery.test.js tests/unit/setup-apply.test.js
- npm run typecheck
- git merge-tree --write-tree origin/main HEAD -> merge_tree_status=0