### PR TITLE
feat(gateway): add MiniMax compatibility

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -3,8 +3,8 @@
 Zeroshot supports two provider shapes:
 
 - CLI-backed providers that shell out to a full agent CLI
-- One bundled `gateway` provider that wraps OpenAI-compatible model APIs with a
-  Zeroshot-owned tool runner
+- One bundled `gateway` provider that wraps OpenAI-compatible or Anthropic-compatible
+  model APIs with a Zeroshot-owned tool runner
 
 ## Supported Providers
 
@@ -29,9 +29,9 @@ Zeroshot supports two provider shapes:
 
 ## Gateway Provider
 
-Use `gateway` for OpenAI-compatible model endpoints such as OpenRouter,
-Ollama, vLLM, or self-hosted gateways. These stay model configs behind one
-provider engine; do not add them as standalone provider ids.
+Use `gateway` for OpenAI-compatible or Anthropic-compatible model endpoints.
+These stay model configs behind one provider engine; do not add them as
+standalone provider ids.
 
 Required settings:
 
@@ -39,6 +39,7 @@ Required settings:
 {
   "providerSettings": {
     "gateway": {
+      "protocol": "openai",
       "baseUrl": "http://127.0.0.1:11434",
       "apiKey": "gateway-key",
       "model": "openrouter/meta-llama/test-model",
@@ -53,9 +54,48 @@ Required settings:
 
 Notes:
 
+- `protocol` defaults to `openai`; set it to `anthropic` for Messages API endpoints.
+- Anthropic-compatible configurations require a positive `maxTokens` value.
 - `toolPolicy` is required. There is no default file or shell access.
 - `headers` is optional for extra gateway-specific request headers.
 - `model` may be any non-empty provider-specific model id.
+
+### MiniMax
+
+The gateway model catalog includes `MiniMax-M3` and `MiniMax-M2.7`. Choose the
+region and protocol with the matching base URL:
+
+| Region | Protocol    | Base URL                             |
+| ------ | ----------- | ------------------------------------ |
+| Global | `openai`    | `https://api.minimax.io/v1`          |
+| Global | `anthropic` | `https://api.minimax.io/anthropic`   |
+| China  | `openai`    | `https://api.minimaxi.com/v1`        |
+| China  | `anthropic` | `https://api.minimaxi.com/anthropic` |
+
+Example Anthropic-compatible settings:
+
+```json
+{
+  "providerSettings": {
+    "gateway": {
+      "protocol": "anthropic",
+      "baseUrl": "https://api.minimax.io/anthropic",
+      "apiKey": "your-api-key",
+      "model": "MiniMax-M3",
+      "maxTokens": 8192,
+      "toolPolicy": {
+        "roots": ["/absolute/path/to/worktree"],
+        "commands": ["node"]
+      }
+    }
+  }
+}
+```
+
+Pass the Anthropic base URL exactly as shown. The bundled client appends
+`/v1/messages` for each request. For OpenAI-compatible settings, use
+`"protocol": "openai"` and omit `maxTokens` unless the endpoint needs a custom
+limit.
 
 ## Model Levels
 

--- a/src/agent-cli-provider/adapters/gateway.ts
+++ b/src/agent-cli-provider/adapters/gateway.ts
@@ -18,7 +18,10 @@ import { classifyBaseProviderError, commandSpec, createParserState, envRedaction
 import { resolveGatewayConfiguration, validateGatewaySettings } from '../gateway-tools';
 import { getBoolean, getString, isRecord, tryParseJson } from '../json';
 
-const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {};
+const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
+  'MiniMax-M3': { rank: 3 },
+  'MiniMax-M2.7': { rank: 2 },
+};
 
 const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
   level1: { rank: 1, model: null },
@@ -27,10 +30,12 @@ const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
 };
 
 export const gatewaySettingsDefaults: Readonly<Record<string, unknown>> = Object.freeze({
+  protocol: 'openai',
   baseUrl: null,
   apiKey: null,
   headers: null,
   model: null,
+  maxTokens: null,
   toolPolicy: null,
 });
 
@@ -52,8 +57,10 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
     context,
     cwd,
     gateway: {
+      protocol: gateway.protocol,
       baseUrl: gateway.baseUrl,
       model: gateway.model,
+      ...(gateway.maxTokens === undefined ? {} : { maxTokens: gateway.maxTokens }),
       toolPolicy: gateway.toolPolicy,
     },
     ...(Object.keys(headerEnv.mapping).length === 0 ? {} : { gatewayHeaderEnv: headerEnv.mapping }),
@@ -160,7 +167,7 @@ function classifyError(error: unknown): ErrorClassification {
       /\bmust be a valid url\b/i,
       /\btoolpolicy\b/i,
       /\bnon-empty model identifier\b/i,
-      /\bgateway\.(?:baseUrl|apiKey|model|toolPolicy)\b/i,
+      /\bgateway\.(?:protocol|baseUrl|apiKey|model|maxTokens|toolPolicy)\b/i,
     ]
   );
 }

