### PR TITLE
fix(attach): support strict-output Codex tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,10 @@ Clusters survive crashes. Resume: `zeroshot resume <id>`.
 Bash subprocess output not streamed: Claude CLI returns `tool_result` after subprocess completes.
 Long scripts show no output until done.
 
+Strict structured-output Codex tasks use the attachable PTY watcher. Claude strict
+structured-output tasks keep the non-PTY watcher because PTY notifications can be
+interpreted as streaming commands; use `zeroshot logs` for those tasks.
+
 ### Kubernetes / Network Storage (SQLite Ledger)
 
 Zeroshot’s message ledger is SQLite (`~/.zeroshot/<id>.db`). On Kubernetes, putting this on a

--- a/cli/index.js
+++ b/cli/index.js
@@ -1597,21 +1597,87 @@ function reportNoActiveAgents(status, id) {
   }
 }
 
-function printAttachableAgentList(id, activeAgents) {
-  console.log(chalk.yellow(`\nCluster ${id} - attachable agents:\n`));
-  for (const agent of activeAgents) {
-    const modelLabel = agent.model ? chalk.dim(` [${agent.model}]`) : '';
-    if (agent.currentTaskId) {
-      console.log(
-        `  ${chalk.cyan(agent.id)}${modelLabel} → task ${chalk.green(agent.currentTaskId)}`
-      );
-      console.log(chalk.dim(`    zeroshot attach ${agent.currentTaskId}`));
-    } else {
-      console.log(`  ${chalk.cyan(agent.id)}${modelLabel} → ${chalk.yellow('starting...')}`);
-      console.log(chalk.dim(`    (task ID not yet assigned, try again in a moment)`));
-    }
+async function inspectAgentAttachment(agent, socketDiscovery, readTask = readTaskFromDisk) {
+  if (!agent.currentTaskId) {
+    return { agent, state: 'starting', task: null, socketPath: null };
   }
-  console.log(chalk.dim('\nAttach to an agent by running: zeroshot attach <taskId>'));
+
+  const task = await readTask(agent.currentTaskId);
+  if (task?.pid && !task.attachable) {
+    return { agent, state: 'non_attachable', task, socketPath: null };
+  }
+
+  const socketPath = task?.socketPath || socketDiscovery.getTaskSocketPath(agent.currentTaskId);
+  if (await socketDiscovery.isSocketAlive(socketPath)) {
+    return { agent, state: 'attachable', task, socketPath };
+  }
+  return { agent, state: 'unavailable', task, socketPath };
+}
+
+function printLiveAttachableAgents(attachments) {
+  for (const { agent } of attachments) {
+    const modelLabel = agent.model ? chalk.dim(` [${agent.model}]`) : '';
+    console.log(
+      `  ${chalk.cyan(agent.id)}${modelLabel} → task ${chalk.green(agent.currentTaskId)}`
+    );
+    console.log(chalk.dim(`    zeroshot attach ${agent.currentTaskId}`));
+  }
+}
+
+function printNonAttachableAgents(id, attachments) {
+  if (attachments.length === 0) {
+    return;
+  }
+
+  console.log(chalk.yellow('\nRunning without PTY attach support:'));
+  for (const { agent, task } of attachments) {
+    const modelLabel = agent.model ? chalk.dim(` [${agent.model}]`) : '';
+    const providerLabel = task?.provider ? chalk.dim(` [provider: ${task.provider}]`) : '';
+    console.log(
+      `  ${chalk.cyan(agent.id)}${modelLabel} → task ${chalk.green(agent.currentTaskId)}${providerLabel}`
+    );
+  }
+  console.log(chalk.dim(`  Follow output instead: zeroshot logs ${id} -f`));
+}
+
+function printUnavailableAgents(attachments) {
+  if (attachments.length === 0) {
+    return;
+  }
+
+  console.log(chalk.yellow('\nActive agents without a live attach socket:'));
+  for (const { agent, state } of attachments) {
+    const modelLabel = agent.model ? chalk.dim(` [${agent.model}]`) : '';
+    const detail =
+      state === 'starting'
+        ? 'task ID not yet assigned'
+        : `task ${agent.currentTaskId} socket not ready`;
+    console.log(`  ${chalk.cyan(agent.id)}${modelLabel} → ${chalk.yellow(detail)}`);
+  }
+}
+
+async function printAttachableAgentList(
+  id,
+  activeAgents,
+  socketDiscovery,
+  readTask = readTaskFromDisk
+) {
+  const inspected = await Promise.all(
+    activeAgents.map((agent) => inspectAgentAttachment(agent, socketDiscovery, readTask))
+  );
+  const attachable = inspected.filter(({ state }) => state === 'attachable');
+  const nonAttachable = inspected.filter(({ state }) => state === 'non_attachable');
+  const unavailable = inspected.filter(({ state }) => ['starting', 'unavailable'].includes(state));
+
+  console.log(chalk.yellow(`\nCluster ${id} - attachable agents:\n`));
+  if (attachable.length === 0) {
+    console.log(chalk.dim('  No live attach sockets.'));
+  } else {
+    printLiveAttachableAgents(attachable);
+    console.log(chalk.dim('\nAttach to an agent by running: zeroshot attach <taskId>'));
+  }
+  printNonAttachableAgents(id, nonAttachable);
+  printUnavailableAgents(unavailable);
 }
 
 function reportMissingAgent(agentName, status) {
@@ -1683,7 +1749,7 @@ async function resolveClusterSocketPath(id, options, socketDiscovery) {
     }
 
     if (!options.agent) {
-      printAttachableAgentList(id, activeAgents);
+      await printAttachableAgentList(id, activeAgents, socketDiscovery);
       return null;
     }
 
@@ -5886,4 +5952,10 @@ if (require.main === module) {
   });
 }
 
-module.exports = { applyModelOverrideToConfig, renderRecentMessagesToTerminal, resolveRunMode };
+module.exports = {
+  applyModelOverrideToConfig,
+  inspectAgentAttachment,
+  printAttachableAgentList,
+  renderRecentMessagesToTerminal,
+  resolveRunMode,
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -1648,6 +1648,27 @@ async function reportClusterStatusUnavailable(err, socketDiscovery) {
   }
 }
 
+async function readTaskFromDisk(taskId) {
+  try {
+    const { getTask } = await import('../task-lib/store.js');
+    return getTask(taskId);
+  } catch {
+    return null;
+  }
+}
+
+function reportAgentTaskNotAttachable(id, agent, task) {
+  console.error(
+    chalk.yellow(
+      `Agent '${agent.id}' is running task ${agent.currentTaskId} without PTY attach support`
+    )
+  );
+  if (task.provider) {
+    console.error(chalk.dim(`Provider: ${task.provider}`));
+  }
+  console.error(chalk.dim(`Follow output instead: zeroshot logs ${id} -f`));
+}
+
 async function resolveClusterSocketPath(id, options, socketDiscovery) {
   const cluster = readClusterFromDisk(id);
   ensureClusterRunning(cluster, id);
@@ -1680,7 +1701,12 @@ async function resolveClusterSocketPath(id, options, socketDiscovery) {
     console.log(
       chalk.dim(`Attaching to agent ${options.agent} via task ${agent.currentTaskId}...`)
     );
-    return socketDiscovery.getTaskSocketPath(agent.currentTaskId);
+    const task = await readTaskFromDisk(agent.currentTaskId);
+    if (task?.pid && !task.attachable) {
+      reportAgentTaskNotAttachable(id, agent, task);
+      return null;
+    }
+    return task?.socketPath || socketDiscovery.getTaskSocketPath(agent.currentTaskId);
   } catch (err) {
     await reportClusterStatusUnavailable(err, socketDiscovery);
     return null;

--- a/task-lib/commands/run.js
+++ b/task-lib/commands/run.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { spawnTask } from '../runner.js';
+import { shouldUseAttachableWatcher, spawnTask } from '../runner.js';
 
 export async function runTask(prompt, options = {}) {
   if (!prompt || prompt.trim().length === 0) {
@@ -46,8 +46,23 @@ export async function runTask(prompt, options = {}) {
   console.log(chalk.dim(`  Log: ${task.logFile}`));
   console.log(chalk.dim(`  CWD: ${task.cwd}`));
 
+  const attachSupported = shouldUseAttachableWatcher(
+    {
+      jsonSchema: outputFormat === 'json' ? jsonSchema : null,
+    },
+    task.provider
+  );
+
   console.log(chalk.dim('\nCommands:'));
-  console.log(chalk.dim(`  zeroshot attach ${task.id}    # Attach to task (Ctrl+B d to detach)`));
+  if (attachSupported) {
+    console.log(chalk.dim(`  zeroshot attach ${task.id}    # Attach to task (Ctrl+B d to detach)`));
+  } else {
+    console.log(
+      chalk.dim(
+        `  Attach unavailable: ${task.provider} strict structured output uses a non-PTY watcher`
+      )
+    );
+  }
   console.log(chalk.dim(`  zeroshot logs ${task.id}      # View output`));
   console.log(chalk.dim(`  zeroshot logs -f ${task.id}   # Follow output`));
   console.log(chalk.dim(`  zeroshot status ${task.id}    # Check status`));

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -53,7 +53,13 @@ export function spawnTask(prompt, options = {}) {
     providerName,
     commandSpec
   );
-  const watcherScript = resolveWatcherScript(options);
+  const watcherScript = resolveWatcherScript(
+    {
+      attachable: options.attachable,
+      jsonSchema,
+    },
+    providerName
+  );
   spawnWatcher({
     watcherScript,
     id,
@@ -165,8 +171,20 @@ function buildWatcherCommandSpec(commandSpec) {
   return watcherCommandSpec;
 }
 
-function resolveWatcherScript(options) {
-  const useAttachable = options.attachable !== false && !options.jsonSchema;
+export function shouldUseAttachableWatcher(options, providerName) {
+  if (options.attachable === false) {
+    return false;
+  }
+
+  // Claude strict structured output still needs the non-PTY watcher. Claude
+  // can treat PTY notifications as streaming commands and reject the run.
+  // Other providers, including Codex, support their structured-output mode in
+  // the attachable PTY watcher and must not lose the advertised attach socket.
+  return !(providerName === 'claude' && options.jsonSchema);
+}
+
+function resolveWatcherScript(options, providerName) {
+  const useAttachable = shouldUseAttachableWatcher(options, providerName);
   return useAttachable ? join(__dirname, 'attachable-watcher.js') : join(__dirname, 'watcher.js');
 }
 

--- a/tests/unit/cli-attach-discovery.test.js
+++ b/tests/unit/cli-attach-discovery.test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const { printAttachableAgentList } = require('../../cli/index.js');
+
+async function captureConsole(callback) {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    await callback();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines.join('\n');
+}
+
+describe('CLI cluster attach discovery', function () {
+  it('advertises only live attachable task sockets in a mixed active cluster', async function () {
+    const agents = [
+      {
+        id: 'worker-codex',
+        model: 'gpt-5.6-sol',
+        state: 'executing',
+        currentTaskId: 'task-live',
+      },
+      {
+        id: 'worker-claude',
+        model: 'claude-opus-4-6',
+        state: 'executing',
+        currentTaskId: 'task-nonpty',
+      },
+      {
+        id: 'worker-stale',
+        model: 'gpt-5.6-terra',
+        state: 'executing',
+        currentTaskId: 'task-stale',
+      },
+    ];
+    const tasks = {
+      'task-live': {
+        pid: 111,
+        attachable: true,
+        provider: 'codex',
+        socketPath: '/sockets/task-live.sock',
+      },
+      'task-nonpty': {
+        pid: 222,
+        attachable: false,
+        provider: 'claude',
+        socketPath: null,
+      },
+      'task-stale': {
+        pid: 333,
+        attachable: true,
+        provider: 'codex',
+        socketPath: '/sockets/task-stale.sock',
+      },
+    };
+    const socketDiscovery = {
+      getTaskSocketPath: (taskId) => `/sockets/${taskId}.sock`,
+      isSocketAlive: (socketPath) => Promise.resolve(socketPath === '/sockets/task-live.sock'),
+    };
+
+    const output = await captureConsole(() =>
+      printAttachableAgentList('mixed-cluster', agents, socketDiscovery, (taskId) =>
+        Promise.resolve(tasks[taskId])
+      )
+    );
+
+    assert(output.includes('zeroshot attach task-live'));
+    assert(!output.includes('zeroshot attach task-nonpty'));
+    assert(!output.includes('zeroshot attach task-stale'));
+    assert(output.includes('Running without PTY attach support'));
+    assert(output.includes('worker-claude'));
+    assert(output.includes('provider: claude'));
+    assert(output.includes('zeroshot logs mixed-cluster -f'));
+    assert(output.includes('task task-stale socket not ready'));
+  });
+});

--- a/tests/unit/task-attachable-selection.test.js
+++ b/tests/unit/task-attachable-selection.test.js
@@ -1,0 +1,234 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+const { pathToFileURL } = require('url');
+
+const runnerUrl = pathToFileURL(path.resolve(__dirname, '../../task-lib/runner.js')).href;
+const storeUrl = pathToFileURL(path.resolve(__dirname, '../../task-lib/store.js')).href;
+const socketDiscoveryPath = path.resolve(__dirname, '../../src/attach/socket-discovery.js');
+
+function createFakeCodex(fakeBinDir) {
+  const fakeCodex = path.join(fakeBinDir, 'codex');
+  fs.writeFileSync(
+    fakeCodex,
+    `#!/usr/bin/env node
+if (process.argv.includes('--help')) {
+  process.stdout.write('codex exec --json --output-schema --config -m -C --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex-cli 1.0.0\\n');
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'fake-thread' }) + '\\n');
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({
+    type: 'item.completed',
+    item: { type: 'agent_message', text: '{"ok":true}' }
+  }) + '\\n');
+  process.exit(0);
+}, 1000);
+`
+  );
+  fs.chmodSync(fakeCodex, 0o755);
+}
+
+function createHarness(shortHome) {
+  const harnessPath = path.join(shortHome, 'attach-regression.mjs');
+  fs.writeFileSync(
+    harnessPath,
+    `import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { spawnTask } = await import(${JSON.stringify(runnerUrl)});
+const { getTask } = await import(${JSON.stringify(storeUrl)});
+const socketDiscovery = require(${JSON.stringify(socketDiscoveryPath)});
+
+async function waitFor(predicate, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+const task = spawnTask('Return structured output', {
+  provider: 'codex',
+  model: 'gpt-5.4',
+  outputFormat: 'json',
+  jsonSchema: {
+    type: 'object',
+    properties: { ok: { type: 'boolean' } },
+    required: ['ok'],
+    additionalProperties: false,
+  },
+});
+
+const attached = await waitFor(() => {
+  const current = getTask(task.id);
+  return current?.attachable && current.socketPath ? current : null;
+});
+
+if (!attached) {
+  const current = getTask(task.id);
+  const log =
+    current?.logFile && fs.existsSync(current.logFile)
+      ? fs.readFileSync(current.logFile, 'utf8')
+      : '<no log>';
+  throw new Error(
+    \`watcher never published attach metadata: \${JSON.stringify(current)}\\n\${log}\`
+  );
+}
+
+if (attached.socketPath !== socketDiscovery.getTaskSocketPath(task.id)) {
+  throw new Error(\`unexpected socket path: \${attached.socketPath}\`);
+}
+if (!(await socketDiscovery.isSocketAlive(attached.socketPath))) {
+  throw new Error(\`attach socket is not live: \${attached.socketPath}\`);
+}
+
+const completed = await waitFor(() => {
+  const current = getTask(task.id);
+  return current?.status === 'completed' ? current : null;
+});
+if (!completed) {
+  throw new Error('structured-output task did not complete');
+}
+
+const log = fs.readFileSync(completed.logFile, 'utf8');
+process.stdout.write(JSON.stringify({ socketPath: attached.socketPath, log }) + '\\n');
+`
+  );
+  return harnessPath;
+}
+
+function runHarness(harnessPath, fakeBinDir, shortHome) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [harnessPath], {
+      env: {
+        ...process.env,
+        HOME: shortHome,
+        USERPROFILE: shortHome,
+        ZEROSHOT_HOME: shortHome,
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`attach regression harness timed out\n${stdout}\n${stderr}`));
+    }, 12000);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`attach regression harness exited ${code}\n${stdout}\n${stderr}`));
+        return;
+      }
+      const output = stdout.trim().split('\n').at(-1);
+      resolve(JSON.parse(output));
+    });
+  });
+}
+
+async function runAttachableRegression() {
+  const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-fake-codex-'));
+  const shortHome = `/tmp/zeroshot-attach-${process.pid}-${Date.now()}`;
+  fs.mkdirSync(shortHome, { recursive: true });
+  createFakeCodex(fakeBinDir);
+  const harnessPath = createHarness(shortHome);
+
+  try {
+    return await runHarness(harnessPath, fakeBinDir, shortHome);
+  } finally {
+    fs.rmSync(fakeBinDir, { recursive: true, force: true });
+    fs.rmSync(shortHome, { recursive: true, force: true });
+  }
+}
+
+describe('task watcher attachment selection', function () {
+  async function loadSelector() {
+    const runner = await import(runnerUrl);
+    expect(runner.shouldUseAttachableWatcher).to.be.a('function');
+    return runner.shouldUseAttachableWatcher;
+  }
+
+  it('keeps strict structured-output Codex tasks attachable', async function () {
+    const shouldUseAttachableWatcher = await loadSelector();
+
+    expect(
+      shouldUseAttachableWatcher(
+        {
+          attachable: true,
+          jsonSchema: { type: 'object' },
+        },
+        'codex'
+      )
+    ).to.equal(true);
+  });
+
+  it('creates a live attach socket for a strict structured-output Codex task', async function () {
+    this.timeout(15000);
+    const result = await runAttachableRegression();
+
+    expect(result.socketPath).to.match(/\.sock$/);
+    expect(result.log).to.include('"type":"thread.started"');
+    expect(result.log).to.include('{\\"ok\\":true}');
+  });
+
+  it('preserves the Claude structured-output PTY safeguard', async function () {
+    const shouldUseAttachableWatcher = await loadSelector();
+
+    expect(
+      shouldUseAttachableWatcher(
+        {
+          attachable: true,
+          jsonSchema: { type: 'object' },
+        },
+        'claude'
+      )
+    ).to.equal(false);
+  });
+
+  it('honors an explicit attachment opt-out for every provider', async function () {
+    const shouldUseAttachableWatcher = await loadSelector();
+
+    for (const provider of ['codex', 'claude', 'gemini', 'opencode']) {
+      expect(
+        shouldUseAttachableWatcher(
+          {
+            attachable: false,
+            jsonSchema: { type: 'object' },
+          },
+          provider
+        )
+      ).to.equal(false);
+    }
+  });
+
+  it('keeps non-schema tasks attachable by default', async function () {
+    const shouldUseAttachableWatcher = await loadSelector();
+
+    for (const provider of ['codex', 'claude', 'gemini', 'opencode']) {
+      expect(shouldUseAttachableWatcher({}, provider)).to.equal(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- route strict structured-output Codex tasks through the attachable PTY watcher
- preserve the Claude strict-output non-PTY safeguard and explicit attachment opt-out
- stop advertising attachment for genuinely non-attachable tasks and provide a logs fallback
- diagnose already-running non-PTY cluster tasks before probing a nonexistent socket
- filter cluster discovery through persisted task metadata and live-socket probes

## Root cause

Watcher selection treated every task with a JSON schema as non-attachable. Zeroshot cluster agents use strict structured output, so Codex agents were started by `watcher.js` with no PTY socket even though `zeroshot attach <cluster> --agent <agent>` advertised and probed one. The schema restriction originated as a Claude-specific PTY workaround but was applied to all providers.

Existing tasks already started without a PTY cannot be retrofitted; the improved CLI now explains that condition and points to `zeroshot logs <cluster> -f`. New Codex strict-output tasks create live attach sockets.

Cluster discovery now lists only tasks whose attach socket is live. Mixed active clusters show non-PTY tasks separately with the provider and logs fallback, while stale or still-starting sockets are not advertised as attachable.

## Verification

- focused attach/watcher regression: 16 passing
- `npm run test:unit`: 1691 passing, 18 pending
- `npm run test:slow`: 143 passing, 18 pending
- `npm run lint`: pass, 155 existing warnings and 0 errors
- `npm run typecheck`: pass
- targeted Prettier and `git diff --check`: pass
- `opcore check --changed`: pass
- post-rebase focused regression against fresh `origin/dev`: 16 passing

Closes #735
