### PR TITLE
fix(hooks): disable lint-staged backup stashes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ if git diff --cached --name-only --diff-filter=ACM -- '*.rs' | grep -q .; then
 fi
 
 # Lint and format only staged files
-npx lint-staged
+node scripts/run-lint-staged-no-stash.js
 
 # Type check the entire project (can't be limited to staged files)
 npm run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -616,12 +616,13 @@ Do NOT assume single root cause.
 
 ## Mechanical Enforcement
 
-| Antipattern               | Enforcement      |
-| ------------------------- | ---------------- |
-| Dangerous fallbacks       | ESLint ERROR     |
-| Manual git tags           | Pre-push hook    |
-| Git in validator prompts  | Config validator |
-| Multiple impl files (-v2) | Pre-commit hook  |
-| Spawn without permission  | Runtime check    |
-| Git stash usage           | Pre-commit hook  |
-| Rust formatting drift     | Pre-commit hook  |
+| Antipattern                | Enforcement        |
+| -------------------------- | ------------------ |
+| Dangerous fallbacks        | ESLint ERROR       |
+| Manual git tags            | Pre-push hook      |
+| Git in validator prompts   | Config validator   |
+| Multiple impl files (-v2)  | Pre-commit hook    |
+| Spawn without permission   | Runtime check      |
+| Git stash usage            | Pre-commit hook    |
+| lint-staged backup stashes | Pre-commit wrapper |
+| Rust formatting drift      | Pre-commit hook    |

