### PR TITLE
fix(recovery): terminate and retry stalled provider tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,19 @@ Fix: added `onComplete` publish of `CLUSTER_COMPLETE` in
 `src/agents/git-pusher-agent.json`.
 Test: `tests/integration/orchestrator-flow.test.js`.
 
+### Foreground Resume Exit Delay (2026-07-17)
+
+Bug: foreground `zeroshot resume` could print cluster completion but remain alive until a
+five-second task-shutdown timer expired.
+
+Root cause: agent shutdown raced in-flight execution against a bounded timeout without clearing the
+losing timer, and the resume CLI omitted the foreground orchestrator cleanup used by `run`.
+
+Fix: clear the bounded-wait timer, close non-daemon resume orchestrators in `finally`, and make
+orchestrator close release snapshotter, message-bus, and ledger resources.
+Tests: `tests/unit/agent-lifecycle-stop.test.js` and
+`tests/e2e/resume-detach-daemon.test.js`.
+
 ## Enforcement Philosophy
 
 **ENFORCE > DOCUMENT. If enforceable, don't document.**

--- a/cli/index.js
+++ b/cli/index.js
@@ -3248,10 +3248,12 @@ program
   .description('Resume a failed task or cluster')
   .option('-d, --detach', 'Resume in background (daemon mode)')
   .action(async (id, prompt, options) => {
+    let orchestrator = null;
+    let keepOrchestratorOpen = false;
     try {
       // Try cluster first, then task (both use same ID format: "adjective-noun-number")
       const OrchestratorModule = require('../src/orchestrator');
-      const orchestrator = await OrchestratorModule.create();
+      orchestrator = await OrchestratorModule.create();
 
       // Check if cluster exists
       const cluster = orchestrator.getCluster(id);
@@ -3356,6 +3358,7 @@ program
         // === DAEMON MODE: stay alive in the background, let signals stop the cluster ===
         if (isResumeDaemon) {
           setupDaemonCleanup(orchestrator, id);
+          keepOrchestratorOpen = true;
           console.log('');
           console.log(chalk.dim(`Follow logs with: zeroshot logs ${id} -f`));
           return;
@@ -3474,7 +3477,11 @@ program
       }
     } catch (error) {
       console.error(chalk.red('Error resuming:'), error.message);
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      if (orchestrator && !keepOrchestratorOpen) {
+        orchestrator.close();
+      }
     }
   });
 

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -81,8 +81,12 @@ class AgentWrapper {
     // LIVENESS DETECTION - Track output freshness to detect stuck agents
     /** @type {number | null} */
     this.lastOutputTime = null; // Timestamp of last output received
+    /** @type {number | null} */
+    this.taskStartedAt = null; // Timestamp used for absolute task timeout
     /** @type {NodeJS.Timeout | null} */
     this.livenessCheckInterval = null; // Interval for health checks
+    this.consecutiveStaleWarnings = 0;
+    this.livenessTerminationStarted = false;
     this.staleDuration = normalizedConfig.staleDuration;
     this.enableLivenessCheck = normalizedConfig.enableLivenessCheck;
 
@@ -499,8 +503,8 @@ class AgentWrapper {
    * Kill current task
    * @private
    */
-  _killTask() {
-    return killTask(this);
+  _killTask(reason) {
+    return killTask(this, reason);
   }
 
   /**

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -7,7 +7,7 @@
  * - Message handling and routing
  * - Trigger action execution (execute_task, stop_cluster)
  * - Task execution with retry logic
- * - Liveness monitoring with multi-indicator stuck detection
+ * - Bounded task runtime and provider-output inactivity monitoring
  *
  * State machine: idle → evaluating → building_context → executing → idle
  */
@@ -17,11 +17,7 @@ const { executeHook } = require('./agent-hook-executor');
 const IsolationManager = require('../isolation-manager');
 const crypto = require('crypto');
 const { bufferMessage, scheduleDrain, drainBufferedMessages } = require('../message-buffer');
-const {
-  analyzeProcessHealth,
-  isPlatformSupported,
-  STUCK_THRESHOLD,
-} = require('./agent-stuck-detector');
+const { isPlatformSupported } = require('./agent-stuck-detector');
 const { normalizeProviderName } = require('../../lib/provider-names');
 const { loadSettings } = require('../../lib/settings');
 const { findPlatformMismatchReason } = require('./validation-platform');
@@ -36,6 +32,7 @@ class HookExecutionError extends Error {
     this.hookFailure = true;
     this.hookRetries = options?.hookRetries;
     this.originalHookError = options?.originalHookError;
+    this.taskId = options?.taskId || null;
   }
 }
 
@@ -217,21 +214,28 @@ async function stop(agent) {
 
   // Kill current task if any
   if (agent.currentTask) {
-    agent._killTask();
+    await agent._killTask('Task stopped by cluster shutdown');
   }
 
   // Wait for in-flight execution to complete (up to 5 seconds)
   // This prevents write-after-close race conditions
   if (agent._currentExecution) {
+    let executionTimeout = null;
     try {
       await Promise.race([
         agent._currentExecution,
-        new Promise((resolve) => setTimeout(resolve, 5000)),
+        new Promise((resolve) => {
+          executionTimeout = setTimeout(resolve, 5000);
+        }),
       ]);
     } catch {
       // Ignore errors from cancelled execution
+    } finally {
+      if (executionTimeout) {
+        clearTimeout(executionTimeout);
+      }
+      agent._currentExecution = null;
     }
-    agent._currentExecution = null;
   }
 
   agent._log(`Agent ${agent.id} stopped`);
@@ -427,7 +431,7 @@ function publishTaskStarted(agent, triggeringMessage) {
 
 function attachResultMetadata(agent, result) {
   // Add task ID to result for debugging and hooks
-  result.taskId = agent.currentTaskId;
+  result.taskId = result.taskId || agent.currentTaskId;
   result.agentId = agent.id;
   result.iteration = agent.iteration;
 }
@@ -465,6 +469,15 @@ function publishTokenUsage(agent, result) {
       },
     },
   });
+}
+
+function clearTransientTaskState(agent) {
+  stopLivenessCheck(agent);
+  agent.currentTask = null;
+  agent.currentTaskId = null;
+  agent.processPid = null;
+  agent.lastOutputTime = null;
+  agent.taskStartedAt = null;
 }
 
 async function executeOnCompleteHookWithRetry(agent, triggeringMessage, result) {
@@ -510,7 +523,11 @@ ${'='.repeat(80)}`);
           `Hook execution failed after ${hookMaxRetries} attempts. ` +
             `Task completed successfully but hook could not publish result. ` +
             `Original error: ${hookError.message}`,
-          { hookRetries: hookMaxRetries, originalHookError: hookError.message }
+          {
+            hookRetries: hookMaxRetries,
+            originalHookError: hookError.message,
+            taskId: result?.taskId || null,
+          }
         );
       }
     }
@@ -554,7 +571,10 @@ async function runTaskAttempt(agent, triggeringMessage) {
 
   // Check if task execution failed
   if (!result.success) {
-    throw new Error(result.error || 'Task execution failed');
+    const error = new Error(result.error || 'Task execution failed');
+    error.code = result.code || result.errorType || null;
+    error.taskId = result.taskId || null;
+    throw error;
   }
 
   const fallbackReason = await maybeRetryValidatorInDocker(agent, result);
@@ -573,6 +593,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
 
   publishTaskCompleted(agent, result);
   publishTokenUsage(agent, result);
+  clearTransientTaskState(agent);
   await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
 }
 
@@ -673,7 +694,7 @@ ${'='.repeat(80)}`);
   // Save failure info to cluster for resume capability
   agent.cluster.failureInfo = {
     agentId: agent.id,
-    taskId: agent.currentTaskId,
+    taskId: error?.taskId || agent.currentTaskId,
     iteration: agent.iteration,
     error: error.message,
     attempts: maxRetries,
@@ -690,12 +711,13 @@ ${'='.repeat(80)}`);
         error: error.message,
         stack: error.stack,
         hookFailure: error?.hookFailure === true,
+        restartExhausted: error?.restartExhausted === true,
         hookRetries: error?.hookRetries ?? undefined,
         originalHookError: error?.originalHookError ?? undefined,
         agent: agent.id,
         role: agent.role,
         iteration: agent.iteration,
-        taskId: agent.currentTaskId,
+        taskId: error?.taskId || agent.currentTaskId,
         attempts: maxRetries,
         hookFailureContext: error.message.includes('Hook uses result')
           ? {
@@ -805,6 +827,97 @@ function maybeExtendMaxRetries({
   return { maxRetries, sigtermRetryGranted, noMessagesRetryGranted };
 }
 
+const RECOVERABLE_STUCK_TASK_CODES = new Set(['PROVIDER_INACTIVITY_TIMEOUT', 'AGENT_TASK_TIMEOUT']);
+
+function readRestartHistory(agent) {
+  const lifecycle = agent.messageBus.query({
+    cluster_id: agent.cluster.id,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agent.id,
+  });
+  let lastCompletedIndex = -1;
+  let totalRestarts = 0;
+
+  lifecycle.forEach((message, index) => {
+    const event = message.content?.data?.event;
+    if (event === 'TASK_COMPLETED') {
+      lastCompletedIndex = index;
+    } else if (event === 'AGENT_RESTART_ATTEMPT') {
+      totalRestarts += 1;
+    }
+  });
+
+  const restartsSinceCompletion = lifecycle
+    .slice(lastCompletedIndex + 1)
+    .filter((message) => message.content?.data?.event === 'AGENT_RESTART_ATTEMPT').length;
+
+  return { restartsSinceCompletion, totalRestarts };
+}
+
+function resolveRestartBudget(agent, settings) {
+  const history = readRestartHistory(agent);
+  const maxRestartAttempts = settings.maxRestartAttempts ?? 3;
+  const maxTotalRestarts = settings.maxTotalRestarts ?? 10;
+  const allowed =
+    history.restartsSinceCompletion < maxRestartAttempts &&
+    history.totalRestarts < maxTotalRestarts;
+
+  return {
+    ...history,
+    maxRestartAttempts,
+    maxTotalRestarts,
+    allowed,
+  };
+}
+
+async function handleRecoverableStuckTaskFailure({
+  agent,
+  triggeringMessage,
+  error,
+  attempt,
+  maxRetries,
+  baseDelay,
+  settings,
+}) {
+  if (!RECOVERABLE_STUCK_TASK_CODES.has(error.code)) {
+    return { handled: false, maxRetries };
+  }
+
+  logTaskAttemptFailure(agent, attempt, maxRetries, error);
+  const budget = resolveRestartBudget(agent, settings);
+  if (!budget.allowed) {
+    agent._publishLifecycle('AGENT_RESTART_EXHAUSTED', {
+      taskId: error.taskId,
+      reason: error.message,
+      code: error.code,
+      attempts: attempt,
+      restartsSinceCompletion: budget.restartsSinceCompletion,
+      totalRestarts: budget.totalRestarts,
+      maxRestartAttempts: budget.maxRestartAttempts,
+      maxTotalRestarts: budget.maxTotalRestarts,
+    });
+    error.restartExhausted = true;
+    await handleFinalFailure(agent, triggeringMessage, error, attempt);
+    return { handled: true, shouldStop: true, maxRetries };
+  }
+
+  const nextRestartAttempt = budget.restartsSinceCompletion + 1;
+  const nextTotalRestart = budget.totalRestarts + 1;
+  agent._publishLifecycle('AGENT_RESTART_ATTEMPT', {
+    taskId: error.taskId,
+    reason: error.message,
+    code: error.code,
+    attempt: nextRestartAttempt,
+    totalRestartAttempt: nextTotalRestart,
+    maxRestartAttempts: budget.maxRestartAttempts,
+    maxTotalRestarts: budget.maxTotalRestarts,
+  });
+
+  const extendedMaxRetries = Math.max(maxRetries, attempt + 1);
+  await scheduleRetry(agent, error, attempt, extendedMaxRetries, baseDelay);
+  return { handled: true, shouldStop: false, maxRetries: extendedMaxRetries };
+}
+
 /**
  * Execute claude-zeroshots with built context
  * Default: uses settings.maxRetries (default 3) for exponential backoff retries.
@@ -849,6 +962,30 @@ async function executeTask(agent, triggeringMessage) {
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;
       }
+      agent._publishLifecycle('TASK_FAILED', {
+        iteration: agent.iteration,
+        taskId: error.taskId || agent.currentTaskId,
+        error: error.message,
+        code: error.code || null,
+        attempt,
+      });
+      clearTransientTaskState(agent);
+      const stuckTaskResult = await handleRecoverableStuckTaskFailure({
+        agent,
+        triggeringMessage,
+        error,
+        attempt,
+        maxRetries,
+        baseDelay,
+        settings,
+      });
+      if (stuckTaskResult.handled) {
+        maxRetries = stuckTaskResult.maxRetries;
+        if (stuckTaskResult.shouldStop) {
+          return;
+        }
+        continue;
+      }
       const updated = maybeExtendMaxRetries({
         error,
         attempt,
@@ -878,89 +1015,78 @@ function startLivenessCheck(agent) {
     clearInterval(agent.livenessCheckInterval);
   }
 
-  // Check if platform supports /proc filesystem (Linux only)
-  if (!isPlatformSupported()) {
-    agent._log(
-      `[${agent.id}] Liveness check disabled: /proc filesystem not available (non-Linux platform)`
-    );
-    return;
-  }
+  const settings = loadSettings();
+  const warningsBeforeKill = Math.max(1, settings.staleWarningsBeforeKill ?? 2);
+  const staleDuration = Math.max(1, agent.staleDuration);
+  const configuredTimeout = agent.timeout > 0 ? agent.timeout : null;
+  const shortestLimit = configuredTimeout
+    ? Math.min(staleDuration, configuredTimeout)
+    : staleDuration;
+  const checkIntervalMs = Math.min(60 * 1000, Math.max(10, Math.floor(shortestLimit / 4)));
 
-  // Check every 60 seconds (gives time for multi-indicator analysis)
-  const CHECK_INTERVAL_MS = 60 * 1000;
-  const ANALYSIS_SAMPLE_MS = 5000; // Sample CPU/context switches over 5 seconds
+  agent.consecutiveStaleWarnings = 0;
+  agent.livenessTerminationStarted = false;
 
-  agent.livenessCheckInterval = setInterval(async () => {
-    // Skip if no task running or no PID tracked
-    if (!agent.currentTask || !agent.processPid) {
+  agent.livenessCheckInterval = setInterval(() => {
+    if (!agent.currentTask || agent.livenessTerminationStarted) {
       return;
     }
 
-    // Skip if output is recent (process is clearly active)
-    if (agent.lastOutputTime) {
-      const timeSinceLastOutput = Date.now() - agent.lastOutputTime;
-      if (timeSinceLastOutput < agent.staleDuration) {
-        return; // Output is recent, definitely not stuck
-      }
+    const now = Date.now();
+    const taskStartedAt = agent.taskStartedAt || agent.lastOutputTime || now;
+    const lastOutputTime = agent.lastOutputTime || taskStartedAt;
+    const taskRuntime = now - taskStartedAt;
+    const timeSinceLastOutput = now - lastOutputTime;
+
+    if (configuredTimeout && taskRuntime >= configuredTimeout) {
+      agent.livenessTerminationStarted = true;
+      const reason = `Task timed out after ${configuredTimeout}ms`;
+      agent._publishLifecycle('AGENT_TASK_TIMEOUT', {
+        taskId: agent.currentTaskId,
+        taskRuntime,
+        timeout: configuredTimeout,
+      });
+      Promise.resolve(agent._killTask({ reason, code: 'AGENT_TASK_TIMEOUT' })).catch((error) => {
+        agent._log(`[${agent.id}] Failed to terminate timed-out task: ${error.message}`);
+      });
+      return;
     }
 
-    // Output is stale - run multi-indicator analysis to confirm
-    agent._log(
-      `[${agent.id}] Output stale for ${Math.round((Date.now() - (agent.lastOutputTime || 0)) / 1000)}s, running multi-indicator analysis...`
+    if (timeSinceLastOutput < staleDuration) {
+      agent.consecutiveStaleWarnings = 0;
+      return;
+    }
+
+    agent.consecutiveStaleWarnings += 1;
+    agent._publishLifecycle('AGENT_STALE_WARNING', {
+      taskId: agent.currentTaskId,
+      timeSinceLastOutput,
+      staleDuration,
+      lastOutputTime,
+      consecutiveWarnings: agent.consecutiveStaleWarnings,
+      warningsBeforeKill,
+      processDiagnosticsAvailable: isPlatformSupported(),
+      analysis: `Provider produced no output for ${timeSinceLastOutput}ms`,
+    });
+
+    if (agent.consecutiveStaleWarnings < warningsBeforeKill) {
+      return;
+    }
+
+    agent.livenessTerminationStarted = true;
+    const reason = `Provider produced no output for ${timeSinceLastOutput}ms`;
+    agent._publishLifecycle('AGENT_INACTIVITY_TIMEOUT', {
+      taskId: agent.currentTaskId,
+      timeSinceLastOutput,
+      staleDuration,
+      consecutiveWarnings: agent.consecutiveStaleWarnings,
+    });
+    Promise.resolve(agent._killTask({ reason, code: 'PROVIDER_INACTIVITY_TIMEOUT' })).catch(
+      (error) => {
+        agent._log(`[${agent.id}] Failed to terminate inactive task: ${error.message}`);
+      }
     );
-
-    try {
-      const analysis = await analyzeProcessHealth(agent.processPid, ANALYSIS_SAMPLE_MS);
-
-      // Process died during analysis
-      if (analysis.isLikelyStuck === null) {
-        agent._log(`[${agent.id}] Process analysis inconclusive: ${analysis.reason}`);
-        return;
-      }
-
-      // Log analysis details for debugging
-      agent._log(
-        `[${agent.id}] Analysis: score=${analysis.stuckScore}/${STUCK_THRESHOLD}, ` +
-          `state=${analysis.state}, wchan=${analysis.wchan}, ` +
-          `CPU=${analysis.cpuPercent}%, ctxSwitches=${analysis.ctxSwitchesDelta}`
-      );
-
-      if (analysis.isLikelyStuck) {
-        agent._log(`⚠️  Agent ${agent.id}: CONFIRMED STUCK (confidence: ${analysis.confidence})`);
-        agent._log(`    ${analysis.analysis}`);
-
-        // CHANGED: Stale detection is informational only - never kills tasks
-        // Publish stale detection event with full analysis (for logging/monitoring)
-        agent._publishLifecycle('AGENT_STALE_WARNING', {
-          timeSinceLastOutput: Date.now() - (agent.lastOutputTime || 0),
-          staleDuration: agent.staleDuration,
-          lastOutputTime: agent.lastOutputTime,
-          // Multi-indicator analysis results
-          stuckScore: analysis.stuckScore,
-          confidence: analysis.confidence,
-          processState: analysis.state,
-          wchan: analysis.wchan,
-          cpuPercent: analysis.cpuPercent,
-          ctxSwitchesDelta: analysis.ctxSwitchesDelta,
-          indicators: analysis.indicators,
-          analysis: analysis.analysis,
-        });
-
-        // Keep monitoring - do NOT stop the agent
-        // User can manually intervene with 'zeroshot resume' if needed
-        // stopLivenessCheck(agent); // REMOVED - keep monitoring
-      } else {
-        agent._log(
-          `[${agent.id}] Process appears WORKING despite stale output (score: ${analysis.stuckScore})`
-        );
-        agent._log(`    ${analysis.analysis}`);
-        // Don't flag as stuck - process is legitimately working
-      }
-    } catch (err) {
-      agent._log(`[${agent.id}] Error during stuck analysis: ${err.message}`);
-      // Don't flag as stuck on analysis error
-    }
-  }, CHECK_INTERVAL_MS);
+  }, checkIntervalMs);
 }
 
 /**
@@ -972,6 +1098,8 @@ function stopLivenessCheck(agent) {
     clearInterval(agent.livenessCheckInterval);
     agent.livenessCheckInterval = null;
   }
+  agent.consecutiveStaleWarnings = 0;
+  agent.livenessTerminationStarted = false;
 }
 
 module.exports = {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -673,11 +673,16 @@ async function spawnClaudeTask(agent, context) {
   const MAX_PID_POLLS = 30; // 3 seconds max
   const PID_POLL_DELAY = 100;
   let realPid = null;
+  let terminalBeforePidObservation = false;
 
   for (let i = 0; i < MAX_PID_POLLS; i++) {
     const taskInfo = getTask(taskId);
     if (taskInfo?.pid) {
       realPid = taskInfo.pid;
+      break;
+    }
+    if (taskInfo && ['completed', 'failed', 'killed', 'stale'].includes(taskInfo.status)) {
+      terminalBeforePidObservation = true;
       break;
     }
     await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
@@ -687,6 +692,8 @@ async function spawnClaudeTask(agent, context) {
     agent.processPid = realPid;
     agent._publishLifecycle('PROCESS_SPAWNED', { pid: realPid });
     agent._log(`📋 Agent ${agent.id}: Process PID: ${realPid}`);
+  } else if (terminalBeforePidObservation) {
+    agent._log(`📋 Agent ${agent.id}: Task finished before PID observation`);
   } else {
     agent._log(`⚠️ Agent ${agent.id}: PID not available (task may use non-standard watcher)`);
   }
@@ -928,7 +935,8 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
 
           // Start liveness monitoring
           if (agent.enableLivenessCheck) {
-            agent.lastOutputTime = Date.now(); // Initialize to spawn time
+            agent.taskStartedAt = Date.now();
+            agent.lastOutputTime = agent.taskStartedAt;
             agent._startLivenessCheck();
           }
 
@@ -1131,6 +1139,7 @@ function parseStatusFlags(cleanStdout) {
     isCompleted: /Status:\s+completed/i.test(cleanStdout),
     isFailed: /Status:\s+failed/i.test(cleanStdout),
     isStale: /Status:\s+stale/i.test(cleanStdout),
+    isKilled: /Status:\s+killed/i.test(cleanStdout),
   };
 }
 
@@ -1329,9 +1338,9 @@ function handleStatusCompletion({
   resolve,
 }) {
   const cleanStdout = stripAnsiCodes(stdout);
-  const { isCompleted, isFailed, isStale } = parseStatusFlags(cleanStdout);
+  const { isCompleted, isFailed, isStale, isKilled } = parseStatusFlags(cleanStdout);
 
-  if (!isCompleted && !isFailed && !isStale) {
+  if (!isCompleted && !isFailed && !isStale && !isKilled) {
     return false;
   }
 
@@ -1370,9 +1379,9 @@ function handleStatusCompletion({
   return true;
 }
 
-function buildKillHandler({ agent, state, providerName, resolve }) {
+function buildKillHandler({ agent, taskId, state, providerName, resolve }) {
   return {
-    kill: (reason = 'Task killed') => {
+    kill: (reason = 'Task killed', details = {}) => {
       if (state.resolved) return;
       state.resolved = true;
       finalizeLogFollow(agent, state);
@@ -1381,6 +1390,8 @@ function buildKillHandler({ agent, state, providerName, resolve }) {
         success: false,
         output: state.output,
         error: reason,
+        code: details.code || null,
+        taskId,
         tokenUsage: extractTokenUsage(state.output, providerName),
       });
     },
@@ -1438,7 +1449,7 @@ function createLogFollower({ agent, taskId, fsModule, ctPath, providerName }) {
       );
     }, 1000);
 
-    agent.currentTask = buildKillHandler({ agent, state, providerName, resolve });
+    agent.currentTask = buildKillHandler({ agent, taskId, state, providerName, resolve });
   });
 }
 
@@ -1584,7 +1595,8 @@ async function spawnClaudeTaskIsolated(agent, context) {
 
           // Start liveness monitoring
           if (agent.enableLivenessCheck) {
-            agent.lastOutputTime = Date.now(); // Initialize to spawn time
+            agent.taskStartedAt = Date.now();
+            agent.lastOutputTime = agent.taskStartedAt;
             agent._startLivenessCheck();
           }
 
@@ -2042,34 +2054,47 @@ async function parseResultOutput(agent, output) {
  * Kill current task
  * @param {Object} agent - Agent instance
  */
-function killTask(agent) {
-  if (agent.currentTask) {
-    // currentTask may be either a ChildProcess or our custom { kill } object
-    if (typeof agent.currentTask.kill === 'function') {
-      agent.currentTask.kill('SIGTERM');
+function normalizeTermination(termination) {
+  if (termination && typeof termination === 'object') {
+    return {
+      reason: termination.reason || 'Task killed',
+      code: termination.code || null,
+    };
+  }
+  return { reason: termination || 'Task killed', code: null };
+}
+
+async function killTask(agent, termination = 'Task killed') {
+  agent._stopLivenessCheck?.();
+
+  const { reason, code } = normalizeTermination(termination);
+  const currentTask = agent.currentTask;
+  const taskId = agent.currentTaskId;
+
+  // Kill the underlying task before resolving the local follower. This keeps
+  // retries from racing a provider process that is still shutting down.
+  if (taskId) {
+    const ctPath = getClaudeTasksPath();
+    try {
+      // `kill` is a top-level smart command. `task kill` has never existed.
+      await runCommandWithTimeout(ctPath, ['kill', taskId], { timeout: 10000 });
+      agent._log?.(`Killed task ${taskId}`);
+    } catch (error) {
+      // Resolve the local follower even if the task is already terminal or the
+      // management CLI is unavailable; shutdown state must still reconcile.
+      agent._log?.(`Note: Could not kill task ${taskId}: ${error.message}`);
     }
-    agent.currentTask = null;
   }
 
-  // Also kill the underlying zeroshot task if we have a task ID
-  // This ensures the task process is stopped, not just our polling intervals
-  if (agent.currentTaskId) {
-    const ctPath = getClaudeTasksPath();
-    runCommandWithTimeout(
-      ctPath,
-      ['task', 'kill', agent.currentTaskId],
-      { timeout: 10000 },
-      (error) => {
-        if (error) {
-          // Task may have already completed or been killed, ignore errors
-          agent._log(`Note: Could not kill task ${agent.currentTaskId}: ${error.message}`);
-        } else {
-          agent._log(`Killed task ${agent.currentTaskId}`);
-        }
-      }
-    );
-    agent.currentTaskId = null;
+  if (currentTask && typeof currentTask.kill === 'function') {
+    currentTask.kill(reason, { code });
   }
+
+  agent.currentTask = null;
+  agent.currentTaskId = null;
+  agent.processPid = null;
+  agent.lastOutputTime = null;
+  agent.taskStartedAt = null;
 }
 
 module.exports = {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1535,6 +1535,7 @@ class Orchestrator {
       const agentRole = message.content?.data?.role;
       const attempts = message.content?.data?.attempts || 1;
       const hookFailure = message.content?.data?.hookFailure === true;
+      const restartExhausted = message.content?.data?.restartExhausted === true;
 
       await this._saveClusters();
 
@@ -1542,7 +1543,7 @@ class Orchestrator {
         agentRole === 'implementation' ||
         agentRole === 'coordinator' ||
         message.sender === 'consensus-coordinator';
-      const shouldStop = shouldStopForRole && (hookFailure || attempts >= 3);
+      const shouldStop = shouldStopForRole && (hookFailure || restartExhausted || attempts >= 3);
 
       if (shouldStop) {
         this._log(`\n${'='.repeat(80)}`);
@@ -1551,6 +1552,7 @@ class Orchestrator {
         this._log(
           `${message.sender} (${agentRole || 'unknown role'}) failed` +
             (hookFailure ? ` (hookFailure=true)` : ``) +
+            (restartExhausted ? ` (restartExhausted=true)` : ``) +
             ` after ${attempts} attempts`
         );
         this._log(`Error: ${message.content?.data?.error || 'unknown'}`);
@@ -1573,7 +1575,7 @@ class Orchestrator {
     });
   }
 
-  _registerAgentLifecycleHandlers(messageBus, clusterId) {
+  _registerAgentLifecycleHandlers(messageBus, _clusterId) {
     messageBus.on('topic:AGENT_LIFECYCLE', async (message) => {
       const event = message.content?.data?.event;
       if (
@@ -1596,13 +1598,14 @@ class Orchestrator {
       const timeSinceLastOutput = message.content?.data?.timeSinceLastOutput;
       const analysis = message.content?.data?.analysis || 'No analysis available';
 
+      const consecutiveWarnings = message.content?.data?.consecutiveWarnings;
+      const warningsBeforeKill = message.content?.data?.warningsBeforeKill;
       this._log(
-        `⚠️  Orchestrator: Agent ${agentId} appears stale (${Math.round(timeSinceLastOutput / 1000)}s no output) but will NOT be killed`
+        `⚠️  Orchestrator: Agent ${agentId} has produced no output for ${Math.round(timeSinceLastOutput / 1000)}s ` +
+          `(warning ${consecutiveWarnings}/${warningsBeforeKill})`
       );
       this._log(`    Analysis: ${analysis}`);
-      this._log(
-        `    Manual intervention may be needed - use 'zeroshot resume ${clusterId}' if stuck`
-      );
+      this._log(`    Zeroshot will terminate and restart the task if inactivity persists`);
     });
   }
 
@@ -2361,6 +2364,15 @@ class Orchestrator {
       return;
     }
     this.closed = true;
+
+    for (const cluster of this.clusters.values()) {
+      if (typeof cluster.snapshotter?.stop === 'function') {
+        cluster.snapshotter.stop();
+      }
+      if (typeof cluster.messageBus?.close === 'function') {
+        cluster.messageBus.close();
+      }
+    }
   }
 
   /**

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import { getTask, updateTask } from '../store.js';
-import { killTask as killProcess, isProcessRunning } from '../runner.js';
+import { isProcessRunning, terminateProcess } from '../runner.js';
 
-export function killTaskCommand(taskId) {
+export async function killTaskCommand(taskId, options = {}) {
   const task = getTask(taskId);
 
   if (!task) {
@@ -17,16 +17,31 @@ export function killTaskCommand(taskId) {
 
   if (!isProcessRunning(task.pid)) {
     console.log(chalk.yellow('Process already dead, updating status...'));
-    updateTask(taskId, { status: 'stale', error: 'Process died unexpectedly' });
+    updateTask(taskId, {
+      status: 'stale',
+      pid: null,
+      error: 'Process died unexpectedly',
+    });
     return;
   }
 
-  const killed = killProcess(task.pid);
+  const result = await terminateProcess(task.pid, options);
 
-  if (killed) {
-    console.log(chalk.green(`✓ Sent SIGTERM to task ${taskId} (PID: ${task.pid})`));
-    updateTask(taskId, { status: 'killed', error: 'Killed by user' });
+  if (result.terminated) {
+    const suffix = result.escalated ? ' after SIGKILL escalation' : ' with SIGTERM';
+    console.log(chalk.green(`✓ Killed task ${taskId} (PID: ${task.pid})${suffix}`));
+    updateTask(taskId, {
+      status: 'killed',
+      pid: null,
+      exitCode: result.escalated ? 137 : 143,
+      error: result.escalated ? 'Killed by user after SIGKILL escalation' : 'Killed by user',
+    });
   } else {
     console.log(chalk.red(`Failed to kill task ${taskId}`));
+    updateTask(taskId, {
+      status: 'failed',
+      pid: null,
+      error: result.error || 'Process termination failed',
+    });
   }
 }

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -196,3 +196,94 @@ export function killTask(pid) {
     return false;
   }
 }
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForProcessExit(pid, timeoutMs, pollMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) return true;
+    await sleep(pollMs);
+  }
+  return !isProcessRunning(pid);
+}
+
+/**
+ * Terminate a provider process without relying on Linux-only process metadata.
+ * SIGTERM gets a bounded grace period, then SIGKILL is used as the final
+ * authority so callers never leave a task persisted as running indefinitely.
+ */
+export async function terminateProcess(pid, options = {}) {
+  const graceMs = options.graceMs ?? 5000;
+  const hardKillWaitMs = options.hardKillWaitMs ?? 1000;
+  const pollMs = options.pollMs ?? 50;
+
+  if (!isProcessRunning(pid)) {
+    return {
+      terminated: true,
+      alreadyDead: true,
+      escalated: false,
+      signal: null,
+    };
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (error) {
+    if (!isProcessRunning(pid)) {
+      return {
+        terminated: true,
+        alreadyDead: true,
+        escalated: false,
+        signal: null,
+      };
+    }
+    return {
+      terminated: false,
+      alreadyDead: false,
+      escalated: false,
+      signal: 'SIGTERM',
+      error: error.message,
+    };
+  }
+
+  if (await waitForProcessExit(pid, graceMs, pollMs)) {
+    return {
+      terminated: true,
+      alreadyDead: false,
+      escalated: false,
+      signal: 'SIGTERM',
+    };
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (error) {
+    if (!isProcessRunning(pid)) {
+      return {
+        terminated: true,
+        alreadyDead: false,
+        escalated: true,
+        signal: 'SIGKILL',
+      };
+    }
+    return {
+      terminated: false,
+      alreadyDead: false,
+      escalated: true,
+      signal: 'SIGKILL',
+      error: error.message,
+    };
+  }
+
+  const terminated = await waitForProcessExit(pid, hardKillWaitMs, pollMs);
+  return {
+    terminated,
+    alreadyDead: false,
+    escalated: true,
+    signal: 'SIGKILL',
+    error: terminated ? null : `Process ${pid} survived SIGKILL`,
+  };
+}

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -1,0 +1,245 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
+const { killTask } = require('../src/agent/agent-task-executor');
+const Orchestrator = require('../src/orchestrator');
+const MockTaskRunner = require('./helpers/mock-task-runner');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+function createLivenessAgent(overrides = {}) {
+  const events = [];
+  const kills = [];
+  const agent = {
+    id: 'worker',
+    role: 'implementation',
+    currentTask: { kill() {} },
+    currentTaskId: 'provider-task',
+    processPid: null,
+    lastOutputTime: Date.now(),
+    taskStartedAt: Date.now(),
+    staleDuration: 30,
+    timeout: 0,
+    livenessCheckInterval: null,
+    _log() {},
+    _publishLifecycle(event, data) {
+      events.push({ event, data });
+    },
+    _killTask(reason) {
+      kills.push(reason);
+      this.currentTask = null;
+    },
+    ...overrides,
+  };
+  return { agent, events, kills };
+}
+
+function workerConfig() {
+  return {
+    agents: [
+      {
+        id: 'worker',
+        role: 'implementation',
+        modelLevel: 'level2',
+        outputFormat: 'text',
+        maxRetries: 1,
+        triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+        hooks: {
+          onComplete: {
+            action: 'publish_message',
+            config: { topic: 'CLUSTER_COMPLETE' },
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('Agent stuck-task recovery', function () {
+  this.timeout(10000);
+  let settingsDir;
+  let originalSettingsFile;
+
+  beforeEach(function () {
+    settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-stuck-recovery-'));
+    originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(settingsDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({
+        staleWarningsBeforeKill: 2,
+        backoffBaseMs: 0,
+        backoffMaxMs: 0,
+        jitterFactor: 0,
+      })
+    );
+  });
+
+  afterEach(function () {
+    if (originalSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+    fs.rmSync(settingsDir, { recursive: true, force: true });
+  });
+
+  it('terminates a live task after bounded cross-platform stale warnings', async function () {
+    const { agent, events, kills } = createLivenessAgent();
+    startLivenessCheck(agent);
+    await waitFor(() => kills.length === 1);
+    stopLivenessCheck(agent);
+
+    assert.strictEqual(events.filter(({ event }) => event === 'AGENT_STALE_WARNING').length, 2);
+    assert.strictEqual(kills[0].code, 'PROVIDER_INACTIVITY_TIMEOUT');
+    assert.ok(events.some(({ event }) => event === 'AGENT_INACTIVITY_TIMEOUT'));
+  });
+
+  it('resets stale warnings when output progress resumes', async function () {
+    const { agent, events, kills } = createLivenessAgent({ staleDuration: 80 });
+    startLivenessCheck(agent);
+    await waitFor(() => events.filter(({ event }) => event === 'AGENT_STALE_WARNING').length === 1);
+    agent.lastOutputTime = Date.now();
+    await sleep(60);
+    stopLivenessCheck(agent);
+
+    assert.strictEqual(kills.length, 0);
+    assert.strictEqual(agent.consecutiveStaleWarnings, 0);
+  });
+
+  it('enforces an absolute task timeout while output remains recent', async function () {
+    const { agent, events, kills } = createLivenessAgent({
+      staleDuration: 1000,
+      timeout: 30,
+      taskStartedAt: Date.now() - 100,
+    });
+    startLivenessCheck(agent);
+    await waitFor(() => kills.length === 1);
+    stopLivenessCheck(agent);
+
+    assert.strictEqual(kills[0].code, 'AGENT_TASK_TIMEOUT');
+    assert.ok(events.some(({ event }) => event === 'AGENT_TASK_TIMEOUT'));
+  });
+
+  it('reconciles transient state and preserves the termination reason', async function () {
+    const reasons = [];
+    const agent = {
+      currentTask: { kill: (reason) => reasons.push(reason) },
+      currentTaskId: null,
+      processPid: 4242,
+      lastOutputTime: Date.now(),
+      taskStartedAt: Date.now(),
+      _stopLivenessCheck() {},
+    };
+    await killTask(agent, 'Provider inactivity timeout');
+
+    assert.deepStrictEqual(reasons, ['Provider inactivity timeout']);
+    for (const field of [
+      'currentTask',
+      'currentTaskId',
+      'processPid',
+      'lastOutputTime',
+      'taskStartedAt',
+    ]) {
+      assert.strictEqual(agent[field], null);
+    }
+  });
+
+  async function runMockRecovery({ failures, maxRestartAttempts, maxTotalRestarts }) {
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({
+        maxRestartAttempts,
+        maxTotalRestarts,
+        staleWarningsBeforeKill: 2,
+        backoffBaseMs: 0,
+        backoffMaxMs: 0,
+        jitterFactor: 0,
+      })
+    );
+    const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-restart-ledger-'));
+    const runner = new MockTaskRunner();
+    const orchestrator = new Orchestrator({
+      storageDir,
+      taskRunner: runner,
+      skipLoad: true,
+      quiet: true,
+    });
+    let calls = 0;
+    runner.when('worker').calls(() => {
+      calls += 1;
+      return calls <= failures
+        ? {
+            success: false,
+            output: '{"type":"turn.started"}\n',
+            error: 'Provider produced no output',
+            code: 'PROVIDER_INACTIVITY_TIMEOUT',
+          }
+        : { success: true, output: 'done' };
+    });
+    const started = await orchestrator.start(workerConfig(), { text: 'recover the task' });
+    await waitFor(() => orchestrator.getStatus(started.id).state === 'stopped');
+    return { orchestrator, storageDir, runner, started };
+  }
+
+  it('records durable restart attempts and completes after bounded retries', async function () {
+    const fixture = await runMockRecovery({
+      failures: 2,
+      maxRestartAttempts: 2,
+      maxTotalRestarts: 5,
+    });
+    try {
+      const cluster = fixture.orchestrator.getCluster(fixture.started.id);
+      const events = cluster.messageBus
+        .query({
+          cluster_id: fixture.started.id,
+          topic: 'AGENT_LIFECYCLE',
+          sender: 'worker',
+        })
+        .map((message) => message.content.data.event);
+      assert.strictEqual(events.filter((event) => event === 'AGENT_RESTART_ATTEMPT').length, 2);
+      assert.strictEqual(events.filter((event) => event === 'TASK_COMPLETED').length, 1);
+    } finally {
+      fixture.orchestrator.close();
+      await sleep(100);
+      fs.rmSync(fixture.storageDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exhausts restart budgets and persists a stopped clean state', async function () {
+    const fixture = await runMockRecovery({
+      failures: 4,
+      maxRestartAttempts: 2,
+      maxTotalRestarts: 2,
+    });
+    try {
+      assert.strictEqual(fixture.runner.getCalls('worker').length, 3);
+      const registry = JSON.parse(
+        fs.readFileSync(path.join(fixture.storageDir, 'clusters.json'), 'utf8')
+      );
+      const saved = registry[fixture.started.id];
+      assert.strictEqual(saved.state, 'stopped');
+      assert.deepStrictEqual(
+        [saved.agentStates[0].currentTask, saved.agentStates[0].currentTaskId],
+        [false, null]
+      );
+      assert.strictEqual(saved.failureInfo.attempts, 3);
+    } finally {
+      fixture.orchestrator.close();
+      await sleep(100);
+      fs.rmSync(fixture.storageDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/e2e/helpers/e2e-harness.js
+++ b/tests/e2e/helpers/e2e-harness.js
@@ -24,7 +24,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execFileSync, spawnSync } = require('child_process');
+const { execFileSync, spawn, spawnSync } = require('child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const CLI_ENTRY = path.join(REPO_ROOT, 'cli', 'index.js');
@@ -145,6 +145,48 @@ function runZeroshot(env, args, envOverrides = {}) {
   };
 }
 
+function runZeroshotUntilNaturalExit(env, args, envOverrides, completionMarker) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_ENTRY, ...args], {
+      cwd: env.repoDir,
+      env: buildEnv(env, envOverrides),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let completionAt = null;
+    let exitTimer = null;
+    const hardTimer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI did not exit within ${envOverrides.timeout}ms\n${stdout}\n${stderr}`));
+    }, envOverrides.timeout);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+      if (completionAt === null && stdout.includes(completionMarker)) {
+        completionAt = Date.now();
+        exitTimer = setTimeout(() => {
+          child.kill('SIGKILL');
+          reject(new Error(`CLI stayed alive after ${completionMarker}\n${stdout}\n${stderr}`));
+        }, 2000);
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (status) => {
+      clearTimeout(hardTimer);
+      clearTimeout(exitTimer);
+      resolve({
+        status,
+        stdout,
+        stderr,
+        completionToExitMs: completionAt === null ? null : Date.now() - completionAt,
+      });
+    });
+  });
+}
+
 function clustersFilePath(env) {
   return path.join(env.homeDir, '.zeroshot', 'clusters.json');
 }
