### PR TITLE
fix(release): fail closed on broken promotions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,40 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
+  release-preflight:
+    name: Release preflight
+    needs: [enforce-main-pr-source]
+    if: |
+      always() &&
+      (needs.enforce-main-pr-source.result == 'success' || needs.enforce-main-pr-source.result == 'skipped') &&
+      (
+        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+        (github.event_name == 'merge_group' && (
+          github.event.merge_group.base_ref == 'main' ||
+          github.event.merge_group.base_ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
+        ))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate release contract
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run release:preflight
+
   # Tier 2: worktree/container isolation e2e (real Docker). Non-blocking and
   # opt-in via workflow_dispatch - the Docker sub-tests in `check`'s
   # "Integration tests (slow)" step self-skip under CI (this is what that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Release preflight
+        run: npm run release:preflight
+
       - name: Verify package before release
         run: |
           # Create tarball (respects 'files' array in package.json)
@@ -176,3 +179,7 @@ jobs:
             echo "🚀 Publishing release (triggered by CI passing)"
             npx semantic-release
           fi
+
+      - name: Assert release published
+        if: github.event_name == 'workflow_run'
+        run: npm run release:assert-published

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "check": "npm run typecheck && npm run lint",
     "check:all": "npm run check && npm run deadcode:all",
     "release": "semantic-release",
+    "release:preflight": "node scripts/release-preflight.js",
+    "release:assert-published": "node scripts/assert-release-published.js",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run check:agent-cli-provider:ci",
     "prepare": "npm run build:agent-cli-provider && husky"
   },

