### PR TITLE
fix(recovery): terminate owned provider process trees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,10 @@ Agent A -> publish() -> SQLite Ledger -> LogicEngine -> trigger match -> Agent B
 
 Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledger so restart limits survive orchestrator restarts.
 
+Provider task ownership: task watchers persist an owned termination boundary with each active task.
+POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
+`taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
+
 ### Guidance Messaging
 
 - Topics: `USER_GUIDANCE_CLUSTER`, `USER_GUIDANCE_AGENT` (see `src/guidance-topics.js`).

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -87,6 +87,9 @@ class AgentWrapper {
     this.livenessCheckInterval = null; // Interval for health checks
     this.consecutiveStaleWarnings = 0;
     this.livenessTerminationStarted = false;
+    this.livenessTerminationContext = null;
+    this.livenessTerminationAttempts = 0;
+    this.livenessTerminationRetryAt = 0;
     this.staleDuration = normalizedConfig.staleDuration;
     this.enableLivenessCheck = normalizedConfig.enableLivenessCheck;
 

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -1028,7 +1028,9 @@ function startLivenessCheck(agent) {
   agent.livenessTerminationStarted = false;
 
   agent.livenessCheckInterval = setInterval(() => {
-    if (!agent.currentTask || agent.livenessTerminationStarted) {
+    const hasRecoverableTask =
+      Boolean(agent.currentTask) || Boolean(agent.isolation?.enabled && agent.currentTaskId);
+    if (!hasRecoverableTask || agent.livenessTerminationStarted) {
       return;
     }
 

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -616,11 +616,12 @@ async function handleLockContention() {
 }
 
 async function handleFinalFailure(agent, triggeringMessage, error, maxRetries) {
+  const failureAttempts = error?.terminationAttempts ?? maxRetries;
   console.error(`
 ${'='.repeat(80)}`);
   console.error(`🔴🔴🔴 MAX RETRIES EXHAUSTED - AGENT: ${agent.id} 🔴🔴🔴`);
   console.error(`${'='.repeat(80)}`);
-  console.error(`All ${maxRetries} attempts failed`);
+  console.error(`All ${failureAttempts} attempts failed`);
   console.error(`Final error: ${error.message}`);
   console.error(`Stack: ${error.stack}`);
   console.error(`${'='.repeat(80)}
@@ -634,7 +635,7 @@ ${'='.repeat(80)}`);
 ${'='.repeat(80)}`);
     console.error(`❌ VALIDATOR CRASHED - REJECTING (NOT AUTO-APPROVING)`);
     console.error(`${'='.repeat(80)}`);
-    console.error(`Validator ${agent.id} crashed ${maxRetries} times`);
+    console.error(`Validator ${agent.id} crashed ${failureAttempts} times`);
     console.error(`Error: ${error.message}`);
     console.error(`REJECTING validation - broken code will NOT be merged`);
     console.error(`Investigation required before retry`);
@@ -648,16 +649,16 @@ ${'='.repeat(80)}`);
         topic: hook.config.topic,
         receiver: hook.config.receiver || 'broadcast',
         content: {
-          text: `REJECTED: Validator crashed ${maxRetries} times - ${error.message}`,
+          text: `REJECTED: Validator crashed ${failureAttempts} times - ${error.message}`,
           data: {
             approved: false, // REJECT!
             crashedAfterRetries: true,
             errors: JSON.stringify([
-              `VALIDATOR CRASHED ${maxRetries}x: ${error.message}`,
+              `VALIDATOR CRASHED ${failureAttempts}x: ${error.message}`,
               `Validation could not be performed - REJECTING to prevent broken code merge`,
               `Investigation required before retry`,
             ]),
-            attempts: maxRetries,
+            attempts: failureAttempts,
             requiresInvestigation: true,
           },
         },
@@ -691,13 +692,32 @@ ${'='.repeat(80)}`);
     });
   }
 
+  if (error?.terminationExhausted) {
+    agent._publish({
+      topic: 'CLUSTER_FAILED',
+      receiver: 'broadcast',
+      content: {
+        text: `Cluster failed: task termination could not be verified for ${agent.id}`,
+        data: {
+          reason: 'task_termination_unverified',
+          agentId: agent.id,
+          role: agent.role,
+          taskId: error.taskId || agent.currentTaskId,
+          attempts: failureAttempts,
+          error: error.message,
+        },
+      },
+    });
+  }
+
   // Save failure info to cluster for resume capability
   agent.cluster.failureInfo = {
+    ...(error?.terminationExhausted ? agent.cluster.failureInfo : {}),
     agentId: agent.id,
     taskId: error?.taskId || agent.currentTaskId,
     iteration: agent.iteration,
     error: error.message,
-    attempts: maxRetries,
+    attempts: failureAttempts,
     timestamp: Date.now(),
   };
 
@@ -706,19 +726,20 @@ ${'='.repeat(80)}`);
     topic: 'AGENT_ERROR',
     receiver: 'broadcast',
     content: {
-      text: `Task execution failed after ${maxRetries} attempts: ${error.message}`,
+      text: `Task execution failed after ${failureAttempts} attempts: ${error.message}`,
       data: {
         error: error.message,
         stack: error.stack,
         hookFailure: error?.hookFailure === true,
         restartExhausted: error?.restartExhausted === true,
+        terminationExhausted: error?.terminationExhausted === true,
         hookRetries: error?.hookRetries ?? undefined,
         originalHookError: error?.originalHookError ?? undefined,
         agent: agent.id,
         role: agent.role,
         iteration: agent.iteration,
         taskId: error?.taskId || agent.currentTaskId,
-        attempts: maxRetries,
+        attempts: failureAttempts,
         hookFailureContext: error.message.includes('Hook uses result')
           ? {
               taskId: agent.currentTaskId || 'UNKNOWN',
@@ -745,7 +766,9 @@ ${'='.repeat(80)}`);
     orchestrator: agent.orchestrator,
   });
 