--- a/scripts/run-lint-staged-no-stash.js
+++ b/scripts/run-lint-staged-no-stash.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const PATCH_NAME = 'lint-staged_unstaged.patch';
+const GIT_APPLY_ARGS = ['apply', '-v', '--whitespace=nowarn', '--recount', '--unidiff-zero'];
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: options.stdio || 'inherit',
+    encoding: options.encoding,
+  });
+}
+
+function resolveUnstagedPatchPath() {
+  const result = run('git', ['rev-parse', '--git-path', PATCH_NAME], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return null;
+  const gitPath = result.stdout.trim();
+  return path.isAbsolute(gitPath) ? gitPath : path.resolve(process.cwd(), gitPath);
+}
+
+function restoreUnstagedPatch(patchPath) {
+  const direct = run('git', [...GIT_APPLY_ARGS, patchPath]);
+  if (direct.status === 0) return true;
+
+  const threeWay = run('git', [...GIT_APPLY_ARGS, '--3way', patchPath]);
+  return threeWay.status === 0;
+}
+
+function main() {
+  const patchPath = resolveUnstagedPatchPath();
+  if (patchPath && fs.existsSync(patchPath)) {
+    console.error(
+      `ERROR: Refusing to overwrite unresolved unstaged changes at ${patchPath}.\n` +
+        `Restore them with 'git apply "${patchPath}"', then remove the patch before committing.`
+    );
+    return 1;
+  }
+
+  const lintStagedBin = require.resolve('lint-staged/bin');
+  const lintStaged = run(process.execPath, [lintStagedBin, '--no-stash', ...process.argv.slice(2)]);
+  const lintStatus = lintStaged.status ?? 1;
+
+  if (!patchPath || !fs.existsSync(patchPath)) {
+    return lintStatus;
+  }
+
+  if (lintStatus === 0 || restoreUnstagedPatch(patchPath)) {
+    fs.rmSync(patchPath, { force: true });
+    return lintStatus;
+  }
+
+  console.error(
+    `ERROR: lint-staged failed and unstaged changes conflicted with task edits.\n` +
+      `The commit remains blocked. Your unstaged changes are preserved at ${patchPath}.\n` +
+      `Resolve them with 'git apply --3way "${patchPath}"'; do not delete the patch first.`
+  );
+  return lintStatus;
+}
+
+process.exitCode = main();

--- a/tests/unit/pre-commit-no-stash.test.js
+++ b/tests/unit/pre-commit-no-stash.test.js
@@ -1,0 +1,173 @@
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+const lintStagedWrapper = path.join(projectRoot, 'scripts', 'run-lint-staged-no-stash.js');
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env || process.env,
+    encoding: 'utf8',
+  });
+}
+
+function runGit(repoDir, args) {
+  const result = run('git', args, { cwd: repoDir });
+  assert.strictEqual(
+    result.status,
+    0,
+    `git ${args.join(' ')} failed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+  );
+  return result.stdout;
+}
+
+function setupPartiallyStagedRepo() {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-lint-staged-'));
+  const filePath = path.join(repoDir, 'example.txt');
+  const formatterPath = path.join(repoDir, 'format-staged.cjs');
+  const configPath = path.join(repoDir, 'lint-staged.config.cjs');
+
+  runGit(repoDir, ['init']);
+  runGit(repoDir, ['config', 'user.email', 'test@example.com']);
+  runGit(repoDir, ['config', 'user.name', 'Test User']);
+  fs.writeFileSync(filePath, 'base\nstaged-target\nmiddle\ntail\n');
+  runGit(repoDir, ['add', 'example.txt']);
+  runGit(repoDir, ['commit', '-m', 'base']);
+
+  fs.writeFileSync(filePath, 'base\nstaged\nmiddle\ntail\n');
+  runGit(repoDir, ['add', 'example.txt']);
+  fs.writeFileSync(filePath, 'base\nstaged\nmiddle\nunstaged-tail\n');
+
+  fs.writeFileSync(
+    formatterPath,
+    [
+      "const fs = require('fs');",
+      'for (const filePath of process.argv.slice(2)) {',
+      "  const source = fs.readFileSync(filePath, 'utf8');",
+      "  fs.writeFileSync(filePath, source.replace('staged\\n', 'formatted-staged\\n'));",
+      '}',
+      "if (process.env.FAIL_FORMATTER === '1') process.exit(1);",
+      '',
+    ].join('\n')
+  );
+  fs.writeFileSync(
+    configPath,
+    `module.exports = { '*.txt': ${JSON.stringify(`${process.execPath} ${formatterPath}`)} };\n`
+  );
+
+  return { repoDir, filePath, configPath };
+}
+
+function readTraceEvents(tracePath) {
+  if (!fs.existsSync(tracePath)) return [];
+  return fs
+    .readFileSync(tracePath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function assertNoStashCommand(tracePath) {
+  const stashStarts = readTraceEvents(tracePath).filter(
+    (event) =>
+      event.event === 'start' &&
+      Array.isArray(event.argv) &&
+      event.argv.some((argument) => argument === 'stash')
+  );
+  assert.deepStrictEqual(stashStarts, [], 'lint-staged must not invoke git stash');
+}
+
+function getRecoveryPatchPath(repoDir) {
+  const gitPath = runGit(repoDir, ['rev-parse', '--git-path', 'lint-staged_unstaged.patch']).trim();
+  return path.isAbsolute(gitPath) ? gitPath : path.resolve(repoDir, gitPath);
+}
+
+describe('pre-commit lint-staged isolation', function () {
+  this.timeout(15000);
+
+  it('disables lint-staged backup stashes without exposing partially staged hunks', function () {
+    const hook = fs.readFileSync(path.join(projectRoot, '.husky', 'pre-commit'), 'utf8');
+    assert.match(hook, /^node scripts\/run-lint-staged-no-stash\.js$/m);
+    assert.doesNotMatch(hook, /--no-hide-partially-staged/);
+  });
+
+  it('preserves unstaged hunks while formatting only the staged snapshot', function () {
+    const fixture = setupPartiallyStagedRepo();
+    const tracePath = path.join(fixture.repoDir, 'git-trace.jsonl');
+    try {
+      const result = run(process.execPath, [lintStagedWrapper, '--config', fixture.configPath], {
+        cwd: fixture.repoDir,
+        env: { ...process.env, GIT_TRACE2_EVENT: tracePath },
+      });
+      assert.strictEqual(
+        result.status,
+        0,
+        `lint-staged failed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+      );
+      assert.strictEqual(
+        runGit(fixture.repoDir, ['show', ':example.txt']),
+        'base\nformatted-staged\nmiddle\ntail\n'
+      );
+      assert.strictEqual(
+        fs.readFileSync(fixture.filePath, 'utf8'),
+        'base\nformatted-staged\nmiddle\nunstaged-tail\n'
+      );
+      assert.strictEqual(fs.existsSync(getRecoveryPatchPath(fixture.repoDir)), false);
+      assertNoStashCommand(tracePath);
+    } finally {
+      fs.rmSync(fixture.repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed without losing the unstaged hunk when a task rejects', function () {
+    const fixture = setupPartiallyStagedRepo();
+    const tracePath = path.join(fixture.repoDir, 'git-trace.jsonl');
+    try {
+      const result = run(process.execPath, [lintStagedWrapper, '--config', fixture.configPath], {
+        cwd: fixture.repoDir,
+        env: { ...process.env, FAIL_FORMATTER: '1', GIT_TRACE2_EVENT: tracePath },
+      });
+      assert.notStrictEqual(result.status, 0, 'a failing lint-staged task must abort the commit');
+      assert.strictEqual(
+        runGit(fixture.repoDir, ['show', ':example.txt']),
+        'base\nformatted-staged\nmiddle\ntail\n'
+      );
+      assert.strictEqual(
+        fs.readFileSync(fixture.filePath, 'utf8'),
+        'base\nformatted-staged\nmiddle\nunstaged-tail\n'
+      );
+      assert.strictEqual(fs.existsSync(getRecoveryPatchPath(fixture.repoDir)), false);
+      assertNoStashCommand(tracePath);
+    } finally {
+      fs.rmSync(fixture.repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite unresolved recovery evidence', function () {
+    const fixture = setupPartiallyStagedRepo();
+    const recoveryPatchPath = getRecoveryPatchPath(fixture.repoDir);
+    try {
+      fs.writeFileSync(recoveryPatchPath, 'previous recovery evidence\n');
+      const result = run(process.execPath, [lintStagedWrapper, '--config', fixture.configPath], {
+        cwd: fixture.repoDir,
+      });
+
+      assert.notStrictEqual(result.status, 0);
+      assert.match(result.stderr, /Refusing to overwrite unresolved unstaged changes/);
+      assert.strictEqual(
+        fs.readFileSync(recoveryPatchPath, 'utf8'),
+        'previous recovery evidence\n'
+      );
+      assert.strictEqual(
+        fs.readFileSync(fixture.filePath, 'utf8'),
+        'base\nstaged\nmiddle\nunstaged-tail\n'
+      );
+    } finally {
+      fs.rmSync(fixture.repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- replace Husky's direct lint-staged invocation with a no-stash wrapper
- retain lint-staged's partial-stage isolation and restore its hidden unstaged patch after task failures
- fail closed when recovery evidence already exists or patch restoration conflicts
- document the enforced no-backup-stash convention

## Root cause

The pre-commit hook invoked lint-staged with its default backup behavior. lint-staged therefore created a Git stash even though this repository explicitly forbids stash-based coordination. Passing `--no-stash` alone is insufficient: in lint-staged 16.2.7 a failed task can leave hidden unstaged hunks only in `.git/lint-staged_unstaged.patch`. The wrapper owns that recovery path without invoking `git stash`.

## Verification

- `npx mocha tests/unit/pre-commit-no-stash.test.js` — 4 passing
- `npm run test:unit` — 1,654 passing, 18 pending
- `npm run lint` — 0 errors (existing warnings only)
- `npm run typecheck`
- `opcore check --changed`
- real staged-hook trace: no Git process with `stash` in argv

Closes #721