### PR TITLE
fix(resume): ignore recovered registry failures

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2649,8 +2649,14 @@ class Orchestrator {
   }
 
   _resolveFailureInfo(cluster, clusterId) {
-    if (cluster.failureInfo) {
-      return cluster.failureInfo.agentId ? cluster.failureInfo : null;
+    const persistedFailure = cluster.failureInfo?.agentId ? cluster.failureInfo : null;
+    if (persistedFailure) {
+      if (!this._hasDurableProgressAfterFailure(cluster, clusterId, persistedFailure)) {
+        return persistedFailure;
+      }
+      this._log(
+        `[Orchestrator] Ignoring recovered registry failure from ${persistedFailure.agentId}; durable task progress followed it`
+      );
     }
 
     const errors = cluster.messageBus.query({
@@ -2660,36 +2666,6 @@ class Orchestrator {
     });
 
     for (const error of errors) {
-      const errorIteration = error.content?.data?.iteration;
-      const durableProgress = cluster.messageBus
-        .query({
-          cluster_id: clusterId,
-          topic: 'AGENT_LIFECYCLE',
-          sender: error.sender,
-          since: error.timestamp,
-        })
-        .some((message) => {
-          const event = message.content?.data?.event;
-          if (!['TASK_STARTED', 'TASK_COMPLETED'].includes(event)) {
-            return false;
-          }
-
-          const iteration = message.content?.data?.iteration;
-          return (
-            message.timestamp > error.timestamp ||
-            (Number.isInteger(errorIteration) &&
-              Number.isInteger(iteration) &&
-              iteration > errorIteration)
-          );
-        });
-
-      if (durableProgress) {
-        this._log(
-          `[Orchestrator] Ignoring recovered ledger failure from ${error.sender}; durable task progress followed it`
-        );
-        continue;
-      }
-
       const failureInfo = {
         agentId: error.sender,
         taskId: error.content?.data?.taskId || null,
@@ -2697,11 +2673,44 @@ class Orchestrator {
         error: error.content?.data?.error || error.content?.text,
         timestamp: error.timestamp,
       };
+      if (this._hasDurableProgressAfterFailure(cluster, clusterId, failureInfo)) {
+        this._log(
+          `[Orchestrator] Ignoring recovered ledger failure from ${error.sender}; durable task progress followed it`
+        );
+        continue;
+      }
+
       this._log(`[Orchestrator] Found failure from ledger: ${failureInfo.agentId}`);
       return failureInfo;
     }
 
     return null;
+  }
+
+  _hasDurableProgressAfterFailure(cluster, clusterId, failureInfo) {
+    const failureIteration = failureInfo.iteration;
+    const failureTimestamp = failureInfo.timestamp;
+    return cluster.messageBus
+      .query({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: failureInfo.agentId,
+        since: failureTimestamp,
+      })
+      .some((message) => {
+        const event = message.content?.data?.event;
+        if (!['TASK_STARTED', 'TASK_COMPLETED'].includes(event)) {
+          return false;
+        }
+
+        const iteration = message.content?.data?.iteration;
+        return (
+          (Number.isFinite(failureTimestamp) && message.timestamp > failureTimestamp) ||
+          (Number.isInteger(failureIteration) &&
+            Number.isInteger(iteration) &&
+            iteration > failureIteration)
+        );
+      });
   }
 
   _requireFailedAgent(clusterId, cluster, failureInfo) {

--- a/tests/e2e/resume-detach-daemon.test.js
+++ b/tests/e2e/resume-detach-daemon.test.js
@@ -183,7 +183,13 @@ function seedPartialValidationState(env, clusterId) {
   overwriteClusterRecord(env, clusterId, {
     state: 'stopped',
     pid: null,
-    failureInfo: null,
+    failureInfo: {
+      agentId: 'worker',
+      taskId: 'stale-worker-task',
+      iteration: 1,
+      error: 'task_not_found',
+      timestamp: 0,
+    },
     agentStates,
   });
 }

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1015,6 +1015,136 @@ function defineLifecycleResumeTests() {
       );
     });
 
+    it('ignores a recovered persisted failure and resumes the other interrupted validator exactly once', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
+      const config = createPartialValidationResumeConfig(worktreeDir);
+      const result = await lifecycleOrchestrator.start(
+        config,
+        { text: 'Repair validation findings' },
+        { clusterId: 'persisted-failure-partial-validation-resume' }
+      );
+      const clusterId = result.id;
+
+      await lifecycleOrchestrator.stop(clusterId);
+      const cluster = lifecycleOrchestrator.getCluster(clusterId);
+      cluster.failureInfo = {
+        agentId: 'validator-requirements',
+        taskId: 'recovered-requirements-task',
+        iteration: 7,
+        error: 'temporary provider lookup failure',
+        timestamp: Date.now() - 1000,
+      };
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'IMPLEMENTATION_READY',
+        sender: 'worker',
+        content: { text: 'Implementation ready for validation' },
+      });
+      publishInterruptedTaskHistory(cluster, clusterId, 'validator-requirements', {
+        iteration: 8,
+        taskId: 'completed-requirements-task',
+        triggeredBy: 'IMPLEMENTATION_READY',
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'validator-requirements',
+        content: {
+          text: 'validator-requirements: TASK_COMPLETED',
+          data: {
+            event: 'TASK_COMPLETED',
+            agent: 'validator-requirements',
+            role: 'validator',
+            state: 'idle',
+            iteration: 8,
+            taskId: 'completed-requirements-task',
+          },
+        },
+      });
+      cluster.messageBus.publish({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-requirements',
+        content: {
+          text: 'Requirements approved',
+          data: { approved: true },
+        },
+      });
+      publishInterruptedTaskHistory(cluster, clusterId, 'validator-code', {
+        iteration: 5,
+        taskId: 'interrupted-code-task',
+        triggeredBy: 'IMPLEMENTATION_READY',
+      });
+
+      const completedValidator = cluster.agents.find(
+        (agent) => agent.id === 'validator-requirements'
+      );
+      completedValidator.state = 'idle';
+      completedValidator.iteration = 8;
+      completedValidator.currentTaskId = 'completed-requirements-task';
+      completedValidator.processPid = null;
+
+      const interruptedValidator = cluster.agents.find((agent) => agent.id === 'validator-code');
+      interruptedValidator.state = 'executing_task';
+      interruptedValidator.iteration = 5;
+      interruptedValidator.currentTaskId = 'interrupted-code-task';
+      interruptedValidator.processPid = 4242;
+
+      await lifecycleOrchestrator._saveClusters();
+      lifecycleOrchestrator.close();
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner
+        .when('validator-requirements')
+        .returns({ approved: true, summary: 'Requirements approved again' });
+      resumedRunner.when('validator-code').returns({ approved: false, summary: 'Code rejected' });
+      resumedRunner.when('worker').returns('Repaired validation findings');
+
+      lifecycleOrchestrator = await Orchestrator.create({
+        taskRunner: resumedRunner,
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
+      const validationCountBeforeResume = restoredCluster.messageBus.count({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+      });
+      const requirementsResultsBeforeResume = restoredCluster.messageBus.query({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator-requirements',
+      }).length;
+
+      const resumed = await lifecycleOrchestrator.resume(clusterId);
+      assert.strictEqual(resumed.resumeType, 'clean');
+      assert.deepStrictEqual(resumed.resumedAgents, ['validator-code']);
+      await waitForAgentCalls(resumedRunner, {
+        'validator-code': 1,
+        worker: 1,
+      });
+
+      resumedRunner.assertCalled('validator-requirements', 0);
+      assert.strictEqual(
+        restoredCluster.messageBus.count({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+        }),
+        validationCountBeforeResume + 1,
+        'only the interrupted validator may append a new validation result'
+      );
+      assert.strictEqual(
+        restoredCluster.messageBus.query({
+          cluster_id: clusterId,
+          topic: 'VALIDATION_RESULT',
+          sender: 'validator-requirements',
+        }).length,
+        requirementsResultsBeforeResume,
+        'the completed validator result must remain a singleton'
+      );
+    });
+
     it('resumes a missing validator in a partial validation cycle without replaying completed results', async function () {
       const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-worktree-'));
       const config = createPartialValidationResumeConfig(worktreeDir);
@@ -1545,6 +1675,8 @@ function defineLifecycleResumeTests() {
       const status = lifecycleOrchestrator.getStatus(result.id);
 
       assert.strictEqual(resumed.resumeType, 'failure');
+      assert.strictEqual(resumed.resumedAgent, 'worker');
+      assert.strictEqual(resumed.previousError, 'boom');
       assert.strictEqual(cluster.pid, process.pid, 'Resumed cluster should record current PID');
       assert.strictEqual(status.state, 'running', 'Resumed cluster should not self-report zombie');
     });

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -343,6 +343,144 @@ function publishRecoveredWorkerFailureHistory(cluster, clusterId) {
   });
 }
 
