### PR TITLE
fix(release): avoid protected branch writes during publish

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,18 +13,10 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         "npmPublish": true
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
- remove semantic-release changelog/git prepare plugins that write release artifacts back to `main`
- keep commit analysis, release notes, npm publishing, and GitHub release publishing

## Why
The #625 release run computed `6.5.0`, then failed because `@semantic-release/git` ran `git push --tags ... HEAD:main`; branch protection rejected the generated commit because `main` requires PR + merge queue.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('.releaserc.json','utf8')); console.log('releaserc json ok')"`