-  agent.state = 'idle';
+  if (!error?.terminationExhausted) {
+    agent.state = 'idle';
+  }
 }
 
 async function scheduleRetry(agent, error, attempt, maxRetries, _baseDelay) {
@@ -1026,6 +1049,9 @@ function startLivenessCheck(agent) {
 
   agent.consecutiveStaleWarnings = 0;
   agent.livenessTerminationStarted = false;
+  agent.livenessTerminationContext = null;
+  agent.livenessTerminationAttempts = 0;
+  agent.livenessTerminationRetryAt = 0;
 
   agent.livenessCheckInterval = setInterval(() => {
     const hasRecoverableTask =
@@ -1035,22 +1061,26 @@ function startLivenessCheck(agent) {
     }
 
     const now = Date.now();
+    if (agent.livenessTerminationContext) {
+      if (now >= agent.livenessTerminationRetryAt) {
+        attemptLivenessTermination(agent, settings);
+      }
+      return;
+    }
+
     const taskStartedAt = agent.taskStartedAt || agent.lastOutputTime || now;
     const lastOutputTime = agent.lastOutputTime || taskStartedAt;
     const taskRuntime = now - taskStartedAt;
     const timeSinceLastOutput = now - lastOutputTime;
 
     if (configuredTimeout && taskRuntime >= configuredTimeout) {
-      agent.livenessTerminationStarted = true;
       const reason = `Task timed out after ${configuredTimeout}ms`;
       agent._publishLifecycle('AGENT_TASK_TIMEOUT', {
         taskId: agent.currentTaskId,
         taskRuntime,
         timeout: configuredTimeout,
       });
-      Promise.resolve(agent._killTask({ reason, code: 'AGENT_TASK_TIMEOUT' })).catch((error) => {
-        agent._log(`[${agent.id}] Failed to terminate timed-out task: ${error.message}`);
-      });
+      beginLivenessTermination(agent, settings, reason, 'AGENT_TASK_TIMEOUT');
       return;
     }
 
@@ -1075,7 +1105,6 @@ function startLivenessCheck(agent) {
       return;
     }
 
-    agent.livenessTerminationStarted = true;
     const reason = `Provider produced no output for ${timeSinceLastOutput}ms`;
     agent._publishLifecycle('AGENT_INACTIVITY_TIMEOUT', {
       taskId: agent.currentTaskId,
@@ -1083,12 +1112,113 @@ function startLivenessCheck(agent) {
       staleDuration,
       consecutiveWarnings: agent.consecutiveStaleWarnings,
     });
-    Promise.resolve(agent._killTask({ reason, code: 'PROVIDER_INACTIVITY_TIMEOUT' })).catch(
-      (error) => {
-        agent._log(`[${agent.id}] Failed to terminate inactive task: ${error.message}`);
-      }
-    );
+    beginLivenessTermination(agent, settings, reason, 'PROVIDER_INACTIVITY_TIMEOUT');
   }, checkIntervalMs);
+}
+
+const MAX_LIVENESS_TERMINATION_ATTEMPTS = 3;
+
+function beginLivenessTermination(agent, settings, reason, code) {
+  agent.livenessTerminationContext = {
+    taskId: agent.currentTaskId,
+    reason,
+    code,
+  };
+  agent.livenessTerminationAttempts = 0;
+  agent.livenessTerminationRetryAt = 0;
+  attemptLivenessTermination(agent, settings);
+}
+
+function terminationRetryDelay(settings, attempt) {
+  const baseDelay = Math.max(0, settings.backoffBaseMs ?? 2000);
+  const maxDelay = Math.max(0, settings.backoffMaxMs ?? 30000);
+  return Math.min(maxDelay, baseDelay * Math.pow(2, Math.max(0, attempt - 1)));
+}
+
+function attemptLivenessTermination(agent, settings) {
+  const context = agent.livenessTerminationContext;
+  if (!context || agent.livenessTerminationStarted) return;
+
+  agent.livenessTerminationStarted = true;
+  agent.livenessTerminationAttempts += 1;
+  const attempt = agent.livenessTerminationAttempts;
+
+  Promise.resolve()
+    .then(() => agent._killTask({ reason: context.reason, code: context.code }))
+    .catch((error) => {
+      if (agent.livenessTerminationContext !== context) return;
+      if (attempt >= MAX_LIVENESS_TERMINATION_ATTEMPTS) {
+        exhaustLivenessTermination(agent, context, error);
+        return;
+      }
+
+      const delayMs = terminationRetryDelay(settings, attempt);
+      agent.livenessTerminationRetryAt = Date.now() + delayMs;
+      agent.livenessTerminationStarted = false;
+      agent._publishLifecycle('AGENT_TERMINATION_RETRY', {
+        taskId: context.taskId,
+        reason: context.reason,
+        code: context.code,
+        error: error.message,
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts: MAX_LIVENESS_TERMINATION_ATTEMPTS,
+        delayMs,
+      });
+      agent._log(
+        `[${agent.id}] Failed to terminate task (attempt ${attempt}/${MAX_LIVENESS_TERMINATION_ATTEMPTS}); ` +
+          `retrying in ${delayMs}ms: ${error.message}`
+      );
+    });
+}
+
+function exhaustLivenessTermination(agent, context, terminationError) {
+  if (agent.livenessCheckInterval) {
+    clearInterval(agent.livenessCheckInterval);
+    agent.livenessCheckInterval = null;
+  }
+
+  const attempts = agent.livenessTerminationAttempts;
+  const error = new Error(
+    `Failed to terminate isolated task ${context.taskId} after ${attempts} attempts; ` +
+      `the provider task may still be running. Manual recovery is required before resume. ` +
+      `Last error: ${terminationError.message}`
+  );
+  error.code = 'ISOLATED_TASK_TERMINATION_EXHAUSTED';
+  error.taskId = context.taskId;
+  error.permanent = true;
+  error.restartExhausted = true;
+  error.terminationExhausted = true;
+  error.terminationAttempts = attempts;
+
+  agent.state = 'error';
+  agent.cluster.failureInfo = {
+    agentId: agent.id,
+    taskId: context.taskId,
+    iteration: agent.iteration,
+    type: 'task_termination',
+    reason: 'termination_unverified',
+    error: error.message,
+    attempts,
+    timestamp: Date.now(),
+  };
+  agent._publishLifecycle('AGENT_TERMINATION_EXHAUSTED', {
+    taskId: context.taskId,
+    reason: context.reason,
+    code: error.code,
+    terminationCode: context.code,
+    attempts,
+    maxAttempts: MAX_LIVENESS_TERMINATION_ATTEMPTS,
+    error: terminationError.message,
+    requiresManualRecovery: true,
+  });
+
+  if (typeof agent.currentTask?.failClosed === 'function') {
+    agent.currentTask.failClosed(error);
+    return;
+  }
+
+  agent._log(`[${agent.id}] ${error.message}`);
 }
 
 /**
@@ -1102,6 +1232,9 @@ function stopLivenessCheck(agent) {
   }
   agent.consecutiveStaleWarnings = 0;
   agent.livenessTerminationStarted = false;
+  agent.livenessTerminationContext = null;
+  agent.livenessTerminationAttempts = 0;
+  agent.livenessTerminationRetryAt = 0;
 }
 
 module.exports = {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -1075,12 +1075,11 @@ function startLivenessCheck(agent) {
 
     if (configuredTimeout && taskRuntime >= configuredTimeout) {
       const reason = `Task timed out after ${configuredTimeout}ms`;
-      agent._publishLifecycle('AGENT_TASK_TIMEOUT', {
+      beginLivenessTermination(agent, settings, reason, 'AGENT_TASK_TIMEOUT', {
         taskId: agent.currentTaskId,
         taskRuntime,
         timeout: configuredTimeout,
       });
-      beginLivenessTermination(agent, settings, reason, 'AGENT_TASK_TIMEOUT');
       return;
     }
 
@@ -1106,27 +1105,37 @@ function startLivenessCheck(agent) {
     }
 
     const reason = `Provider produced no output for ${timeSinceLastOutput}ms`;
-    agent._publishLifecycle('AGENT_INACTIVITY_TIMEOUT', {
+    beginLivenessTermination(agent, settings, reason, 'PROVIDER_INACTIVITY_TIMEOUT', {
       taskId: agent.currentTaskId,
       timeSinceLastOutput,
       staleDuration,
       consecutiveWarnings: agent.consecutiveStaleWarnings,
     });
-    beginLivenessTermination(agent, settings, reason, 'PROVIDER_INACTIVITY_TIMEOUT');
   }, checkIntervalMs);
 }
 
 const MAX_LIVENESS_TERMINATION_ATTEMPTS = 3;
 
-function beginLivenessTermination(agent, settings, reason, code) {
+function beginLivenessTermination(agent, settings, reason, code, eventData) {
   agent.livenessTerminationContext = {
     taskId: agent.currentTaskId,
     reason,
     code,
+    eventData,
+    eventPublished: false,
   };
   agent.livenessTerminationAttempts = 0;
   agent.livenessTerminationRetryAt = 0;
   attemptLivenessTermination(agent, settings);
+}
+
+function publishLivenessTerminationEvent(agent, context) {
+  if (context.eventPublished) return;
+  context.eventPublished = true;
+  agent._publishLifecycle(
+    context.code === 'AGENT_TASK_TIMEOUT' ? 'AGENT_TASK_TIMEOUT' : 'AGENT_INACTIVITY_TIMEOUT',
+    context.eventData
+  );
 }
 
 function terminationRetryDelay(settings, attempt) {
@@ -1145,6 +1154,10 @@ function attemptLivenessTermination(agent, settings) {
 
   Promise.resolve()
     .then(() => agent._killTask({ reason: context.reason, code: context.code }))
+    .then((termination) => {
+      if (termination?.forced === false) return;
+      publishLivenessTerminationEvent(agent, context);
+    })
     .catch((error) => {
       if (agent.livenessTerminationContext !== context) return;
       if (attempt >= MAX_LIVENESS_TERMINATION_ATTEMPTS) {
@@ -1179,6 +1192,7 @@ function exhaustLivenessTermination(agent, context, terminationError) {
   }
 
   const attempts = agent.livenessTerminationAttempts;
+  publishLivenessTerminationEvent(agent, context);
   const error = new Error(
     `Failed to terminate isolated task ${context.taskId} after ${attempts} attempts; ` +
       `the provider task may still be running. Manual recovery is required before resume. ` +

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1652,6 +1652,7 @@ function createIsolatedLogState() {
     resolved: false,
     terminationPromise: null,
     lifecycleHandle: null,
+    logFilePath: null,
     fullOutput: '',
     tailProcess: null,
     statusCheckInterval: null,
@@ -1706,24 +1707,124 @@ function rejectIsolatedFollower({ agent, state, cleanup, reject, error }) {
   reject(error);
 }
 
-function isTerminalIsolatedStatus(output) {
-  return /Status:\s+(?:completed|failed|killed|stale)/i.test(output);
+function parseIsolatedStatus(output) {
+  return output.match(/Status:\s+(completed|failed|killed|stale|cancelled)/i)?.[1].toLowerCase();
 }
 
 async function terminateIsolatedTask(manager, clusterId, taskId) {
   const before = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
-  if (before.code === 0 && isTerminalIsolatedStatus(before.stdout)) {
-    return { alreadyTerminal: true };
+  const beforeStatus = before.code === 0 ? parseIsolatedStatus(before.stdout) : null;
+  if (beforeStatus) {
+    return { alreadyTerminal: true, forced: false, status: beforeStatus };
   }
 
   const result = await manager.execInContainer(clusterId, ['zeroshot', 'kill', taskId]);
   const status = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
-  if (result.code !== 0 || status.code !== 0 || !isTerminalIsolatedStatus(status.stdout)) {
+  const afterStatus = status.code === 0 ? parseIsolatedStatus(status.stdout) : null;
+  if (!afterStatus) {
     throw new Error(
       `Failed to terminate isolated task ${taskId}: ${result.stderr || result.stdout || `exit ${result.code}`}`
     );
   }
-  return { alreadyTerminal: false };
+
+  return {
+    alreadyTerminal: false,
+    forced: afterStatus === 'killed',
+    status: afterStatus,
+  };
+}
+
+async function resolveIsolatedLogFilePath(manager, clusterId, taskId, state) {
+  if (state.logFilePath) return state.logFilePath;
+
+  const result = await manager.execInContainer(clusterId, [
+    'sh',
+    '-c',
+    `zeroshot get-log-path ${taskId}`,
+  ]);
+  if (result.code !== 0 || !result.stdout.trim()) {
+    throw new Error(
+      `Failed to get log path for ${taskId} inside container: ${result.stderr || result.stdout}`
+    );
+  }
+  state.logFilePath = result.stdout.trim();
+  return state.logFilePath;
+}
+
+function settleIsolatedTerminalStatus({
+  agent,
+  manager,
+  clusterId,
+  taskId,
+  providerName,
+  status,
+  isNotFound = false,
+  state,
+  cleanup,
+  resolve,
+  reject,
+  onLine,
+}) {
+  if (state.resolved) return Promise.resolve();
+  if (state.terminalSettlementPromise) return state.terminalSettlementPromise;
+
+  state.taskExited = true;
+  const settlement = (async () => {
+    const logFilePath = await resolveIsolatedLogFilePath(manager, clusterId, taskId, state);
+    await new Promise((settle) => setTimeout(settle, 200));
+    const finalReadResult = await manager.execInContainer(clusterId, [
+      'sh',
+      '-c',
+      `cat "${logFilePath}" 2>/dev/null || echo ""`,
+    ]);
+
+    if (finalReadResult.code === 0 && finalReadResult.stdout) {
+      state.fullOutput = finalReadResult.stdout;
+      for (const line of state.fullOutput.split('\n')) {
+        if (line.trim()) onLine(line);
+      }
+    }
+
+    const success = status === 'completed';
+    const errorContext = !success
+      ? extractErrorContext({
+          output: state.fullOutput,
+          statusOutput: status ? `Status: ${status}` : '',
+          taskId,
+          isNotFound,
+          debug: {
+            agentId: agent.id,
+            providerName,
+            pid: agent.processPid,
+            cwd: agent.config.cwd || process.cwd(),
+            worktreePath: agent.worktree?.path || null,
+            isolation: true,
+            clusterId,
+            logFilePath,
+          },
+        })
+      : null;
+    const parsedResult = await agent._parseResultOutput(state.fullOutput);
+
+    settleIsolatedFollower({
+      agent,
+      state,
+      cleanup,
+      resolve,
+      result: {
+        success,
+        output: state.fullOutput,
+        taskId,
+        result: parsedResult,
+        error: errorContext,
+        tokenUsage: extractTokenUsage(state.fullOutput, providerName),
+      },
+    });
+  })().catch((error) => {
+    rejectIsolatedFollower({ agent, state, cleanup, reject, error });
+  });
+  state.terminalSettlementPromise = settlement;
+  return settlement;
 }
 
 function buildIsolatedLifecycleHandle({
@@ -1736,6 +1837,7 @@ function buildIsolatedLifecycleHandle({
   cleanup,
   resolve,
   reject,
+  onLine,
 }) {
   const terminate = (reason = 'Task killed', details = {}) => {
     if (state.resolved || state.taskExited) return;
@@ -1743,7 +1845,22 @@ function buildIsolatedLifecycleHandle({
 
     const terminationPromise = (async () => {
       const termination = await terminateIsolatedTask(manager, clusterId, taskId);
-      if (termination.alreadyTerminal) return;
+      if (!termination.forced) {
+        await settleIsolatedTerminalStatus({
+          agent,
+          manager,
+          clusterId,
+          taskId,
+          providerName,
+          status: termination.status,
+          state,
+          cleanup,
+          resolve,
+          reject,
+          onLine,
+        });
+        return termination;
+      }
 
       settleIsolatedFollower({
         agent,
@@ -1759,6 +1876,7 @@ function buildIsolatedLifecycleHandle({
           tokenUsage: extractTokenUsage(state.fullOutput, providerName),
         },
       });
+      return termination;
     })();
     state.terminationPromise = terminationPromise;
     terminationPromise.catch(() => {
@@ -1870,72 +1988,28 @@ async function checkIsolatedStatus({
   ]);
 
   const statusOutput = statusResult.stdout;
-  const isSuccess = /Status:\s+completed/i.test(statusOutput);
-  const isError = /Status:\s+(?:failed|killed|stale)/i.test(statusOutput);
+  const status = parseIsolatedStatus(statusOutput);
   const isNotFound = statusOutput.includes('not_found');
 
-  if (!isSuccess && !isError && !isNotFound) {
+  if (!status && !isNotFound) {
     return;
   }
 
-  state.taskExited = true;
-  clearIsolatedLifecycleHandle(agent, state);
-  await new Promise((r) => setTimeout(r, 200));
-
-  try {
-    const finalReadResult = await manager.execInContainer(clusterId, [
-      'sh',
-      '-c',
-      `cat "${logFilePath}" 2>/dev/null || echo ""`,
-    ]);
-
-    if (finalReadResult.code === 0 && finalReadResult.stdout) {
-      state.fullOutput = finalReadResult.stdout;
-      const remainingLines = state.fullOutput.split('\n');
-      for (const line of remainingLines) {
-        if (line.trim()) {
-          onLine(line);
-        }
-      }
-    }
-
-    const success = isSuccess && !isError;
-    const errorContext = !success
-      ? extractErrorContext({
-          output: state.fullOutput,
-          taskId,
-          isNotFound,
-          debug: {
-            agentId: agent.id,
-            providerName,
-            pid: agent.processPid,
-            cwd: agent.config.cwd || process.cwd(),
-            worktreePath: agent.worktree?.path || null,
-            isolation: true,
-            clusterId,
-            logFilePath,
-          },
-        })
-      : null;
-    const parsedResult = await agent._parseResultOutput(state.fullOutput);
-
-    settleIsolatedFollower({
-      agent,
-      state,
-      cleanup,
-      resolve,
-      result: {
-        success,
-        output: state.fullOutput,
-        taskId,
-        result: parsedResult,
-        error: errorContext,
-        tokenUsage: extractTokenUsage(state.fullOutput, providerName),
-      },
-    });
-  } catch (error) {
-    rejectIsolatedFollower({ agent, state, cleanup, reject, error });
-  }
+  state.logFilePath = logFilePath;
+  await settleIsolatedTerminalStatus({
+    agent,
+    manager,
+    clusterId,
+    taskId,
+    providerName,
+    status,
+    isNotFound,
+    state,
+    cleanup,
+    resolve,
+    reject,
+    onLine,
+  });
 }
 
 function startIsolatedStatusChecks({
@@ -1994,6 +2068,7 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
       cleanup,
       resolve,
       reject,
+      onLine,
     });
     agent.currentTask = state.lifecycleHandle;
 
@@ -2021,6 +2096,10 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
             reject,
             error: new Error(`Empty log path returned for ${taskId}`),
           });
+        }
+        state.logFilePath = logFilePath;
+        if (state.resolved || state.taskExited) {
+          return;
         }
 
         agent._log(`[${agent.id}] Following isolated task logs (streaming): ${logFilePath}`);
@@ -2248,21 +2327,31 @@ async function killTask(agent, termination = 'Task killed') {
 }
 
 async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
+  let termination;
   if (currentTask && typeof currentTask.terminate === 'function') {
-    await currentTask.terminate(reason, { code });
+    termination = await currentTask.terminate(reason, { code });
   } else {
-    await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
+    termination = await terminateIsolatedTask(
+      agent.isolation.manager,
+      agent.isolation.clusterId,
+      taskId
+    );
     if (currentTask && typeof currentTask.kill === 'function') {
       currentTask.kill(reason, { code });
     }
   }
 
   agent._stopLivenessCheck?.();
+  if (termination?.forced === false) {
+    return termination;
+  }
+
   agent.currentTask = null;
   agent.currentTaskId = null;
   agent.processPid = null;
   agent.lastOutputTime = null;
   agent.taskStartedAt = null;
+  return termination;
 }
 
 module.exports = {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1735,6 +1735,7 @@ function buildIsolatedLifecycleHandle({
   state,
   cleanup,
   resolve,
+  reject,
 }) {
   const terminate = (reason = 'Task killed', details = {}) => {
     if (state.resolved || state.taskExited) return;
@@ -1773,6 +1774,9 @@ function buildIsolatedLifecycleHandle({
     isolated: true,
     terminate,
     kill: terminate,
+    failClosed(error) {
+      rejectIsolatedFollower({ agent, state, cleanup, reject, error });
+    },
   };
 }
 
@@ -1989,6 +1993,7 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
       state,
       cleanup,
       resolve,
+      reject,
     });
     agent.currentTask = state.lifecycleHandle;
 
@@ -2243,20 +2248,13 @@ async function killTask(agent, termination = 'Task killed') {
 }
 
 async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
-  try {
-    if (currentTask && typeof currentTask.terminate === 'function') {
-      await currentTask.terminate(reason, { code });
-    } else {
-      await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
-      if (currentTask && typeof currentTask.kill === 'function') {
-        currentTask.kill(reason, { code });
-      }
+  if (currentTask && typeof currentTask.terminate === 'function') {
+    await currentTask.terminate(reason, { code });
+  } else {
+    await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
+    if (currentTask && typeof currentTask.kill === 'function') {
+      currentTask.kill(reason, { code });
     }
-  } catch (error) {
-    // The status follower remains active. Re-arm the existing watchdog so a
-    // later bounded interval can retry without overlapping this attempt.
-    agent.livenessTerminationStarted = false;
-    throw error;
   }
 
   agent._stopLivenessCheck?.();

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1740,7 +1740,7 @@ function buildIsolatedLifecycleHandle({
     if (state.resolved || state.taskExited) return;
     if (state.terminationPromise) return state.terminationPromise;
 
-    state.terminationPromise = (async () => {
+    const terminationPromise = (async () => {
       const termination = await terminateIsolatedTask(manager, clusterId, taskId);
       if (termination.alreadyTerminal) return;
 
@@ -1759,8 +1759,14 @@ function buildIsolatedLifecycleHandle({
         },
       });
     })();
+    state.terminationPromise = terminationPromise;
+    terminationPromise.catch(() => {
+      if (state.terminationPromise === terminationPromise) {
+        state.terminationPromise = null;
+      }
+    });
 
-    return state.terminationPromise;
+    return terminationPromise;
   };
 
   return {
@@ -2200,28 +2206,15 @@ function normalizeTermination(termination) {
 }
 
 async function killTask(agent, termination = 'Task killed') {
-  agent._stopLivenessCheck?.();
-
   const { reason, code } = normalizeTermination(termination);
   const currentTask = agent.currentTask;
   const taskId = agent.currentTaskId;
 
   if (agent.isolation?.enabled && taskId) {
-    if (currentTask && typeof currentTask.terminate === 'function') {
-      await currentTask.terminate(reason, { code });
-    } else {
-      await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
-      if (currentTask && typeof currentTask.kill === 'function') {
-        currentTask.kill(reason, { code });
-      }
-    }
-    agent.currentTask = null;
-    agent.currentTaskId = null;
-    agent.processPid = null;
-    agent.lastOutputTime = null;
-    agent.taskStartedAt = null;
-    return;
+    return killIsolatedTask(agent, currentTask, taskId, reason, code);
   }
+
+  agent._stopLivenessCheck?.();
 
   // Kill the underlying task before resolving the local follower. This keeps
   // retries from racing a provider process that is still shutting down.
@@ -2242,6 +2235,31 @@ async function killTask(agent, termination = 'Task killed') {
     currentTask.kill(reason, { code });
   }
 
+  agent.currentTask = null;
+  agent.currentTaskId = null;
+  agent.processPid = null;
+  agent.lastOutputTime = null;
+  agent.taskStartedAt = null;
+}
+
+async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
+  try {
+    if (currentTask && typeof currentTask.terminate === 'function') {
+      await currentTask.terminate(reason, { code });
+    } else {
+      await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
+      if (currentTask && typeof currentTask.kill === 'function') {
+        currentTask.kill(reason, { code });
+      }
+    }
+  } catch (error) {
+    // The status follower remains active. Re-arm the existing watchdog so a
+    // later bounded interval can retry without overlapping this attempt.
+    agent.livenessTerminationStarted = false;
+    throw error;
+  }
+
+  agent._stopLivenessCheck?.();
   agent.currentTask = null;
   agent.currentTaskId = null;
   agent.processPid = null;

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1593,13 +1593,6 @@ async function spawnClaudeTaskIsolated(agent, context) {
             taskId: spawnedTaskId,
           });
 
-          // Start liveness monitoring
-          if (agent.enableLivenessCheck) {
-            agent.taskStartedAt = Date.now();
-            agent.lastOutputTime = agent.taskStartedAt;
-            agent._startLivenessCheck();
-          }
-
           resolve(spawnedTaskId);
         } else {
           reject(new Error(`Could not parse task ID from output: ${stdout}`));
@@ -1619,8 +1612,15 @@ async function spawnClaudeTaskIsolated(agent, context) {
 
   agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId} in container...`);
 
-  // STEP 2: Follow the task's log file inside container (NOT the spawn stdout!)
-  return followClaudeTaskLogsIsolated(agent, taskId);
+  // STEP 2: Install the lifecycle-owned handle before liveness monitoring can
+  // observe the task, then follow the task's log file inside the container.
+  const execution = followClaudeTaskLogsIsolated(agent, taskId);
+  if (agent.enableLivenessCheck) {
+    agent.taskStartedAt = Date.now();
+    agent.lastOutputTime = agent.taskStartedAt;
+    agent._startLivenessCheck();
+  }
+  return execution;
 }
 
 /**
@@ -1649,9 +1649,13 @@ async function spawnClaudeTaskIsolated(agent, context) {
 function createIsolatedLogState() {
   return {
     taskExited: false,
+    resolved: false,
+    terminationPromise: null,
+    lifecycleHandle: null,
     fullOutput: '',
     tailProcess: null,
     statusCheckInterval: null,
+    timeoutTimer: null,
     lineBuffer: '',
   };
 }
@@ -1670,6 +1674,99 @@ function buildIsolatedCleanup(state) {
       clearInterval(state.statusCheckInterval);
       state.statusCheckInterval = null;
     }
+    if (state.timeoutTimer) {
+      clearTimeout(state.timeoutTimer);
+      state.timeoutTimer = null;
+    }
+  };
+}
+
+function clearIsolatedLifecycleHandle(agent, state) {
+  if (agent.currentTask === state.lifecycleHandle) {
+    agent.currentTask = null;
+  }
+  agent._stopLivenessCheck?.();
+}
+
+function settleIsolatedFollower({ agent, state, cleanup, resolve, result }) {
+  if (state.resolved) return;
+  state.resolved = true;
+  state.taskExited = true;
+  cleanup();
+  clearIsolatedLifecycleHandle(agent, state);
+  resolve(result);
+}
+
+function rejectIsolatedFollower({ agent, state, cleanup, reject, error }) {
+  if (state.resolved) return;
+  state.resolved = true;
+  state.taskExited = true;
+  cleanup();
+  clearIsolatedLifecycleHandle(agent, state);
+  reject(error);
+}
+
+function isTerminalIsolatedStatus(output) {
+  return /Status:\s+(?:completed|failed|killed|stale)/i.test(output);
+}
+
+async function terminateIsolatedTask(manager, clusterId, taskId) {
+  const before = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
+  if (before.code === 0 && isTerminalIsolatedStatus(before.stdout)) {
+    return { alreadyTerminal: true };
+  }
+
+  const result = await manager.execInContainer(clusterId, ['zeroshot', 'kill', taskId]);
+  const status = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
+  if (result.code !== 0 || status.code !== 0 || !isTerminalIsolatedStatus(status.stdout)) {
+    throw new Error(
+      `Failed to terminate isolated task ${taskId}: ${result.stderr || result.stdout || `exit ${result.code}`}`
+    );
+  }
+  return { alreadyTerminal: false };
+}
+
+function buildIsolatedLifecycleHandle({
+  agent,
+  manager,
+  clusterId,
+  taskId,
+  providerName,
+  state,
+  cleanup,
+  resolve,
+}) {
+  const terminate = (reason = 'Task killed', details = {}) => {
+    if (state.resolved || state.taskExited) return;
+    if (state.terminationPromise) return state.terminationPromise;
+
+    state.terminationPromise = (async () => {
+      const termination = await terminateIsolatedTask(manager, clusterId, taskId);
+      if (termination.alreadyTerminal) return;
+
+      settleIsolatedFollower({
+        agent,
+        state,
+        cleanup,
+        resolve,
+        result: {
+          success: false,
+          output: state.fullOutput,
+          error: reason,
+          code: details.code || null,
+          taskId,
+          tokenUsage: extractTokenUsage(state.fullOutput, providerName),
+        },
+      });
+    })();
+
+    return state.terminationPromise;
+  };
+
+  return {
+    isolated: true,
+    terminate,
+    kill: terminate,
   };
 }
 
@@ -1751,6 +1848,7 @@ async function checkIsolatedStatus({
   state,
   cleanup,
   resolve,
+  reject,
   onLine,
 }) {
   if (state.taskExited) return;
@@ -1763,7 +1861,7 @@ async function checkIsolatedStatus({
 
   const statusOutput = statusResult.stdout;
   const isSuccess = /Status:\s+completed/i.test(statusOutput);
-  const isError = /Status:\s+failed/i.test(statusOutput);
+  const isError = /Status:\s+(?:failed|killed|stale)/i.test(statusOutput);
   const isNotFound = statusOutput.includes('not_found');
 
   if (!isSuccess && !isError && !isNotFound) {
@@ -1771,54 +1869,63 @@ async function checkIsolatedStatus({
   }
 
   state.taskExited = true;
+  clearIsolatedLifecycleHandle(agent, state);
   await new Promise((r) => setTimeout(r, 200));
 
-  const finalReadResult = await manager.execInContainer(clusterId, [
-    'sh',
-    '-c',
-    `cat "${logFilePath}" 2>/dev/null || echo ""`,
-  ]);
+  try {
+    const finalReadResult = await manager.execInContainer(clusterId, [
+      'sh',
+      '-c',
+      `cat "${logFilePath}" 2>/dev/null || echo ""`,
+    ]);
 
-  if (finalReadResult.code === 0 && finalReadResult.stdout) {
-    state.fullOutput = finalReadResult.stdout;
-    const remainingLines = state.fullOutput.split('\n');
-    for (const line of remainingLines) {
-      if (line.trim()) {
-        onLine(line);
+    if (finalReadResult.code === 0 && finalReadResult.stdout) {
+      state.fullOutput = finalReadResult.stdout;
+      const remainingLines = state.fullOutput.split('\n');
+      for (const line of remainingLines) {
+        if (line.trim()) {
+          onLine(line);
+        }
       }
     }
-  }
 
-  cleanup();
+    const success = isSuccess && !isError;
+    const errorContext = !success
+      ? extractErrorContext({
+          output: state.fullOutput,
+          taskId,
+          isNotFound,
+          debug: {
+            agentId: agent.id,
+            providerName,
+            pid: agent.processPid,
+            cwd: agent.config.cwd || process.cwd(),
+            worktreePath: agent.worktree?.path || null,
+            isolation: true,
+            clusterId,
+            logFilePath,
+          },
+        })
+      : null;
+    const parsedResult = await agent._parseResultOutput(state.fullOutput);
 
-  const success = isSuccess && !isError;
-  const errorContext = !success
-    ? extractErrorContext({
+    settleIsolatedFollower({
+      agent,
+      state,
+      cleanup,
+      resolve,
+      result: {
+        success,
         output: state.fullOutput,
         taskId,
-        isNotFound,
-        debug: {
-          agentId: agent.id,
-          providerName,
-          pid: agent.processPid,
-          cwd: agent.config.cwd || process.cwd(),
-          worktreePath: agent.worktree?.path || null,
-          isolation: true,
-          clusterId,
-          logFilePath,
-        },
-      })
-    : null;
-  const parsedResult = await agent._parseResultOutput(state.fullOutput);
-
-  resolve({
-    success,
-    output: state.fullOutput,
-    taskId,
-    result: parsedResult,
-    error: errorContext,
-    tokenUsage: extractTokenUsage(state.fullOutput, providerName),
-  });
+        result: parsedResult,
+        error: errorContext,
+        tokenUsage: extractTokenUsage(state.fullOutput, providerName),
+      },
+    });
+  } catch (error) {
+    rejectIsolatedFollower({ agent, state, cleanup, reject, error });
+  }
 }
 
 function startIsolatedStatusChecks({
@@ -1831,6 +1938,7 @@ function startIsolatedStatusChecks({
   state,
   cleanup,
   resolve,
+  reject,
   onLine,
 }) {
   state.statusCheckInterval = setInterval(() => {
@@ -1844,6 +1952,7 @@ function startIsolatedStatusChecks({
       state,
       cleanup,
       resolve,
+      reject,
       onLine,
     }).catch((statusErr) => {
       agent._log(`[${agent.id}] Status check error (will retry): ${statusErr.message}`);
@@ -1865,21 +1974,42 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
     const state = createIsolatedLogState();
     const cleanup = buildIsolatedCleanup(state);
     const onLine = (line) => broadcastIsolatedLine({ agent, providerName, taskId, line });
+    state.lifecycleHandle = buildIsolatedLifecycleHandle({
+      agent,
+      manager,
+      clusterId,
+      taskId,
+      providerName,
+      state,
+      cleanup,
+      resolve,
+    });
+    agent.currentTask = state.lifecycleHandle;
 
     manager
       .execInContainer(clusterId, ['sh', '-c', `zeroshot get-log-path ${taskId}`])
       .then(({ stdout, stderr, code }) => {
         if (code !== 0) {
-          cleanup();
-          return reject(
-            new Error(`Failed to get log path for ${taskId} inside container: ${stderr || stdout}`)
-          );
+          return rejectIsolatedFollower({
+            agent,
+            state,
+            cleanup,
+            reject,
+            error: new Error(
+              `Failed to get log path for ${taskId} inside container: ${stderr || stdout}`
+            ),
+          });
         }
 
         const logFilePath = stdout.trim();
         if (!logFilePath) {
-          cleanup();
-          return reject(new Error(`Empty log path returned for ${taskId}`));
+          return rejectIsolatedFollower({
+            agent,
+            state,
+            cleanup,
+            reject,
+            error: new Error(`Empty log path returned for ${taskId}`),
+          });
         }
 
         agent._log(`[${agent.id}] Following isolated task logs (streaming): ${logFilePath}`);
@@ -1903,21 +2033,26 @@ function followClaudeTaskLogsIsolated(agent, taskId) {
           state,
           cleanup,
           resolve,
+          reject,
           onLine,
         });
 
-        if (agent.timeout > 0) {
-          setTimeout(() => {
-            if (!state.taskExited) {
-              cleanup();
-              reject(new Error(`Task ${taskId} timeout after ${agent.timeout}ms (isolated mode)`));
-            }
+        if (agent.timeout > 0 && !agent.enableLivenessCheck) {
+          state.timeoutTimer = setTimeout(() => {
+            state.lifecycleHandle
+              .terminate(`Task timed out after ${agent.timeout}ms`, {
+                code: 'AGENT_TASK_TIMEOUT',
+              })
+              .catch((error) => {
+                agent._log(
+                  `[${agent.id}] Failed to terminate timed-out isolated task: ${error.message}`
+                );
+              });
           }, agent.timeout);
         }
       })
       .catch((err) => {
-        cleanup();
-        reject(err);
+        rejectIsolatedFollower({ agent, state, cleanup, reject, error: err });
       });
   });
 }
@@ -2071,6 +2206,23 @@ async function killTask(agent, termination = 'Task killed') {
   const currentTask = agent.currentTask;
   const taskId = agent.currentTaskId;
 
+  if (agent.isolation?.enabled && taskId) {
+    if (currentTask && typeof currentTask.terminate === 'function') {
+      await currentTask.terminate(reason, { code });
+    } else {
+      await terminateIsolatedTask(agent.isolation.manager, agent.isolation.clusterId, taskId);
+      if (currentTask && typeof currentTask.kill === 'function') {
+        currentTask.kill(reason, { code });
+      }
+    }
+    agent.currentTask = null;
+    agent.currentTaskId = null;
+    agent.processPid = null;
+    agent.lastOutputTime = null;
+    agent.taskStartedAt = null;
+    return;
+  }
+
   // Kill the underlying task before resolving the local follower. This keeps
   // retries from racing a provider process that is still shutting down.
   if (taskId) {
@@ -2101,6 +2253,7 @@ module.exports = {
   ensureAskUserQuestionHook,
   spawnClaudeTask,
   followClaudeTaskLogs,
+  followClaudeTaskLogsIsolated,
   waitForTaskReady,
   spawnClaudeTaskIsolated,
   getClaudeTasksPath,

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -319,6 +319,8 @@ server.on('exit', async ({ exitCode, signal }) => {
   try {
     await updateTask(taskId, {
       status,
+      pid: null,
+      processGroupId: null,
       exitCode: resolvedCode,
       error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
       socketPath: null,
@@ -336,7 +338,12 @@ server.on('error', async (err) => {
   log(`\nError: ${err.message}\n`);
   await cleanupCommandSpec();
   try {
-    await updateTask(taskId, { status: 'failed', error: err.message });
+    await updateTask(taskId, {
+      status: 'failed',
+      pid: null,
+      processGroupId: null,
+      error: err.message,
+    });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
   }
@@ -358,6 +365,8 @@ try {
     pid: server.pid,
     socketPath,
     attachable: true,
+    processGroupId: process.platform === 'win32' ? null : server.pid,
+    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
   });
 
   log(`[${Date.now()}][SYSTEM] Started with PTY (attachable)\n`);

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getTask, updateTask } from '../store.js';
-import { isProcessRunning, terminateProcess } from '../runner.js';
+import { isOwnedProcessTreeRunning, terminateProcess } from '../runner.js';
 
 export async function killTaskCommand(taskId, options = {}) {
   const task = getTask(taskId);
@@ -15,33 +15,43 @@ export async function killTaskCommand(taskId, options = {}) {
     return;
   }
 
-  if (!isProcessRunning(task.pid)) {
+  const terminationOptions = {
+    ...options,
+    processGroupId: task.processGroupId,
+    terminationStrategy: task.terminationStrategy || 'process',
+  };
+
+  if (!isOwnedProcessTreeRunning(task.pid, terminationOptions)) {
     console.log(chalk.yellow('Process already dead, updating status...'));
     updateTask(taskId, {
       status: 'stale',
       pid: null,
+      processGroupId: null,
       error: 'Process died unexpectedly',
     });
     return;
   }
 
-  const result = await terminateProcess(task.pid, options);
+  const result = await terminateProcess(task.pid, terminationOptions);
 
   if (result.terminated) {
     const suffix = result.escalated ? ' after SIGKILL escalation' : ' with SIGTERM';
     console.log(chalk.green(`✓ Killed task ${taskId} (PID: ${task.pid})${suffix}`));
+    if (result.degraded) {
+      console.log(chalk.yellow(`Warning: ${result.degradedReason}`));
+    }
     updateTask(taskId, {
       status: 'killed',
       pid: null,
+      processGroupId: null,
       exitCode: result.escalated ? 137 : 143,
       error: result.escalated ? 'Killed by user after SIGKILL escalation' : 'Killed by user',
     });
   } else {
     console.log(chalk.red(`Failed to kill task ${taskId}`));
     updateTask(taskId, {
-      status: 'failed',
-      pid: null,
       error: result.error || 'Process termination failed',
     });
+    process.exitCode = 1;
   }
 }

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getTask, updateTask } from '../store.js';
-import { isOwnedProcessTreeRunning, terminateProcess } from '../runner.js';
+import { terminateProcess } from '../runner.js';
 
 export async function killTaskCommand(taskId, options = {}) {
   const task = getTask(taskId);
@@ -21,7 +21,9 @@ export async function killTaskCommand(taskId, options = {}) {
     terminationStrategy: task.terminationStrategy || 'process',
   };
 
-  if (!isOwnedProcessTreeRunning(task.pid, terminationOptions)) {
+  const result = await terminateProcess(task.pid, terminationOptions);
+
+  if (result.terminated && result.alreadyDead) {
     console.log(chalk.yellow('Process already dead, updating status...'));
     updateTask(taskId, {
       status: 'stale',
@@ -31,8 +33,6 @@ export async function killTaskCommand(taskId, options = {}) {
     });
     return;
   }
-
-  const result = await terminateProcess(task.pid, terminationOptions);
 
   if (result.terminated) {
     const suffix = result.escalated ? ' after SIGKILL escalation' : ' with SIGTERM';

--- a/task-lib/commands/status.js
+++ b/task-lib/commands/status.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getTask } from '../store.js';
-import { isProcessRunning } from '../runner.js';
+import { isOwnedProcessTreeRunning } from '../runner.js';
 
 export function showStatus(taskId) {
   const task = getTask(taskId);
@@ -12,7 +12,13 @@ export function showStatus(taskId) {
 
   // Verify running status
   let status = task.status;
-  if (status === 'running' && !isProcessRunning(task.pid)) {
+  if (
+    status === 'running' &&
+    !isOwnedProcessTreeRunning(task.pid, {
+      processGroupId: task.processGroupId,
+      terminationStrategy: task.terminationStrategy || 'process',
+    })
+  ) {
     status = 'stale (process died)';
   }
 

--- a/task-lib/commands/status.js
+++ b/task-lib/commands/status.js
@@ -12,14 +12,18 @@ export function showStatus(taskId) {
 
   // Verify running status
   let status = task.status;
-  if (
-    status === 'running' &&
-    !isOwnedProcessTreeRunning(task.pid, {
-      processGroupId: task.processGroupId,
-      terminationStrategy: task.terminationStrategy || 'process',
-    })
-  ) {
-    status = 'stale (process died)';
+  if (status === 'running') {
+    try {
+      const running = isOwnedProcessTreeRunning(task.pid, {
+        processGroupId: task.processGroupId,
+        terminationStrategy: task.terminationStrategy || 'process',
+      });
+      if (!running) {
+        status = 'stale (process died)';
+      }
+    } catch (error) {
+      status = `stale (invalid process ownership: ${error.message})`;
+    }
   }
 
   const statusColor =

--- a/task-lib/process-termination.js
+++ b/task-lib/process-termination.js
@@ -1,0 +1,202 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export function isProcessRunning(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function killTask(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 'SIGTERM');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeTerminationOwnership(pid, options) {
+  const terminationStrategy = options.terminationStrategy || 'process';
+  const processGroupId = Number(options.processGroupId) || null;
+
+  if (terminationStrategy === 'process-group') {
+    if (process.platform === 'win32') {
+      throw new Error(
+        'Process-group termination is unavailable on Windows; use terminationStrategy "process-tree"'
+      );
+    }
+    if (!processGroupId || processGroupId !== pid) {
+      throw new Error(
+        `Refusing process-group termination for PID ${pid}: owned processGroupId must equal the provider root PID`
+      );
+    }
+  }
+
+  if (terminationStrategy === 'process-tree' && process.platform !== 'win32') {
+    throw new Error(
+      `Process-tree termination is only supported on Windows; use terminationStrategy "process-group" on ${process.platform}`
+    );
+  }
+
+  if (!['process', 'process-group', 'process-tree'].includes(terminationStrategy)) {
+    throw new Error(`Unsupported termination strategy: ${terminationStrategy}`);
+  }
+
+  return { terminationStrategy, processGroupId };
+}
+
+function isProcessGroupRunning(processGroupId) {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+export function isOwnedProcessTreeRunning(pid, options = {}) {
+  if (!pid) return false;
+  const ownership = normalizeTerminationOwnership(pid, options);
+  if (ownership.terminationStrategy === 'process-group') {
+    return isProcessGroupRunning(ownership.processGroupId);
+  }
+  return isProcessRunning(pid);
+}
+
+async function signalWindowsProcessTree(pid, force) {
+  const args = ['/PID', String(pid), '/T'];
+  if (force) args.push('/F');
+  await execFileAsync('taskkill', args, { windowsHide: true });
+}
+
+async function signalOwnedProcessTree(pid, signal, ownership) {
+  if (ownership.terminationStrategy === 'process-group') {
+    process.kill(-ownership.processGroupId, signal);
+    return;
+  }
+  if (ownership.terminationStrategy === 'process-tree') {
+    await signalWindowsProcessTree(pid, signal === 'SIGKILL');
+    return;
+  }
+  process.kill(pid, signal);
+}
+
+async function waitForOwnedProcessTreeExit(pid, ownership, timeoutMs, pollMs) {
+  const deadline = Date.now() + timeoutMs;
+  const options = {
+    terminationStrategy: ownership.terminationStrategy,
+    processGroupId: ownership.processGroupId,
+  };
+  while (Date.now() < deadline) {
+    if (!isOwnedProcessTreeRunning(pid, options)) return true;
+    await sleep(pollMs);
+  }
+  return !isOwnedProcessTreeRunning(pid, options);
+}
+
+function terminationResult(ownership, overrides = {}) {
+  const degraded = ownership.terminationStrategy === 'process';
+  return {
+    terminated: false,
+    alreadyDead: false,
+    escalated: false,
+    signal: null,
+    scope: ownership.terminationStrategy,
+    degraded,
+    degradedReason: degraded
+      ? 'Task has no process-tree ownership metadata; only the provider root PID can be terminated'
+      : null,
+    ...overrides,
+  };
+}
+
+async function signalAndWait(pid, ownership, signal, timeoutMs, pollMs) {
+  const escalated = signal === 'SIGKILL';
+  try {
+    await signalOwnedProcessTree(pid, signal, ownership);
+  } catch (error) {
+    if (
+      !isOwnedProcessTreeRunning(pid, {
+        terminationStrategy: ownership.terminationStrategy,
+        processGroupId: ownership.processGroupId,
+      })
+    ) {
+      return terminationResult(ownership, {
+        terminated: true,
+        alreadyDead: signal === 'SIGTERM',
+        escalated,
+        signal: escalated ? signal : null,
+      });
+    }
+    return terminationResult(ownership, {
+      escalated,
+      signal,
+      error: error.message,
+    });
+  }
+
+  const terminated = await waitForOwnedProcessTreeExit(pid, ownership, timeoutMs, pollMs);
+  return terminationResult(ownership, {
+    terminated,
+    escalated,
+    signal,
+    error:
+      terminated || !escalated
+        ? null
+        : `Owned ${ownership.terminationStrategy} for PID ${pid} survived ${signal}`,
+  });
+}
+
+/**
+ * Terminate an owned provider process tree. Watchers create a dedicated process
+ * group on POSIX and persist that ownership boundary; Windows uses taskkill /T.
+ * Legacy tasks without ownership metadata fall back to root-only termination
+ * and report the degraded scope explicitly.
+ */
+export async function terminateProcess(pid, options = {}) {
+  let ownership;
+  try {
+    ownership = normalizeTerminationOwnership(pid, options);
+  } catch (error) {
+    return {
+      terminated: false,
+      alreadyDead: false,
+      escalated: false,
+      signal: null,
+      error: error.message,
+    };
+  }
+
+  if (!isOwnedProcessTreeRunning(pid, options)) {
+    return terminationResult(ownership, { terminated: true, alreadyDead: true });
+  }
+
+  const graceful = await signalAndWait(
+    pid,
+    ownership,
+    'SIGTERM',
+    options.graceMs ?? 5000,
+    options.pollMs ?? 50
+  );
+  if (graceful.terminated || graceful.error) return graceful;
+
+  return signalAndWait(
+    pid,
+    ownership,
+    'SIGKILL',
+    options.hardKillWaitMs ?? 1000,
+    options.pollMs ?? 50
+  );
+}

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -7,6 +7,12 @@ import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { prepareSingleAgentProviderCommand } = require('./provider-helper-runtime.js');
+export {
+  isOwnedProcessTreeRunning,
+  isProcessRunning,
+  killTask,
+  terminateProcess,
+} from './process-termination.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -136,6 +142,8 @@ function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, mode
     // Attach support
     socketPath: null,
     attachable: false,
+    processGroupId: null,
+    terminationStrategy: null,
   };
 }
 