@@ -232,6 +274,7 @@ module.exports = {
   setupE2ERepo,
   cleanupE2ERepo,
   runZeroshot,
+  runZeroshotUntilNaturalExit,
   buildEnv,
   clustersFilePath,
   readClusters,

--- a/tests/e2e/resume-detach-daemon.test.js
+++ b/tests/e2e/resume-detach-daemon.test.js
@@ -18,6 +18,7 @@ const {
   setupE2ERepo,
   cleanupE2ERepo,
   runZeroshot,
+  runZeroshotUntilNaturalExit,
   buildEnv,
   CLI_ENTRY,
   readCluster,
@@ -207,17 +208,30 @@ describe('e2e: resume --detach daemon handoff', function () {
       if (detached) {
         resumeArgs.push('-d');
       }
-      const resumed = runZeroshot(env, resumeArgs, {
+      const resumeEnv = {
         FAKE_AGENT_SCENARIO: scenarioPath('worker-success'),
         FAKE_AGENT_SCENARIO_VALIDATOR_REQUIREMENTS: scenarioPath('validator-approve'),
         FAKE_AGENT_SCENARIO_WORKER: scenarioPath('worker-success'),
-        timeout: 30000,
-      });
+        // Validator recovery includes deliberate 0-15s jitter plus three
+        // sequential fake tasks. Process-exit latency is asserted separately.
+        timeout: detached ? 30000 : 60000,
+      };
+      const resumed = detached
+        ? runZeroshot(env, resumeArgs, resumeEnv)
+        : await runZeroshotUntilNaturalExit(
+            env,
+            resumeArgs,
+            resumeEnv,
+            `Cluster ${clusterId} completed.`
+          );
       assert.strictEqual(
         resumed.status,
         0,
         `${mode} resume failed\nSTDOUT:\n${resumed.stdout}\nSTDERR:\n${resumed.stderr}`
       );
+      if (!detached) {
+        assert.notStrictEqual(resumed.completionToExitMs, null);
+      }
 
       if (detached) {
         await pollUntil(

--- a/tests/e2e/stuck-agent-recovery.test.js
+++ b/tests/e2e/stuck-agent-recovery.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const { runDetachedRecovery, runInProcessRecovery } = require('../helpers/stuck-recovery-fixture');
+
+function eventCount(result, event) {
+  return result.lifecycle.filter((candidate) => candidate === event).length;
+}
+
+describe('e2e: stuck agent recovery', function () {
+  this.timeout(30000);
+
+  it('recovers a normal-mode fake Codex provider stalled after turn.started', async function () {
+    const result = await runInProcessRecovery();
+    assert.strictEqual(result.state, 'stopped');
+    assert.strictEqual(eventCount(result, 'AGENT_INACTIVITY_TIMEOUT'), 1);
+    assert.strictEqual(eventCount(result, 'AGENT_RESTART_ATTEMPT'), 1);
+    assert.strictEqual(eventCount(result, 'TASK_COMPLETED'), 1);
+    assert.strictEqual(result.agentState.currentTask, false);
+    assert.strictEqual(result.agentState.currentTaskId, null);
+    assert.strictEqual(result.agentState.processPid, null);
+    assert.strictEqual(result.fakeCount, '2');
+  });
+
+  it('recovers in a detached daemon and reconciles external provider death', async function () {
+    const result = await runDetachedRecovery();
+    assert.deepStrictEqual([result.state, result.pid, result.fakeCount], ['stopped', null, '3']);
+    assert.strictEqual(eventCount(result, 'AGENT_INACTIVITY_TIMEOUT'), 1);
+    assert.strictEqual(eventCount(result, 'AGENT_RESTART_ATTEMPT'), 1);
+    assert.strictEqual(eventCount(result, 'TASK_FAILED'), 2);
+    assert.strictEqual(eventCount(result, 'RETRY_SCHEDULED'), 2);
+    assert.strictEqual(eventCount(result, 'TASK_COMPLETED'), 1);
+  });
+});

--- a/tests/fixtures/fake-codex-recovery.js
+++ b/tests/fixtures/fake-codex-recovery.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+if (process.argv.includes('--version')) {
+  console.log('codex-cli 99.0.0');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log(
+    'codex exec --json --output-schema -m -C --config --skip-git-repo-check ' +
+      '--dangerously-bypass-approvals-and-sandbox'
+  );
+  process.exit(0);
+}
+
+const stateFile = process.env.FAKE_CODEX_COUNT;
+const count = Number(fs.existsSync(stateFile) ? fs.readFileSync(stateFile, 'utf8') : '0') + 1;
+fs.writeFileSync(stateFile, String(count));
+console.log(JSON.stringify({ type: 'turn.started' }));
+
+const actions = JSON.parse(process.env.FAKE_CODEX_ACTIONS || '["success"]');
+const action = actions[count - 1] || actions.at(-1);
+if (action === 'hang') {
+  setInterval(() => {}, 1000);
+} else if (action === 'exit') {
+  console.error('simulated provider process death');
+  process.exit(17);
+} else {
+  console.log(
+    JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '{"done":true}' },
+    })
+  );
+  console.log(
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    })
+  );
+}

--- a/tests/fixtures/run-stuck-recovery.js
+++ b/tests/fixtures/run-stuck-recovery.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const Orchestrator = require('../../src/orchestrator');
+const { loadTasks } = require('../../task-lib/store.js');
+
+async function main() {
+  const storageDir = process.env.RECOVERY_STORAGE_DIR;
+  const config = JSON.parse(fs.readFileSync(process.env.RECOVERY_CONFIG, 'utf8'));
+  const orchestrator = new Orchestrator({ storageDir, skipLoad: true, quiet: true });
+  const started = await orchestrator.start(config, { text: 'fake hang recovery' });
+  const deadline = Date.now() + 15000;
+  const registryPath = path.join(storageDir, 'clusters.json');
+
+  while (Date.now() < deadline) {
+    const status = orchestrator.getStatus(started.id);
+    const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    const saved = registry[started.id];
+    const agent = saved?.agentStates?.[0];
+    if (
+      status.state === 'stopped' &&
+      saved?.state === 'stopped' &&
+      agent?.currentTask === false &&
+      agent?.currentTaskId === null &&
+      agent?.processPid === null
+    ) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  const cluster = orchestrator.getCluster(started.id);
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  const lifecycle = cluster.messageBus
+    .query({
+      cluster_id: started.id,
+      topic: 'AGENT_LIFECYCLE',
+      sender: 'worker',
+    })
+    .map((message) => message.content.data.event);
+  console.log(
+    'RESULT:' +
+      JSON.stringify({
+        state: orchestrator.getStatus(started.id).state,
+        lifecycle,
+        agentState: registry[started.id].agentStates[0],
+        tasks: Object.fromEntries(
+          Object.entries(loadTasks()).map(([id, task]) => [
+            id,
+            { status: task.status, pid: task.pid, error: task.error },
+          ])
+        ),
+        fakeCount: fs.readFileSync(process.env.FAKE_CODEX_COUNT, 'utf8'),
+      })
+  );
+  orchestrator.close();
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/tests/fixtures/sigterm-resistant-process.js
+++ b/tests/fixtures/sigterm-resistant-process.js
@@ -1,0 +1,3 @@
+process.on('SIGTERM', () => {});
+process.stdout.write('ready\n');
+setInterval(() => {}, 1000);

--- a/tests/helpers/stuck-recovery-fixture.js
+++ b/tests/helpers/stuck-recovery-fixture.js
@@ -1,0 +1,245 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Ledger = require('../../src/ledger');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function workerConfig(maxRetries, timeout) {
+  return {
+    defaultProvider: 'codex',
+    agents: [
+      {
+        id: 'worker',
+        role: 'implementation',
+        provider: 'codex',
+        modelLevel: 'level2',
+        outputFormat: 'json',
+        jsonSchema: {
+          type: 'object',
+          properties: { done: { type: 'boolean' } },
+          required: ['done'],
+        },
+        staleDuration: 1500,
+        timeout,
+        maxRetries,
+        triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],
+        hooks: {
+          onComplete: {
+            action: 'publish_message',
+            config: { topic: 'CLUSTER_COMPLETE' },
+          },
+        },
+      },
+    ],
+  };
+}
+
+function setupFixture({ actions, maxRetries, timeout, prefix }) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const home = path.join(root, '.zeroshot');
+  const bin = path.join(root, 'bin');
+  const storage = path.join(root, 'clusters');
+  const stateFile = path.join(root, 'codex-count');
+  const settingsFile = path.join(root, 'settings.json');
+  const configFile = path.join(root, 'cluster.json');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.mkdirSync(storage, { recursive: true });
+  fs.symlinkSync(path.join(REPO_ROOT, 'cli/index.js'), path.join(bin, 'zeroshot'));
+  fs.symlinkSync(
+    path.join(REPO_ROOT, 'tests/fixtures/fake-codex-recovery.js'),
+    path.join(bin, 'codex')
+  );
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({
+      defaultProvider: 'codex',
+      maxRestartAttempts: 1,
+      maxTotalRestarts: 2,
+      staleWarningsBeforeKill: 2,
+      backoffBaseMs: 0,
+      backoffMaxMs: 0,
+      jitterFactor: 0,
+    })
+  );
+  fs.writeFileSync(configFile, JSON.stringify(workerConfig(maxRetries, timeout)));
+  const env = {
+    ...process.env,
+    HOME: root,
+    USERPROFILE: root,
+    ZEROSHOT_HOME: root,
+    ZEROSHOT_SETTINGS_FILE: settingsFile,
+    FAKE_CODEX_COUNT: stateFile,
+    FAKE_CODEX_ACTIONS: JSON.stringify(actions),
+    NODE_ENV: 'test',
+    PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+  };
+  return { root, home, storage, stateFile, configFile, env };
+}
+
+function runProcess(args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, options);
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`fixture failed (${code}): ${stderr}\n${stdout}`));
+      }
+    });
+  });
+}
+
+async function runInProcessRecovery() {
+  const fixture = setupFixture({
+    actions: ['hang', 'success'],
+    maxRetries: 1,
+    timeout: 5000,
+    prefix: 'zeroshot-fake-hang-',
+  });
+  try {
+    const stdout = await runProcess(
+      [path.join(REPO_ROOT, 'tests/fixtures/run-stuck-recovery.js')],
+      {
+        env: {
+          ...fixture.env,
+          RECOVERY_CONFIG: fixture.configFile,
+          RECOVERY_STORAGE_DIR: fixture.storage,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+    if (!line) throw new Error(`missing fixture result in:\n${stdout}`);
+    return JSON.parse(line.slice('RESULT:'.length));
+  } finally {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+function readSavedCluster(fixture, clusterId) {
+  const registryPath = path.join(fixture.home, 'clusters.json');
+  if (!fs.existsSync(registryPath)) return null;
+  return JSON.parse(fs.readFileSync(registryPath, 'utf8'))[clusterId] || null;
+}
+
+async function waitForDetachedStop(fixture, clusterId) {
+  const deadline = Date.now() + 25000;
+  let saved = null;
+  let daemonPid = null;
+  while (Date.now() < deadline) {
+    saved = readSavedCluster(fixture, clusterId);
+    daemonPid = saved?.pid || daemonPid;
+    const agent = saved?.agentStates?.[0];
+    if (
+      saved?.state === 'stopped' &&
+      agent?.currentTask === false &&
+      agent?.currentTaskId === null &&
+      agent?.processPid === null
+    ) {
+      return { saved, daemonPid };
+    }
+    await sleep(50);
+  }
+  return { saved, daemonPid };
+}
+
+function readLifecycle(home, clusterId) {
+  const ledger = new Ledger(path.join(home, `${clusterId}.db`), { readonly: true });
+  try {
+    return ledger
+      .query({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+      })
+      .map((message) => message.content.data.event);
+  } finally {
+    ledger.close();
+  }
+}
+
+async function terminateDaemon(pid) {
+  if (!pid) return;
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return;
+  }
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await sleep(25);
+    } catch {
+      return;
+    }
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Process exited during the bounded graceful wait.
+  }
+}
+
+async function runDetachedRecovery() {
+  const fixture = setupFixture({
+    actions: ['hang', 'exit', 'success'],
+    maxRetries: 3,
+    timeout: 10000,
+    prefix: 'zeroshot-detached-hang-',
+  });
+  let daemonPid = null;
+  try {
+    const stdout = await runProcess(
+      [
+        path.join(REPO_ROOT, 'cli/index.js'),
+        'run',
+        'detached fake provider recovery',
+        '--config',
+        fixture.configFile,
+        '--provider',
+        'codex',
+        '--sim',
+        'off',
+        '--detach',
+      ],
+      {
+        cwd: REPO_ROOT,
+        env: fixture.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const clusterId = stdout.match(/Started ([a-z]+-[a-z]+-\d+)/)?.[1];
+    if (!clusterId) throw new Error(`missing detached cluster id in:\n${stdout}`);
+    const stopped = await waitForDetachedStop(fixture, clusterId);
+    daemonPid = stopped.daemonPid;
+    return {
+      state: stopped.saved?.state,
+      pid: stopped.saved?.pid,
+      fakeCount: fs.readFileSync(fixture.stateFile, 'utf8'),
+      lifecycle: readLifecycle(fixture.home, clusterId),
+    };
+  } finally {
+    await terminateDaemon(daemonPid);
+    fs.rmSync(fixture.root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+  }
+}
+
+module.exports = { runDetachedRecovery, runInProcessRecovery };

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -2242,13 +2242,16 @@ describe('Orchestrator - Edge Cases', function () {
     const config = loadFixture('single-worker.json');
     mockRunner.when('worker').returns({ done: true });
 
-    await orchestrator.start(config, { text: 'Task' });
+    const result = await orchestrator.start(config, { text: 'Task' });
+    const cluster = orchestrator.getCluster(result.id);
 
     // Close orchestrator
     orchestrator.close();
 
     // Verify: closed flag set
     assert.strictEqual(orchestrator.closed, true, 'Orchestrator should be closed');
+    assert.strictEqual(cluster.messageBus._closed, true, 'Message bus should be closed');
+    assert.strictEqual(cluster.ledger._closed, true, 'Ledger should be closed');
 
     // _saveClusters should be a no-op now (prevents race conditions)
     // No assertion needed - just verify it doesn't throw

--- a/tests/task-termination-recovery.test.js
+++ b/tests/task-termination-recovery.test.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+const { execFile, spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { URL } = require('url');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+describe('Task termination recovery', function () {
+  this.timeout(10000);
+
+  it('escalates graceful provider termination to a hard kill', async function () {
+    const { terminateProcess } = await import('../task-lib/runner.js');
+    const child = spawn(
+      process.execPath,
+      [path.resolve(__dirname, 'fixtures/sigterm-resistant-process.js')],
+      { stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    await new Promise((resolve) => child.stdout.once('data', resolve));
+
+    try {
+      const result = await terminateProcess(child.pid, { graceMs: 40, pollMs: 5 });
+      assert.strictEqual(result.terminated, true);
+      assert.strictEqual(result.signal, 'SIGKILL');
+      assert.strictEqual(result.escalated, true);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }
+  });
+
+  it('persists killed and already-dead tasks as terminal with no PID', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-kill-store-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const resistantScript = path.resolve(__dirname, 'fixtures/sigterm-resistant-process.js');
+    const script = `
+      import { spawn } from 'child_process';
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      const base = {
+        prompt: 'hang', fullPrompt: 'hang', cwd: process.cwd(), status: 'running',
+        sessionId: null, logFile: null, createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(), exitCode: null, error: null,
+        provider: 'codex', model: 'fake', scheduleId: null, socketPath: null,
+        attachable: false
+      };
+      const child = spawn(process.execPath, [${JSON.stringify(resistantScript)}],
+        { stdio: ['ignore', 'pipe', 'ignore'] });
+      await new Promise((resolve) => child.stdout.once('data', resolve));
+      addTask({ ...base, id: 'live-task', pid: child.pid });
+      await killTaskCommand('live-task', { graceMs: 40, pollMs: 5 });
+      addTask({ ...base, id: 'dead-task', pid: 99999999 });
+      await killTaskCommand('dead-task', { graceMs: 40, pollMs: 5 });
+      console.log('RESULT:' + JSON.stringify({
+        live: getTask('live-task'),
+        dead: getTask('dead-task')
+      }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const terminal = JSON.parse(line.slice('RESULT:'.length));
+      assert.deepStrictEqual(
+        [terminal.live.status, terminal.live.pid, terminal.dead.status, terminal.dead.pid],
+        ['killed', null, 'stale', null]
+      );
+      assert.match(terminal.live.error, /SIGKILL/);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/agent-lifecycle-stop.test.js
+++ b/tests/unit/agent-lifecycle-stop.test.js
@@ -14,4 +14,36 @@ describe('Agent lifecycle stop', function () {
 
     assert.strictEqual(agent.livenessCheckInterval, null);
   });
+
+  it('cancels the bounded-wait timer after in-flight execution settles', async function () {
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+    const timeoutHandle = {};
+    let clearedHandle = null;
+    global.setTimeout = (callback, delay) => {
+      assert.strictEqual(delay, 5000);
+      return timeoutHandle;
+    };
+    global.clearTimeout = (handle) => {
+      clearedHandle = handle;
+    };
+
+    try {
+      const agent = {
+        running: true,
+        currentTask: null,
+        _currentExecution: Promise.resolve(),
+        unsubscribe: null,
+        _log() {},
+      };
+
+      await stop(agent);
+
+      assert.strictEqual(clearedHandle, timeoutHandle);
+      assert.strictEqual(agent._currentExecution, null);
+    } finally {
+      global.setTimeout = originalSetTimeout;
+      global.clearTimeout = originalClearTimeout;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- make stalled-task liveness recovery cross-platform instead of disabling it when `/proc` is unavailable
- escalate bounded stale tasks from graceful termination to hard kill, persist restart attempts and exhaustion, and reconcile task handles, task IDs, PIDs, and agent state
- close foreground-resume resources after completion so the CLI exits naturally while preserving detached daemon ownership
- repair task termination bookkeeping and use the supported top-level `zeroshot kill` command

## Root cause

The provider watchdog coupled liveness recovery to Linux `/proc` diagnostics, so a live provider that stopped emitting output on macOS could remain running indefinitely. Separately, foreground `resume` reached `CLUSTER_COMPLETE` but did not close the orchestrator, leaving snapshot and SQLite/message-bus resources alive and preventing Node from exiting.

## Verification

Rebased onto verified `origin/dev` `d7c7e062a06588823a0e80b53073abdc0f5a4e62`, whose post-merge CI passed.

- `npx mocha tests/agent-stuck-recovery.test.js tests/task-termination-recovery.test.js tests/unit/agent-lifecycle-stop.test.js --timeout 120000` — 10 passing
- `npx mocha tests/e2e/stuck-agent-recovery.test.js tests/e2e/resume-detach-daemon.test.js --timeout 120000` — 6 passing, including natural foreground exit and detached recovery
- `npx mocha tests/orchestrator.test.js --grep 'resume|retry once on SIGTERM' --timeout 120000` — 16 passing
- `npm run typecheck` — passing via the commit/push guardrails
- `npm run lint` — 0 errors (baseline warnings only)
- `opcore check --changed --json` — passing with 0 diagnostics; graph extraction remains degraded because the external graph parser rejects this repository's valid JSONC `tsconfig.json`
- independent direct-file review — APPROVED

Closes #710
Closes #720