### PR TITLE
fix(resume): ignore recovered ledger failures

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2656,54 +2656,52 @@ class Orchestrator {
     const errors = cluster.messageBus.query({
       cluster_id: clusterId,
       topic: 'AGENT_ERROR',
-      limit: 10,
       order: 'desc',
     });
 
-    if (errors.length === 0) {
-      return null;
-    }
+    for (const error of errors) {
+      const errorIteration = error.content?.data?.iteration;
+      const durableProgress = cluster.messageBus
+        .query({
+          cluster_id: clusterId,
+          topic: 'AGENT_LIFECYCLE',
+          sender: error.sender,
+          since: error.timestamp,
+        })
+        .some((message) => {
+          const event = message.content?.data?.event;
+          if (!['TASK_STARTED', 'TASK_COMPLETED'].includes(event)) {
+            return false;
+          }
 
-    const firstError = errors[0];
-    const errorIteration = firstError.content?.data?.iteration;
-    const durableProgress = cluster.messageBus
-      .query({
-        cluster_id: clusterId,
-        topic: 'AGENT_LIFECYCLE',
-        sender: firstError.sender,
-        since: firstError.timestamp,
-      })
-      .some((message) => {
-        const event = message.content?.data?.event;
-        if (!['TASK_STARTED', 'TASK_COMPLETED'].includes(event)) {
-          return false;
-        }
+          const iteration = message.content?.data?.iteration;
+          return (
+            message.timestamp > error.timestamp ||
+            (Number.isInteger(errorIteration) &&
+              Number.isInteger(iteration) &&
+              iteration > errorIteration)
+          );
+        });
 
-        const iteration = message.content?.data?.iteration;
-        return (
-          message.timestamp > firstError.timestamp ||
-          (Number.isInteger(errorIteration) &&
-            Number.isInteger(iteration) &&
-            iteration > errorIteration)
+      if (durableProgress) {
+        this._log(
+          `[Orchestrator] Ignoring recovered ledger failure from ${error.sender}; durable task progress followed it`
         );
-      });
+        continue;
+      }
 
-    if (durableProgress) {
-      this._log(
-        `[Orchestrator] Ignoring recovered ledger failure from ${firstError.sender}; durable task progress followed it`
-      );
-      return null;
+      const failureInfo = {
+        agentId: error.sender,
+        taskId: error.content?.data?.taskId || null,
+        iteration: error.content?.data?.iteration || 0,
+        error: error.content?.data?.error || error.content?.text,
+        timestamp: error.timestamp,
+      };
+      this._log(`[Orchestrator] Found failure from ledger: ${failureInfo.agentId}`);
+      return failureInfo;
     }
 
-    const failureInfo = {
-      agentId: firstError.sender,
-      taskId: firstError.content?.data?.taskId || null,
-      iteration: firstError.content?.data?.iteration || 0,
-      error: firstError.content?.data?.error || firstError.content?.text,
-      timestamp: firstError.timestamp,
-    };
-    this._log(`[Orchestrator] Found failure from ledger: ${failureInfo.agentId}`);
-    return failureInfo;
+    return null;
   }
 
   _requireFailedAgent(clusterId, cluster, failureInfo) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2665,6 +2665,36 @@ class Orchestrator {
     }
 
     const firstError = errors[0];
+    const errorIteration = firstError.content?.data?.iteration;
+    const durableProgress = cluster.messageBus
+      .query({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: firstError.sender,
+        since: firstError.timestamp,
+      })
+      .some((message) => {
+        const event = message.content?.data?.event;
+        if (!['TASK_STARTED', 'TASK_COMPLETED'].includes(event)) {
+          return false;
+        }
+
+        const iteration = message.content?.data?.iteration;
+        return (
+          message.timestamp > firstError.timestamp ||
+          (Number.isInteger(errorIteration) &&
+            Number.isInteger(iteration) &&
+            iteration > errorIteration)
+        );
+      });
+
+    if (durableProgress) {
+      this._log(
+        `[Orchestrator] Ignoring recovered ledger failure from ${firstError.sender}; durable task progress followed it`
+      );
+      return null;
+    }
+
     const failureInfo = {
       agentId: firstError.sender,
       taskId: firstError.content?.data?.taskId || null,

--- a/tests/e2e/resume-detach-daemon.test.js
+++ b/tests/e2e/resume-detach-daemon.test.js
@@ -80,9 +80,42 @@ function appendLedgerMessage(ledger, clusterId, topic, sender, data = {}) {
   });
 }
 
+function seedRecoveredWorkerFailure(ledger, clusterId) {
+  appendLedgerMessage(ledger, clusterId, 'AGENT_ERROR', 'worker', {
+    agent: 'worker',
+    error: 'task_not_found',
+    iteration: 1,
+    taskId: 'stale-worker-task',
+  });
+  appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'worker', {
+    event: 'TASK_STARTED',
+    agent: 'worker',
+    role: 'implementation',
+    state: 'executing_task',
+    iteration: 2,
+    triggeredBy: 'PLAN_READY',
+  });
+  appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'worker', {
+    event: 'TASK_ID_ASSIGNED',
+    agent: 'worker',
+    role: 'implementation',
+    state: 'executing_task',
+    taskId: 'recovered-worker-task',
+  });
+  appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'worker', {
+    event: 'TASK_COMPLETED',
+    agent: 'worker',
+    role: 'implementation',
+    state: 'idle',
+    iteration: 2,
+    taskId: 'recovered-worker-task',
+  });
+}
+
 function seedPartialValidationState(env, clusterId) {
   const ledger = new Ledger(clusterDbPath(env, clusterId));
   try {
+    seedRecoveredWorkerFailure(ledger, clusterId);
     appendLedgerMessage(ledger, clusterId, 'IMPLEMENTATION_READY', 'worker');
     appendLedgerMessage(ledger, clusterId, 'AGENT_LIFECYCLE', 'validator-requirements', {
       event: 'TASK_STARTED',
@@ -199,6 +232,12 @@ describe('e2e: resume --detach daemon handoff', function () {
       assert.strictEqual(readCluster(env, clusterId)?.state, 'stopped');
 
       seedPartialValidationState(env, clusterId);
+      const workerStartsBeforeResume = countLifecycleEvents(
+        env,
+        clusterId,
+        'worker',
+        'TASK_STARTED'
+      );
       const completionCountBeforeResume = readLedgerMessages(
         env,
         clusterId,
@@ -258,7 +297,11 @@ describe('e2e: resume --detach daemon handoff', function () {
         countLifecycleEvents(env, clusterId, 'validator-requirements', 'TASK_STARTED'),
         2
       );
-      assert.strictEqual(countLifecycleEvents(env, clusterId, 'worker', 'TASK_STARTED'), 1);
+      assert.strictEqual(
+        countLifecycleEvents(env, clusterId, 'worker', 'TASK_STARTED'),
+        workerStartsBeforeResume + 1,
+        'recovered historical failure must not start the worker before the missing validator reports'
+      );
       assert.strictEqual(
         readLedgerMessages(env, clusterId, 'CLUSTER_COMPLETE').length,
         completionCountBeforeResume + 1,

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -305,6 +305,44 @@ function publishInterruptedTaskHistory(
   });
 }
 
+function publishRecoveredWorkerFailureHistory(cluster, clusterId) {
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_ERROR',
+    sender: 'worker',
+    content: {
+      text: 'Task stale-worker-task not found - restarting for safety',
+      data: {
+        agent: 'worker',
+        error: 'task_not_found',
+        iteration: 1,
+        taskId: 'stale-worker-task',
+      },
+    },
+  });
+  publishInterruptedTaskHistory(cluster, clusterId, 'worker', {
+    iteration: 2,
+    taskId: 'recovered-worker-task',
+    triggeredBy: 'PLAN_READY',
+  });
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: 'worker',
+    content: {
+      text: 'worker: TASK_COMPLETED',
+      data: {
+        event: 'TASK_COMPLETED',
+        agent: 'worker',
+        role: 'implementation',
+        state: 'idle',
+        iteration: 2,
+        taskId: 'recovered-worker-task',
+      },
+    },
+  });
+}
+
 function deleteLedgerTopics(cluster, clusterId, topics) {
   const placeholders = topics.map(() => '?').join(', ');
   cluster.ledger.db
@@ -842,7 +880,7 @@ function defineLifecycleKillTests() {
 
 function defineLifecycleResumeTests() {
   describe('resume()', function () {
-    it('resumes an interrupted validator before routing the aggregate rejection to the worker', async function () {
+    it('ignores a recovered historical failure and resumes the interrupted validator before routing the aggregate rejection', async function () {
       const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
       const config = createPartialValidationResumeConfig(worktreeDir);
       const result = await lifecycleOrchestrator.start(
@@ -855,6 +893,7 @@ function defineLifecycleResumeTests() {
       await lifecycleOrchestrator.stop(clusterId);
       const cluster = lifecycleOrchestrator.getCluster(clusterId);
 
+      publishRecoveredWorkerFailureHistory(cluster, clusterId);
       cluster.messageBus.publish({
         cluster_id: clusterId,
         topic: 'IMPLEMENTATION_READY',
@@ -941,6 +980,8 @@ function defineLifecycleResumeTests() {
         .messageBus.count({ cluster_id: clusterId, topic: 'VALIDATION_RESULT' });
 
       const resumed = await lifecycleOrchestrator.resume(clusterId);
+      assert.strictEqual(resumed.resumeType, 'clean');
+      assert.deepStrictEqual(resumed.resumedAgents, ['validator-requirements']);
       await waitForAgentCalls(resumedRunner, {
         'validator-requirements': 1,
         worker: 1,
@@ -951,7 +992,6 @@ function defineLifecycleResumeTests() {
         (agent) => agent.id === 'validator-requirements'
       );
 
-      assert.deepStrictEqual(resumed.resumedAgents, ['validator-requirements']);
       assert.strictEqual(resumed.state, 'running');
       assert.notStrictEqual(
         resumedRequirements.currentTaskId,
@@ -1507,6 +1547,49 @@ function defineLifecycleResumeTests() {
       assert.strictEqual(resumed.resumeType, 'failure');
       assert.strictEqual(cluster.pid, process.pid, 'Resumed cluster should record current PID');
       assert.strictEqual(status.state, 'running', 'Resumed cluster should not self-report zombie');
+    });
+
+    it('should preserve the failed-agent path for an unresolved ledger failure', async function () {
+      const config = createSimpleConfig();
+      lifecycleMockRunner.when('worker').returns({ done: true });
+
+      const result = await lifecycleOrchestrator.start(config, { text: 'Task' });
+      await sleep(500);
+      await lifecycleOrchestrator.stop(result.id);
+
+      const cluster = lifecycleOrchestrator.getCluster(result.id);
+      cluster.failureInfo = null;
+      cluster.messageBus.publish({
+        cluster_id: result.id,
+        topic: 'AGENT_ERROR',
+        sender: 'worker',
+        content: {
+          text: 'Current worker failure',
+          data: {
+            agent: 'worker',
+            error: 'current failure',
+            iteration: 2,
+            taskId: 'current-failed-task',
+          },
+        },
+      });
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner.when('worker').returns({ done: true, resumed: true });
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const resumed = await lifecycleOrchestrator.resume(result.id);
+      await waitForAgentCalls(resumedRunner, { worker: 1 });
+
+      assert.strictEqual(resumed.resumeType, 'failure');
+      assert.strictEqual(resumed.resumedAgent, 'worker');
+      assert.strictEqual(resumed.previousError, 'current failure');
     });
 
     it('should not restore serialized currentTask handles from disk', async function () {

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1592,6 +1592,59 @@ function defineLifecycleResumeTests() {
       assert.strictEqual(resumed.previousError, 'current failure');
     });
 
+    it('should skip every recovered error and select the newest unresolved failure from complete history', async function () {
+      const worktreeDir = fs.mkdtempSync(
+        path.join(lifecycleStorageDir, 'resume-failure-ordering-')
+      );
+      const result = await lifecycleOrchestrator.start(
+        createPartialValidationResumeConfig(worktreeDir),
+        { text: 'Task' },
+        { worktreeDir }
+      );
+      await lifecycleOrchestrator.stop(result.id);
+
+      const cluster = lifecycleOrchestrator.getCluster(result.id);
+      cluster.messageBus.publish({
+        cluster_id: result.id,
+        topic: 'AGENT_ERROR',
+        sender: 'validator-code',
+        content: {
+          text: 'Older validator failure',
+          data: {
+            agent: 'validator-code',
+            error: 'older unresolved validator failure',
+            iteration: 3,
+            taskId: 'older-unresolved-validator-task',
+          },
+        },
+      });
+      cluster.messageBus.publish({
+        cluster_id: result.id,
+        topic: 'AGENT_ERROR',
+        sender: 'validator-requirements',
+        content: {
+          text: 'Validator still failed',
+          data: {
+            agent: 'validator-requirements',
+            error: 'unresolved validator failure',
+            iteration: 4,
+            taskId: 'unresolved-validator-task',
+          },
+        },
+      });
+
+      for (let index = 0; index < 12; index += 1) {
+        publishRecoveredWorkerFailureHistory(cluster, result.id);
+      }
+      cluster.failureInfo = null;
+
+      const failureInfo = lifecycleOrchestrator._resolveFailureInfo(cluster, result.id);
+
+      assert.strictEqual(failureInfo.agentId, 'validator-requirements');
+      assert.strictEqual(failureInfo.taskId, 'unresolved-validator-task');
+      assert.strictEqual(failureInfo.error, 'unresolved validator failure');
+    });
+
     it('should not restore serialized currentTask handles from disk', async function () {
       const config = createSimpleConfig();
       lifecycleMockRunner.when('worker').delays(1000, { done: true });


### PR DESCRIPTION
## Summary

- ignore historical `AGENT_ERROR` records when the same agent has durable later task progress
- scan complete error history newest-first and select the first unresolved failure
- preserve the failed-agent resume path for genuinely unresolved ledger failures
- recover interrupted partial validation by resuming only the missing validator before aggregate rejection wakes the worker once
- cover equivalent foreground and detached resume behavior

## Root cause

`_resolveFailureInfo()` treated the newest ledger `AGENT_ERROR` as current whenever registry `failureInfo` was empty. In the reproduced cluster, that error belonged to worker iteration 1 and the worker subsequently completed iterations 2-11. The stale error bypassed clean reconstruction and resumed the worker instead of the interrupted requirements validator.

Independent review then identified a second ordering hazard: returning null as soon as the newest error was found recovered could hide an older unresolved failure. The resolver now reads complete `AGENT_ERROR` history, skips recovered candidates newest-first, and returns the newest unresolved candidate.

The lifecycle split between `TASK_STARTED` and later `TASK_ID_ASSIGNED` is expected and was not the cause.

## Evidence

- original regression first: `0 passing, 1 failing`, expected clean resume but observed failure resume
- reviewer regression first: `0 passing, 1 failing`, newest recovered error hid older unresolved validator failure
- ordering regression covers two unresolved validators followed by 12 recovered worker errors, proving newest-unresolved selection and removing the old 10-error bound
- focused recovery regressions: 3 passing
- complete `resume()` suite: 17 passing
- `npm run test:unit`: 1687 passing, 18 pending
- `npm run test:e2e`: 24 passing (isolated rerun; first run had a teardown-only ENOTEMPTY race after assertions)
- `npm run lint`: pass with existing warnings
- `npm run typecheck`: pass
- `npm run protocol:check`: pass
- `opcore check --changed --json`: passed
- earlier unchanged gates on this PR: `npm run test:slow`, `npm run rust:check`

Closes #734