@@ -175,115 +183,4 @@ function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfi
 
   watcher.unref();
   watcher.disconnect(); // Close IPC channel so parent can exit
-}
-
-export function isProcessRunning(pid) {
-  if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function killTask(pid) {
-  if (!pid) return false;
-  try {
-    process.kill(pid, 'SIGTERM');
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitForProcessExit(pid, timeoutMs, pollMs) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isProcessRunning(pid)) return true;
-    await sleep(pollMs);
-  }
-  return !isProcessRunning(pid);
-}
-
-/**
- * Terminate a provider process without relying on Linux-only process metadata.
- * SIGTERM gets a bounded grace period, then SIGKILL is used as the final
- * authority so callers never leave a task persisted as running indefinitely.
- */
-export async function terminateProcess(pid, options = {}) {
-  const graceMs = options.graceMs ?? 5000;
-  const hardKillWaitMs = options.hardKillWaitMs ?? 1000;
-  const pollMs = options.pollMs ?? 50;
-
-  if (!isProcessRunning(pid)) {
-    return {
-      terminated: true,
-      alreadyDead: true,
-      escalated: false,
-      signal: null,
-    };
-  }
-
-  try {
-    process.kill(pid, 'SIGTERM');
-  } catch (error) {
-    if (!isProcessRunning(pid)) {
-      return {
-        terminated: true,
-        alreadyDead: true,
-        escalated: false,
-        signal: null,
-      };
-    }
-    return {
-      terminated: false,
-      alreadyDead: false,
-      escalated: false,
-      signal: 'SIGTERM',
-      error: error.message,
-    };
-  }
-
-  if (await waitForProcessExit(pid, graceMs, pollMs)) {
-    return {
-      terminated: true,
-      alreadyDead: false,
-      escalated: false,
-      signal: 'SIGTERM',
-    };
-  }
-
-  try {
-    process.kill(pid, 'SIGKILL');
-  } catch (error) {
-    if (!isProcessRunning(pid)) {
-      return {
-        terminated: true,
-        alreadyDead: false,
-        escalated: true,
-        signal: 'SIGKILL',
-      };
-    }
-    return {
-      terminated: false,
-      alreadyDead: false,
-      escalated: true,
-      signal: 'SIGKILL',
-      error: error.message,
-    };
-  }
-
-  const terminated = await waitForProcessExit(pid, hardKillWaitMs, pollMs);
-  return {
-    terminated,
-    alreadyDead: false,
-    escalated: true,
-    signal: 'SIGKILL',
-    error: terminated ? null : `Process ${pid} survived SIGKILL`,
-  };
 }

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -297,11 +297,11 @@ export function addTask(task) {
     INSERT INTO tasks (
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
-      schedule_id, socket_path, attachable
+      schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
-      @scheduleId, @socketPath, @attachable
+      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
   `
     )
@@ -323,6 +323,8 @@ export function addTask(task) {
       scheduleId: fullTask.scheduleId || null,
       socketPath: fullTask.socketPath || null,
       attachable: fullTask.attachable ? 1 : 0,
+      processGroupId: fullTask.processGroupId || null,
+      terminationStrategy: fullTask.terminationStrategy || null,
     });
 
   return fullTask;

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -50,7 +50,9 @@ function getDb() {
       model TEXT,
       schedule_id TEXT,
       socket_path TEXT,
-      attachable INTEGER DEFAULT 0
+      attachable INTEGER DEFAULT 0,
+      process_group_id INTEGER,
+      termination_strategy TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -75,7 +77,17 @@ function getDb() {
     CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled);
   `);
 
+  ensureTaskColumn(db, 'process_group_id', 'INTEGER');
+  ensureTaskColumn(db, 'termination_strategy', 'TEXT');
+
   return db;
+}
+
+function ensureTaskColumn(database, name, definition) {
+  const columns = database.pragma('table_info(tasks)');
+  if (!columns.some((column) => column.name === name)) {
+    database.exec(`ALTER TABLE tasks ADD COLUMN ${name} ${definition}`);
+  }
 }
 
 export function ensureDirs() {
@@ -110,6 +122,8 @@ function rowToTask(row) {
     scheduleId: row.schedule_id,
     socketPath: row.socket_path,
     attachable: Boolean(row.attachable),
+    processGroupId: row.process_group_id,
+    terminationStrategy: row.termination_strategy,
   };
 }
 
