### PR TITLE
fix(release): wait for npm latest propagation

### DIFF
--- a/scripts/assert-release-published.js
+++ b/scripts/assert-release-published.js
@@ -2,6 +2,9 @@
 
 const { execFileSync } = require('child_process');
 
+const DEFAULT_ATTEMPTS = 24;
+const DEFAULT_DELAY_MS = 5000;
+
 function run(command, args) {
   return execFileSync(command, args, { encoding: 'utf8' }).trim();
 }
@@ -22,32 +25,83 @@ function tagsPointingAtHead() {
     .filter(Boolean);
 }
 
-function main() {
+function releaseTagParts(tag) {
+  const match = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return match.slice(1).map((part) => Number(part));
+}
+
+function compareReleaseTags(left, right) {
+  const leftParts = releaseTagParts(left);
+  const rightParts = releaseTagParts(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
+function latestReleaseTag(tags) {
+  const releaseTags = tags.filter((tag) => releaseTagParts(tag));
+  releaseTags.sort(compareReleaseTags);
+  return releaseTags.at(-1) || null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForNpmLatest(name, expectedVersion, options = {}) {
+  const attempts =
+    options.attempts || Number(process.env.RELEASE_ASSERT_ATTEMPTS || DEFAULT_ATTEMPTS);
+  const delayMs =
+    options.delayMs || Number(process.env.RELEASE_ASSERT_DELAY_MS || DEFAULT_DELAY_MS);
+
+  let latest = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    latest = npmLatest(name);
+    if (latest === expectedVersion) return latest;
+
+    if (attempt < attempts) {
+      console.log(
+        `npm latest for ${name} is ${latest}; waiting for ${expectedVersion} (${attempt}/${attempts})`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error(`expected npm latest for ${name} to be ${expectedVersion}, got ${latest}`);
+}
+
+async function main() {
   const name = packageName();
-  const latest = npmLatest(name);
-  const expectedTag = `v${latest}`;
   const headTags = tagsPointingAtHead();
+  const expectedTag = latestReleaseTag(headTags);
+
+  if (!expectedTag) {
+    throw new Error('expected a vX.Y.Z release tag to point at HEAD after release');
+  }
+
+  console.log(`tags on HEAD: ${headTags.join(', ') || '(none)'}`);
+  const expectedVersion = expectedTag.slice(1);
+  const latest = await waitForNpmLatest(name, expectedVersion);
 
   console.log(`npm latest for ${name}: ${latest}`);
-  console.log(`tags on HEAD: ${headTags.join(', ') || '(none)'}`);
-
-  if (!headTags.includes(expectedTag)) {
-    throw new Error(`expected ${expectedTag} to point at HEAD after release`);
-  }
 
   console.log(`Release publication verified: ${name}@${latest}`);
 }
 
 if (require.main === module) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     console.error(`Release publication check failed: ${error.message}`);
     process.exit(1);
-  }
+  });
 }
 
 module.exports = {
+  latestReleaseTag,
   npmLatest,
   tagsPointingAtHead,
+  waitForNpmLatest,
 };

--- a/tests/assert-release-published.test.js
+++ b/tests/assert-release-published.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+const { latestReleaseTag } = require('../scripts/assert-release-published');
+
+describe('release publication assertion', () => {
+  it('selects the highest semver release tag on HEAD', () => {
+    assert.strictEqual(latestReleaseTag(['v6.5.0', 'v6.6.0']), 'v6.6.0');
+    assert.strictEqual(latestReleaseTag(['v6.10.0', 'v6.9.9']), 'v6.10.0');
+  });
+
+  it('ignores non-release tags', () => {
+    assert.strictEqual(latestReleaseTag(['nightly', 'v6.6.0-beta.1', 'v6.6.0']), 'v6.6.0');
+    assert.strictEqual(latestReleaseTag(['nightly']), null);
+  });
+});


### PR DESCRIPTION
## Summary
- make post-release verification use the git tag on HEAD as the expected version
- poll npm latest until the registry dist-tag catches up instead of failing on propagation lag
- add focused unit coverage for release-tag selection

## Verification
- node -c scripts/assert-release-published.js
- node tests/run-tests.js tests/assert-release-published.test.js
- npx eslint scripts/assert-release-published.js tests/assert-release-published.test.js
- npx prettier --check scripts/assert-release-published.js tests/assert-release-published.test.js
- commit hook: typecheck passed
- push hook: lint warnings only, typecheck passed