### PR TITLE
fix(providers): support current GPT and Claude models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,7 +314,7 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 - Set `provider` per agent or `defaultProvider`/`forceProvider` at cluster level.
 - Provider names use CLI identifiers: `claude`, `codex`, `gemini`, `opencode`, `pi`, `copilot` (legacy `anthropic`/`openai`/`google` map to these).
 - `model` remains a provider-specific escape hatch.
-- Codex/Opencode only: `reasoningEffort` (`low|medium|high|xhigh`).
+- Claude/Codex/Opencode only: `reasoningEffort` (`low|medium|high|xhigh|max`).
 
 ### Logic Script API
 

--- a/cli/commands/providers.js
+++ b/cli/commands/providers.js
@@ -122,7 +122,10 @@ async function setupCommand(args) {
         const modelChoice = await question(rl, `Model for ${level} (${catalog.join(', ')}): `);
         if (modelChoice) levelOverrides[level] = { model: modelChoice };
         if (!providerSupportsCapability(provider, 'reasoningEffort')) continue;
-        const reasoning = await question(rl, `Reasoning for ${level} (low|medium|high|xhigh): `);
+        const reasoning = await question(
+          rl,
+          `Reasoning for ${level} (low|medium|high|xhigh|max): `
+        );
         if (reasoning) {
           levelOverrides[level] = {
             ...(levelOverrides[level] || {}),

--- a/cli/index.js
+++ b/cli/index.js
@@ -438,14 +438,13 @@ function applyModelOverrideToConfig(config, modelOverride, providerOverride, set
 
   if (providerName === 'claude') {
     const { validateModelAgainstMax, VALID_MODELS } = require('../lib/settings');
-    if (!VALID_MODELS.includes(modelOverride)) {
-      return;
-    }
-    try {
-      validateModelAgainstMax(modelOverride, settings.maxModel);
-    } catch (err) {
-      console.error(chalk.red(`Error: ${err.message}`));
-      process.exit(1);
+    if (VALID_MODELS.includes(modelOverride)) {
+      try {
+        validateModelAgainstMax(modelOverride, settings.maxModel);
+      } catch (err) {
+        console.error(chalk.red(`Error: ${err.message}`));
+        process.exit(1);
+      }
     }
   }
 
@@ -2745,7 +2744,7 @@ taskCmd
   .option('--provider <provider>', `Provider to use (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
-  .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh)')
+  .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
   .option('-r, --resume <sessionId>', 'Resume a specific Claude session (claude only)')
   .option('-c, --continue', 'Continue the most recent Claude session (claude only)')
   .option(
@@ -5854,4 +5853,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { renderRecentMessagesToTerminal, resolveRunMode };
+module.exports = { applyModelOverrideToConfig, renderRecentMessagesToTerminal, resolveRunMode };

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -85,8 +85,36 @@ Set levels per provider in settings:
 
 Notes:
 
-- `reasoningEffort` applies to Codex and Opencode only.
+- `reasoningEffort` accepts `low`, `medium`, `high`, `xhigh`, or `max`.
+- Claude passes reasoning effort to Claude Code as `--effort`.
+- Codex passes reasoning effort as the `model_reasoning_effort` config override.
+- Opencode passes reasoning effort as `--variant`.
 - `model` is still supported as a provider-specific escape hatch.
+
+### Current explicit model IDs
+
+Zeroshot keeps provider-agnostic `modelLevel` defaults and also recognizes these
+provider-specific IDs for explicit overrides:
+
+- Codex: `gpt-5.6` (alias for Sol), `gpt-5.6-sol`, `gpt-5.6-terra`, and
+  `gpt-5.6-luna`.
+- Claude aliases: `haiku`, `sonnet`, `opus`, and `fable`.
+- Claude current IDs: `claude-fable-5`, `claude-opus-4-8`,
+  `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5`,
+  `claude-opus-4-5-20251101`, `claude-sonnet-5`, `claude-sonnet-4-6`,
+  `claude-sonnet-4-5`, `claude-sonnet-4-5-20250929`,
+  `claude-haiku-4-5`, and `claude-haiku-4-5-20251001`.
+- Claude limited-access IDs: `claude-mythos-5` and `claude-mythos-preview`.
+  Recognition does not grant account access.
+
+The legacy Claude `maxModel` ceiling treats `fable` as a top-tier alias alongside
+`opus`. Explicit canonical Claude IDs remain provider-specific overrides and are
+not ranked by the legacy alias ceiling.
+
+Sources: [OpenAI models](https://developers.openai.com/api/docs/models),
+[Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview),
+[Anthropic model lifecycle](https://platform.claude.com/docs/en/about-claude/model-deprecations),
+and [Anthropic model ID rules](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions).
 
 ## Docker Isolation and Credentials
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -50,6 +50,7 @@ const { getProviderDefaults, clearProviderDefaultsCache } = require('./provider-
  */
 const MODEL_HIERARCHY = {
   opus: 3,
+  fable: 3,
   sonnet: 2,
   haiku: 1,
 };

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -4,7 +4,6 @@ import {
   type ClaudeCliFeatures,
   type CommandSpec,
   type ErrorClassification,
-  InvalidProviderModelError,
   type LevelModelSpec,
   type LevelOverrides,
   type ModelCatalogEntry,
@@ -28,8 +27,23 @@ import { parseClaudeEvent } from './claude-parser';
 
 const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
   haiku: { rank: 1 },
+  'claude-haiku-4-5': { rank: 1 },
+  'claude-haiku-4-5-20251001': { rank: 1 },
   sonnet: { rank: 2 },
+  'claude-sonnet-4-5': { rank: 2 },
+  'claude-sonnet-4-5-20250929': { rank: 2 },
+  'claude-sonnet-4-6': { rank: 2 },
+  'claude-sonnet-5': { rank: 2 },
   opus: { rank: 3 },
+  'claude-opus-4-5': { rank: 3 },
+  'claude-opus-4-5-20251101': { rank: 3 },
+  'claude-opus-4-6': { rank: 3 },
+  'claude-opus-4-7': { rank: 3 },
+  'claude-opus-4-8': { rank: 3 },
+  fable: { rank: 3 },
+  'claude-fable-5': { rank: 3 },
+  'claude-mythos-5': { rank: 3 },
+  'claude-mythos-preview': { rank: 3 },
 };
 
 const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
@@ -50,6 +64,7 @@ function detectCliFeatures(helpText?: string | null): ClaudeCliFeatures {
     supportsIncludePartials: unknown ? true : /--include-partial-messages/.test(help),
     supportsVerbose: unknown ? true : /--verbose/.test(help),
     supportsModel: unknown ? true : /--model/.test(help),
+    supportsEffort: unknown ? true : /--effort/.test(help),
     unknown,
   };
 }
@@ -85,6 +100,9 @@ function addModelArgs(args: string[], options: BuildProviderCommandOptions): voi
   const features = optionFeatures(options);
   if (options.modelSpec?.model && features.supportsModel !== false) {
     args.push('--model', options.modelSpec.model);
+  }
+  if (options.modelSpec?.reasoningEffort && features.supportsEffort !== false) {
+    args.push('--effort', options.modelSpec.reasoningEffort);
   }
 }
 
@@ -139,6 +157,15 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
       )
     );
   }
+  if (options.modelSpec?.reasoningEffort && features.supportsEffort === false) {
+    warnings.push(
+      warning(
+        'claude',
+        'claude-reasoning',
+        'Claude CLI does not support --effort; skipping reasoningEffort.'
+      )
+    );
+  }
   return warnings;
 }
 
@@ -176,16 +203,7 @@ function resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): Resolv
 }
 
 function validateModelId(modelId: string | null | undefined): string | null | undefined {
-  try {
-    return validateModelIdFromCatalog('claude', MODEL_CATALOG, modelId);
-  } catch (error) {
-    if (modelId && (modelId === 'opus-4.6' || modelId === 'claude-opus-4-6')) {
-      throw new InvalidProviderModelError(
-        `Invalid model "${modelId}" for provider "claude". Use canonical model ids: haiku, sonnet, opus.`
-      );
-    }
-    throw error;
-  }
+  return validateModelIdFromCatalog('claude', MODEL_CATALOG, modelId);
 }
 
 function classifyError(error: unknown): ErrorClassification {

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -27,6 +27,10 @@ import { parseCodexEvent } from './codex-parser';
 const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
   'gpt-5.4': { rank: 2 },
   'gpt-5.5': { rank: 3 },
+  'gpt-5.6': { rank: 3 },
+  'gpt-5.6-sol': { rank: 3 },
+  'gpt-5.6-terra': { rank: 2 },
+  'gpt-5.6-luna': { rank: 1 },
 };
 
 const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -100,8 +100,9 @@ export function validateModelIdFromCatalog(
 ): string | null | undefined {
   if (!modelId) return modelId;
   if (catalog[modelId] !== undefined) return modelId;
+  const validModels = Object.keys(catalog).join(', ');
   throw new InvalidProviderModelError(
-    `Invalid model "${modelId}" for provider "${provider}". Use a model listed in provider settings/catalog.`
+    `Invalid model "${modelId}" for provider "${provider}". Valid models: ${validModels}.`
   );
 }
 

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -13,7 +13,7 @@ import type {
 
 const OUTPUT_FORMATS: readonly OutputFormat[] = ['text', 'json', 'stream-json'];
 const MODEL_LEVELS: readonly ModelLevel[] = ['level1', 'level2', 'level3'];
-const REASONING_EFFORTS: readonly ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh'];
+const REASONING_EFFORTS: readonly ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
 const CLI_FEATURE_FIELDS = [
   'supportsOutputFormat',
   'supportsStreamJson',
@@ -22,6 +22,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsIncludePartials',
   'supportsVerbose',
   'supportsModel',
+  'supportsEffort',
   'supportsJson',
   'supportsOutputSchema',
   'supportsDir',

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -91,6 +91,7 @@ export type {
   ProviderId,
   ProviderRegistryEntry,
   RedactionMetadata,
+  ReasoningEffort,
   ResolvedGatewayBuildOptions,
   ResolvedModelSpec,
   ResultEvent,

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -160,7 +160,7 @@ export const providerRegistry = [
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
-      reasoningEffort: false,
+      reasoningEffort: true,
     },
     docs: {
       label: 'Claude',

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -61,7 +61,7 @@ type MutableModelSpec = {
 };
 
 const MODEL_LEVELS: readonly ModelLevel[] = ['level1', 'level2', 'level3'];
-const REASONING_EFFORTS: readonly ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh'];
+const REASONING_EFFORTS: readonly ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
 const settingsModule: unknown = require('../../lib/settings');
 const providerDetectionModule: unknown = require('../../lib/provider-detection');
 const claudeAuthModule: unknown = require('../../lib/settings/claude-auth');
@@ -420,7 +420,13 @@ function optionalModelLevel(value: unknown, field: string): ModelLevel | undefin
 
 function optionalReasoningEffort(value: unknown, field: string): ReasoningEffort | undefined {
   if (value === undefined) return undefined;
-  if (value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh') {
+  if (
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh' ||
+    value === 'max'
+  ) {
     return value;
   }
   throw new Error(`${field} must be one of: ${REASONING_EFFORTS.join(', ')}.`);

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -15,7 +15,7 @@ export type ProviderId = (typeof providerIds)[number];
 export type ProviderAlias = (typeof providerAliases)[number];
 export type KnownProviderName = ProviderId | ProviderAlias;
 export type ModelLevel = 'level1' | 'level2' | 'level3';
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 export type OutputFormat = 'text' | 'json' | 'stream-json';
 export type {
   ProviderCapabilities,
@@ -95,6 +95,7 @@ export interface ClaudeCliFeatures extends BaseCliFeatures {
   readonly supportsIncludePartials: boolean;
   readonly supportsVerbose: boolean;
   readonly supportsModel: boolean;
+  readonly supportsEffort: boolean;
 }
 
 export interface CodexCliFeatures extends BaseCliFeatures {
@@ -186,6 +187,7 @@ export interface CliFeatureOverrides {
   readonly supportsIncludePartials?: boolean;
   readonly supportsVerbose?: boolean;
   readonly supportsModel?: boolean;
+  readonly supportsEffort?: boolean;
   readonly supportsJson?: boolean;
   readonly supportsOutputSchema?: boolean;
   readonly supportsDir?: boolean;

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -21,6 +21,9 @@ const { getProvider } = require('./providers');
 const { CAPABILITIES } = require('./providers/capabilities');
 const { GUIDANCE_TOPICS } = require('./guidance-topics');
 
+const REASONING_EFFORTS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
+const REASONING_EFFORT_LABEL = REASONING_EFFORTS.join('|');
+
 const HOOK_ACTION_TOPIC_CONTRACTS = Object.freeze({
   verify_pull_request: Object.freeze([
     { topic: 'CLUSTER_COMPLETE', keys: null },
@@ -2054,14 +2057,13 @@ function validateProviderSettings(provider, providerSettings) {
       providerModule.validateModelId(override.model);
     }
     if (override?.reasoningEffort && !providerSupportsCapability(provider, 'reasoningEffort')) {
-      throw new Error(`reasoningEffort overrides are only supported for Codex and Opencode`);
-    }
-    if (
-      override?.reasoningEffort &&
-      !['low', 'medium', 'high', 'xhigh'].includes(override.reasoningEffort)
-    ) {
       throw new Error(
-        `Invalid reasoningEffort "${override.reasoningEffort}" (low|medium|high|xhigh)`
+        `reasoningEffort overrides are only supported for Claude, Codex, and Opencode`
+      );
+    }
+    if (override?.reasoningEffort && !REASONING_EFFORTS.includes(override.reasoningEffort)) {
+      throw new Error(
+        `Invalid reasoningEffort "${override.reasoningEffort}" (${REASONING_EFFORT_LABEL})`
       );
     }
   }
@@ -2172,12 +2174,9 @@ function validateModelRulesSupport(agent, provider, providerModule, levels, warn
 function validateReasoningEffortSupport(agent, provider, warnings) {
   if (agent.reasoningEffort && !providerSupportsCapability(provider, 'reasoningEffort')) {
     warnings.push(`Agent "${agent.id}" sets reasoningEffort but ${provider} does not support it`);
-  } else if (
-    agent.reasoningEffort &&
-    !['low', 'medium', 'high', 'xhigh'].includes(agent.reasoningEffort)
-  ) {
+  } else if (agent.reasoningEffort && !REASONING_EFFORTS.includes(agent.reasoningEffort)) {
     warnings.push(
-      `Agent "${agent.id}" has invalid reasoningEffort "${agent.reasoningEffort}" (low|medium|high|xhigh)`
+      `Agent "${agent.id}" has invalid reasoningEffort "${agent.reasoningEffort}" (${REASONING_EFFORT_LABEL})`
     );
   }
 }

--- a/tests/agent-cli-provider/current-model-support.test.js
+++ b/tests/agent-cli-provider/current-model-support.test.js
@@ -1,0 +1,133 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const helper = require('../../lib/agent-cli-provider');
+const { runExecutable } = require('./executable-contract-helpers.cjs');
+
+const OPENAI_GPT_56_MODELS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'];
+
+const CURRENT_CLAUDE_MODELS = [
+  'fable',
+  'claude-fable-5',
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-opus-4-5',
+  'claude-opus-4-5-20251101',
+  'claude-sonnet-5',
+  'claude-sonnet-4-6',
+  'claude-sonnet-4-5',
+  'claude-sonnet-4-5-20250929',
+  'claude-haiku-4-5',
+  'claude-haiku-4-5-20251001',
+  'claude-mythos-5',
+  'claude-mythos-preview',
+];
+
+test('Codex catalog accepts the GPT-5.6 family and alias', () => {
+  const adapter = helper.getProviderAdapter('codex');
+
+  for (const model of OPENAI_GPT_56_MODELS) {
+    assert.equal(adapter.validateModelId(model), model);
+  }
+});
+
+test('Claude catalog accepts current canonical ids, aliases, and limited-access models', () => {
+  const adapter = helper.getProviderAdapter('claude');
+
+  for (const model of CURRENT_CLAUDE_MODELS) {
+    assert.equal(adapter.validateModelId(model), model);
+  }
+});
+
+test('Codex sends max reasoning effort through its config override', () => {
+  const spec = helper.buildProviderCommand('codex', 'test context', {
+    modelSpec: { model: 'gpt-5.6-sol', reasoningEffort: 'max' },
+    cliFeatures: {
+      supportsConfigOverride: true,
+      supportsSkipGitRepoCheck: true,
+    },
+  });
+
+  assert.deepEqual(spec.args.slice(spec.args.indexOf('-m'), spec.args.indexOf('-m') + 2), [
+    '-m',
+    'gpt-5.6-sol',
+  ]);
+  assert.deepEqual(
+    spec.args.slice(spec.args.indexOf('--config'), spec.args.indexOf('--config') + 2),
+    ['--config', 'model_reasoning_effort="max"']
+  );
+});
+
+test('Claude sends max reasoning effort through the installed CLI effort flag', () => {
+  const spec = helper.buildProviderCommand('claude', 'test context', {
+    modelSpec: { model: 'claude-fable-5', reasoningEffort: 'max' },
+    cliFeatures: {
+      supportsModel: true,
+      supportsEffort: true,
+    },
+  });
+
+  assert.deepEqual(
+    spec.args.slice(spec.args.indexOf('--model'), spec.args.indexOf('--model') + 2),
+    ['--model', 'claude-fable-5']
+  );
+  assert.deepEqual(
+    spec.args.slice(spec.args.indexOf('--effort'), spec.args.indexOf('--effort') + 2),
+    ['--effort', 'max']
+  );
+});
+
+test('Claude registry reports reasoning-effort support', () => {
+  const metadata = helper.getProviderRegistryEntry('claude');
+  assert.equal(metadata.capabilities.reasoningEffort, true);
+});
+
+test('provider executable contract accepts and preserves max reasoning effort', () => {
+  for (const { provider, model, flag, expected } of [
+    {
+      provider: 'codex',
+      model: 'gpt-5.6-terra',
+      flag: '--config',
+      expected: 'model_reasoning_effort="max"',
+    },
+    {
+      provider: 'claude',
+      model: 'claude-sonnet-5',
+      flag: '--effort',
+      expected: 'max',
+    },
+  ]) {
+    const response = runExecutable({
+      schemaVersion: 1,
+      command: 'build-command',
+      provider,
+      context: 'test context',
+      options: {
+        modelSpec: { model, reasoningEffort: 'max' },
+      },
+    });
+
+    assert.equal(response.exitCode, 0, provider);
+    assert.equal(response.envelope.ok, true, provider);
+    const args = response.envelope.result.commandSpec.args;
+    assert.deepEqual(args.slice(args.indexOf(flag), args.indexOf(flag) + 2), [flag, expected]);
+  }
+});
+
+test('invalid-model diagnostics enumerate the current provider catalog', () => {
+  for (const { provider, expectedModel } of [
+    { provider: 'codex', expectedModel: 'gpt-5.6-sol' },
+    { provider: 'claude', expectedModel: 'claude-opus-4-8' },
+  ]) {
+    let modelError;
+    try {
+      helper.getProviderAdapter(provider).validateModelId('not-a-current-model');
+    } catch (error) {
+      modelError = error;
+    }
+    assert.ok(modelError instanceof Error, provider);
+    assert.ok(modelError.message.includes('Valid models:'), provider);
+    assert.ok(modelError.message.includes(expectedModel), provider);
+  }
+});

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -429,6 +429,7 @@ test('feature probing is deterministic from injected help text', () => {
     supportsIncludePartials: true,
     supportsVerbose: true,
     supportsModel: true,
+    supportsEffort: true,
     unknown: true,
   });
 

--- a/tests/agent-cli-provider/strict-lane.test.ts
+++ b/tests/agent-cli-provider/strict-lane.test.ts
@@ -18,6 +18,7 @@ import {
   type OutputEvent,
   type ProcessRunner,
   type ProviderId,
+  type ReasoningEffort,
 } from '../../src/agent-cli-provider/index';
 
 const expectedMetadata: Readonly<AgentCliProviderHelperMetadata> = agentCliProviderHelperMetadata;
@@ -127,12 +128,14 @@ test('discriminated output events narrow without unsafe assertions', (): void =>
 
 test('model levels and error classifications are explicit unions', (): void => {
   const level: ModelLevel = 'level3';
+  const effort: ReasoningEffort = 'max';
   const spec = resolveModelSpec('codex', level);
   const classification: ErrorClassification = classifyProviderError('codex', {
     message: 'server_error',
   });
 
   assert.equal(spec.reasoningEffort, 'xhigh');
+  assert.equal(effort, 'max');
   assert.equal(classification.retryable, true);
 });
 

--- a/tests/max-model.test.js
+++ b/tests/max-model.test.js
@@ -276,7 +276,7 @@ function registerSettingsValidationTests() {
       const error = settingsModule.validateSetting('maxModel', 'gpt4');
       assert.ok(error !== null);
       assert.ok(error.includes('Invalid model'));
-      assert.ok(error.includes('opus, sonnet, haiku'));
+      assert.ok(error.includes('opus, fable, sonnet, haiku'));
     });
 
     it('should accept valid maxModel values', function () {
@@ -392,8 +392,19 @@ function registerModelHierarchyConstantTests() {
       const { MODEL_HIERARCHY } = settingsModule;
 
       assert.strictEqual(MODEL_HIERARCHY.opus, 3);
+      assert.strictEqual(MODEL_HIERARCHY.fable, 3);
       assert.strictEqual(MODEL_HIERARCHY.sonnet, 2);
       assert.strictEqual(MODEL_HIERARCHY.haiku, 1);
+    });
+
+    it('should treat fable as a top-tier legacy alias', function () {
+      const { validateModelAgainstMax } = settingsModule;
+
+      assert.strictEqual(validateModelAgainstMax('fable', 'opus'), 'fable');
+      assert.throws(
+        () => validateModelAgainstMax('fable', 'sonnet'),
+        /Agent requests "fable" but maxModel is "sonnet"/
+      );
     });
 
     it('should have all valid models in hierarchy', function () {

--- a/tests/model-override.test.js
+++ b/tests/model-override.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { applyModelOverrideToConfig } = require('../cli/index');
 const Orchestrator = require('../src/orchestrator');
 const MockTaskRunner = require('./helpers/mock-task-runner');
 
@@ -35,6 +36,27 @@ describe('Model Override (--model flag)', () => {
       console.error('Cleanup failed:', e.message);
     }
     delete process.env.ZEROSHOT_SETTINGS_FILE;
+  });
+
+  it('applies a canonical Claude model through the CLI config override path', function () {
+    const config = {
+      agents: [
+        {
+          id: 'worker',
+          modelRules: [{ iterations: 'all', model: 'sonnet' }],
+          role: 'implementation',
+          triggers: [],
+        },
+      ],
+    };
+
+    applyModelOverrideToConfig(config, 'claude-fable-5', 'claude', {
+      defaultProvider: 'claude',
+      maxModel: 'opus',
+    });
+
+    assert.strictEqual(config.agents[0].model, 'claude-fable-5');
+    assert.strictEqual(config.agents[0].modelRules, undefined);
   });
 
   it('should override all agent models when modelOverride is provided', async function () {

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -3,7 +3,11 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { loadSettings, validateSetting } = require('../lib/settings');
-const { validateProviderSettings, validateProviderLevel } = require('../src/config-validator');
+const {
+  validateProviderFeatures,
+  validateProviderSettings,
+  validateProviderLevel,
+} = require('../src/config-validator');
 const { getProvider } = require('../src/providers');
 
 describe('Provider settings', function () {
@@ -64,6 +68,28 @@ describe('Provider settings', function () {
       });
     });
 
+    assert.doesNotThrow(() => {
+      validateProviderSettings('codex', {
+        minLevel: 'level1',
+        maxLevel: 'level3',
+        defaultLevel: 'level3',
+        levelOverrides: {
+          level3: { model: 'gpt-5.6-sol', reasoningEffort: 'max' },
+        },
+      });
+    });
+
+    assert.doesNotThrow(() => {
+      validateProviderSettings('claude', {
+        minLevel: 'level1',
+        maxLevel: 'level3',
+        defaultLevel: 'level3',
+        levelOverrides: {
+          level3: { model: 'claude-opus-4-8', reasoningEffort: 'max' },
+        },
+      });
+    });
+
     assert.throws(() => {
       validateProviderSettings('gemini', {
         minLevel: 'level1',
@@ -108,6 +134,52 @@ describe('Provider settings', function () {
     }, /toolPolicy\.roots must be an array of strings/);
   });
 
+  it('accepts max reasoning effort in agent config for Claude and Codex', function () {
+    const settings = loadSettings();
+    const result = validateProviderFeatures(
+      {
+        agents: [
+          {
+            id: 'claude-worker',
+            role: 'implementation',
+            provider: 'claude',
+            model: 'claude-opus-4-8',
+            reasoningEffort: 'max',
+          },
+          {
+            id: 'codex-worker',
+            role: 'implementation',
+            provider: 'codex',
+            model: 'gpt-5.6-sol',
+            reasoningEffort: 'max',
+          },
+        ],
+      },
+      settings
+    );
+
+    assert.deepStrictEqual(result.errors, []);
+    assert.deepStrictEqual(result.warnings, []);
+  });
+
+  it('lists max in invalid reasoning-effort diagnostics', function () {
+    const result = validateProviderFeatures(
+      {
+        agents: [
+          {
+            id: 'worker',
+            role: 'implementation',
+            provider: 'codex',
+            reasoningEffort: 'extreme',
+          },
+        ],
+      },
+      loadSettings()
+    );
+
+    assert.ok(result.warnings.some((warning) => warning.includes('low|medium|high|xhigh|max')));
+  });
+
   it('applies legacy maxModel to claude levels', function () {
     process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
     fs.writeFileSync(settingsFile, JSON.stringify({ maxModel: 'haiku' }, null, 2), 'utf8');
@@ -129,11 +201,9 @@ describe('Provider settings', function () {
     assert.strictEqual(modelSpec.model, 'opus');
   });
 
-  it('rejects legacy claude model aliases as invalid input', function () {
+  it('accepts recent canonical Claude model ids', function () {
     const claude = getProvider('claude');
-    assert.throws(() => {
-      claude.validateModelId('opus-4.6');
-    }, /Use canonical model ids: haiku, sonnet, opus/);
+    assert.strictEqual(claude.validateModelId('claude-opus-4-6'), 'claude-opus-4-6');
   });
 
   it('marks invalid model errors as permanent', function () {
@@ -155,6 +225,6 @@ describe('Provider settings', function () {
         modelSpec: { model: 'opus-4.6' },
         cliFeatures: { supportsModel: true },
       });
-    }, /Use canonical model ids: haiku, sonnet, opus/);
+    }, /Invalid model "opus-4.6"/);
   });
 });

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -53,4 +53,27 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
       assert.ok(pathEntries.includes(entry));
     }
   });
+
+  it('forwards max reasoning effort into the detached task invocation', function () {
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    const args = runner._buildRunArgs({
+      context: 'test context',
+      providerName: 'claude',
+      runOutputFormat: 'stream-json',
+      resolvedModelSpec: {
+        model: 'claude-opus-4-8',
+        reasoningEffort: 'max',
+      },
+      jsonSchema: null,
+    });
+
+    assert.deepStrictEqual(args.slice(args.indexOf('--model'), args.indexOf('--model') + 2), [
+      '--model',
+      'claude-opus-4-8',
+    ]);
+    assert.deepStrictEqual(
+      args.slice(args.indexOf('--reasoning-effort'), args.indexOf('--reasoning-effort') + 2),
+      ['--reasoning-effort', 'max']
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- recognize the current GPT-5.6 Sol, Terra, and Luna model IDs plus the `gpt-5.6` Sol alias
- recognize current and limited-access Claude model IDs while preserving provider-agnostic level defaults
- accept and forward `max` reasoning effort for Codex, Claude, Opencode, the JSON executable contract, and detached task handoff
- route canonical Claude IDs through the real top-level `--model` config-application path
- treat the `fable` Claude alias as legacy top-tier for `maxModel` checks
- enumerate valid provider models in invalid-model diagnostics and document the official provider contracts

## Contract sources

- https://developers.openai.com/api/docs/models
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/about-claude/model-deprecations
- https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` — 1,651 passing, 18 pending
- focused model/config/argv/detached tests — 43 passing plus 7 Node contract tests
- `npm run test:slow` — 143 passing, 18 pending
- `npm run protocol:check`
- `npm run rust:check`
- `opcore check --changed`
- independent file-level review: `APPROVED`

The full e2e suite completed 21 tests and reached the separate resume-process bug lane: foreground resume completed successfully but the subprocess reported a null exit code. The independent hang-fix lane owns that failure; this PR does not modify resume/process lifecycle code.