@@ -137,11 +151,11 @@ export function saveTasks(tasks) {
     INSERT OR REPLACE INTO tasks (
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
-      schedule_id, socket_path, attachable
+      schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
-      @scheduleId, @socketPath, @attachable
+      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
   `);
 
@@ -168,6 +182,8 @@ export function saveTasks(tasks) {
         scheduleId: task.scheduleId || null,
         socketPath: task.socketPath || null,
         attachable: task.attachable ? 1 : 0,
+        processGroupId: task.processGroupId || null,
+        terminationStrategy: task.terminationStrategy || null,
       });
     }
   });
@@ -232,7 +248,9 @@ export function updateTask(id, updates) {
       model = @model,
       schedule_id = @scheduleId,
       socket_path = @socketPath,
-      attachable = @attachable
+      attachable = @attachable,
+      process_group_id = @processGroupId,
+      termination_strategy = @terminationStrategy
     WHERE id = @id
   `
     )
@@ -253,6 +271,8 @@ export function updateTask(id, updates) {
       scheduleId: updated.scheduleId || null,
       socketPath: updated.socketPath || null,
       attachable: updated.attachable ? 1 : 0,
+      processGroupId: updated.processGroupId || null,
+      terminationStrategy: updated.terminationStrategy || null,
     });
 
   return updated;

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -45,10 +45,15 @@ const child = spawn(command, finalArgs, {
   cwd: commandSpec.cwd || cwd,
   env,
   stdio: ['ignore', 'pipe', 'pipe'],
+  detached: process.platform !== 'win32',
   windowsHide: true,
 });
 
