### PR TITLE
test(recovery): share permanent watchdog fixture

### DIFF
--- a/tests/helpers/isolated-task-recovery-fixture.js
+++ b/tests/helpers/isolated-task-recovery-fixture.js
@@ -169,6 +169,42 @@ async function runWatchdogRecovery(overrides, managerOptions = {}) {
   return { agent, events, manager, result };
 }
 
+async function runPermanentWatchdogFailure(managerOptions) {
+  const manager = createIsolationManager(managerOptions);
+  const { agent, events } = createIsolatedAgent(manager, {
+    lastOutputTime: Date.now() - 100,
+    taskStartedAt: Date.now() - 100,
+  });
+  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+
+  await waitFor(() => agent.currentTask);
+  startLivenessCheck(agent);
+  const outcome = await Promise.race([
+    execution.then(
+      (result) => ({ result }),
+      (error) => ({ error })
+    ),
+    sleep(300).then(() => ({ timedOut: true })),
+  ]);
+  const observed = {
+    agent,
+    events,
+    manager,
+    outcome,
+    killCalls: manager.killCalls,
+    stillMonitored: Boolean(agent.livenessCheckInterval),
+  };
+
+  if (outcome.timedOut) {
+    stopLivenessCheck(agent);
+    manager.allowTermination();
+    await agent.currentTask?.terminate('test cleanup');
+    await execution;
+  }
+
+  return observed;
+}
+
 async function runLifecycleRecovery(managerOptions = {}) {
   const manager = createIsolationManager(managerOptions);
   const { agent, events } = createIsolatedAgent(manager, {
@@ -231,6 +267,7 @@ module.exports = {
   createIsolatedAgent,
   createIsolationManager,
   runLifecycleRecovery,
+  runPermanentWatchdogFailure,
   runWatchdogRecovery,
   sleep,
   useZeroBackoffSettings,

--- a/tests/isolated-task-termination-exhaustion.test.js
+++ b/tests/isolated-task-termination-exhaustion.test.js
@@ -1,51 +1,11 @@
 const assert = require('assert');
 
-const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
-const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
 const {
-  createIsolatedAgent,
-  createIsolationManager,
   runLifecycleRecovery,
+  runPermanentWatchdogFailure,
   sleep,
   useZeroBackoffSettings,
-  waitFor,
 } = require('./helpers/isolated-task-recovery-fixture');
-
-async function runPermanentWatchdogFailure(managerOptions) {
-  const manager = createIsolationManager(managerOptions);
-  const { agent, events } = createIsolatedAgent(manager, {
-    lastOutputTime: Date.now() - 100,
-    taskStartedAt: Date.now() - 100,
-  });
-  const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
-
-  await waitFor(() => agent.currentTask);
-  startLivenessCheck(agent);
-  const outcome = await Promise.race([
-    execution.then(
-      (result) => ({ result }),
-      (error) => ({ error })
-    ),
-    sleep(300).then(() => ({ timedOut: true })),
-  ]);
-  const observed = {
-    agent,
-    events,
-    manager,
-    outcome,
-    killCalls: manager.killCalls,
-    stillMonitored: Boolean(agent.livenessCheckInterval),
-  };
-
-  if (outcome.timedOut) {
-    stopLivenessCheck(agent);
-    manager.allowTermination();
-    await agent.currentTask?.terminate('test cleanup');
-    await execution;
-  }
-
-  return observed;
-}
 
 describe('Bounded isolated task recovery', function () {
   this.timeout(7000);


### PR DESCRIPTION
## Summary

- move the permanent isolated-watchdog recovery harness into the existing shared recovery fixture
- remove duplicated lifecycle/task-executor setup from the terminal-exhaustion spec
- preserve the distinct transient-recovery and terminal-exhaustion assertions and cleanup behavior

## Root cause

Opcore normalizes nonblank source into five-line clone windows. Both recovery specs began with the same `assert`, lifecycle, task-executor, and fixture-destructuring setup, producing `clone-d5dcb9038dd73b67`.

## Validation

- focused recovery/ownership suite: 29 passing
- `npm run lint`: pass (155 warnings, 0 errors)
- `npm run typecheck`: pass
- `npm run test:unit`: 1685 passing, 18 pending
- `npm run protocol:check`: pass
- `npm run rust:check`: pass
- `opcore check --changed --base 05c50af0cd91a008889bd89498368b79f14d618f --json`: pass; no clone diagnostic for either recovery spec

The tag-based `v6.7.0` comparison is reserved for the narrow release candidate; on `dev` it also spans unrelated #717 Rust work.

Closes #727
