### PR TITLE
fix(resume): reconstruct stopped workflows atomically

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -582,7 +582,9 @@ class Orchestrator {
         isolationManager,
         containerId: isolation?.containerId || null,
       });
-      this._startSnapshotter(clusterContext);
+      if (clusterContext.state === 'running' && this._isProcessRunning(clusterContext.pid)) {
+        this._startSnapshotter(clusterContext);
+      }
     }
     this._log(`[Orchestrator] Loaded cluster: ${clusterId} with ${agents.length} agents`);
 
@@ -627,7 +629,12 @@ class Orchestrator {
       id: clusterId,
       quiet: this.quiet,
       modelOverride: clusterData.modelOverride || null,
+      testMode: Boolean(this.taskRunner),
     };
+
+    if (this.taskRunner) {
+      agentOptions.taskRunner = this.taskRunner;
+    }
 
     if (isolation?.enabled && isolationManager) {
       agentOptions.isolation = {
@@ -2414,19 +2421,28 @@ class Orchestrator {
     }
 
     const failureInfo = this._resolveFailureInfo(cluster, clusterId);
+    const recentMessages = this._loadRecentMessages(cluster, clusterId, 50);
+    const cleanResumePlan = failureInfo ? null : this._buildCleanResumePlan(clusterId, cluster);
+
+    if (cleanResumePlan?.kind === 'failure') {
+      return this._failResumeReconstruction(clusterId, cluster, cleanResumePlan);
+    }
+
+    if (failureInfo) {
+      this._requireFailedAgent(clusterId, cluster, failureInfo);
+    }
 
     await this._ensureIsolationForResume(clusterId, cluster);
     this._ensureWorktreeForResume(clusterId, cluster);
     this._startSnapshotter(cluster);
+    this._clearTransientAgentState(cluster);
     await this._restartClusterAgents(cluster);
-
-    const recentMessages = this._loadRecentMessages(cluster, clusterId, 50);
 
     if (failureInfo) {
       return this._resumeFailedCluster(clusterId, cluster, failureInfo, recentMessages, prompt);
     }
 
-    return this._resumeCleanCluster(clusterId, cluster, recentMessages, prompt);
+    return this._resumeCleanCluster(clusterId, cluster, recentMessages, prompt, cleanResumePlan);
   }
 
   _validateGuidanceAgentArgs(clusterId, agentId, text) {
@@ -2622,7 +2638,7 @@ class Orchestrator {
 
   _resolveFailureInfo(cluster, clusterId) {
     if (cluster.failureInfo) {
-      return cluster.failureInfo;
+      return cluster.failureInfo.agentId ? cluster.failureInfo : null;
     }
 
     const errors = cluster.messageBus.query({
@@ -2646,6 +2662,15 @@ class Orchestrator {
     };
     this._log(`[Orchestrator] Found failure from ledger: ${failureInfo.agentId}`);
     return failureInfo;
+  }
+
+  _requireFailedAgent(clusterId, cluster, failureInfo) {
+    const failedAgent = cluster.agents.find((agent) => agent.id === failureInfo.agentId);
+    if (!failedAgent) {
+      throw new Error(
+        `Cannot resume cluster ${clusterId}: Failed agent '${failureInfo.agentId}' is not present in the restored configuration.`
+      );
+    }
   }
 
   _checkContainerExists(containerId) {
@@ -2741,12 +2766,35 @@ class Orchestrator {
       .reverse();
   }
 
+  _findLastDurableWorkflowTrigger(cluster, clusterId) {
+    let latest = null;
+
+    for (const topic of WORKFLOW_TRIGGERS) {
+      const candidate = cluster.messageBus.findLast({
+        cluster_id: clusterId,
+        topic,
+      });
+      if (candidate && (!latest || candidate.timestamp > latest.timestamp)) {
+        latest = candidate;
+      }
+    }
+
+    return latest;
+  }
+
   _buildResumeContext(recentMessages, prompt, options) {
     const resumePrompt = prompt || 'Continue from where you left off. Complete the task.';
     let context = `${options.header}\n\n`;
 
     if (options.error) {
       context += `Previous error: ${options.error}\n\n`;
+    }
+
+    if (options.durableMessages?.length > 0) {
+      context += `## Durable Workflow Context\n\n`;
+      for (const msg of options.durableMessages) {
+        context += `[${msg.topic}] [${msg.sender}]\n${msg.content?.text || ''}\n\n`;
+      }
     }
 
     context += `## Recent Context\n\n`;
@@ -2771,7 +2819,8 @@ class Orchestrator {
   }
 
   _selectAgentsToResume(cluster, lastTrigger) {
-    const agentsToResume = [];
+    const matching = [];
+    const eligible = [];
 
     for (const agent of cluster.agents) {
       if (!agent.config.triggers) continue;
@@ -2781,15 +2830,365 @@ class Orchestrator {
       );
       if (!matchingTrigger) continue;
 
+      const candidate = { agent, message: lastTrigger, trigger: matchingTrigger };
+      matching.push(candidate);
+
       if (matchingTrigger.logic?.script) {
         const shouldTrigger = agent._evaluateTrigger(matchingTrigger, lastTrigger);
         if (!shouldTrigger) continue;
       }
 
-      agentsToResume.push({ agent, message: lastTrigger, trigger: matchingTrigger });
+      eligible.push(candidate);
     }
 
-    return agentsToResume;
+    return { matching, eligible };
+  }
+
+  _findDurableTriggerBefore(cluster, clusterId, topic, timestamp) {
+    if (!topic || topic === 'AGENT_RESUME') {
+      return null;
+    }
+
+    return cluster.messageBus.findLast({
+      cluster_id: clusterId,
+      topic,
+      until: timestamp - 1,
+    });
+  }
+
+  _collectDurableResumeContext(cluster, clusterId, messages = []) {
+    const durableMessages = [
+      cluster.messageBus.findLast({ cluster_id: clusterId, topic: 'ISSUE_OPENED' }),
+      cluster.messageBus.findLast({ cluster_id: clusterId, topic: 'PLAN_READY' }),
+      cluster.messageBus.findLast({ cluster_id: clusterId, topic: 'IMPLEMENTATION_READY' }),
+      ...messages,
+    ].filter(Boolean);
+    const uniqueById = new Map(durableMessages.map((message) => [message.id, message]));
+    return [...uniqueById.values()].sort((left, right) => left.timestamp - right.timestamp);
+  }
+
+  _findInterruptedResumeTargets(clusterId, cluster) {
+    const targets = [];
+    const invalid = [];
+    const issueMessage = cluster.messageBus.findLast({
+      cluster_id: clusterId,
+      topic: 'ISSUE_OPENED',
+    });
+
+    for (const agent of cluster.agents) {
+      if (agent.state !== 'executing_task') {
+        continue;
+      }
+
+      const lifecycle = cluster.messageBus.query({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: agent.id,
+      });
+      const startedIndex = lifecycle.findLastIndex(
+        (message) => message.content?.data?.event === 'TASK_STARTED'
+      );
+      const lastStarted = startedIndex >= 0 ? lifecycle[startedIndex] : null;
+      const lifecycleAfterStart = startedIndex >= 0 ? lifecycle.slice(startedIndex + 1) : [];
+      const completedAfterStart = lifecycleAfterStart.some(
+        (message) => message.content?.data?.event === 'TASK_COMPLETED'
+      );
+      const lastTaskIdAssigned = [...lifecycleAfterStart]
+        .reverse()
+        .find((message) => message.content?.data?.event === 'TASK_ID_ASSIGNED');
+      const assignedTaskId = lastTaskIdAssigned?.content?.data?.taskId || null;
+      const startedIteration = lastStarted?.content?.data?.iteration;
+      const triggeredBy = lastStarted?.content?.data?.triggeredBy;
+      const triggeringMessage = lastStarted
+        ? this._findDurableTriggerBefore(cluster, clusterId, triggeredBy, lastStarted.timestamp)
+        : null;
+
+      if (
+        !agent.currentTaskId ||
+        !lastStarted ||
+        completedAfterStart ||
+        startedIteration !== agent.iteration ||
+        !assignedTaskId ||
+        assignedTaskId !== agent.currentTaskId ||
+        !issueMessage
+      ) {
+        invalid.push({
+          agentId: agent.id,
+          reason: !issueMessage ? 'missing_durable_context' : 'ambiguous_task_identity',
+          state: agent.state,
+          iteration: agent.iteration,
+          currentTaskId: agent.currentTaskId || null,
+          assignedTaskId,
+          lastStartedIteration: startedIteration ?? null,
+          completedAfterStart: Boolean(completedAfterStart),
+        });
+        continue;
+      }
+
+      targets.push({
+        agent,
+        message: triggeringMessage || issueMessage,
+        lifecycleMessage: lastStarted,
+        issueMessage,
+        trigger: null,
+        reason: 'interrupted_task',
+      });
+    }
+
+    const interruptedRoles = new Set(targets.map(({ agent }) => agent.role));
+    if (interruptedRoles.size > 1) {
+      invalid.push({
+        reason: 'multiple_interrupted_phases',
+        agents: targets.map(({ agent }) => agent.id),
+      });
+    }
+
+    return { targets, invalid };
+  }
+
+  _findPartialValidationTargets(clusterId, cluster, lastTrigger) {
+    if (
+      !lastTrigger ||
+      !['IMPLEMENTATION_READY', 'VALIDATION_RESULT'].includes(lastTrigger.topic)
+    ) {
+      return null;
+    }
+
+    const implementationReady = cluster.messageBus.findLast({
+      cluster_id: clusterId,
+      topic: 'IMPLEMENTATION_READY',
+      until: lastTrigger.timestamp,
+    });
+    if (!implementationReady) {
+      return null;
+    }
+
+    const validators = cluster.agents.filter((agent) => agent.role === 'validator');
+    if (validators.length === 0) {
+      return null;
+    }
+
+    const validatorIds = new Set(validators.map((agent) => agent.id));
+    const validationResults = cluster.messageBus
+      .query({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        since: implementationReady.timestamp,
+      })
+      .filter(
+        (message) =>
+          message.timestamp > implementationReady.timestamp && validatorIds.has(message.sender)
+      );
+    const responded = new Set(validationResults.map((message) => message.sender));
+    const missing = validators.filter((agent) => !responded.has(agent.id));
+    if (missing.length === 0) {
+      return { kind: 'complete', validationResults, implementationReady };
+    }
+
+    const missingIds = new Set(missing.map((agent) => agent.id));
+    const selection = this._selectAgentsToResume(cluster, implementationReady);
+    const matching = selection.matching.filter(({ agent }) => missingIds.has(agent.id));
+    const eligible = selection.eligible.filter(({ agent }) => missingIds.has(agent.id));
+
+    if (eligible.length !== missing.length) {
+      return {
+        kind: 'failure',
+        missingAgentIds: missing.map((agent) => agent.id),
+        matchingAgentIds: matching.map(({ agent }) => agent.id),
+        implementationReady,
+        validationResults,
+      };
+    }
+
+    return {
+      kind: 'agents',
+      agentsToResume: eligible.map((target) => ({
+        ...target,
+        reason: 'missing_validation_result',
+      })),
+      implementationReady,
+      validationResults,
+    };
+  }
+
+  _buildCleanResumePlan(clusterId, cluster) {
+    const interrupted = this._findInterruptedResumeTargets(clusterId, cluster);
+    if (interrupted.invalid.length > 0) {
+      const missingContext = interrupted.invalid.some(
+        (entry) => entry.reason === 'missing_durable_context'
+      );
+      return {
+        kind: 'failure',
+        error: missingContext
+          ? `Cannot resume cluster ${clusterId}: interrupted work has no durable workflow context. ` +
+            `No agents were started and the preserved cluster remains stopped. ` +
+            `Inspect it with 'zeroshot export ${clusterId}' before repairing its persisted state; do not launch a duplicate run.`
+          : `Cannot resume cluster ${clusterId}: persisted interrupted-task state is ambiguous. ` +
+            `No agents were started; inspect failureInfo for reconstruction details.`,
+        details: {
+          reason: missingContext ? 'missing_workflow_history' : 'ambiguous_interrupted_task',
+          interrupted: interrupted.invalid,
+        },
+      };
+    }
+
+    const lastTrigger = this._findLastDurableWorkflowTrigger(cluster, clusterId);
+    const partialValidation = this._findPartialValidationTargets(clusterId, cluster, lastTrigger);
+    if (partialValidation?.kind === 'failure') {
+      return {
+        kind: 'failure',
+        error:
+          `Cannot resume cluster ${clusterId}: validators ${partialValidation.missingAgentIds.join(
+            ', '
+          )} are missing results, but not every missing validator has an eligible IMPLEMENTATION_READY handler. ` +
+          `No agents were started.`,
+        details: {
+          reason: 'partial_validation_handlers_ineligible',
+          missingAgentIds: partialValidation.missingAgentIds,
+          matchingAgentIds: partialValidation.matchingAgentIds,
+        },
+      };
+    }
+
+    if (interrupted.targets.length > 0) {
+      const interruptedValidators = interrupted.targets.filter(
+        ({ agent }) => agent.role === 'validator'
+      );
+      if (interruptedValidators.length > 0 && partialValidation?.kind !== 'agents') {
+        return {
+          kind: 'failure',
+          error:
+            `Cannot resume cluster ${clusterId}: interrupted validator state does not match an active validation cycle. ` +
+            `No agents were started.`,
+          details: {
+            reason: 'ambiguous_validation_cycle',
+            interruptedAgentIds: interruptedValidators.map(({ agent }) => agent.id),
+          },
+        };
+      }
+
+      const targets =
+        interruptedValidators.length > 0 ? partialValidation.agentsToResume : interrupted.targets;
+      return {
+        kind: 'agents',
+        reason: interruptedValidators.length > 0 ? 'partial_validation' : 'interrupted_tasks',
+        agentsToResume: targets,
+        lastTrigger,
+        durableMessages: this._collectDurableResumeContext(
+          cluster,
+          clusterId,
+          targets.map(({ message }) => message)
+        ),
+      };
+    }
+
+    if (partialValidation?.kind === 'agents') {
+      return {
+        kind: 'agents',
+        reason: 'partial_validation',
+        agentsToResume: partialValidation.agentsToResume,
+        lastTrigger,
+        durableMessages: this._collectDurableResumeContext(
+          cluster,
+          clusterId,
+          partialValidation.validationResults
+        ),
+      };
+    }
+
+    if (!lastTrigger) {
+      const issueMessage = cluster.messageBus.findLast({
+        cluster_id: clusterId,
+        topic: 'ISSUE_OPENED',
+      });
+      if (issueMessage) {
+        return {
+          kind: 'bootstrap',
+          reason: 'missing_workflow_trigger',
+          issueMessage,
+          agentsToResume: [],
+          lastTrigger: null,
+          durableMessages: [issueMessage],
+        };
+      }
+
+      return {
+        kind: 'failure',
+        error:
+          `Cannot resume cluster ${clusterId}: no workflow trigger or ISSUE_OPENED message exists. ` +
+          `No agents were started and the preserved cluster remains stopped. ` +
+          `Inspect it with 'zeroshot export ${clusterId}' before repairing its persisted state; do not launch a duplicate run.`,
+        details: { reason: 'missing_workflow_history' },
+      };
+    }
+
+    const selection = this._selectAgentsToResume(cluster, lastTrigger);
+    if (selection.eligible.length > 0) {
+      return {
+        kind: 'agents',
+        reason: 'eligible_handlers',
+        agentsToResume: selection.eligible,
+        lastTrigger,
+        durableMessages: this._collectDurableResumeContext(
+          cluster,
+          clusterId,
+          selection.eligible.map(({ message }) => message)
+        ),
+      };
+    }
+
+    const matchingAgentIds = selection.matching.map(({ agent }) => agent.id);
+    if (matchingAgentIds.length > 0) {
+      return {
+        kind: 'failure',
+        error:
+          `Cannot resume cluster ${clusterId}: trigger ${lastTrigger.topic} is registered by ` +
+          `${matchingAgentIds.join(', ')}, but no handler is currently eligible and no interrupted task can be reconstructed. ` +
+          `No agents were started.`,
+        details: {
+          reason: 'registered_handlers_ineligible',
+          trigger: lastTrigger.topic,
+          matchingAgentIds,
+        },
+      };
+    }
+
+    return {
+      kind: 'failure',
+      error:
+        `Cannot resume cluster ${clusterId}: no restored agent registers trigger ${lastTrigger.topic}. ` +
+        `No agents were started; check the persisted agent configuration.`,
+      details: {
+        reason: 'unhandled_trigger',
+        trigger: lastTrigger.topic,
+      },
+    };
+  }
+
+  async _failResumeReconstruction(clusterId, cluster, plan) {
+    cluster.state = 'stopped';
+    cluster.pid = null;
+    cluster.failureInfo = {
+      type: 'resume_reconstruction',
+      error: plan.error,
+      ...plan.details,
+      timestamp: Date.now(),
+    };
+    await this._saveClusters();
+
+    const error = new Error(plan.error);
+    error.code = 'RESUME_RECONSTRUCTION_FAILED';
+    throw error;
+  }
+
+  _clearTransientAgentState(cluster) {
+    for (const agent of cluster.agents) {
+      agent.currentTask = null;
+      agent.currentTaskId = null;
+      agent.processPid = null;
+      agent._currentExecution = null;
+      agent.state = 'idle';
+    }
   }
 
   _resumeAgents(agentsToResume, context) {
@@ -2855,15 +3254,16 @@ class Orchestrator {
     };
   }
 
-  async _resumeCleanCluster(clusterId, cluster, recentMessages, prompt) {
+  async _resumeCleanCluster(clusterId, cluster, recentMessages, prompt, plan) {
     this._log(`[Orchestrator] Resuming stopped cluster ${clusterId} (no failure)`);
 
     const context = this._buildResumeContext(recentMessages, prompt, {
       header: 'Resuming cluster from previous session.',
       topics: ['AGENT_OUTPUT', 'VALIDATION_RESULT', 'ISSUE_OPENED'],
+      durableMessages: plan.durableMessages,
     });
 
-    const lastTrigger = this._findLastWorkflowTrigger(recentMessages);
+    const lastTrigger = plan.lastTrigger;
     if (lastTrigger) {
       this._log(
         `[Orchestrator] Last workflow trigger: ${lastTrigger.topic} (${new Date(lastTrigger.timestamp).toISOString()})`
@@ -2872,31 +3272,16 @@ class Orchestrator {
       this._log(`[Orchestrator] No workflow triggers found in ledger`);
     }
 
-    const agentsToResume = lastTrigger ? this._selectAgentsToResume(cluster, lastTrigger) : [];
-    if (agentsToResume.length === 0) {
-      if (!lastTrigger) {
-        this._log(
-          `[Orchestrator] WARNING: No workflow triggers in ledger. Cluster may not have started properly.`
-        );
-        this._log(`[Orchestrator] Publishing ISSUE_OPENED to bootstrap workflow...`);
-
-        if (!this._republishIssue(cluster, clusterId, recentMessages)) {
-          throw new Error(
-            `Cannot resume cluster ${clusterId}: No workflow triggers found and no ISSUE_OPENED message. ` +
-              `The cluster may not have started properly. Try: zeroshot run <issue> instead.`
-          );
-        }
-      } else {
-        throw new Error(
-          `Cannot resume cluster ${clusterId}: Found trigger ${lastTrigger.topic} but no agents handle it. ` +
-            `Check agent trigger configurations.`
-        );
-      }
+    const agentsToResume = plan.agentsToResume;
+    if (plan.kind === 'bootstrap') {
+      this._log(`[Orchestrator] Publishing ISSUE_OPENED to bootstrap workflow...`);
+      this._republishIssue(cluster, clusterId, [plan.issueMessage]);
     } else {
       this._log(`[Orchestrator] Resuming ${agentsToResume.length} agent(s) based on ledger state`);
       this._resumeAgents(agentsToResume, context);
     }
 
+    cluster.failureInfo = null;
     await this._saveClusters();
     this._log(`[Orchestrator] Cluster ${clusterId} resumed`);
 

--- a/tests/e2e/fixtures/resume-partial-validation-config.json
+++ b/tests/e2e/fixtures/resume-partial-validation-config.json
@@ -1,0 +1,102 @@
+{
+  "agents": [
+    {
+      "id": "bootstrap",
+      "role": "planning",
+      "timeout": 0,
+      "triggers": [{ "topic": "ISSUE_OPENED", "action": "execute_task" }],
+      "prompt": "FAKE_AGENT_ID=bootstrap Persist the resumable test cluster.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "FIXTURE_READY",
+            "content": { "text": "Initial fixture persisted." }
+          }
+        }
+      }
+    },
+    {
+      "id": "worker",
+      "role": "implementation",
+      "timeout": 0,
+      "triggers": [
+        {
+          "topic": "VALIDATION_RESULT",
+          "logic": {
+            "engine": "javascript",
+            "script": "const validators = cluster.getAgentsByRole('validator');\nconst lastPush = ledger.findLast({ topic: 'IMPLEMENTATION_READY' });\nif (!lastPush) return false;\nconst responses = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.timestamp });\nconst validatorIds = new Set(validators.map((validator) => validator.id));\nconst latestByValidator = new Map();\nfor (const response of responses) {\n  if (validatorIds.has(response.sender)) latestByValidator.set(response.sender, response);\n}\nif (latestByValidator.size < validators.length) return false;\nreturn Array.from(latestByValidator.values()).some((response) => response.content?.data?.approved === false || response.content?.data?.approved === 'false');"
+          },
+          "action": "execute_task"
+        }
+      ],
+      "prompt": "FAKE_AGENT_ID=worker Repair rejected validation findings.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "WORKER_REPAIRED",
+            "content": { "text": "Validation findings repaired." }
+          }
+        }
+      }
+    },
+    {
+      "id": "finisher",
+      "role": "completion",
+      "timeout": 0,
+      "triggers": [
+        { "topic": "FIXTURE_READY", "action": "execute_task" },
+        { "topic": "WORKER_REPAIRED", "action": "execute_task" }
+      ],
+      "prompt": "FAKE_AGENT_ID=finisher Stop the completed test cluster.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "CLUSTER_COMPLETE",
+            "content": { "text": "Test workflow completed." }
+          }
+        }
+      }
+    },
+    {
+      "id": "validator-requirements",
+      "role": "validator",
+      "timeout": 0,
+      "triggers": [{ "topic": "IMPLEMENTATION_READY", "action": "execute_task" }],
+      "prompt": "FAKE_AGENT_ID=validator-requirements Validate requirements.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "VALIDATION_RESULT",
+            "content": {
+              "text": "Requirements approved.",
+              "data": { "approved": true }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "validator-code",
+      "role": "validator",
+      "timeout": 0,
+      "triggers": [{ "topic": "IMPLEMENTATION_READY", "action": "execute_task" }],
+      "prompt": "FAKE_AGENT_ID=validator-code Validate code.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": {
+            "topic": "VALIDATION_RESULT",
+            "content": {
+              "text": "Code rejected.",
+              "data": { "approved": false }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/resume-detach-daemon.test.js
+++ b/tests/e2e/resume-detach-daemon.test.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
+const Ledger = require('../../src/ledger');
 
 const {
   setupE2ERepo,
@@ -21,11 +22,18 @@ const {
   CLI_ENTRY,
   readCluster,
   clustersFilePath,
+  clusterDbPath,
+  readLedgerMessages,
   worktreePath,
   scenarioPath,
 } = require('./helpers/e2e-harness');
 
 const CONFIG_PATH = path.join(__dirname, 'fixtures', 'single-worker-config.json');
+const PARTIAL_VALIDATION_CONFIG_PATH = path.join(
+  __dirname,
+  'fixtures',
+  'resume-partial-validation-config.json'
+);
 
 function pollUntil(predicate, timeoutMs, intervalMs = 200) {
   const start = Date.now();
@@ -58,6 +66,100 @@ function overwriteClusterRecord(env, clusterId, patch) {
   fs.writeFileSync(file, JSON.stringify(clusters, null, 2));
 }
 
+function appendLedgerMessage(ledger, clusterId, topic, sender, data = {}) {
+  ledger.append({
+    cluster_id: clusterId,
+    topic,
+    sender,
+    receiver: 'broadcast',
+    content: {
+      text: `${sender}: ${topic}`,
+      data,
+    },
+  });
+}
+
+function seedPartialValidationState(env, clusterId) {
+  const ledger = new Ledger(clusterDbPath(env, clusterId));
+  try {
+    appendLedgerMessage(ledger, clusterId, 'IMPLEMENTATION_READY', 'worker');
+    appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'validator-requirements', {
+      event: 'TASK_STARTED',
+      agent: 'validator-requirements',
+      role: 'validator',
+      state: 'executing_task',
+      iteration: 3,
+      triggeredBy: 'IMPLEMENTATION_READY',
+    });
+    appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'validator-requirements', {
+      event: 'TASK_ID_ASSIGNED',
+      agent: 'validator-requirements',
+      role: 'validator',
+      state: 'executing_task',
+      taskId: 'interrupted-validator-task',
+    });
+    appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'validator-code', {
+      event: 'TASK_STARTED',
+      agent: 'validator-code',
+      role: 'validator',
+      state: 'executing_task',
+      iteration: 3,
+    });
+    appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'validator-code', {
+      event: 'TASK_COMPLETED',
+      agent: 'validator-code',
+      role: 'validator',
+      state: 'idle',
+      iteration: 3,
+      taskId: 'completed-validator-task',
+    });
+    appendLedgerMessage(ledger, clusterId, 'VALIDATION_RESULT', 'validator-code', {
+      approved: false,
+      errors: ['repair this'],
+    });
+  } finally {
+    ledger.close();
+  }
+
+  const cluster = readCluster(env, clusterId);
+  const agentStates = cluster.agentStates.map((agent) => {
+    if (agent.id === 'validator-requirements') {
+      return {
+        ...agent,
+        state: 'executing_task',
+        iteration: 3,
+        currentTask: false,
+        currentTaskId: 'interrupted-validator-task',
+        processPid: 4242,
+      };
+    }
+    if (agent.id === 'validator-code') {
+      return {
+        ...agent,
+        state: 'idle',
+        iteration: 3,
+        currentTask: false,
+        currentTaskId: 'completed-validator-task',
+        processPid: null,
+      };
+    }
+    return { ...agent, state: 'idle', currentTask: false };
+  });
+
+  overwriteClusterRecord(env, clusterId, {
+    state: 'stopped',
+    pid: null,
+    failureInfo: null,
+    agentStates,
+  });
+}
+
+function countLifecycleEvents(env, clusterId, agentId, event) {
+  return readLedgerMessages(env, clusterId, 'AGENT_LIFECYCLE').filter(
+    (message) => message.sender === agentId && message.content?.data?.event === event
+  ).length;
+}
+
 describe('e2e: resume --detach daemon handoff', function () {
   this.timeout(60000);
 
@@ -70,6 +172,90 @@ describe('e2e: resume --detach daemon handoff', function () {
   afterEach(() => {
     cleanupE2ERepo(env);
   });
+
+  for (const detached of [false, true]) {
+    const mode = detached ? 'detached' : 'foreground';
+    it(`recovers partial validation exactly once in ${mode} mode`, async function () {
+      const issueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-e2e-issue-'));
+      const issuePath = path.join(issueDir, 'feature.md');
+      fs.writeFileSync(issuePath, '# Repair validation\n\nAddress the rejected findings.\n');
+
+      const clusterId = `e2e-partial-validation-${mode}`;
+      const initialRun = runZeroshot(
+        env,
+        ['run', issuePath, '--worktree', '--config', PARTIAL_VALIDATION_CONFIG_PATH],
+        {
+          ZEROSHOT_CLUSTER_ID: clusterId,
+          FAKE_AGENT_SCENARIO: scenarioPath('validator-approve'),
+          timeout: 30000,
+        }
+      );
+      assert.strictEqual(
+        initialRun.status,
+        0,
+        `initial fixture run failed\nSTDOUT:\n${initialRun.stdout}\nSTDERR:\n${initialRun.stderr}`
+      );
+      assert.strictEqual(readCluster(env, clusterId)?.state, 'stopped');
+
+      seedPartialValidationState(env, clusterId);
+      const completionCountBeforeResume = readLedgerMessages(
+        env,
+        clusterId,
+        'CLUSTER_COMPLETE'
+      ).length;
+      const resumeArgs = ['resume', clusterId];
+      if (detached) {
+        resumeArgs.push('-d');
+      }
+      const resumed = runZeroshot(env, resumeArgs, {
+        FAKE_AGENT_SCENARIO: scenarioPath('worker-success'),
+        FAKE_AGENT_SCENARIO_VALIDATOR_REQUIREMENTS: scenarioPath('validator-approve'),
+        FAKE_AGENT_SCENARIO_WORKER: scenarioPath('worker-success'),
+        timeout: 30000,
+      });
+      assert.strictEqual(
+        resumed.status,
+        0,
+        `${mode} resume failed\nSTDOUT:\n${resumed.stdout}\nSTDERR:\n${resumed.stderr}`
+      );
+
+      if (detached) {
+        await pollUntil(
+          () =>
+            readLedgerMessages(env, clusterId, 'CLUSTER_COMPLETE').length ===
+            completionCountBeforeResume + 1,
+          30000
+        );
+      }
+      await pollUntil(() => readCluster(env, clusterId)?.state === 'stopped', 30000);
+
+      const validationResults = readLedgerMessages(env, clusterId, 'VALIDATION_RESULT');
+      assert.strictEqual(validationResults.length, 2);
+      assert.strictEqual(
+        validationResults.filter((message) => message.sender === 'validator-code').length,
+        1
+      );
+      assert.strictEqual(
+        validationResults.filter((message) => message.sender === 'validator-requirements').length,
+        1
+      );
+      assert.strictEqual(countLifecycleEvents(env, clusterId, 'validator-code', 'TASK_STARTED'), 1);
+      assert.strictEqual(
+        countLifecycleEvents(env, clusterId, 'validator-requirements', 'TASK_STARTED'),
+        2
+      );
+      assert.strictEqual(countLifecycleEvents(env, clusterId, 'worker', 'TASK_STARTED'), 1);
+      assert.strictEqual(
+        readLedgerMessages(env, clusterId, 'CLUSTER_COMPLETE').length,
+        completionCountBeforeResume + 1,
+        'worker repair completion must be emitted exactly once'
+      );
+      assert.ok(
+        fs.existsSync(path.join(worktreePath(env, clusterId), 'implementation.txt')),
+        'recovered worker must execute in the preserved worktree'
+      );
+    });
+  }
 
   it('recovers a zombie (state=running, dead pid) via a real detached daemon without a manual stop', async function () {
     const issueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-e2e-issue-'));

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -175,6 +175,144 @@ function _createValidatorConfig() {
   };
 }
 
+function createPartialValidationResumeConfig(worktreeDir) {
+  const validationSchema = {
+    type: 'object',
+    properties: {
+      approved: { type: 'boolean' },
+      summary: { type: 'string' },
+    },
+    required: ['approved'],
+  };
+
+  const validationHook = {
+    onComplete: {
+      action: 'publish_message',
+      config: {
+        topic: 'VALIDATION_RESULT',
+        content: {
+          text: '{{result.summary}}',
+          data: {
+            approved: '{{result.approved}}',
+          },
+        },
+      },
+    },
+  };
+
+  return {
+    agents: [
+      {
+        id: 'worker',
+        role: 'implementation',
+        modelLevel: 'level2',
+        outputFormat: 'text',
+        cwd: worktreeDir,
+        triggers: [
+          {
+            topic: 'VALIDATION_RESULT',
+            logic: {
+              engine: 'javascript',
+              script:
+                "const validators = cluster.getAgentsByRole('validator');\n" +
+                "const lastPush = ledger.findLast({ topic: 'IMPLEMENTATION_READY' });\n" +
+                'if (!lastPush) return false;\n' +
+                "const responses = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.timestamp });\n" +
+                'const validatorIds = new Set(validators.map((v) => v.id));\n' +
+                'const latestByValidator = new Map();\n' +
+                'for (const response of responses) {\n' +
+                '  if (validatorIds.has(response.sender)) latestByValidator.set(response.sender, response);\n' +
+                '}\n' +
+                'if (latestByValidator.size < validators.length) return false;\n' +
+                'return Array.from(latestByValidator.values()).some((response) =>\n' +
+                "  response.content?.data?.approved === false || response.content?.data?.approved === 'false'\n" +
+                ');',
+            },
+            action: 'execute_task',
+          },
+        ],
+        prompt: 'Repair rejected validation findings.',
+      },
+      ...['validator-requirements', 'validator-code'].map((id) => ({
+        id,
+        role: 'validator',
+        modelLevel: 'level2',
+        outputFormat: 'json',
+        jsonSchema: validationSchema,
+        cwd: worktreeDir,
+        triggers: [{ topic: 'IMPLEMENTATION_READY', action: 'execute_task' }],
+        hooks: validationHook,
+        prompt: `Validate as ${id}.`,
+      })),
+    ],
+  };
+}
+
+async function waitForAgentCalls(runner, expectedCalls, timeoutMs = 3000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const complete = Object.entries(expectedCalls).every(
+      ([agentId, count]) => runner.getCalls(agentId).length === count
+    );
+    if (complete) {
+      return;
+    }
+    await sleep(20);
+  }
+
+  const actual = Object.fromEntries(
+    Object.keys(expectedCalls).map((agentId) => [agentId, runner.getCalls(agentId).length])
+  );
+  throw new Error(
+    `Agent calls did not reach ${JSON.stringify(expectedCalls)}; actual ${JSON.stringify(actual)}`
+  );
+}
+
+function publishInterruptedTaskHistory(
+  cluster,
+  clusterId,
+  agentId,
+  { iteration, taskId, triggeredBy }
+) {
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agentId,
+    content: {
+      text: `${agentId}: TASK_STARTED`,
+      data: {
+        event: 'TASK_STARTED',
+        agent: agentId,
+        state: 'executing_task',
+        iteration,
+        triggeredBy,
+      },
+    },
+  });
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agentId,
+    content: {
+      text: `${agentId}: TASK_ID_ASSIGNED`,
+      data: {
+        event: 'TASK_ID_ASSIGNED',
+        agent: agentId,
+        state: 'executing_task',
+        taskId,
+      },
+    },
+  });
+}
+
+function deleteLedgerTopics(cluster, clusterId, topics) {
+  const placeholders = topics.map(() => '?').join(', ');
+  cluster.ledger.db
+    .prepare(`DELETE FROM messages WHERE cluster_id = ? AND topic IN (${placeholders})`)
+    .run(clusterId, ...topics);
+  cluster.ledger.cache.clear();
+}
+
 let lifecycleOrchestrator;
 let lifecycleMockRunner;
 let lifecycleStorageDir;
@@ -704,6 +842,619 @@ function defineLifecycleKillTests() {
 
 function defineLifecycleResumeTests() {
   describe('resume()', function () {
+    it('resumes an interrupted validator before routing the aggregate rejection to the worker', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'partial-validation-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        content: { text: 'Implementation ready for validation' },
+      });
+      publishInterruptedTaskHistory(cluster, clusterId, 'validator-requirements', {
+        iteration: 3,
+        taskId: 'interrupted-validator-task',
+        triggeredBy: 'IMPLEMENTATION_READY',
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'validator-code',
+        content: {
+          text: 'validator-code: TASK_STARTED',
+          data: {
+            event: 'TASK_STARTED',
+            agent: 'validator-code',
+            role: 'validator',
+            state: 'executing_task',
+            iteration: 3,
+          },
+        },
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'validator-code',
+        content: {
+          text: 'validator-code: TASK_COMPLETED',
+          data: {
+            event: 'TASK_COMPLETED',
+            agent: 'validator-code',
+            role: 'validator',
+            state: 'idle',
+            iteration: 3,
+            taskId: 'completed-validator-task',
+          },
+        },
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-code',
+        content: {
+          text: 'Rejected with actionable findings',
+          data: { approved: false, errors: ['repair this'] },
+        },
+      });
+
+      const interruptedValidator = cluster.agents.find(
+        (agent) => agent.id === 'validator-requirements'
+      );
+      interruptedValidator.state = 'executing_task';
+      interruptedValidator.iteration = 3;
+      interruptedValidator.currentTaskId = 'interrupted-validator-task';
+      interruptedValidator.processPid = 4242;
+
+      const completedValidator = cluster.agents.find((agent) => agent.id === 'validator-code');
+      completedValidator.state = 'idle';
+      completedValidator.iteration = 3;
+      completedValidator.currentTaskId = 'completed-validator-task';
+      completedValidator.processPid = null;
+
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner
+        .when('validator-requirements')
+        .returns({ approved: true, summary: 'Requirements approved' });
+      resumedRunner.when('worker').returns('Repaired validation findings');
+
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const validationCountBeforeResume = lifecycleOrchestrator
+        .getCluster(clusterId)
+        .messageBus.count({ cluster_id: clusterId, topic: 'VALIDATION_RESULT' });
+
+      const resumed = await lifecycleOrchestrator.resume(clusterId);
+      await waitForAgentCalls(resumedRunner, {
+        'validator-requirements': 1,
+        worker: 1,
+      });
+
+      const resumedCluster = lifecycleOrchestrator.getCluster(clusterId);
+      const resumedRequirements = resumedCluster.agents.find(
+        (agent) => agent.id === 'validator-requirements'
+      );
+
+      assert.deepStrictEqual(resumed.resumedAgents, ['validator-requirements']);
+      assert.strictEqual(resumed.state, 'running');
+      assert.notStrictEqual(
+        resumedRequirements.currentTaskId,
+        'interrupted-validator-task',
+        'the stale interrupted task id must not survive recovery'
+      );
+      assert.strictEqual(resumedRequirements.processPid, null);
+      assert.strictEqual(
+        resumedRequirements.config.cwd,
+        worktreeDir,
+        'resume must reuse the persisted worktree cwd'
+      );
+      resumedRunner.assertCalled('validator-code', 0);
+      assert.strictEqual(
+        resumedCluster.messageBus.count({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+        }),
+        validationCountBeforeResume + 1,
+        'only the interrupted validator may append a new validation result'
+      );
+    });
+
+    it('resumes a missing validator in a partial validation cycle without replaying completed results', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'missing-validator-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        content: { text: 'Implementation ready for validation' },
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-code',
+        content: {
+          text: 'Rejected with actionable findings',
+          data: { approved: false, errors: ['repair this'] },
+        },
+      });
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner
+        .when('validator-requirements')
+        .returns({ approved: true, summary: 'Requirements approved' });
+      resumedRunner.when('worker').returns('Repaired validation findings');
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+      const validationCountBeforeResume = restoredCluster.messageBus.count({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+      });
+
+      const resumed = await lifecycleOrchestrator.resume(clusterId);
+      await waitForAgentCalls(resumedRunner, {
+        'validator-requirements': 1,
+        worker: 1,
+      });
+
+      assert.deepStrictEqual(resumed.resumedAgents, ['validator-requirements']);
+      resumedRunner.assertCalled('validator-code', 0);
+      assert.strictEqual(
+        restoredCluster.messageBus.count({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+        }),
+        validationCountBeforeResume + 1,
+        'the completed validator result must remain a singleton'
+      );
+    });
+
+    it('recovers an interrupted worker when durable workflow history is older than recent output', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const workerConfig = config.agents.find((agent) => agent.id === 'worker');
+      workerConfig.triggers = [{ topic: 'WORKER_PROGRESS', action: 'execute_task' }];
+
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Continue the original issue exactly once' },
+        { clusterId: 'old-workflow-history-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'WORKER_PROGRESS',
+        sender: 'worker',
+        content: { text: 'Previous iteration needs another pass' },
+      });
+      publishInterruptedTaskHistory(cluster, clusterId, 'worker', {
+        iteration: 3,
+        taskId: 'interrupted-worker-task',
+        triggeredBy: 'WORKER_PROGRESS',
+      });
+      for (let index = 0; index < 75; index += 1) {
+        cluster.messageBus.publish({
+          cluster_id: clusterId,
+          topic: 'AGENT_OUTPUT',
+          sender: 'worker',
+          content: { text: `historical output ${index}` },
+        });
+      }
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+        content: {
+          text: 'worker: STARTED',
+          data: {
+            event: 'STARTED',
+            agent: 'worker',
+            role: 'implementation',
+            state: 'idle',
+          },
+        },
+      });
+
+      const interruptedWorker = cluster.agents.find((agent) => agent.id === 'worker');
+      interruptedWorker.state = 'executing_task';
+      interruptedWorker.iteration = 3;
+      interruptedWorker.currentTaskId = 'interrupted-worker-task';
+      interruptedWorker.processPid = 88623;
+
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner.when('worker').returns('Continued original issue');
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+      const issueCountBeforeResume = restoredCluster.messageBus.count({
+        cluster_id: clusterId,
+        topic: 'ISSUE_OPENED',
+      });
+
+      const resumed = await lifecycleOrchestrator.resume(clusterId);
+      await waitForAgentCalls(resumedRunner, { worker: 1 });
+
+      const resumedWorker = restoredCluster.agents.find((agent) => agent.id === 'worker');
+      assert.deepStrictEqual(resumed.resumedAgents, ['worker']);
+      assert.notStrictEqual(resumedWorker.currentTaskId, 'interrupted-worker-task');
+      assert.strictEqual(resumedWorker.config.cwd, worktreeDir);
+      assert.strictEqual(
+        restoredCluster.messageBus.count({ cluster_id: clusterId, topic: 'ISSUE_OPENED' }),
+        issueCountBeforeResume,
+        'recovery must not duplicate durable issue execution'
+      );
+      assert.match(
+        resumedRunner.getCalls('worker')[0].context,
+        /Continue the original issue exactly once/,
+        'the resumed invocation must receive durable original task context even when it is old'
+      );
+      resumedRunner.assertCalled('validator-code', 0);
+      resumedRunner.assertCalled('validator-requirements', 0);
+    });
+
+    it('fails atomically when interrupted task-id history is missing or mismatched', async function () {
+      for (const scenario of [
+        { clusterId: 'missing-task-id-history', assignedTaskId: null },
+        { clusterId: 'mismatched-task-id-history', assignedTaskId: 'different-ledger-task' },
+      ]) {
+        const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+        const config = createPartialValidationResumeConfig(worktreeDir);
+        config.agents.find((agent) => agent.id === 'worker').triggers = [
+          { topic: 'WORKER_PROGRESS', action: 'execute_task' },
+        ];
+        const result = await lifecycleOrchestrator.start(
+          config,
+          { text: 'Preserve task identity during resume' },
+          { clusterId: scenario.clusterId }
+        );
+        const clusterId = result.id;
+
+        await lifecycleOrchestrator.stop(clusterId);
+        const cluster = lifecycleOrchestrator.getCluster(clusterId);
+        cluster.messageBus.publish({
+          cluster_id: clusterId,
+          topic: 'WORKER_PROGRESS',
+          sender: 'worker',
+          content: { text: 'Interrupted work' },
+        });
+        cluster.messageBus.publish({
+          cluster_id: clusterId,
+          topic: 'AGENT_LIFECYCLE',
+          sender: 'worker',
+          content: {
+            text: 'worker: TASK_STARTED',
+            data: {
+              event: 'TASK_STARTED',
+              agent: 'worker',
+              state: 'executing_task',
+              iteration: 3,
+              triggeredBy: 'WORKER_PROGRESS',
+            },
+          },
+        });
+        if (scenario.assignedTaskId) {
+          cluster.messageBus.publish({
+            cluster_id: clusterId,
+            topic: 'AGENT_LIFECYCLE',
+            sender: 'worker',
+            content: {
+              text: 'worker: TASK_ID_ASSIGNED',
+              data: {
+                event: 'TASK_ID_ASSIGNED',
+                agent: 'worker',
+                state: 'executing_task',
+                taskId: scenario.assignedTaskId,
+              },
+            },
+          });
+        }
+
+        const interruptedWorker = cluster.agents.find((agent) => agent.id === 'worker');
+        interruptedWorker.state = 'executing_task';
+        interruptedWorker.iteration = 3;
+        interruptedWorker.currentTaskId = 'persisted-task-id';
+        interruptedWorker.processPid = 88623;
+
+        deleteLedgerTopics(cluster, clusterId, ['STATE_SNAPSHOT']);
+        await lifecycleOrchestrator._saveClusters();
+        const messageCountBeforeReload = cluster.messageBus.count({ cluster_id: clusterId });
+        lifecycleOrchestrator.close();
+
+        const resumedRunner = new MockTaskRunner();
+        lifecycleOrchestrator = await Orchestrator.create({
+          taskRunner: resumedRunner,
+          storageDir: lifecycleStorageDir,
+          quiet: true,
+        });
+
+        const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+        await assert.rejects(
+          () => lifecycleOrchestrator.resume(clusterId),
+          (error) => {
+            assert.strictEqual(error.code, 'RESUME_RECONSTRUCTION_FAILED');
+            assert.match(error.message, /interrupted-task state is ambiguous/i);
+            return true;
+          }
+        );
+
+        assert.strictEqual(
+          restoredCluster.messageBus.count({ cluster_id: clusterId }),
+          messageCountBeforeReload,
+          'loading and rejecting resume must not append a snapshot or other ledger event'
+        );
+        resumedRunner.assertCalled('worker', 0);
+      }
+    });
+
+    it('fails atomically when interrupted work has no durable workflow context', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      config.agents.find((agent) => agent.id === 'worker').triggers = [
+        { topic: 'WORKER_PROGRESS', action: 'execute_task' },
+      ];
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'This task context must not be guessed' },
+        { clusterId: 'missing-workflow-context' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      publishInterruptedTaskHistory(cluster, clusterId, 'worker', {
+        iteration: 3,
+        taskId: 'interrupted-worker-task',
+        triggeredBy: 'WORKER_PROGRESS',
+      });
+      const interruptedWorker = cluster.agents.find((agent) => agent.id === 'worker');
+      interruptedWorker.state = 'executing_task';
+      interruptedWorker.iteration = 3;
+      interruptedWorker.currentTaskId = 'interrupted-worker-task';
+      interruptedWorker.processPid = 88623;
+
+      deleteLedgerTopics(cluster, clusterId, [
+        'ISSUE_OPENED',
+        'PLAN_READY',
+        'IMPLEMENTATION_READY',
+        'VALIDATION_RESULT',
+        'PUSH_BLOCKED',
+        'CONDUCTOR_ESCALATE',
+        'STATE_SNAPSHOT',
+      ]);
+      await lifecycleOrchestrator._saveClusters();
+      const messageCountBeforeReload = cluster.messageBus.count({ cluster_id: clusterId });
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+
+      await assert.rejects(
+        () => lifecycleOrchestrator.resume(clusterId),
+        (error) => {
+          assert.strictEqual(error.code, 'RESUME_RECONSTRUCTION_FAILED');
+          assert.match(error.message, /no durable workflow context/i);
+          assert.match(error.message, /zeroshot export missing-workflow-context/i);
+          assert.match(error.message, /do not launch a duplicate run/i);
+          assert.doesNotMatch(error.message, /zeroshot run/i);
+          return true;
+        }
+      );
+
+      assert.strictEqual(
+        restoredCluster.messageBus.count({ cluster_id: clusterId }),
+        messageCountBeforeReload
+      );
+      resumedRunner.assertCalled('worker', 0);
+    });
+
+    it('fails atomically when handlers are registered but no continuation is eligible', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'ineligible-validation-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        content: { text: 'Implementation ready for validation' },
+      });
+      for (const sender of ['validator-code', 'validator-requirements']) {
+        cluster.messageBus.publish({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+          sender,
+          content: {
+            text: 'Approved',
+            data: { approved: true },
+          },
+        });
+      }
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: new MockTaskRunner(),
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+      const messageCountBeforeResume = restoredCluster.messageBus.count({
+        cluster_id: clusterId,
+      });
+
+      await assert.rejects(
+        () => lifecycleOrchestrator.resume(clusterId),
+        (error) => {
+          assert.strictEqual(error.code, 'RESUME_RECONSTRUCTION_FAILED');
+          assert.match(error.message, /registered by worker.*no handler is currently eligible/i);
+          assert.doesNotMatch(error.message, /no agents handle it/i);
+          return true;
+        }
+      );
+
+      assert.strictEqual(restoredCluster.state, 'stopped');
+      assert.strictEqual(restoredCluster.pid, null);
+      assert.strictEqual(restoredCluster.failureInfo.type, 'resume_reconstruction');
+      assert.strictEqual(restoredCluster.failureInfo.reason, 'registered_handlers_ineligible');
+      assert.strictEqual(
+        restoredCluster.messageBus.count({ cluster_id: clusterId }),
+        messageCountBeforeResume,
+        'failed reconstruction must not append ledger messages'
+      );
+      assert.ok(
+        restoredCluster.agents.every((agent) => agent.running === false),
+        'failed reconstruction must not start any agent'
+      );
+    });
+
+    it('distinguishes an unhandled trigger from an ineligible registered handler', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      config.agents.find((agent) => agent.id === 'worker').triggers = [];
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'unhandled-validation-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-code',
+        content: { text: 'Rejected', data: { approved: false } },
+      });
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: new MockTaskRunner(),
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      await assert.rejects(
+        () => lifecycleOrchestrator.resume(clusterId),
+        (error) => {
+          assert.strictEqual(error.code, 'RESUME_RECONSTRUCTION_FAILED');
+          assert.match(error.message, /no restored agent registers trigger VALIDATION_RESULT/i);
+          assert.doesNotMatch(error.message, /currently eligible/i);
+          return true;
+        }
+      );
+
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+      assert.strictEqual(restoredCluster.failureInfo.reason, 'unhandled_trigger');
+      assert.deepStrictEqual(restoredCluster.failureInfo.matchingAgentIds, undefined);
+    });
+
+    it('uses normal trigger eligibility after every validator result is durable', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'complete-validation-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        content: { text: 'Implementation ready for validation' },
+      });
+      for (const [sender, approved] of [
+        ['validator-code', false],
+        ['validator-requirements', true],
+      ]) {
+        cluster.messageBus.publish({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+          sender,
+          content: {
+            text: approved ? 'Approved' : 'Rejected',
+            data: { approved },
+          },
+        });
+      }
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner.when('worker').returns('Repaired validation findings');
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const resumed = await lifecycleOrchestrator.resume(clusterId);
+      await waitForAgentCalls(resumedRunner, { worker: 1 });
+
+      assert.deepStrictEqual(resumed.resumedAgents, ['worker']);
+      resumedRunner.assertCalled('validator-code', 0);
+      resumedRunner.assertCalled('validator-requirements', 0);
+    });
+
     it('should restore ledger and cluster state', async function () {
       const config = createSimpleConfig();
       lifecycleMockRunner.when('worker').returns({ done: true });

--- a/tests/state-snapshot.test.js
+++ b/tests/state-snapshot.test.js
@@ -327,7 +327,7 @@ describe('Snapshotter orchestration integration', () => {
     mockRunner.assertContextIncludes('worker', 'STATE_SNAPSHOT');
   });
 
-  it('should publish STATE_SNAPSHOT when loading legacy clusters', async () => {
+  it('should defer legacy STATE_SNAPSHOT publication until a valid resume plan', async () => {
     const clusterId = 'legacy-cluster';
     const clusterDir = tempDir;
     const dbPath = path.join(clusterDir, `${clusterId}.db`);
@@ -350,6 +350,7 @@ describe('Snapshotter orchestration integration', () => {
 
     const fixturePath = path.join(__dirname, 'fixtures', 'single-worker.json');
     const config = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+    config.agents[0].triggers = [{ topic: 'PLAN_READY', action: 'execute_task' }];
     const clustersFile = path.join(clusterDir, 'clusters.json');
     fs.writeFileSync(
       clustersFile,
@@ -368,14 +369,31 @@ describe('Snapshotter orchestration integration', () => {
       )
     );
 
-    orchestrator = await Orchestrator.create({ storageDir: clusterDir, quiet: true });
+    const taskRunner = new MockTaskRunner();
+    taskRunner.when('worker').returns('resumed');
+    orchestrator = await Orchestrator.create({
+      storageDir: clusterDir,
+      quiet: true,
+      taskRunner,
+    });
     const cluster = orchestrator.getCluster(clusterId);
+    const snapshotBeforeResume = cluster.messageBus.findLast({
+      cluster_id: clusterId,
+      topic: 'STATE_SNAPSHOT',
+    });
+    assert.strictEqual(
+      snapshotBeforeResume,
+      null,
+      'loading a stopped legacy cluster must not mutate its ledger'
+    );
+
+    await orchestrator.resume(clusterId);
     const snapshot = cluster.messageBus.findLast({
       cluster_id: clusterId,
       topic: 'STATE_SNAPSHOT',
     });
 
-    assert.ok(snapshot, 'STATE_SNAPSHOT should be created during load');
+    assert.ok(snapshot, 'STATE_SNAPSHOT should be created only after the resume plan succeeds');
     assert.strictEqual(snapshot.content.data.plan.text, 'Legacy plan');
   });
 });


### PR DESCRIPTION
## Summary

- plan resume recovery before starting agents or mutating the ledger
- selectively resume missing/interrupted validators and preserve completed validation evidence
- recover durable issue context from complete history, with structured no-mutation diagnostics when reconstruction is unsafe
- make foreground and detached resume behavior equivalent

## Related Issues

Fixes #712
Fixes #713

## Changes Made

- add an internal preflight resume plan with explicit target precedence and registered-vs-eligible handler diagnostics
- cross-check lifecycle, persisted execution, iteration, and task ID state before considering work interrupted
- clear transient execution state only after a valid plan while preserving worktree and iteration history
- prevent snapshot/ledger mutation for impossible recovery and persist registry-only `resume_reconstruction` failure information
- add unit and daemon E2E coverage for partial validation, stale context, atomic failure, and foreground/detached parity

## Testing

- focused resume tests: 15 passing
- state snapshot tests: 7 passing
- `npm run lint` (0 errors)
- `npm run typecheck`
- `npm run test:unit` (1646 passing, 18 pending)
- `npm run test:e2e` (22 passing)
- `npm run test:slow` (143 passing, 18 pending)
- `npm run protocol:check`
- `npm run rust:check`
- `opcore check --changed`
- independent direct-file review: `APPROVED`

## Checklist

- [x] Tests pass
- [x] Documentation updated (not needed; no public interface change)
- [x] Follows commit guidelines
