### PR TITLE
test(recovery): await durable stopped state

### DIFF
--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -226,10 +226,15 @@ describe('Agent stuck-task recovery', function () {
     });
     try {
       assert.strictEqual(fixture.runner.getCalls('worker').length, 3);
-      const registry = JSON.parse(
-        fs.readFileSync(path.join(fixture.storageDir, 'clusters.json'), 'utf8')
-      );
-      const saved = registry[fixture.started.id];
+      assert.strictEqual(fixture.orchestrator.getStatus(fixture.started.id).state, 'stopped');
+      let saved;
+      await waitFor(() => {
+        const registry = JSON.parse(
+          fs.readFileSync(path.join(fixture.storageDir, 'clusters.json'), 'utf8')
+        );
+        saved = registry[fixture.started.id];
+        return saved?.state === 'stopped';
+      });
       assert.strictEqual(saved.state, 'stopped');
       assert.deepStrictEqual(
         [saved.agentStates[0].currentTask, saved.agentStates[0].currentTaskId],


### PR DESCRIPTION
## Summary

- wait until the exact `clusters.json` record reaches durable `stopped` state before asserting persisted recovery cleanup
- explicitly preserve the separate in-memory `stopped` assertion
- retain exact persisted assertions for `currentTask: false`, `currentTaskId: null`, and three failure attempts
- keep production unchanged because `Orchestrator.stop()` already awaits the atomic `_saveClusters()` durability boundary

## Root cause

The test waited only for `orchestrator.getStatus(id).state === 'stopped'`. Auto-stop is launched asynchronously from the message-bus handler, so the in-memory state can become `stopped` while the final `_saveClusters()` write is still acquiring its lock or committing the atomic registry rename. The test could therefore read the previous durable `running` record even though production was correctly completing the awaited save.

The fix synchronizes on an observable condition: it repeatedly reads the registry through the existing bounded `waitFor` helper until this cluster's saved record itself reports `stopped`. It adds no fixed sleep, retry wrapper, timeout inflation, or weakened assertion.

## Validation

- base: freshly fetched `origin/dev` at `cd84c1112cec33c4514f0309d423216816d17d5d`
- load-amplified red proof: 2 of 48 isolated concurrent base runs failed with durable `running` versus expected `stopped` at the original assertion
- fixed affected test under the same load: 100 of 100 isolated concurrent runs passed
- focused recovery/ownership suite: 29 passing
- `npm run test:unit`: 1,685 passing, 18 pending
- `npm run lint`: 0 errors, 155 baseline warnings
- `npm run typecheck`: passing
- `npm run protocol:check`: passing
- `npm run rust:check`: passing
- `opcore check --changed --base cd84c1112cec33c4514f0309d423216816d17d5d --json`: passed; optional graph snapshot remains stale and only warnings were reported

Closes #731