--- a/scripts/assert-release-published.js
+++ b/scripts/assert-release-published.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+
+function run(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' }).trim();
+}
+
+function packageName() {
+  return require('../package.json').name;
+}
+
+function npmLatest(name) {
+  return JSON.parse(run('npm', ['view', name, 'dist-tags.latest', '--json']));
+}
+
+function tagsPointingAtHead() {
+  run('git', ['fetch', '--tags', '--force']);
+  return run('git', ['tag', '--points-at', 'HEAD', '--list', 'v[0-9]*'])
+    .split(/\r?\n/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function main() {
+  const name = packageName();
+  const latest = npmLatest(name);
+  const expectedTag = `v${latest}`;
+  const headTags = tagsPointingAtHead();
+
+  console.log(`npm latest for ${name}: ${latest}`);
+  console.log(`tags on HEAD: ${headTags.join(', ') || '(none)'}`);
+
+  if (!headTags.includes(expectedTag)) {
+    throw new Error(`expected ${expectedTag} to point at HEAD after release`);
+  }
+
+  console.log(`Release publication verified: ${name}@${latest}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Release publication check failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  npmLatest,
+  tagsPointingAtHead,
+};

--- a/scripts/release-preflight.js
+++ b/scripts/release-preflight.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const https = require('https');
+const { execFileSync } = require('child_process');
+
+const RELEASE_ORDER = ['patch', 'minor', 'major'];
+const REQUIRED_PLUGINS = [
+  '@semantic-release/commit-analyzer',
+  '@semantic-release/release-notes-generator',
+  '@semantic-release/npm',
+  '@semantic-release/github',
+];
+const FORBIDDEN_EFFECTIVE_PLUGINS = new Set([
+  '@semantic-release/changelog',
+  '@semantic-release/git',
+]);
+
+function normalizePlugin(plugin) {
+  return Array.isArray(plugin) ? plugin[0] : plugin;
+}
+
+function releaseRank(type) {
+  return RELEASE_ORDER.indexOf(type);
+}
+
+function maxReleaseType(current, candidate) {
+  if (!candidate) return current;
+  if (!current) return candidate;
+  return releaseRank(candidate) > releaseRank(current) ? candidate : current;
+}
+
+function analyzeMessage(message) {
+  const firstLine = String(message || '')
+    .split(/\r?\n/, 1)[0]
+    .trim();
+  if (!firstLine) return null;
+  if (/BREAKING CHANGE:|BREAKING-CHANGE:/m.test(message)) return 'major';
+
+  const separator = firstLine.indexOf(': ');
+  if (separator <= 0) return null;
+
+  const header = firstLine.slice(0, separator);
+  const breaking = header.endsWith('!');
+  const typeAndScope = breaking ? header.slice(0, -1) : header;
+  const scopeStart = typeAndScope.indexOf('(');
+  const type = scopeStart === -1 ? typeAndScope : typeAndScope.slice(0, scopeStart);
+
+  if (!/^[a-z][a-z0-9-]*$/i.test(type)) return null;
+  if (breaking) return 'major';
+
+  switch (type) {
+    case 'release':
+    case 'feat':
+      return 'minor';
+    case 'fix':
+    case 'perf':
+      return 'patch';
+    default:
+      return null;
+  }
+}
+
+function getPluginNames(releaseConfig) {
+  return (releaseConfig.plugins || []).map(normalizePlugin);
+}
+
+function validateReleaseConfig(packageJson) {
+  const releaseConfig = packageJson.release;
+  if (!releaseConfig || typeof releaseConfig !== 'object') {
+    throw new Error(
+      'package.json#release is required so it takes precedence over stale .releaserc files'
+    );
+  }
+
+  const branches = Array.isArray(releaseConfig.branches)
+    ? releaseConfig.branches
+    : [releaseConfig.branches].filter(Boolean);
+  if (!branches.includes('main')) {
+    throw new Error('package.json#release.branches must include main');
+  }
+
+  const pluginNames = getPluginNames(releaseConfig);
+  for (const required of REQUIRED_PLUGINS) {
+    if (!pluginNames.includes(required)) {
+      throw new Error(`package.json#release.plugins is missing ${required}`);
+    }
+  }
+
+  for (const forbidden of FORBIDDEN_EFFECTIVE_PLUGINS) {
+    if (pluginNames.includes(forbidden)) {
+      throw new Error(
+        `${forbidden} must not be in the effective release config for protected main`
+      );
+    }
+  }
+
+  const npmPlugin = releaseConfig.plugins.find(
+    (plugin) => normalizePlugin(plugin) === '@semantic-release/npm'
+  );
+  const npmOptions = Array.isArray(npmPlugin) ? npmPlugin[1] || {} : {};
+  if (npmOptions.npmPublish !== true) {
+    throw new Error('@semantic-release/npm must publish to npm');
+  }
+
+  return pluginNames;
+}
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function latestReleaseTag() {
+  return git(['describe', '--tags', '--abbrev=0', '--match', 'v[0-9]*']);
+}
+
+function commitMessagesSince(tag) {
+  const output = git(['log', '--format=%B%x1e', `${tag}..HEAD`]);
+  return output
+    .split('\x1e')
+    .map((message) => message.trim())
+    .filter(Boolean);
+}
+
+function prTitleFromEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) return null;
+  const event = readJson(eventPath);
+  return event.pull_request?.title || null;
+}
+
+function prNumberFromMergeQueueRef() {
+  const refName = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF || '';
+  const match = refName.match(/(?:^|\/)pr-(\d+)-/);
+  return match ? match[1] : null;
+}
+
+function githubJson(path) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) return Promise.resolve(null);
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      {
+        hostname: 'api.github.com',
+        path: `/repos/${repository}${path}`,
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'zeroshot-release-preflight',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+      (response) => {
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          body += chunk;
+        });
+        response.on('end', () => {
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            reject(new Error(`GitHub API ${path} returned ${response.statusCode}: ${body}`));
+            return;
+          }
+          resolve(JSON.parse(body));
+        });
+      }
+    );
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function prTitleFromMergeQueue() {
+  const number = prNumberFromMergeQueueRef();
+  if (!number) return null;
+  const pull = await githubJson(`/pulls/${number}`);
+  return pull?.title || null;
+}
+
+async function releaseSignal() {
+  const tag = latestReleaseTag();
+  const messages = commitMessagesSince(tag);
+  let releaseType = null;
+  for (const message of messages) {
+    releaseType = maxReleaseType(releaseType, analyzeMessage(message));
+  }
+
+  let title = prTitleFromEvent();
+  if (!title) title = await prTitleFromMergeQueue();
+  releaseType = maxReleaseType(releaseType, analyzeMessage(title));
+
+  return {
+    latestTag: tag,
+    commitCount: messages.length,
+    prTitle: title,
+    releaseType,
+  };
+}
+
+async function main() {
+  const packageJson = readJson('package.json');
+  const pluginNames = validateReleaseConfig(packageJson);
+  const signal = await releaseSignal();
+
+  console.log(`Effective release plugins: ${pluginNames.join(', ')}`);
+  console.log(`Latest release tag: ${signal.latestTag}`);
+  console.log(`Commits since tag: ${signal.commitCount}`);
+  if (signal.prTitle) console.log(`Release PR title: ${signal.prTitle}`);
+
+  if (!signal.releaseType) {
+    throw new Error(
+      'Release promotion would publish nothing; use a release-worthy PR title/commit'
+    );
+  }
+
+  console.log(`Release preflight passed: ${signal.releaseType}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Release preflight failed: ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  analyzeMessage,
+  maxReleaseType,
+  validateReleaseConfig,
+};

--- a/tests/release-preflight.test.js
+++ b/tests/release-preflight.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+
+const {
+  analyzeMessage,
+  maxReleaseType,
+  validateReleaseConfig,
+} = require('../scripts/release-preflight');
+
+describe('release preflight', () => {
+  it('classifies release promotion commits as minor releases', () => {
+    assert.strictEqual(analyzeMessage('release: promote dev to main'), 'minor');
+    assert.strictEqual(analyzeMessage('release(main): promote dev to main'), 'minor');
+  });
+
+  it('classifies conventional breaking commits as majors', () => {
+    assert.strictEqual(analyzeMessage('feat!: replace release flow'), 'major');
+    assert.strictEqual(
+      analyzeMessage('fix: repair release\n\nBREAKING CHANGE: config moved'),
+      'major'
+    );
+  });
+
+  it('preserves the highest release type found', () => {
+    assert.strictEqual(maxReleaseType('patch', 'minor'), 'minor');
+    assert.strictEqual(maxReleaseType('minor', 'patch'), 'minor');
+    assert.strictEqual(maxReleaseType('minor', 'major'), 'major');
+  });
+
+  it('rejects branch-writing plugins in the effective release config', () => {
+    assert.throws(
+      () =>
+        validateReleaseConfig({
+          release: {
+            branches: ['main'],
+            plugins: [
+              '@semantic-release/commit-analyzer',
+              '@semantic-release/release-notes-generator',
+              ['@semantic-release/npm', { npmPublish: true }],
+              '@semantic-release/git',
+              '@semantic-release/github',
+            ],
+          },
+        }),
+      /must not be in the effective release config/
+    );
+  });
+
+  it('accepts the protected-main release config', () => {
+    const plugins = validateReleaseConfig({
+      release: {
+        branches: ['main'],
+        plugins: [
+          [
+            '@semantic-release/commit-analyzer',
+            { releaseRules: [{ type: 'release', release: 'minor' }] },
+          ],
+          '@semantic-release/release-notes-generator',
+          ['@semantic-release/npm', { npmPublish: true }],
+          '@semantic-release/github',
+        ],
+      },
+    });
+
+    assert.deepStrictEqual(plugins, [
+      '@semantic-release/commit-analyzer',
+      '@semantic-release/release-notes-generator',
+      '@semantic-release/npm',
+      '@semantic-release/github',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a release preflight that validates the effective semantic-release config and release-worthy promotion signal
- run the preflight on main promotion PRs/merge queue and in the release workflow
- assert after release that npm latest and the git tag both point at the released HEAD

## Verification
- node -c scripts/release-preflight.js && node -c scripts/assert-release-published.js
- node tests/run-tests.js tests/release-preflight.test.js
- npx eslint scripts/release-preflight.js scripts/assert-release-published.js tests/release-preflight.test.js
- npx prettier --check .github/workflows/ci.yml .github/workflows/release.yml package.json scripts/release-preflight.js scripts/assert-release-published.js tests/release-preflight.test.js
- npm run release:preflight