--- a/src/agent-cli-provider/gateway-client.ts
+++ b/src/agent-cli-provider/gateway-client.ts
@@ -1,4 +1,5 @@
 import { getArray, getRecord, getString, isRecord, unknownToMessage } from './json';
+import type { GatewayProtocol } from './types';
 
 export interface GatewayChatToolDefinition {
   readonly type: 'function';
@@ -37,14 +38,32 @@ class GatewayHttpError extends Error {
   }
 }
 
-export async function createGatewayChatCompletion(input: {
+interface GatewayChatCompletionInput {
+  readonly protocol: GatewayProtocol;
   readonly baseUrl: string;
   readonly apiKey: string;
   readonly headers: Readonly<Record<string, string>>;
   readonly model: string;
+  readonly maxTokens?: number;
   readonly messages: readonly GatewayChatMessage[];
   readonly tools: readonly GatewayChatToolDefinition[];
-}): Promise<GatewayChatResponse> {
+}
+
+export function createGatewayChatCompletion(
+  input: GatewayChatCompletionInput
+): Promise<GatewayChatResponse> {
+  if (input.protocol === 'anthropic') {
+    if (input.maxTokens === undefined) {
+      throw new Error('Gateway Anthropic requests require maxTokens.');
+    }
+    return createAnthropicChatCompletion({ ...input, maxTokens: input.maxTokens });
+  }
+  return createOpenAIChatCompletion(input);
+}
+
+async function createOpenAIChatCompletion(
+  input: GatewayChatCompletionInput
+): Promise<GatewayChatResponse> {
   const response = await fetch(`${input.baseUrl}/chat/completions`, {
     method: 'POST',
     headers: {
@@ -54,7 +73,7 @@ export async function createGatewayChatCompletion(input: {
     },
     body: JSON.stringify({
       model: input.model,
-      messages: input.messages.map((message) => serializeMessage(message)),
+      messages: input.messages.map((message) => serializeOpenAIMessage(message)),
       tools: input.tools,
       tool_choice: 'auto',
       temperature: 0,
@@ -85,7 +104,49 @@ export async function createGatewayChatCompletion(input: {
   };
 }
 
-function serializeMessage(message: GatewayChatMessage): Record<string, unknown> {
+async function createAnthropicChatCompletion(
+  input: GatewayChatCompletionInput & { readonly maxTokens: number }
+): Promise<GatewayChatResponse> {
+  const system = input.messages
+    .filter((message) => message.role === 'system')
+    .map((message) => message.content)
+    .join('\n\n');
+  const response = await fetch(`${input.baseUrl}/v1/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': input.apiKey,
+      'anthropic-version': '2023-06-01',
+      ...input.headers,
+    },
+    body: JSON.stringify({
+      model: input.model,
+      max_tokens: input.maxTokens,
+      ...(system ? { system } : {}),
+      messages: serializeAnthropicMessages(input.messages),
+      tools: input.tools.map((tool) => ({
+        name: tool.function.name,
+        description: tool.function.description,
+        input_schema: tool.function.parameters,
+      })),
+    }),
+  });
+
+  const bodyText = await response.text();
+  const parsed = tryParseJson(bodyText);
+  if (!response.ok) {
+    throw httpError(response.status, parsed ?? bodyText);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error('Gateway returned a non-JSON response.');
+  }
+  return {
+    text: getAnthropicMessageText(parsed),
+    toolCalls: getAnthropicToolCalls(parsed),
+  };
+}
+
+function serializeOpenAIMessage(message: GatewayChatMessage): Record<string, unknown> {
   if (message.role === 'assistant' && message.toolCalls && message.toolCalls.length > 0) {
     return {
       role: 'assistant',
@@ -111,6 +172,45 @@ function serializeMessage(message: GatewayChatMessage): Record<string, unknown> 
     role: message.role,
     content: message.content,
   };
+}
+
+function serializeAnthropicMessages(
+  messages: readonly GatewayChatMessage[]
+): readonly Record<string, unknown>[] {
+  const result: Record<string, unknown>[] = [];
+  for (const message of messages) {
+    if (message.role === 'system') continue;
+    if (message.role === 'tool') {
+      result.push({
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: message.toolCallId,
+            content: message.content,
+          },
+        ],
+      });
+      continue;
+    }
+    if (message.role === 'assistant' && message.toolCalls && message.toolCalls.length > 0) {
+      result.push({
+        role: 'assistant',
+        content: [
+          ...(message.content ? [{ type: 'text', text: message.content }] : []),
+          ...message.toolCalls.map((toolCall) => ({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.name,
+            input: tryParseJson(toolCall.argumentsText) ?? {},
+          })),
+        ],
+      });
+      continue;
+    }
+    result.push({ role: message.role, content: message.content });
+  }
+  return result;
 }
 
 function getGatewayMessageText(message: Record<string, unknown>): string {
@@ -139,6 +239,29 @@ function getGatewayToolCalls(message: Record<string, unknown>): readonly Gateway
     const argumentsText = fn === null ? null : getString(fn, 'arguments');
     if (!id || !name || argumentsText === null) continue;
     result.push({ id, name, argumentsText });
+  }
+  return result;
+}
+
+function getAnthropicMessageText(message: Record<string, unknown>): string {
+  return getArray(message, 'content')
+    .filter((item) => isRecord(item) && getString(item, 'type') === 'text')
+    .map((item) => (isRecord(item) ? getString(item, 'text') ?? '' : ''))
+    .join('');
+}
+
+function getAnthropicToolCalls(message: Record<string, unknown>): readonly GatewayToolCall[] {
+  const result: GatewayToolCall[] = [];
+  for (const item of getArray(message, 'content')) {
+    if (!isRecord(item) || getString(item, 'type') !== 'tool_use') continue;
+    const id = getString(item, 'id');
+    const name = getString(item, 'name');
+    if (!id || !name) continue;
+    result.push({
+      id,
+      name,
+      argumentsText: JSON.stringify(isRecord(item.input) ? item.input : {}),
+    });
   }
   return result;
 }

--- a/src/agent-cli-provider/gateway-runner.ts
+++ b/src/agent-cli-provider/gateway-runner.ts
@@ -164,10 +164,12 @@ async function runGatewayLoop(
 
   for (let turn = 0; turn < MAX_GATEWAY_TURNS; turn += 1) {
     const response = await createGatewayChatCompletion({
+      protocol: gateway.protocol,
       baseUrl: gateway.baseUrl,
       apiKey: gateway.apiKey,
       headers: gateway.headers,
       model: gateway.model,
+      ...(gateway.maxTokens === undefined ? {} : { maxTokens: gateway.maxTokens }),
       messages,
       tools: TOOL_DEFINITIONS,
     });

--- a/src/agent-cli-provider/gateway-tools.ts
+++ b/src/agent-cli-provider/gateway-tools.ts
@@ -5,6 +5,7 @@ import { contractError, invalidField } from './contract-errors';
 import { getString, isRecord, unknownToMessage } from './json';
 import type {
   GatewayBuildOptions,
+  GatewayProtocol,
   GatewayToolPolicy,
   ResolvedGatewayBuildOptions,
 } from './types';
@@ -48,15 +49,19 @@ export function normalizeGatewayBuildOptions(
   }
 
   const result: Record<string, unknown> = {};
+  const protocol = optionalGatewayProtocol(value.protocol, `${field}.protocol`);
   const baseUrl = optionalString(value.baseUrl, `${field}.baseUrl`);
   const apiKey = optionalString(value.apiKey, `${field}.apiKey`);
   const model = optionalNullableString(value.model, `${field}.model`);
+  const maxTokens = optionalNullablePositiveInteger(value.maxTokens, `${field}.maxTokens`);
   const headers = optionalStringRecord(value.headers, `${field}.headers`);
   const toolPolicy = optionalGatewayToolPolicy(value.toolPolicy, `${field}.toolPolicy`, cwd);
 
+  if (protocol !== undefined) result.protocol = protocol;
   if (baseUrl !== undefined) result.baseUrl = baseUrl;
   if (typeof apiKey === 'string') result.apiKey = apiKey;
   if (model !== undefined) result.model = model;
+  if (maxTokens !== undefined) result.maxTokens = maxTokens;
   if (headers !== undefined) result.headers = headers;
   if (toolPolicy !== undefined) result.toolPolicy = toolPolicy;
 
@@ -76,27 +81,51 @@ export function resolveGatewayConfiguration(
       message: `${field} is required for the gateway provider.`,
     });
   }
+  const protocol = value.protocol ?? 'openai';
   const baseUrl = requiredNonEmptyString(value.baseUrl, `${field}.baseUrl`);
   const apiKey = requiredNonEmptyString(value.apiKey, `${field}.apiKey`);
   const model = requiredNonEmptyString(value.model, `${field}.model`);
+  const maxTokens = value.maxTokens;
   const headers = value.headers ?? {};
   const toolPolicy = requiredGatewayToolPolicy(value.toolPolicy, `${field}.toolPolicy`, cwd);
 
+  if (protocol === 'anthropic' && maxTokens === undefined) {
+    invalidField(
+      `${field}.maxTokens`,
+      `${field}.maxTokens is required when ${field}.protocol is "anthropic".`
+    );
+  }
   assertValidGatewayBaseUrl(baseUrl, `${field}.baseUrl`);
   return {
+    protocol,
     baseUrl: normalizeBaseUrl(baseUrl),
     apiKey,
     headers,
     model,
+    ...(maxTokens === undefined ? {} : { maxTokens }),
     toolPolicy,
   };
 }
 
 export function validateGatewaySettings(settings: Record<string, unknown>): string | null {
   try {
+    const protocol = optionalGatewayProtocol(
+      settings.protocol,
+      'providerSettings.gateway.protocol'
+    );
     optionalString(settings.baseUrl, 'providerSettings.gateway.baseUrl');
     optionalString(settings.apiKey, 'providerSettings.gateway.apiKey');
     optionalNullableString(settings.model, 'providerSettings.gateway.model');
+    const maxTokens = optionalNullablePositiveInteger(
+      settings.maxTokens,
+      'providerSettings.gateway.maxTokens'
+    );
+    if (protocol === 'anthropic' && maxTokens === undefined) {
+      invalidField(
+        'providerSettings.gateway.maxTokens',
+        'providerSettings.gateway.maxTokens is required when providerSettings.gateway.protocol is "anthropic".'
+      );
+    }
     optionalStringRecord(settings.headers, 'providerSettings.gateway.headers');
     optionalGatewayToolPolicy(
       settings.toolPolicy,
@@ -593,6 +622,17 @@ function requiredArrayIfPresent(
 function optionalFiniteInteger(value: unknown, field: string): number | undefined {
   if (value === undefined) return undefined;
   return requiredFiniteInteger(value, field);
+}
+
+function optionalNullablePositiveInteger(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  return requiredFiniteInteger(value, field);
+}
+
+function optionalGatewayProtocol(value: unknown, field: string): GatewayProtocol | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value === 'openai' || value === 'anthropic') return value;
+  invalidField(field, `${field} must be "openai" or "anthropic".`);
 }
 
 function requiredFiniteInteger(value: unknown, field: string): number {

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -68,6 +68,7 @@ export type {
   ErrorClassificationKind,
   GatewayBuildOptions,
   GatewayCliFeatures,
+  GatewayProtocol,
   GatewayToolPolicy,
   GeminiCliFeatures,
   KnownProviderName,

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -227,10 +227,18 @@ export const providerRegistry = [
     invoke: SPAWN_INVOKE,
     installInstructions: 'Bundled with Zeroshot; no external provider CLI install is required.',
     authInstructions:
-      'Configure providerSettings.gateway.baseUrl, apiKey, model, and toolPolicy in Zeroshot settings.',
+      'Configure providerSettings.gateway.protocol, baseUrl, apiKey, model, maxTokens when required, and toolPolicy in Zeroshot settings.',
     credentialPaths: [],
     credentialEnvKeys: gatewayAdapter.credentialEnvKeys,
-    settingsFields: ['baseUrl', 'apiKey', 'headers', 'model', 'toolPolicy'],
+    settingsFields: [
+      'protocol',
+      'baseUrl',
+      'apiKey',
+      'headers',
+      'model',
+      'maxTokens',
+      'toolPolicy',
+    ],
     settingsDefaults: gatewaySettingsDefaults,
     settingsValidator: validateGatewaySettings,
     capabilities: {

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -218,6 +218,9 @@ function resolveRuntimeGatewayOptions(
       ? settingsGateway.headers
       : { ...(settingsGateway.headers ?? {}), ...requestGateway.headers };
   const mergedGateway: GatewayBuildOptions = {
+    ...(requestGateway.protocol ?? settingsGateway.protocol
+      ? { protocol: requestGateway.protocol ?? settingsGateway.protocol }
+      : {}),
     ...(requestGateway.baseUrl ?? settingsGateway.baseUrl
       ? { baseUrl: requestGateway.baseUrl ?? settingsGateway.baseUrl }
       : {}),
@@ -226,6 +229,9 @@ function resolveRuntimeGatewayOptions(
       : {}),
     ...(mergedHeaders === undefined ? {} : { headers: mergedHeaders }),
     model: requestGateway.model ?? modelSpec.model ?? settingsGateway.model ?? null,
+    ...(requestGateway.maxTokens ?? settingsGateway.maxTokens
+      ? { maxTokens: requestGateway.maxTokens ?? settingsGateway.maxTokens }
+      : {}),
     ...(requestGateway.toolPolicy ?? settingsGateway.toolPolicy
       ? { toolPolicy: requestGateway.toolPolicy ?? settingsGateway.toolPolicy }
       : {}),

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -17,6 +17,7 @@ export type KnownProviderName = ProviderId | ProviderAlias;
 export type ModelLevel = 'level1' | 'level2' | 'level3';
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
 export type OutputFormat = 'text' | 'json' | 'stream-json';
+export type GatewayProtocol = 'openai' | 'anthropic';
 export type {
   ProviderCapabilities,
   ProviderCapabilityState,
@@ -66,18 +67,22 @@ export interface GatewayToolPolicy {
 }
 
 export interface GatewayBuildOptions {
+  readonly protocol?: GatewayProtocol;
   readonly baseUrl?: string;
   readonly apiKey?: string;
   readonly headers?: Readonly<Record<string, string>>;
   readonly model?: string | null;
+  readonly maxTokens?: number;
   readonly toolPolicy?: GatewayToolPolicy;
 }
 
 export interface ResolvedGatewayBuildOptions {
+  readonly protocol: GatewayProtocol;
   readonly baseUrl: string;
   readonly apiKey: string;
   readonly headers: Readonly<Record<string, string>>;
   readonly model: string;
+  readonly maxTokens?: number;
   readonly toolPolicy: GatewayToolPolicy;
 }
 

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -426,11 +426,12 @@ function validateGatewayProvider() {
     errors: [
       formatError(
         'Gateway provider not configured',
-        'providerSettings.gateway must define baseUrl, apiKey, model, and toolPolicy before gateway can run.',
+        'providerSettings.gateway must define protocol, baseUrl, apiKey, model, and toolPolicy before gateway can run.',
         [
           'Run: zeroshot settings',
-          'Set providerSettings.gateway.baseUrl to your OpenAI-compatible endpoint base URL',
+          'Set providerSettings.gateway.protocol and baseUrl for your compatible endpoint',
           'Set providerSettings.gateway.apiKey and providerSettings.gateway.model',
+          'Set providerSettings.gateway.maxTokens when protocol is anthropic',
           'Set providerSettings.gateway.toolPolicy.roots and toolPolicy.commands explicitly',
         ]
       ),

--- a/tests/agent-cli-provider/executable-contract-option-validation.test.js
+++ b/tests/agent-cli-provider/executable-contract-option-validation.test.js
@@ -77,6 +77,16 @@ const invalidNestedOptionCases = [
     field: 'options.gateway.headers.Authorization',
   },
   {
+    name: 'gateway protocol enum',
+    options: { gateway: { protocol: 'messages' } },
+    field: 'options.gateway.protocol',
+  },
+  {
+    name: 'gateway max tokens positive integer',
+    options: { gateway: { maxTokens: 0 } },
+    field: 'options.gateway.maxTokens',
+  },
+  {
     name: 'gateway tool policy object',
     options: { gateway: { toolPolicy: 'all-access' } },
     field: 'options.gateway.toolPolicy',

--- a/tests/agent-cli-provider/gateway-runner.test.js
+++ b/tests/agent-cli-provider/gateway-runner.test.js
@@ -148,6 +148,78 @@ test('gateway invoke completes deterministic edit task', async () => {
   }
 });
 
+test('gateway sends Anthropic-compatible requests through the configured base URL', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-gateway-anthropic-'));
+  fs.writeFileSync(path.join(tempDir, 'note.txt'), 'gateway note\n', 'utf8');
+
+  try {
+    const requests = [];
+    const response = await withGatewayServer((req, res, json) => {
+      requests.push({ url: req.url, headers: req.headers, body: json });
+      if (requests.length === 1) {
+        jsonResponse(res, 200, {
+          content: [
+            { type: 'text', text: 'Reading the target file.' },
+            {
+              type: 'tool_use',
+              id: 'tool-read',
+              name: 'read_file',
+              input: { path: 'note.txt' },
+            },
+          ],
+        });
+        return;
+      }
+      jsonResponse(res, 200, {
+        content: [{ type: 'text', text: 'Task complete.' }],
+      });
+    }, (baseUrl) =>
+      runProviderExecutable(
+        JSON.stringify({
+          schemaVersion: 1,
+          command: 'invoke',
+          provider: 'gateway',
+          context: 'Read note.txt.',
+          options: {
+            cwd: tempDir,
+            gateway: {
+              protocol: 'anthropic',
+              baseUrl: `${baseUrl}/anthropic`,
+              apiKey: 'gateway-test-key',
+              model: 'MiniMax-M3',
+              maxTokens: 4096,
+              toolPolicy: {
+                roots: ['.'],
+                commands: [],
+              },
+            },
+          },
+          timeoutMs: 2_000,
+        })
+      )
+    );
+
+    assert.equal(response.exitCode, 0);
+    assert.equal(response.envelope.ok, true);
+    assert.deepEqual(requests.map((request) => request.url), [
+      '/anthropic/v1/messages',
+      '/anthropic/v1/messages',
+    ]);
+    assert.equal(requests[0].headers['x-api-key'], 'gateway-test-key');
+    assert.equal(requests[0].headers['anthropic-version'], '2023-06-01');
+    assert.equal(requests[0].body.model, 'MiniMax-M3');
+    assert.equal(requests[0].body.max_tokens, 4096);
+    assert.equal(requests[0].body.messages[0].role, 'user');
+    assert.equal(requests[0].body.tools[0].input_schema.type, 'object');
+    assert.equal(requests[1].body.messages[1].role, 'assistant');
+    assert.equal(requests[1].body.messages[1].content[1].type, 'tool_use');
+    assert.equal(requests[1].body.messages[2].content[0].type, 'tool_result');
+    assert.equal(response.envelope.result.events.at(-1).success, true);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('gateway rejects invalid config as permanent failures', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-gateway-invalid-'));
 

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -108,6 +108,41 @@ describe('Provider settings', function () {
     }, /toolPolicy\.roots must be an array of strings/);
   });
 
+  it('validates Anthropic-compatible gateway settings', function () {
+    assert.doesNotThrow(() => {
+      validateProviderSettings('gateway', {
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimax.io/anthropic',
+        apiKey: 'gateway-key',
+        model: 'MiniMax-M3',
+        maxTokens: 8192,
+        toolPolicy: {
+          roots: ['.'],
+          commands: ['node'],
+        },
+      });
+    });
+
+    assert.throws(() => {
+      validateProviderSettings('gateway', {
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimax.io/anthropic',
+        apiKey: 'gateway-key',
+        model: 'MiniMax-M3',
+        toolPolicy: {
+          roots: ['.'],
+          commands: ['node'],
+        },
+      });
+    }, /maxTokens is required/);
+  });
+
+  it('registers the supported MiniMax gateway models', function () {
+    const catalog = getProvider('gateway').getModelCatalog();
+    assert.deepStrictEqual(catalog['MiniMax-M3'], { rank: 3 });
+    assert.deepStrictEqual(catalog['MiniMax-M2.7'], { rank: 2 });
+  });
+
   it('applies legacy maxModel to claude levels', function () {
     process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
     fs.writeFileSync(settingsFile, JSON.stringify({ maxModel: 'haiku' }, null, 2), 'utf8');


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary

Adds MiniMax model compatibility to the bundled gateway configuration.

## Related Issues

None.

## Changes Made

- Register MiniMax-M3 and MiniMax-M2.7 in the gateway model catalog.
- Support selectable compatibility protocols and token limits in gateway requests.
- Document global and China endpoint configurations and cover request and configuration behavior with tests.

## Testing

- `npm ci`
- `npm run check:agent-cli-provider:ci`
- `npm run check`
- `npm test`

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated (if needed)
- [x] Follows commit guidelines