### PR TITLE
fix(release): treat promotion commits as minor releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,17 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {
+            "type": "release",
+            "release": "minor"
+          }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [


### PR DESCRIPTION
## Summary
- teach semantic-release that repository promotion commits using the `release:` type should publish a minor version
- preserves the existing semantic-release default handling for `feat`, `fix`, and breaking changes

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('.releaserc.json','utf8')); console.log('releaserc json ok')"`
- direct commit-analyzer probe: `release: promote dev to main` => `minor`
- commit hook: `tsc --noEmit`
- push hook: `npm run lint` (warnings only), `tsc --noEmit`