-updateTask(taskId, { pid: child.pid });
+updateTask(taskId, {
+  pid: child.pid,
+  processGroupId: process.platform === 'win32' ? null : child.pid,
+  terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+});
 
 const silentJsonMode =
   config.outputFormat === 'json' &&
@@ -285,6 +290,8 @@ child.on('close', async (code, signal) => {
   try {
     await updateTask(taskId, {
       status,
+      pid: null,
+      processGroupId: null,
       exitCode: resolvedCode,
       error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
     });
@@ -298,7 +305,12 @@ child.on('error', async (err) => {
   log(`\nError: ${err.message}\n`);
   cleanupCommandSpecSync();
   try {
-    await updateTask(taskId, { status: 'failed', error: err.message });
+    await updateTask(taskId, {
+      status: 'failed',
+      pid: null,
+      processGroupId: null,
+      error: err.message,
+    });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
   }

--- a/tests/fixtures/sigterm-root-with-child.js
+++ b/tests/fixtures/sigterm-root-with-child.js
@@ -1,0 +1,9 @@
+const { spawn } = require('child_process');
+
+const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+  stdio: 'ignore',
+});
+
+process.stdout.write(`${child.pid}\n`);
+process.on('SIGTERM', () => process.exit(0));
+setInterval(() => {}, 1000);

--- a/tests/fixtures/watcher-ownership-runtime.js
+++ b/tests/fixtures/watcher-ownership-runtime.js
@@ -1,0 +1,161 @@
+const { spawn } = require('child_process');
+const { existsSync, mkdirSync, readFileSync } = require('fs');
+const { dirname, resolve } = require('path');
+const { pathToFileURL } = require('url');
+
+const watcherName = process.argv[2];
+const repoRoot = resolve(__dirname, '../..');
+const watcherPath = resolve(repoRoot, 'task-lib', watcherName);
+const providerPath = resolve(__dirname, 'sigterm-root-with-child.js');
+const logFile = resolve(process.env.HOME, '.zeroshot', `${watcherName}.log`);
+const taskId = watcherName === 'attachable-watcher.js' ? 'runtime-a' : 'runtime-w';
+
+const sleep = (ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+
+async function waitFor(predicate, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = predicate();
+    if (result) return result;
+    await sleep(20);
+  }
+  throw new Error(`Timed out waiting for ${watcherName} runtime state`);
+}
+
+function isRunning(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function forceKill(pid) {
+  if (!pid) return;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already stopped.
+  }
+}
+
+async function main() {
+  const storeUrl = pathToFileURL(resolve(repoRoot, 'task-lib/store.js')).href;
+  const killUrl = pathToFileURL(resolve(repoRoot, 'task-lib/commands/kill.js')).href;
+  const { addTask, getTask } = await import(storeUrl);
+  const { killTaskCommand } = await import(killUrl);
+
+  mkdirSync(dirname(logFile), { recursive: true });
+  addTask({
+    id: taskId,
+    prompt: 'runtime ownership proof',
+    fullPrompt: 'runtime ownership proof',
+    cwd: repoRoot,
+    status: 'running',
+    pid: null,
+    logFile,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    provider: 'codex',
+    attachable: watcherName === 'attachable-watcher.js',
+  });
+
+  const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    detached: process.platform !== 'win32',
+    stdio: 'ignore',
+  });
+  const config = {
+    provider: 'codex',
+    outputFormat: 'stream-json',
+    commandSpec: {
+      binary: process.execPath,
+      args: [providerPath],
+      env: {},
+      cleanup: [],
+    },
+  };
+  const watcher = spawn(
+    process.execPath,
+    [watcherPath, taskId, repoRoot, logFile, '[]', JSON.stringify(config)],
+    {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+  let watcherOutput = '';
+  watcher.stdout.on('data', (chunk) => {
+    watcherOutput += chunk;
+  });
+  watcher.stderr.on('data', (chunk) => {
+    watcherOutput += chunk;
+  });
+
+  let providerPid;
+  let descendantPid;
+  try {
+    const persisted = await waitFor(() => {
+      const task = getTask(taskId);
+      if (watcher.exitCode !== null && !task?.pid) {
+        const logOutput = existsSync(logFile) ? readFileSync(logFile, 'utf8') : '';
+        throw new Error(
+          `${watcherName} exited ${watcher.exitCode} before persisting ownership: ${watcherOutput}${logOutput}`
+        );
+      }
+      return task?.pid && task.processGroupId && task.terminationStrategy ? task : null;
+    });
+    providerPid = persisted.pid;
+    assertOwnedMetadata(persisted);
+    descendantPid = await waitFor(() => readDescendantPid(logFile));
+
+    await killTaskCommand(taskId, {
+      graceMs: 100,
+      hardKillWaitMs: 500,
+      pollMs: 10,
+    });
+    await waitFor(() => !isRunning(providerPid) && !isRunning(descendantPid));
+
+    const terminal = getTask(taskId);
+    const result = {
+      watcherName,
+      providerPid,
+      descendantPid,
+      unrelatedAlive: isRunning(unrelated.pid),
+      providerAlive: isRunning(providerPid),
+      descendantAlive: isRunning(descendantPid),
+      persistedStrategy: persisted.terminationStrategy,
+      persistedGroupId: persisted.processGroupId,
+      terminalGroupId: terminal.processGroupId,
+    };
+    process.stdout.write(`RESULT:${JSON.stringify(result)}\n`);
+  } finally {
+    forceKill(watcher.pid);
+    forceKill(providerPid);
+    forceKill(descendantPid);
+    forceKill(unrelated.pid);
+  }
+}
+
+function assertOwnedMetadata(task) {
+  if (process.platform === 'win32') {
+    if (task.processGroupId !== null || task.terminationStrategy !== 'process-tree') {
+      throw new Error(`Invalid Windows ownership metadata: ${JSON.stringify(task)}`);
+    }
+    return;
+  }
+  if (task.processGroupId !== task.pid || task.terminationStrategy !== 'process-group') {
+    throw new Error(`Invalid POSIX ownership metadata: ${JSON.stringify(task)}`);
+  }
+}
+
+function readDescendantPid(path) {
+  if (!existsSync(path)) return null;
+  const match = readFileSync(path, 'utf8').match(/\](\d+)\r?\n/);
+  return match ? Number(match[1]) : null;
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/helpers/isolated-task-recovery-fixture.js
+++ b/tests/helpers/isolated-task-recovery-fixture.js
@@ -1,0 +1,190 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { PassThrough } = require('stream');
+
+const { startLivenessCheck, stopLivenessCheck } = require('../../src/agent/agent-lifecycle');
+const { followClaudeTaskLogsIsolated, killTask } = require('../../src/agent/agent-task-executor');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(5);
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+function createFakeProcess() {
+  return {
+    pid: 9012,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill() {},
+    on() {},
+  };
+}
+
+function createIsolationManager({
+  status = 'running',
+  killCommandFailures = 0,
+  unverifiableKillAttempts = 0,
+} = {}) {
+  const commands = [];
+  let taskStatus = status;
+  let remainingKillCommandFailures = killCommandFailures;
+  let remainingUnverifiableKillAttempts = unverifiableKillAttempts;
+  let activeKillCalls = 0;
+  let pendingStatusFailures = 0;
+  return {
+    commands,
+    killCalls: 0,
+    maxConcurrentKillCalls: 0,
+    setStatus(nextStatus) {
+      taskStatus = nextStatus;
+    },
+    allowTermination() {
+      remainingKillCommandFailures = 0;
+      remainingUnverifiableKillAttempts = 0;
+      pendingStatusFailures = 0;
+    },
+    spawnInContainer() {
+      return createFakeProcess();
+    },
+    async execInContainer(_clusterId, command) {
+      commands.push(command);
+      const commandText = command.join(' ');
+      if (commandText.includes('get-log-path')) {
+        return { code: 0, stdout: '/tmp/provider.log\n', stderr: '' };
+      }
+      if (commandText.includes('kill')) {
+        this.killCalls += 1;
+        activeKillCalls += 1;
+        this.maxConcurrentKillCalls = Math.max(this.maxConcurrentKillCalls, activeKillCalls);
+        try {
+          await sleep(10);
+          if (remainingKillCommandFailures > 0) {
+            remainingKillCommandFailures -= 1;
+            return { code: 1, stdout: '', stderr: 'kill command failed' };
+          }
+          if (remainingUnverifiableKillAttempts > 0) {
+            remainingUnverifiableKillAttempts -= 1;
+            pendingStatusFailures += 1;
+            return { code: 0, stdout: 'kill requested\n', stderr: '' };
+          }
+          taskStatus = 'killed';
+          return { code: 0, stdout: 'killed\n', stderr: '' };
+        } finally {
+          activeKillCalls -= 1;
+        }
+      }
+      if (commandText.includes('status')) {
+        if (pendingStatusFailures > 0) {
+          pendingStatusFailures -= 1;
+          return { code: 1, stdout: '', stderr: 'status verification failed' };
+        }
+        return {
+          code: 0,
+          stdout: `Status: ${taskStatus}\n`,
+          stderr: '',
+        };
+      }
+      if (commandText.includes('cat')) {
+        return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
+      }
+      throw new Error(`Unexpected isolated command: ${command.join(' ')}`);
+    },
+  };
+}
+
+function createIsolatedAgent(manager, overrides = {}) {
+  const events = [];
+  const agent = {
+    id: 'isolated-worker',
+    role: 'implementation',
+    isolation: {
+      enabled: true,
+      manager,
+      clusterId: 'isolated-cluster',
+    },
+    cluster: { id: 'cluster' },
+    config: { cwd: '/tmp/work' },
+    worktree: null,
+    iteration: 1,
+    timeout: 0,
+    staleDuration: 20,
+    enableLivenessCheck: true,
+    currentTask: null,
+    currentTaskId: 'isolated-task',
+    processPid: 9012,
+    lastOutputTime: Date.now(),
+    taskStartedAt: Date.now(),
+    livenessCheckInterval: null,
+    livenessTerminationStarted: false,
+    consecutiveStaleWarnings: 0,
+    messageBus: { publish() {} },
+    _resolveProvider: () => 'codex',
+    _parseResultOutput: () => Promise.resolve({ summary: 'done', result: 'ok' }),
+    _log() {},
+    _publishLifecycle(event, data) {
+      events.push({ event, data });
+    },
+    _stopLivenessCheck() {
+      stopLivenessCheck(this);
+    },
+    _killTask(termination) {
+      return killTask(this, termination);
+    },
+    ...overrides,
+  };
+  return { agent, events };
+}
+
+async function runWatchdogRecovery(overrides, managerOptions = {}) {
+  const manager = createIsolationManager(managerOptions);
+  const { agent, events } = createIsolatedAgent(manager, overrides);
+  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+  await waitFor(() => agent.currentTask);
+  startLivenessCheck(agent);
+  const result = await execution;
+  await sleep(80);
+  stopLivenessCheck(agent);
+
+  return { agent, events, manager, result };
+}
+
+function useZeroBackoffSettings() {
+  let originalSettingsFile;
+  let settingsDir;
+
+  beforeEach(function () {
+    originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-isolated-recovery-'));
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(settingsDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+    );
+  });
+
+  afterEach(function () {
+    if (originalSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+    fs.rmSync(settingsDir, { recursive: true, force: true });
+  });
+}
+
+module.exports = {
+  createIsolatedAgent,
+  createIsolationManager,
+  runWatchdogRecovery,
+  sleep,
+  useZeroBackoffSettings,
+  waitFor,
+};

--- a/tests/helpers/isolated-task-recovery-fixture.js
+++ b/tests/helpers/isolated-task-recovery-fixture.js
@@ -3,7 +3,11 @@ const os = require('os');
 const path = require('path');
 const { PassThrough } = require('stream');
 
-const { startLivenessCheck, stopLivenessCheck } = require('../../src/agent/agent-lifecycle');
+const {
+  executeTask,
+  startLivenessCheck,
+  stopLivenessCheck,
+} = require('../../src/agent/agent-lifecycle');
 const { followClaudeTaskLogsIsolated, killTask } = require('../../src/agent/agent-task-executor');
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -31,6 +35,7 @@ function createIsolationManager({
   status = 'running',
   killCommandFailures = 0,
   unverifiableKillAttempts = 0,
+  terminalStatusOnKill = null,
 } = {}) {
   const commands = [];
   let taskStatus = status;
@@ -73,6 +78,14 @@ function createIsolationManager({
             remainingUnverifiableKillAttempts -= 1;
             pendingStatusFailures += 1;
             return { code: 0, stdout: 'kill requested\n', stderr: '' };
+          }
+          if (terminalStatusOnKill) {
+            taskStatus = terminalStatusOnKill;
+            return {
+              code: 0,
+              stdout: `Task is not running (status: ${terminalStatusOnKill})\n`,
+              stderr: '',
+            };
           }
           taskStatus = 'killed';
           return { code: 0, stdout: 'killed\n', stderr: '' };
@@ -156,6 +169,40 @@ async function runWatchdogRecovery(overrides, managerOptions = {}) {
   return { agent, events, manager, result };
 }
 
+async function runLifecycleRecovery(managerOptions = {}) {
+  const manager = createIsolationManager(managerOptions);
+  const { agent, events } = createIsolatedAgent(manager, {
+    config: { cwd: '/tmp/work', hooks: {}, maxRetries: 3 },
+    currentTaskId: null,
+    iteration: 0,
+    maxIterations: 10,
+    running: true,
+    state: 'idle',
+    testMode: true,
+    quiet: true,
+    messageBus: { publish() {}, query: () => [] },
+    _buildContext: () => 'task context',
+    _selectModel: () => 'test-model',
+    _resolveModelSpec: () => null,
+  });
+  const published = [];
+  let spawnCalls = 0;
+  agent._publish = (message) => published.push(message);
+  agent._spawnClaudeTask = async function () {
+    spawnCalls += 1;
+    this.currentTaskId = `isolated-task-${spawnCalls}`;
+    this.lastOutputTime = Date.now() - 100;
+    this.taskStartedAt = Date.now() - 100;
+    const execution = followClaudeTaskLogsIsolated(this, this.currentTaskId);
+    await waitFor(() => this.currentTask);
+    startLivenessCheck(this);
+    return execution;
+  };
+
+  await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
+  return { agent, events, manager, published, spawnCalls };
+}
+
 function useZeroBackoffSettings() {
   let originalSettingsFile;
   let settingsDir;
@@ -183,6 +230,7 @@ function useZeroBackoffSettings() {
 module.exports = {
   createIsolatedAgent,
   createIsolationManager,
+  runLifecycleRecovery,
   runWatchdogRecovery,
   sleep,
   useZeroBackoffSettings,

--- a/tests/isolated-task-recovery.test.js
+++ b/tests/isolated-task-recovery.test.js
@@ -1,152 +1,18 @@
 const assert = require('assert');
-const { PassThrough } = require('stream');
 
 const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
-const { followClaudeTaskLogsIsolated, killTask } = require('../src/agent/agent-task-executor');
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function waitFor(predicate, timeoutMs = 1000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await sleep(5);
-  }
-  throw new Error('Timed out waiting for condition');
-}
-
-function createFakeProcess() {
-  return {
-    pid: 9012,
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
-    kill() {},
-    on() {},
-  };
-}
-
-function createIsolationManager({
-  status = 'running',
-  killCommandFailures = 0,
-  unverifiableKillAttempts = 0,
-} = {}) {
-  const commands = [];
-  let taskStatus = status;
-  let activeKillCalls = 0;
-  let pendingStatusFailures = 0;
-  return {
-    commands,
-    killCalls: 0,
-    maxConcurrentKillCalls: 0,
-    setStatus(nextStatus) {
-      taskStatus = nextStatus;
-    },
-    spawnInContainer() {
-      return createFakeProcess();
-    },
-    async execInContainer(_clusterId, command) {
-      commands.push(command);
-      const commandText = command.join(' ');
-      if (commandText.includes('get-log-path')) {
-        return { code: 0, stdout: '/tmp/provider.log\n', stderr: '' };
-      }
-      if (commandText.includes('kill')) {
-        this.killCalls += 1;
-        activeKillCalls += 1;
-        this.maxConcurrentKillCalls = Math.max(this.maxConcurrentKillCalls, activeKillCalls);
-        try {
-          await sleep(10);
-          if (this.killCalls <= killCommandFailures) {
-            return { code: 1, stdout: '', stderr: 'kill command failed' };
-          }
-          if (this.killCalls <= killCommandFailures + unverifiableKillAttempts) {
-            pendingStatusFailures += 1;
-            return { code: 0, stdout: 'kill requested\n', stderr: '' };
-          }
-          taskStatus = 'killed';
-          return { code: 0, stdout: 'killed\n', stderr: '' };
-        } finally {
-          activeKillCalls -= 1;
-        }
-      }
-      if (commandText.includes('status')) {
-        if (pendingStatusFailures > 0) {
-          pendingStatusFailures -= 1;
-          return { code: 1, stdout: '', stderr: 'status verification failed' };
-        }
-        return {
-          code: 0,
-          stdout: `Status: ${taskStatus}\n`,
-          stderr: '',
-        };
-      }
-      if (commandText.includes('cat')) {
-        return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
-      }
-      throw new Error(`Unexpected isolated command: ${command.join(' ')}`);
-    },
-  };
-}
-
-function createIsolatedAgent(manager, overrides = {}) {
-  const events = [];
-  const agent = {
-    id: 'isolated-worker',
-    role: 'implementation',
-    isolation: {
-      enabled: true,
-      manager,
-      clusterId: 'isolated-cluster',
-    },
-    cluster: { id: 'cluster' },
-    config: { cwd: '/tmp/work' },
-    worktree: null,
-    iteration: 1,
-    timeout: 0,
-    staleDuration: 20,
-    enableLivenessCheck: true,
-    currentTask: null,
-    currentTaskId: 'isolated-task',
-    processPid: 9012,
-    lastOutputTime: Date.now(),
-    taskStartedAt: Date.now(),
-    livenessCheckInterval: null,
-    livenessTerminationStarted: false,
-    consecutiveStaleWarnings: 0,
-    messageBus: { publish() {} },
-    _resolveProvider: () => 'codex',
-    _parseResultOutput: () => Promise.resolve({ summary: 'done', result: 'ok' }),
-    _log() {},
-    _publishLifecycle(event, data) {
-      events.push({ event, data });
-    },
-    _stopLivenessCheck() {
-      stopLivenessCheck(this);
-    },
-    _killTask(termination) {
-      return killTask(this, termination);
-    },
-    ...overrides,
-  };
-  return { agent, events };
-}
-
-async function runWatchdogRecovery(overrides, managerOptions = {}) {
-  const manager = createIsolationManager(managerOptions);
-  const { agent, events } = createIsolatedAgent(manager, overrides);
-  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
-
-  await waitFor(() => agent.currentTask);
-  startLivenessCheck(agent);
-  const result = await execution;
-  await sleep(80);
-  stopLivenessCheck(agent);
-
-  return { agent, events, manager, result };
-}
+const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
+const {
+  createIsolatedAgent,
+  createIsolationManager,
+  runWatchdogRecovery,
+  useZeroBackoffSettings,
+  waitFor,
+} = require('./helpers/isolated-task-recovery-fixture');
 
 describe('Isolated task recovery', function () {
   this.timeout(7000);
+  useZeroBackoffSettings();
 
   it('terminates a stale task inside its container exactly once', async function () {
     const recovered = await runWatchdogRecovery({
@@ -215,6 +81,11 @@ describe('Isolated task recovery', function () {
     assert.strictEqual(recovered.agent.currentTask, null);
     assert.strictEqual(recovered.agent.currentTaskId, null);
   });
+});
+
+describe('Isolated task lifecycle handles', function () {
+  this.timeout(7000);
+  useZeroBackoffSettings();
 
   it('does not ignore a tracked isolated task while its local handle is briefly absent', async function () {
     const manager = createIsolationManager();

--- a/tests/isolated-task-recovery.test.js
+++ b/tests/isolated-task-recovery.test.js
@@ -25,12 +25,19 @@ function createFakeProcess() {
   };
 }
 
-function createIsolationManager({ status = 'running' } = {}) {
+function createIsolationManager({
+  status = 'running',
+  killCommandFailures = 0,
+  unverifiableKillAttempts = 0,
+} = {}) {
   const commands = [];
   let taskStatus = status;
+  let activeKillCalls = 0;
+  let pendingStatusFailures = 0;
   return {
     commands,
     killCalls: 0,
+    maxConcurrentKillCalls: 0,
     setStatus(nextStatus) {
       taskStatus = nextStatus;
     },
@@ -45,11 +52,28 @@ function createIsolationManager({ status = 'running' } = {}) {
       }
       if (commandText.includes('kill')) {
         this.killCalls += 1;
-        taskStatus = 'killed';
-        await sleep(10);
-        return { code: 0, stdout: 'killed\n', stderr: '' };
+        activeKillCalls += 1;
+        this.maxConcurrentKillCalls = Math.max(this.maxConcurrentKillCalls, activeKillCalls);
+        try {
+          await sleep(10);
+          if (this.killCalls <= killCommandFailures) {
+            return { code: 1, stdout: '', stderr: 'kill command failed' };
+          }
+          if (this.killCalls <= killCommandFailures + unverifiableKillAttempts) {
+            pendingStatusFailures += 1;
+            return { code: 0, stdout: 'kill requested\n', stderr: '' };
+          }
+          taskStatus = 'killed';
+          return { code: 0, stdout: 'killed\n', stderr: '' };
+        } finally {
+          activeKillCalls -= 1;
+        }
       }
       if (commandText.includes('status')) {
+        if (pendingStatusFailures > 0) {
+          pendingStatusFailures -= 1;
+          return { code: 1, stdout: '', stderr: 'status verification failed' };
+        }
         return {
           code: 0,
           stdout: `Status: ${taskStatus}\n`,
@@ -107,8 +131,8 @@ function createIsolatedAgent(manager, overrides = {}) {
   return { agent, events };
 }
 
-async function runWatchdogRecovery(overrides) {
-  const manager = createIsolationManager();
+async function runWatchdogRecovery(overrides, managerOptions = {}) {
+  const manager = createIsolationManager(managerOptions);
   const { agent, events } = createIsolatedAgent(manager, overrides);
   const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
 
@@ -158,6 +182,38 @@ describe('Isolated task recovery', function () {
       recovered.events.some(({ event }) => event === 'AGENT_TASK_TIMEOUT'),
       'durable absolute-timeout recovery event should be emitted'
     );
+  });
+
+  it('re-arms lifecycle recovery after an in-container kill command fails', async function () {
+    const recovered = await runWatchdogRecovery(
+      {
+        lastOutputTime: Date.now() - 100,
+        taskStartedAt: Date.now() - 100,
+      },
+      { killCommandFailures: 1 }
+    );
+
+    assert.strictEqual(recovered.manager.killCalls, 2);
+    assert.strictEqual(recovered.manager.maxConcurrentKillCalls, 1);
+    assert.strictEqual(recovered.result.success, false);
+    assert.strictEqual(recovered.agent.currentTask, null);
+    assert.strictEqual(recovered.agent.currentTaskId, null);
+  });
+
+  it('re-arms lifecycle recovery when kill status cannot be verified', async function () {
+    const recovered = await runWatchdogRecovery(
+      {
+        lastOutputTime: Date.now() - 100,
+        taskStartedAt: Date.now() - 100,
+      },
+      { unverifiableKillAttempts: 1 }
+    );
+
+    assert.strictEqual(recovered.manager.killCalls, 2);
+    assert.strictEqual(recovered.manager.maxConcurrentKillCalls, 1);
+    assert.strictEqual(recovered.result.success, false);
+    assert.strictEqual(recovered.agent.currentTask, null);
+    assert.strictEqual(recovered.agent.currentTaskId, null);
   });
 
   it('does not ignore a tracked isolated task while its local handle is briefly absent', async function () {

--- a/tests/isolated-task-recovery.test.js
+++ b/tests/isolated-task-recovery.test.js
@@ -1,0 +1,224 @@
+const assert = require('assert');
+const { PassThrough } = require('stream');
+
+const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
+const { followClaudeTaskLogsIsolated, killTask } = require('../src/agent/agent-task-executor');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await sleep(5);
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+function createFakeProcess() {
+  return {
+    pid: 9012,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill() {},
+    on() {},
+  };
+}
+
+function createIsolationManager({ status = 'running' } = {}) {
+  const commands = [];
+  let taskStatus = status;
+  return {
+    commands,
+    killCalls: 0,
+    setStatus(nextStatus) {
+      taskStatus = nextStatus;
+    },
+    spawnInContainer() {
+      return createFakeProcess();
+    },
+    async execInContainer(_clusterId, command) {
+      commands.push(command);
+      const commandText = command.join(' ');
+      if (commandText.includes('get-log-path')) {
+        return { code: 0, stdout: '/tmp/provider.log\n', stderr: '' };
+      }
+      if (commandText.includes('kill')) {
+        this.killCalls += 1;
+        taskStatus = 'killed';
+        await sleep(10);
+        return { code: 0, stdout: 'killed\n', stderr: '' };
+      }
+      if (commandText.includes('status')) {
+        return {
+          code: 0,
+          stdout: `Status: ${taskStatus}\n`,
+          stderr: '',
+        };
+      }
+      if (commandText.includes('cat')) {
+        return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
+      }
+      throw new Error(`Unexpected isolated command: ${command.join(' ')}`);
+    },
+  };
+}
+
+function createIsolatedAgent(manager, overrides = {}) {
+  const events = [];
+  const agent = {
+    id: 'isolated-worker',
+    role: 'implementation',
+    isolation: {
+      enabled: true,
+      manager,
+      clusterId: 'isolated-cluster',
+    },
+    cluster: { id: 'cluster' },
+    config: { cwd: '/tmp/work' },
+    worktree: null,
+    iteration: 1,
+    timeout: 0,
+    staleDuration: 20,
+    enableLivenessCheck: true,
+    currentTask: null,
+    currentTaskId: 'isolated-task',
+    processPid: 9012,
+    lastOutputTime: Date.now(),
+    taskStartedAt: Date.now(),
+    livenessCheckInterval: null,
+    livenessTerminationStarted: false,
+    consecutiveStaleWarnings: 0,
+    messageBus: { publish() {} },
+    _resolveProvider: () => 'codex',
+    _parseResultOutput: () => Promise.resolve({ summary: 'done', result: 'ok' }),
+    _log() {},
+    _publishLifecycle(event, data) {
+      events.push({ event, data });
+    },
+    _stopLivenessCheck() {
+      stopLivenessCheck(this);
+    },
+    _killTask(termination) {
+      return killTask(this, termination);
+    },
+    ...overrides,
+  };
+  return { agent, events };
+}
+
+async function runWatchdogRecovery(overrides) {
+  const manager = createIsolationManager();
+  const { agent, events } = createIsolatedAgent(manager, overrides);
+  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+  await waitFor(() => agent.currentTask);
+  startLivenessCheck(agent);
+  const result = await execution;
+  await sleep(80);
+  stopLivenessCheck(agent);
+
+  return { agent, events, manager, result };
+}
+
+describe('Isolated task recovery', function () {
+  this.timeout(7000);
+
+  it('terminates a stale task inside its container exactly once', async function () {
+    const recovered = await runWatchdogRecovery({
+      lastOutputTime: Date.now() - 100,
+      taskStartedAt: Date.now() - 100,
+    });
+
+    assert.strictEqual(recovered.manager.killCalls, 1);
+    assert.strictEqual(recovered.result.success, false);
+    assert.strictEqual(recovered.result.code, 'PROVIDER_INACTIVITY_TIMEOUT');
+    assert.strictEqual(recovered.agent.currentTask, null);
+    assert.strictEqual(recovered.agent.currentTaskId, null);
+    assert.ok(
+      recovered.events.some(({ event }) => event === 'AGENT_INACTIVITY_TIMEOUT'),
+      'durable inactivity recovery event should be emitted'
+    );
+  });
+
+  it('terminates an absolute-timeout task inside its container exactly once', async function () {
+    const recovered = await runWatchdogRecovery({
+      timeout: 30,
+      staleDuration: 1000,
+      lastOutputTime: Date.now(),
+      taskStartedAt: Date.now() - 100,
+    });
+
+    assert.strictEqual(recovered.manager.killCalls, 1);
+    assert.strictEqual(recovered.result.success, false);
+    assert.strictEqual(recovered.result.code, 'AGENT_TASK_TIMEOUT');
+    assert.strictEqual(recovered.agent.currentTask, null);
+    assert.strictEqual(recovered.agent.currentTaskId, null);
+    assert.ok(
+      recovered.events.some(({ event }) => event === 'AGENT_TASK_TIMEOUT'),
+      'durable absolute-timeout recovery event should be emitted'
+    );
+  });
+
+  it('does not ignore a tracked isolated task while its local handle is briefly absent', async function () {
+    const manager = createIsolationManager();
+    const { agent, events } = createIsolatedAgent(manager, {
+      currentTask: null,
+      lastOutputTime: Date.now() - 100,
+      taskStartedAt: Date.now() - 100,
+    });
+    let termination = null;
+    agent._killTask = (reason) => {
+      termination = reason;
+      agent.currentTaskId = null;
+    };
+
+    startLivenessCheck(agent);
+    await waitFor(() => termination);
+    stopLivenessCheck(agent);
+
+    assert.strictEqual(termination.code, 'PROVIDER_INACTIVITY_TIMEOUT');
+    assert.ok(events.some(({ event }) => event === 'AGENT_INACTIVITY_TIMEOUT'));
+  });
+
+  it('does not kill or retry a task that completed before recovery reconciliation', async function () {
+    const manager = createIsolationManager({ status: 'completed' });
+    const { agent } = createIsolatedAgent(manager, {
+      lastOutputTime: Date.now() - 100,
+      taskStartedAt: Date.now() - 100,
+    });
+    const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+    await waitFor(() => agent.currentTask);
+    startLivenessCheck(agent);
+    const result = await execution;
+    stopLivenessCheck(agent);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(manager.killCalls, 0);
+    assert.strictEqual(agent.currentTask, null);
+  });
+
+  it('clears the lifecycle handle on normal isolated completion without recovery', async function () {
+    const manager = createIsolationManager({ status: 'completed' });
+    const { agent } = createIsolatedAgent(manager);
+    const result = await followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(manager.killCalls, 0);
+    assert.strictEqual(agent.currentTask, null);
+  });
+
+  it('clears the lifecycle handle when isolated log setup fails', async function () {
+    const manager = createIsolationManager();
+    manager.execInContainer = () =>
+      Promise.resolve({ code: 1, stdout: '', stderr: 'log lookup failed' });
+    const { agent } = createIsolatedAgent(manager);
+
+    await assert.rejects(
+      followClaudeTaskLogsIsolated(agent, agent.currentTaskId),
+      /log lookup failed/
+    );
+    assert.strictEqual(agent.currentTask, null);
+  });
+});

--- a/tests/isolated-task-recovery.test.js
+++ b/tests/isolated-task-recovery.test.js
@@ -5,10 +5,15 @@ const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-execut
 const {
   createIsolatedAgent,
   createIsolationManager,
+  runLifecycleRecovery,
   runWatchdogRecovery,
   useZeroBackoffSettings,
   waitFor,
 } = require('./helpers/isolated-task-recovery-fixture');
+
+function countLifecycleEvents(events, expectedEvent) {
+  return events.filter(({ event }) => event === expectedEvent).length;
+}
 
 describe('Isolated task recovery', function () {
   this.timeout(7000);
@@ -148,4 +153,62 @@ describe('Isolated task lifecycle handles', function () {
     );
     assert.strictEqual(agent.currentTask, null);
   });
+});
+
+describe('Isolated task termination reconciliation', function () {
+  this.timeout(7000);
+  useZeroBackoffSettings();
+
+  it('preserves a natural completion that wins the in-container kill race', async function () {
+    const recovered = await runWatchdogRecovery(
+      {
+        lastOutputTime: Date.now() - 100,
+        taskStartedAt: Date.now() - 100,
+      },
+      { terminalStatusOnKill: 'completed' }
+    );
+
+    assert.deepStrictEqual(
+      {
+        killCalls: recovered.manager.killCalls,
+        success: recovered.result.success,
+        code: recovered.result.code,
+        timeoutEvents: countLifecycleEvents(recovered.events, 'AGENT_INACTIVITY_TIMEOUT'),
+      },
+      { killCalls: 1, success: true, code: undefined, timeoutEvents: 0 }
+    );
+  });
+
+  it('does not start a replacement provider after natural completion wins the kill race', async function () {
+    const recovered = await runLifecycleRecovery({ terminalStatusOnKill: 'completed' });
+
+    assert.deepStrictEqual(
+      {
+        spawnCalls: recovered.spawnCalls,
+        killCalls: recovered.manager.killCalls,
+        timeoutEvents: countLifecycleEvents(recovered.events, 'AGENT_INACTIVITY_TIMEOUT'),
+        completions: countLifecycleEvents(recovered.events, 'TASK_COMPLETED'),
+        restarts: countLifecycleEvents(recovered.events, 'AGENT_RESTART_ATTEMPT'),
+      },
+      { spawnCalls: 1, killCalls: 1, timeoutEvents: 0, completions: 1, restarts: 0 }
+    );
+  });
+
+  for (const terminalStatus of ['failed', 'cancelled']) {
+    it(`preserves natural ${terminalStatus} semantics when it wins the kill race`, async function () {
+      const recovered = await runWatchdogRecovery(
+        {
+          lastOutputTime: Date.now() - 100,
+          taskStartedAt: Date.now() - 100,
+        },
+        { terminalStatusOnKill: terminalStatus }
+      );
+
+      assert.strictEqual(recovered.manager.killCalls, 1);
+      assert.strictEqual(recovered.result.success, false);
+      assert.strictEqual(recovered.result.code, undefined);
+      assert.doesNotMatch(recovered.result.error, /produced no output for \d+ms/);
+      assert.strictEqual(countLifecycleEvents(recovered.events, 'AGENT_INACTIVITY_TIMEOUT'), 0);
+    });
+  }
 });

--- a/tests/isolated-task-termination-exhaustion.test.js
+++ b/tests/isolated-task-termination-exhaustion.test.js
@@ -1,0 +1,149 @@
+const assert = require('assert');
+
+const {
+  executeTask,
+  startLivenessCheck,
+  stopLivenessCheck,
+} = require('../src/agent/agent-lifecycle');
+const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
+const {
+  createIsolatedAgent,
+  createIsolationManager,
+  sleep,
+  useZeroBackoffSettings,
+  waitFor,
+} = require('./helpers/isolated-task-recovery-fixture');
+
+async function runPermanentWatchdogFailure(managerOptions) {
+  const manager = createIsolationManager(managerOptions);
+  const { agent, events } = createIsolatedAgent(manager, {
+    lastOutputTime: Date.now() - 100,
+    taskStartedAt: Date.now() - 100,
+  });
+  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+  await waitFor(() => agent.currentTask);
+  startLivenessCheck(agent);
+  const outcome = await Promise.race([
+    execution.then(
+      (result) => ({ result }),
+      (error) => ({ error })
+    ),
+    sleep(300).then(() => ({ timedOut: true })),
+  ]);
+  const observed = {
+    agent,
+    events,
+    manager,
+    outcome,
+    killCalls: manager.killCalls,
+    stillMonitored: Boolean(agent.livenessCheckInterval),
+  };
+
+  if (outcome.timedOut) {
+    stopLivenessCheck(agent);
+    manager.allowTermination();
+    await agent.currentTask?.terminate('test cleanup');
+    await execution;
+  }
+
+  return observed;
+}
+
+async function runPermanentLifecycleFailure(managerOptions) {
+  const manager = createIsolationManager(managerOptions);
+  const { agent, events } = createIsolatedAgent(manager, {
+    config: { cwd: '/tmp/work', hooks: {}, maxRetries: 3 },
+    currentTaskId: null,
+    iteration: 0,
+    maxIterations: 10,
+    running: true,
+    state: 'idle',
+    testMode: true,
+    quiet: true,
+    _buildContext: () => 'task context',
+    _selectModel: () => 'test-model',
+    _resolveModelSpec: () => null,
+  });
+  const published = [];
+  let spawnCalls = 0;
+  agent._publish = (message) => published.push(message);
+  agent._spawnClaudeTask = async function () {
+    spawnCalls += 1;
+    this.currentTaskId = `isolated-task-${spawnCalls}`;
+    this.lastOutputTime = Date.now() - 100;
+    this.taskStartedAt = Date.now() - 100;
+    const execution = followClaudeTaskLogsIsolated(this, this.currentTaskId);
+    await waitFor(() => this.currentTask);
+    startLivenessCheck(this);
+    return execution;
+  };
+
+  await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
+  return { agent, events, manager, published, spawnCalls };
+}
+
+describe('Bounded isolated task recovery', function () {
+  this.timeout(7000);
+  useZeroBackoffSettings();
+
+  const permanentFailures = [
+    ['kill command failure', { killCommandFailures: Infinity }],
+    ['status verification failure', { unverifiableKillAttempts: Infinity }],
+  ];
+
+  for (const [label, managerOptions] of permanentFailures) {
+    it(`fails closed after bounded ${label} attempts`, async function () {
+      const recovered = await runPermanentWatchdogFailure(managerOptions);
+
+      assert.strictEqual(recovered.outcome.timedOut, undefined);
+      assert.strictEqual(recovered.outcome.error?.code, 'ISOLATED_TASK_TERMINATION_EXHAUSTED');
+      assert.strictEqual(recovered.outcome.error?.permanent, true);
+      assert.strictEqual(recovered.killCalls, 3);
+      assert.strictEqual(recovered.manager.maxConcurrentKillCalls, 1);
+      assert.strictEqual(recovered.stillMonitored, false);
+      assert.strictEqual(recovered.agent.currentTask, null);
+      assert.strictEqual(recovered.agent.currentTaskId, 'isolated-task');
+      assert.strictEqual(recovered.agent.state, 'error');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.type, 'task_termination');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.reason, 'termination_unverified');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.attempts, 3);
+      assert.strictEqual(
+        recovered.events.filter(({ event }) => event === 'AGENT_INACTIVITY_TIMEOUT').length,
+        1
+      );
+      assert.strictEqual(
+        recovered.events.filter(({ event }) => event === 'AGENT_TERMINATION_RETRY').length,
+        2
+      );
+      assert.strictEqual(
+        recovered.events.filter(({ event }) => event === 'AGENT_TERMINATION_EXHAUSTED').length,
+        1
+      );
+
+      await sleep(50);
+      assert.strictEqual(recovered.manager.killCalls, 3);
+    });
+
+    it(`does not retry the provider after permanent ${label}`, async function () {
+      const recovered = await runPermanentLifecycleFailure(managerOptions);
+      const agentErrors = recovered.published.filter(({ topic }) => topic === 'AGENT_ERROR');
+      const clusterFailures = recovered.published.filter(({ topic }) => topic === 'CLUSTER_FAILED');
+
+      assert.strictEqual(recovered.spawnCalls, 1);
+      assert.strictEqual(recovered.manager.killCalls, 3);
+      assert.strictEqual(recovered.manager.maxConcurrentKillCalls, 1);
+      assert.strictEqual(recovered.agent.state, 'error');
+      assert.strictEqual(recovered.agent.currentTaskId, 'isolated-task-1');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.type, 'task_termination');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.reason, 'termination_unverified');
+      assert.strictEqual(recovered.agent.cluster.failureInfo.attempts, 3);
+      assert.strictEqual(agentErrors.length, 1);
+      assert.strictEqual(agentErrors[0].content.data.terminationExhausted, true);
+      assert.strictEqual(agentErrors[0].content.data.restartExhausted, true);
+      assert.strictEqual(agentErrors[0].content.data.attempts, 3);
+      assert.strictEqual(clusterFailures.length, 1);
+      assert.strictEqual(clusterFailures[0].content.data.reason, 'task_termination_unverified');
+    });
+  }
+});

--- a/tests/isolated-task-termination-exhaustion.test.js
+++ b/tests/isolated-task-termination-exhaustion.test.js
@@ -1,14 +1,11 @@
 const assert = require('assert');
 
-const {
-  executeTask,
-  startLivenessCheck,
-  stopLivenessCheck,
-} = require('../src/agent/agent-lifecycle');
+const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
 const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
 const {
   createIsolatedAgent,
   createIsolationManager,
+  runLifecycleRecovery,
   sleep,
   useZeroBackoffSettings,
   waitFor,
@@ -48,39 +45,6 @@ async function runPermanentWatchdogFailure(managerOptions) {
   }
 
   return observed;
-}
-
-async function runPermanentLifecycleFailure(managerOptions) {
-  const manager = createIsolationManager(managerOptions);
-  const { agent, events } = createIsolatedAgent(manager, {
-    config: { cwd: '/tmp/work', hooks: {}, maxRetries: 3 },
-    currentTaskId: null,
-    iteration: 0,
-    maxIterations: 10,
-    running: true,
-    state: 'idle',
-    testMode: true,
-    quiet: true,
-    _buildContext: () => 'task context',
-    _selectModel: () => 'test-model',
-    _resolveModelSpec: () => null,
-  });
-  const published = [];
-  let spawnCalls = 0;
-  agent._publish = (message) => published.push(message);
-  agent._spawnClaudeTask = async function () {
-    spawnCalls += 1;
-    this.currentTaskId = `isolated-task-${spawnCalls}`;
-    this.lastOutputTime = Date.now() - 100;
-    this.taskStartedAt = Date.now() - 100;
-    const execution = followClaudeTaskLogsIsolated(this, this.currentTaskId);
-    await waitFor(() => this.currentTask);
-    startLivenessCheck(this);
-    return execution;
-  };
-
-  await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
-  return { agent, events, manager, published, spawnCalls };
 }
 
 describe('Bounded isolated task recovery', function () {
@@ -126,7 +90,7 @@ describe('Bounded isolated task recovery', function () {
     });
 
     it(`does not retry the provider after permanent ${label}`, async function () {
-      const recovered = await runPermanentLifecycleFailure(managerOptions);
+      const recovered = await runLifecycleRecovery(managerOptions);
       const agentErrors = recovered.published.filter(({ topic }) => topic === 'AGENT_ERROR');
       const clusterFailures = recovered.published.filter(({ topic }) => topic === 'CLUSTER_FAILED');
 

--- a/tests/task-termination-recovery.test.js
+++ b/tests/task-termination-recovery.test.js
@@ -11,6 +11,48 @@ const execFileAsync = promisify(execFile);
 describe('Task termination recovery', function () {
   this.timeout(10000);
 
+  it('terminates the exact owned provider process group including descendants', async function () {
+    const { isProcessRunning, terminateProcess } = await import('../task-lib/runner.js');
+    const root = spawn(
+      process.execPath,
+      [path.resolve(__dirname, 'fixtures/sigterm-root-with-child.js')],
+      {
+        detached: process.platform !== 'win32',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }
+    );
+    const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      detached: process.platform !== 'win32',
+      stdio: 'ignore',
+    });
+    const childPid = Number(
+      String(await new Promise((resolve) => root.stdout.once('data', resolve))).trim()
+    );
+
+    try {
+      const result = await terminateProcess(root.pid, {
+        processGroupId: process.platform === 'win32' ? null : root.pid,
+        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+        graceMs: 200,
+        hardKillWaitMs: 500,
+        pollMs: 10,
+      });
+
+      assert.strictEqual(result.terminated, true);
+      assert.strictEqual(isProcessRunning(root.pid), false);
+      assert.strictEqual(isProcessRunning(childPid), false);
+      assert.strictEqual(isProcessRunning(unrelated.pid), true);
+    } finally {
+      for (const pid of [root.pid, childPid, unrelated.pid]) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Already terminated.
+        }
+      }
+    }
+  });
+
   it('escalates graceful provider termination to a hard kill', async function () {
     const { terminateProcess } = await import('../task-lib/runner.js');
     const child = spawn(
@@ -44,12 +86,21 @@ describe('Task termination recovery', function () {
         sessionId: null, logFile: null, createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(), exitCode: null, error: null,
         provider: 'codex', model: 'fake', scheduleId: null, socketPath: null,
-        attachable: false
+        attachable: false, processGroupId: null, terminationStrategy: null
       };
       const child = spawn(process.execPath, [${JSON.stringify(resistantScript)}],
-        { stdio: ['ignore', 'pipe', 'ignore'] });
+        {
+          detached: process.platform !== 'win32',
+          stdio: ['ignore', 'pipe', 'ignore']
+        });
       await new Promise((resolve) => child.stdout.once('data', resolve));
-      addTask({ ...base, id: 'live-task', pid: child.pid });
+      addTask({
+        ...base,
+        id: 'live-task',
+        pid: child.pid,
+        processGroupId: process.platform === 'win32' ? null : child.pid,
+        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group'
+      });
       await killTaskCommand('live-task', { graceMs: 40, pollMs: 5 });
       addTask({ ...base, id: 'dead-task', pid: 99999999 });
       await killTaskCommand('dead-task', { graceMs: 40, pollMs: 5 });
@@ -75,8 +126,14 @@ describe('Task termination recovery', function () {
       const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
       const terminal = JSON.parse(line.slice('RESULT:'.length));
       assert.deepStrictEqual(
-        [terminal.live.status, terminal.live.pid, terminal.dead.status, terminal.dead.pid],
-        ['killed', null, 'stale', null]
+        [
+          terminal.live.status,
+          terminal.live.pid,
+          terminal.live.processGroupId,
+          terminal.dead.status,
+          terminal.dead.pid,
+        ],
+        ['killed', null, null, 'stale', null]
       );
       assert.match(terminal.live.error, /SIGKILL/);
     } finally {

--- a/tests/task-termination-recovery.test.js
+++ b/tests/task-termination-recovery.test.js
@@ -3,13 +3,13 @@ const { execFile, spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { URL } = require('url');
+const { URL, pathToFileURL } = require('url');
 const { promisify } = require('util');
 
 const execFileAsync = promisify(execFile);
 
 describe('Task termination recovery', function () {
-  this.timeout(10000);
+  this.timeout(40000);
 
   it('terminates the exact owned provider process group including descendants', async function () {
     const { isProcessRunning, terminateProcess } = await import('../task-lib/runner.js');
@@ -138,6 +138,139 @@ describe('Task termination recovery', function () {
       assert.match(terminal.live.error, /SIGKILL/);
     } finally {
       fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Task ownership persistence and runtime wiring', function () {
+  this.timeout(40000);
+
+  it('round-trips owned process metadata through addTask', async function () {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-ownership-store-'));
+    const storeUrl = pathToFileURL(path.resolve(__dirname, '../task-lib/store.js')).href;
+    const script = `
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      addTask({
+        id: 'owned-task',
+        status: 'running',
+        pid: 4242,
+        processGroupId: 4242,
+        terminationStrategy: 'process-group'
+      });
+      const task = getTask('owned-task');
+      process.stdout.write(JSON.stringify({
+        processGroupId: task.processGroupId,
+        terminationStrategy: task.terminationStrategy
+      }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+      assert.deepStrictEqual(JSON.parse(stdout), {
+        processGroupId: 4242,
+        terminationStrategy: 'process-group',
+      });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  for (const watcherName of ['watcher.js', 'attachable-watcher.js']) {
+    it(`persists ${watcherName} ownership and kills its provider descendants`, async function () {
+      const shortTmp = process.platform === 'win32' ? os.tmpdir() : '/tmp';
+      const tempHome = fs.mkdtempSync(path.join(shortTmp, 'zsw-'));
+      const fixture = path.resolve(__dirname, 'fixtures/watcher-ownership-runtime.js');
+      try {
+        const { stdout } = await execFileAsync(process.execPath, [fixture, watcherName], {
+          env: { ...process.env, HOME: tempHome },
+          timeout: 30000,
+        });
+        const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+        const result = JSON.parse(line.slice('RESULT:'.length));
+        assert.strictEqual(result.providerAlive, false);
+        assert.strictEqual(result.descendantAlive, false);
+        assert.strictEqual(result.unrelatedAlive, true);
+        assert.strictEqual(result.terminalGroupId, null);
+        assert.strictEqual(
+          result.persistedStrategy,
+          process.platform === 'win32' ? 'process-tree' : 'process-group'
+        );
+        if (process.platform !== 'win32') {
+          assert.strictEqual(result.persistedGroupId, result.providerPid);
+        }
+      } finally {
+        fs.rmSync(tempHome, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it('fails closed instead of crashing on corrupt ownership metadata', async function () {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-corrupt-ownership-'));
+    const storeUrl = pathToFileURL(path.resolve(__dirname, '../task-lib/store.js')).href;
+    const killUrl = pathToFileURL(path.resolve(__dirname, '../task-lib/commands/kill.js')).href;
+    const statusUrl = pathToFileURL(path.resolve(__dirname, '../task-lib/commands/status.js')).href;
+    const script = `
+      import { spawn } from 'child_process';
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      const { showStatus } = await import(${JSON.stringify(statusUrl)});
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+        stdio: 'ignore'
+      });
+      addTask({
+        id: 'corrupt-task',
+        status: 'running',
+        pid: child.pid,
+        processGroupId: child.pid + 1,
+        terminationStrategy: 'process-group'
+      });
+      let statusThrew = false;
+      let killThrew = false;
+      try { showStatus('corrupt-task'); } catch { statusThrew = true; }
+      try { await killTaskCommand('corrupt-task'); } catch { killThrew = true; }
+      const task = getTask('corrupt-task');
+      let childAlive = true;
+      try { process.kill(child.pid, 0); } catch { childAlive = false; }
+      try { process.kill(child.pid, 'SIGKILL'); } catch {}
+      const exitCode = process.exitCode || 0;
+      process.exitCode = 0;
+      process.stdout.write('\\nRESULT:' + JSON.stringify({
+        statusThrew,
+        killThrew,
+        childAlive,
+        status: task.status,
+        pid: task.pid,
+        exitCode
+      }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: { ...process.env, HOME: tempHome },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.deepStrictEqual(result, {
+        statusThrew: false,
+        killThrew: false,
+        childAlive: true,
+        status: 'running',
+        pid: result.pid,
+        exitCode: 1,
+      });
+      assert.ok(Number.isInteger(result.pid));
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

- install a lifecycle-owned handle before isolated-task liveness monitoring begins
- terminate and reconcile isolated tasks through their container before retrying
- persist provider process ownership and terminate the full POSIX process group or Windows process tree
- preserve legacy root-only behavior with explicit degraded diagnostics
- migrate existing task databases without losing task history
- bound permanent isolated termination failures and fail closed without retrying the provider
- reconcile terminal status after a kill race so natural completion, failure, or cancellation
  keeps its original semantics

## Regression coverage

- isolated stale and absolute timeout recovery issue exactly one in-container kill
- a tracked isolated task cannot be skipped while its local handle is briefly absent
- a task that completes during recovery is not killed or retried
- normal completion and setup errors clear the lifecycle-owned handle
- owned provider descendants terminate while unrelated processes survive
- graceful shutdown escalates to a hard tree kill
- task-store metadata drives CLI kill/status and is cleared on terminal state
- failed isolated kill or status verification re-arms recovery without overlapping attempts
- permanent kill and verification failures stop after three serialized attempts, emit one
  actionable terminal failure, and preserve the task ID for manual recovery
- exhausted termination never reports success or starts a replacement provider task
- addTask round-trips process ownership before watcher updates
- real watcher and attachable-watcher runtimes persist ownership and kill provider descendants
- corrupt ownership metadata fails closed without signaling an unowned process
- natural completion during an in-container kill settles successfully exactly once without a
  timeout event or replacement provider
- natural failure and cancellation during an in-container kill do not become false inactivity
  timeouts

## Validation

- focused recovery tests: 29 passing
- `npm run lint`: pass (155 warnings, 0 errors)
- `npm run typecheck`: pass
- `npm run test:unit`: 1685 passing, 18 pending
- `npm run test:e2e`: 24 passing
- `npm run test:slow`: 143 passing, 18 pending
- `npm run protocol:check`: pass
- `npm run rust:check`: pass
- `opcore check --changed --json`: pass

Base proof: `origin/dev` at `551a27c54cab828908de069c61e497e12e836a77`.

Closes #724
Closes #725
