### PR TITLE
fix(release): avoid main promotion workflow conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,40 +100,6 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
-  release-preflight:
-    name: Release preflight
-    needs: [enforce-main-pr-source]
-    if: |
-      always() &&
-      (needs.enforce-main-pr-source.result == 'success' || needs.enforce-main-pr-source.result == 'skipped') &&
-      (
-        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-        (github.event_name == 'merge_group' && (
-          github.event.merge_group.base_ref == 'main' ||
-          github.event.merge_group.base_ref == 'refs/heads/main' ||
-          startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
-        ))
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Validate release contract
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run release:preflight
-
   # Tier 2: worktree/container isolation e2e (real Docker). Non-blocking and
   # opt-in via workflow_dispatch - the Docker sub-tests in `check`'s
   # "Integration tests (slow)" step self-skip under CI (this is what that
@@ -250,3 +216,37 @@ jobs:
           footer.stop();
           console.log('✓ StatusFooter test passed');
           "
+
+  release-preflight:
+    name: Release preflight
+    needs: [enforce-main-pr-source]
+    if: |
+      always() &&
+      (needs.enforce-main-pr-source.result == 'success' || needs.enforce-main-pr-source.result == 'skipped') &&
+      (
+        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+        (github.event_name == 'merge_group' && (
+          github.event.merge_group.base_ref == 'main' ||
+          github.event.merge_group.base_ref == 'refs/heads/main' ||
+          startsWith(github.ref, 'refs/heads/gh-readonly-queue/main/')
+        ))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate release contract
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run release:preflight


### PR DESCRIPTION
## Summary
- move the release-preflight CI job to the end of the workflow to avoid the old dev/main merge-base conflict hunk
- preserve the same release preflight behavior

## Verification
- npx prettier --check .github/workflows/ci.yml
- commit hook: typecheck passed
- local merge test: origin/main merges codex/relocate-release-preflight without conflicts
- push hook: lint warnings only, typecheck passed