### PR TITLE
fix(release): prefer package-owned publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,32 @@
     "example": "examples",
     "test": "tests"
   },
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "releaseRules": [
+            {
+              "type": "release",
+              "release": "minor"
+            }
+          ]
+        }
+      ],
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": true
+        }
+      ],
+      "@semantic-release/github"
+    ]
+  },
   "scripts": {
     "pretest": "npm run build:agent-cli-provider",
     "test": "node tests/run-tests.js",


### PR DESCRIPTION
## Summary
- add semantic-release config under `package.json#release`
- package config is discovered before `.releaserc.json`, so release publishes with npm/GitHub only even if the divergent main/dev merge keeps resolving `.releaserc.json` to the stale branch-writing version

## Why
The merge queue repeatedly leaves `main:.releaserc.json` with `@semantic-release/changelog` and `@semantic-release/git`; semantic-release then computes `6.5.0` but fails when `@semantic-release/git` tries to push generated commits to protected `main`.

This moves the effective release contract to the first config source semantic-release reads.

## Verification
- package release plugin list: `commit-analyzer, release-notes-generator, npm, github`
- simulated `git merge-tree origin/main HEAD` preserves `package.json#release` with no changelog/git plugins even though `.releaserc.json` resolves stale