+function publishCompletedTaskHistory(cluster, clusterId, agentId, { iteration, taskId }) {
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agentId,
+    content: {
+      text: `${agentId}: TASK_COMPLETED`,
+      data: {
+        event: 'TASK_COMPLETED',
+        agent: agentId,
+        role: 'validator',
+        state: 'idle',
+        iteration,
+        taskId,
+      },
+    },
+  });
+}
+
+function publishValidationResult(cluster, clusterId, agentId, approved, text) {
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'VALIDATION_RESULT',
+    sender: agentId,
+    content: { text, data: { approved } },
+  });
+}
+
+function setPersistedAgentTaskState(cluster, agentId, { state, iteration, taskId, processPid }) {
+  const agent = cluster.agents.find((candidate) => candidate.id === agentId);
+  agent.state = state;
+  agent.iteration = iteration;
+  agent.currentTaskId = taskId;
+  agent.processPid = processPid;
+}
+
+function prepareRecoveredRequirementsFailure(cluster, clusterId) {
+  cluster.failureInfo = {
+    agentId: 'validator-requirements',
+    taskId: 'recovered-requirements-task',
+    iteration: 7,
+    error: 'temporary provider lookup failure',
+    timestamp: Date.now() - 1000,
+  };
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'IMPLEMENTATION_READY',
+    sender: 'worker',
+    content: { text: 'Implementation ready for validation' },
+  });
+  publishInterruptedTaskHistory(cluster, clusterId, 'validator-requirements', {
+    iteration: 8,
+    taskId: 'completed-requirements-task',
+    triggeredBy: 'IMPLEMENTATION_READY',
+  });
+  publishCompletedTaskHistory(cluster, clusterId, 'validator-requirements', {
+    iteration: 8,
+    taskId: 'completed-requirements-task',
+  });
+  publishValidationResult(
+    cluster,
+    clusterId,
+    'validator-requirements',
+    true,
+    'Requirements approved'
+  );
+  setPersistedAgentTaskState(cluster, 'validator-requirements', {
+    state: 'idle',
+    iteration: 8,
+    taskId: 'completed-requirements-task',
+    processPid: null,
+  });
+}
+
+function prepareInterruptedCodeValidator(cluster, clusterId) {
+  publishInterruptedTaskHistory(cluster, clusterId, 'validator-code', {
+    iteration: 5,
+    taskId: 'interrupted-code-task',
+    triggeredBy: 'IMPLEMENTATION_READY',
+  });
+  setPersistedAgentTaskState(cluster, 'validator-code', {
+    state: 'executing_task',
+    iteration: 5,
+    taskId: 'interrupted-code-task',
+    processPid: 4242,
+  });
+}
+
+function publishAgentError(cluster, clusterId, agentId, { error, iteration, taskId }) {
+  cluster.messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_ERROR',
+    sender: agentId,
+    content: {
+      text: error,
+      data: { agent: agentId, error, iteration, taskId },
+    },
+  });
+}
+
+async function reloadLifecycleOrchestrator(orchestrator, storageDir, taskRunner) {
+  await orchestrator._saveClusters();
+  orchestrator.close();
+  return Orchestrator.create({
+    taskRunner,
+    storageDir,
+    quiet: true,
+  });
+}
+
+function validationResultCounts(cluster, clusterId) {
+  return {
+    total: cluster.messageBus.count({
+      cluster_id: clusterId,
+      topic: 'VALIDATION_RESULT',
+    }),
+    requirements: cluster.messageBus.query({
+      cluster_id: clusterId,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-requirements',
+    }).length,
+  };
+}
+
+function assertValidationResultsAdvancedOnce(cluster, clusterId, before) {
+  const after = validationResultCounts(cluster, clusterId);
+  assert.strictEqual(
+    after.total,
+    before.total + 1,
+    'only the interrupted validator may append a new validation result'
+  );
+  assert.strictEqual(
+    after.requirements,
+    before.requirements,
+    'the completed validator result must remain a singleton'
+  );
+}
+
 function deleteLedgerTopics(cluster, clusterId, topics) {
   const placeholders = topics.map(() => '?').join(', ');
   cluster.ledger.db
@@ -1027,71 +1165,8 @@ function defineLifecycleResumeTests() {
 
       await lifecycleOrchestrator.stop(clusterId);
       const cluster = lifecycleOrchestrator.getCluster(clusterId);
-      cluster.failureInfo = {
-        agentId: 'validator-requirements',
-        taskId: 'recovered-requirements-task',
-        iteration: 7,
-        error: 'temporary provider lookup failure',
-        timestamp: Date.now() - 1000,
-      };
-      cluster.messageBus.publish({
-        cluster_id: clusterId,
-        topic: 'IMPLEMENTATION_READY',
-        sender: 'worker',
-        content: { text: 'Implementation ready for validation' },
-      });
-      publishInterruptedTaskHistory(cluster, clusterId, 'validator-requirements', {
-        iteration: 8,
-        taskId: 'completed-requirements-task',
-        triggeredBy: 'IMPLEMENTATION_READY',
-      });
-      cluster.messageBus.publish({
-        cluster_id: clusterId,
-        topic: 'AGENT_LIFECYCLE',
-        sender: 'validator-requirements',
-        content: {
-          text: 'validator-requirements: TASK_COMPLETED',
-          data: {
-            event: 'TASK_COMPLETED',
-            agent: 'validator-requirements',
-            role: 'validator',
-            state: 'idle',
-            iteration: 8,
-            taskId: 'completed-requirements-task',
-          },
-        },
-      });
-      cluster.messageBus.publish({
-        cluster_id: clusterId,
-        topic: 'VALIDATION_RESULT',
-        sender: 'validator-requirements',
-        content: {
-          text: 'Requirements approved',
-          data: { approved: true },
-        },
-      });
-      publishInterruptedTaskHistory(cluster, clusterId, 'validator-code', {
-        iteration: 5,
-        taskId: 'interrupted-code-task',
-        triggeredBy: 'IMPLEMENTATION_READY',
-      });
-
-      const completedValidator = cluster.agents.find(
-        (agent) => agent.id === 'validator-requirements'
-      );
-      completedValidator.state = 'idle';
-      completedValidator.iteration = 8;
-      completedValidator.currentTaskId = 'completed-requirements-task';
-      completedValidator.processPid = null;
-
-      const interruptedValidator = cluster.agents.find((agent) => agent.id === 'validator-code');
-      interruptedValidator.state = 'executing_task';
-      interruptedValidator.iteration = 5;
-      interruptedValidator.currentTaskId = 'interrupted-code-task';
-      interruptedValidator.processPid = 4242;
-
-      await lifecycleOrchestrator._saveClusters();
-      lifecycleOrchestrator.close();
+      prepareRecoveredRequirementsFailure(cluster, clusterId);
+      prepareInterruptedCodeValidator(cluster, clusterId);
 
       const resumedRunner = new MockTaskRunner();
       resumedRunner
@@ -1099,23 +1174,14 @@ function defineLifecycleResumeTests() {
         .returns({ approved: true, summary: 'Requirements approved again' });
       resumedRunner.when('validator-code').returns({ approved: false, summary: 'Code rejected' });
       resumedRunner.when('worker').returns('Repaired validation findings');
-
-      lifecycleOrchestrator = await Orchestrator.create({
-        taskRunner: resumedRunner,
-        storageDir: lifecycleStorageDir,
-        quiet: true,
-      });
+      lifecycleOrchestrator = await reloadLifecycleOrchestrator(
+        lifecycleOrchestrator,
+        lifecycleStorageDir,
+        resumedRunner
+      );
 
       const restoredCluster = lifecycleOrchestrator.getCluster(clusterId);
-      const validationCountBeforeResume = restoredCluster.messageBus.count({
-        cluster_id: clusterId,
-        topic: 'VALIDATION_RESULT',
-      });
-      const requirementsResultsBeforeResume = restoredCluster.messageBus.query({
-        cluster_id: clusterId,
-        topic: 'VALIDATION_RESULT',
-        sender: 'validator-requirements',
-      }).length;
+      const validationCountsBeforeResume = validationResultCounts(restoredCluster, clusterId);
 
       const resumed = await lifecycleOrchestrator.resume(clusterId);
       assert.strictEqual(resumed.resumeType, 'clean');
@@ -1126,23 +1192,7 @@ function defineLifecycleResumeTests() {
       });
 
       resumedRunner.assertCalled('validator-requirements', 0);
-      assert.strictEqual(
-        restoredCluster.messageBus.count({
-          cluster_id: clusterId,
-          topic: 'VALIDATION_RESULT',
-        }),
-        validationCountBeforeResume + 1,
-        'only the interrupted validator may append a new validation result'
-      );
-      assert.strictEqual(
-        restoredCluster.messageBus.query({
-          cluster_id: clusterId,
-          topic: 'VALIDATION_RESULT',
-          sender: 'validator-requirements',
-        }).length,
-        requirementsResultsBeforeResume,
-        'the completed validator result must remain a singleton'
-      );
+      assertValidationResultsAdvancedOnce(restoredCluster, clusterId, validationCountsBeforeResume);
     });
 
     it('resumes a missing validator in a partial validation cycle without replaying completed results', async function () {
@@ -1665,19 +1715,32 @@ function defineLifecycleResumeTests() {
       const cluster = lifecycleOrchestrator.getCluster(result.id);
       cluster.failureInfo = {
         agentId: 'worker',
+        taskId: 'persisted-worker-failure',
         iteration: 1,
         error: 'boom',
+        timestamp: Date.now(),
       };
 
-      lifecycleMockRunner.when('worker').delays(500, { done: true, resumed: true });
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner.when('worker').delays(500, { done: true, resumed: true });
+      lifecycleOrchestrator = await reloadLifecycleOrchestrator(
+        lifecycleOrchestrator,
+        lifecycleStorageDir,
+        resumedRunner
+      );
 
       const resumed = await lifecycleOrchestrator.resume(result.id);
       const status = lifecycleOrchestrator.getStatus(result.id);
+      const restoredCluster = lifecycleOrchestrator.getCluster(result.id);
 
       assert.strictEqual(resumed.resumeType, 'failure');
       assert.strictEqual(resumed.resumedAgent, 'worker');
       assert.strictEqual(resumed.previousError, 'boom');
-      assert.strictEqual(cluster.pid, process.pid, 'Resumed cluster should record current PID');
+      assert.strictEqual(
+        restoredCluster.pid,
+        process.pid,
+        'Resumed cluster should record current PID'
+      );
       assert.strictEqual(status.state, 'running', 'Resumed cluster should not self-report zombie');
     });
 
@@ -1722,6 +1785,49 @@ function defineLifecycleResumeTests() {
       assert.strictEqual(resumed.resumeType, 'failure');
       assert.strictEqual(resumed.resumedAgent, 'worker');
       assert.strictEqual(resumed.previousError, 'current failure');
+    });
+
+    it('selects an unresolved ledger failure after reloading recovered registry and ledger failures', async function () {
+      const worktreeDir = fs.mkdtempSync(path.join(lifecycleStorageDir, 'resume-ordering-'));
+      const result = await lifecycleOrchestrator.start(
+        createPartialValidationResumeConfig(worktreeDir),
+        { text: 'Task' },
+        { clusterId: 'persisted-composed-failure-ordering' }
+      );
+      await lifecycleOrchestrator.stop(result.id);
+
+      const cluster = lifecycleOrchestrator.getCluster(result.id);
+      prepareRecoveredRequirementsFailure(cluster, result.id);
+      publishAgentError(cluster, result.id, 'validator-code', {
+        error: 'unresolved code validator failure',
+        iteration: 5,
+        taskId: 'unresolved-code-task',
+      });
+      publishRecoveredWorkerFailureHistory(cluster, result.id);
+
+      const resumedRunner = new MockTaskRunner();
+      resumedRunner.when('validator-code').delays(500, {
+        approved: false,
+        summary: 'Code rejected',
+      });
+      lifecycleOrchestrator = await reloadLifecycleOrchestrator(
+        lifecycleOrchestrator,
+        lifecycleStorageDir,
+        resumedRunner
+      );
+
+      const restored = lifecycleOrchestrator.getCluster(result.id);
+      const failureInfo = lifecycleOrchestrator._resolveFailureInfo(restored, result.id);
+      assert.strictEqual(failureInfo.agentId, 'validator-code');
+      assert.strictEqual(failureInfo.taskId, 'unresolved-code-task');
+
+      const resumed = await lifecycleOrchestrator.resume(result.id);
+      await waitForAgentCalls(resumedRunner, { 'validator-code': 1 });
+      assert.strictEqual(resumed.resumeType, 'failure');
+      assert.strictEqual(resumed.resumedAgent, 'validator-code');
+      assert.strictEqual(resumed.previousError, 'unresolved code validator failure');
+      resumedRunner.assertCalled('validator-requirements', 0);
+      resumedRunner.assertCalled('worker', 0);
     });
 
     it('should skip every recovered error and select the newest unresolved failure from complete history', async function () {


### PR DESCRIPTION
## Summary
- ignore stale persisted registry `failureInfo` after the same agent has durable later task progress
- preserve the existing failed-agent resume path when no recovery evidence exists
- exercise recovered registry failures through both foreground and detached partial-validation recovery

## Root cause
PR #737 made ledger-derived `AGENT_ERROR` recovery durable-history aware, but `_resolveFailureInfo()` still returned persisted registry `cluster.failureInfo` unconditionally. A cluster could therefore re-enter an already recovered validator failure instead of planning the genuinely interrupted validator from the ledger.

## Regression evidence
- Red before fix: `npx mocha tests/orchestrator.test.js --grep "ignores a recovered persisted failure" --timeout 15000` -> 0 passing, 1 failing (`failure` instead of `clean`)
- Focused resume: 18 passing
- Foreground/detached partial validation: 2 passing
- Full unit: 1,694 passing, 18 pending
- Full E2E with short macOS temp root: 24 passing
- Slow/integration: 143 passing, 18 pending
- `npm run lint`: 0 errors (155 existing warnings)
- `npm run typecheck`: passed
- `npm run protocol:check`: passed
- `npm run rust:check`: passed
- `opcore check --changed`: passed

## Environment note
The first macOS E2E invocation inherited a long `$TMPDIR` and hit Unix-domain socket `listen EINVAL` plus missing fake-provider artifacts. Re-running the unchanged suite with `TMPDIR=/tmp` removed the path-length confounder and passed 24/24. The earlier Node 24 `node-pty` spawn failures were caused by installing with `npm ci --ignore-scripts`; running the repository postinstall permission repair restored the executable spawn helper, after which affected tests and the full unit suite passed.

Closes #739