### PR TITLE
fix(attach): shorten Unix socket paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,8 @@ Long scripts show no output until done.
 Strict structured-output Codex tasks use the attachable PTY watcher. Claude strict
 structured-output tasks keep the non-PTY watcher because PTY notifications can be
 interpreted as streaming commands; use `zeroshot logs` for those tasks.
+Attach sockets use the shared short runtime namespace from `src/attach/socket-paths.js`;
+never reconstruct their path from `HOME` in a watcher or client.
 
 ### Kubernetes / Network Storage (SQLite Ledger)
 

--- a/src/attach/socket-discovery.js
+++ b/src/attach/socket-discovery.js
@@ -1,10 +1,8 @@
 /**
  * Socket Discovery - Utilities for socket path management
  *
- * Socket locations:
- * - Tasks: ~/.zeroshot/sockets/task-<id>.sock
- * - Clusters: ~/.zeroshot/sockets/cluster-<id>.sock (cluster-level, future)
- * - Agents: ~/.zeroshot/sockets/cluster-<id>/<agent-id>.sock
+ * Socket locations are allocated by socket-paths.js under a short, per-user
+ * runtime directory so long HOME paths cannot exceed Unix socket limits.
  */
 
 const path = require('path');
@@ -12,9 +10,10 @@ const fs = require('fs');
 const os = require('os');
 const net = require('net');
 const { readClustersFileSync } = require('../../lib/clusters-registry');
+const socketPaths = require('./socket-paths');
 
 const ZEROSHOT_DIR = path.join(os.homedir(), '.zeroshot');
-const SOCKET_DIR = path.join(ZEROSHOT_DIR, 'sockets');
+const SOCKET_DIR = socketPaths.getSocketDir();
 
 /**
  * Check if an ID is a known cluster by looking up clusters.json
@@ -35,9 +34,7 @@ function isKnownCluster(id) {
  * Ensure socket directory exists
  */
 function ensureSocketDir() {
-  if (!fs.existsSync(SOCKET_DIR)) {
-    fs.mkdirSync(SOCKET_DIR, { recursive: true });
-  }
+  socketPaths.ensureSocketDir();
 }
 
 /**
@@ -46,8 +43,7 @@ function ensureSocketDir() {
  * @returns {string} - Socket path
  */
 function getTaskSocketPath(taskId) {
-  ensureSocketDir();
-  return path.join(SOCKET_DIR, `${taskId}.sock`);
+  return socketPaths.getTaskSocketPath(taskId);
 }
 
 /**
@@ -57,11 +53,7 @@ function getTaskSocketPath(taskId) {
  * @returns {string} - Socket path
  */
 function getAgentSocketPath(clusterId, agentId) {
-  const clusterDir = path.join(SOCKET_DIR, clusterId);
-  if (!fs.existsSync(clusterDir)) {
-    fs.mkdirSync(clusterDir, { recursive: true });
-  }
-  return path.join(clusterDir, `${agentId}.sock`);
+  return socketPaths.getAgentSocketPath(clusterId, agentId);
 }
 
 /**
@@ -81,8 +73,7 @@ function getSocketPath(id, agentId = null) {
       return getAgentSocketPath(id, agentId);
     }
     // Cluster-level socket (future use)
-    ensureSocketDir();
-    return path.join(SOCKET_DIR, `${id}.sock`);
+    return socketPaths.getClusterSocketPath(id);
   }
   // Unknown format, treat as task
   return getTaskSocketPath(id);

--- a/src/attach/socket-discovery.js
+++ b/src/attach/socket-discovery.js
@@ -7,12 +7,11 @@
 
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const net = require('net');
 const { readClustersFileSync } = require('../../lib/clusters-registry');
 const socketPaths = require('./socket-paths');
 
-const ZEROSHOT_DIR = path.join(os.homedir(), '.zeroshot');
+const ZEROSHOT_DIR = path.join(socketPaths.resolveHomeDir(), '.zeroshot');
 const SOCKET_DIR = socketPaths.getSocketDir();
 
 /**

--- a/src/attach/socket-paths.js
+++ b/src/attach/socket-paths.js
@@ -1,0 +1,76 @@
+/**
+ * Deterministic attach socket paths.
+ *
+ * Unix-domain sockets have a small path budget (104 bytes on macOS). Keep the
+ * live socket namespace independent from HOME while retaining one namespace
+ * per OS user and Zeroshot home.
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SOCKET_ROOT = process.platform === 'win32' ? null : '/tmp';
+const SOCKET_DIR_MODE = 0o700;
+
+function shortHash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function userNamespace() {
+  if (typeof process.getuid === 'function') {
+    return String(process.getuid());
+  }
+  return shortHash(os.userInfo().username);
+}
+
+function getSocketDir(homeDir = os.homedir()) {
+  if (process.platform === 'win32') {
+    return path.join(homeDir, '.zeroshot', 'sockets');
+  }
+  return path.join(SOCKET_ROOT, `zeroshot-${userNamespace()}-${shortHash(homeDir)}`);
+}
+
+function assertSafeSocketDir(socketDir) {
+  const stat = fs.lstatSync(socketDir);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Attach socket path is not a directory: ${socketDir}`);
+  }
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    throw new Error(`Attach socket directory is not owned by the current user: ${socketDir}`);
+  }
+}
+
+function ensureSocketDir(homeDir = os.homedir()) {
+  const socketDir = getSocketDir(homeDir);
+  fs.mkdirSync(socketDir, { recursive: true, mode: SOCKET_DIR_MODE });
+  assertSafeSocketDir(socketDir);
+  if (process.platform !== 'win32') {
+    fs.chmodSync(socketDir, SOCKET_DIR_MODE);
+  }
+  return socketDir;
+}
+
+function getTaskSocketPath(taskId, homeDir = os.homedir()) {
+  return path.join(ensureSocketDir(homeDir), `${taskId}.sock`);
+}
+
+function getAgentSocketPath(clusterId, agentId, homeDir = os.homedir()) {
+  const clusterDir = path.join(ensureSocketDir(homeDir), clusterId);
+  fs.mkdirSync(clusterDir, { recursive: true, mode: SOCKET_DIR_MODE });
+  return path.join(clusterDir, `${agentId}.sock`);
+}
+
+function getClusterSocketPath(clusterId, homeDir = os.homedir()) {
+  return path.join(ensureSocketDir(homeDir), `${clusterId}.sock`);
+}
+
+module.exports = {
+  SOCKET_DIR_MODE,
+  getSocketDir,
+  ensureSocketDir,
+  getTaskSocketPath,
+  getAgentSocketPath,
+  getClusterSocketPath,
+};

--- a/src/attach/socket-paths.js
+++ b/src/attach/socket-paths.js
@@ -25,7 +25,11 @@ function userNamespace() {
   return shortHash(os.userInfo().username);
 }
 
-function getSocketDir(homeDir = os.homedir()) {
+function resolveHomeDir(env = process.env) {
+  return env.ZEROSHOT_HOME || env.HOME || env.USERPROFILE || os.homedir();
+}
+
+function getSocketDir(homeDir = resolveHomeDir()) {
   if (process.platform === 'win32') {
     return path.join(homeDir, '.zeroshot', 'sockets');
   }
@@ -42,8 +46,7 @@ function assertSafeSocketDir(socketDir) {
   }
 }
 
-function ensureSocketDir(homeDir = os.homedir()) {
-  const socketDir = getSocketDir(homeDir);
+function ensureOwnedDirectory(socketDir) {
   fs.mkdirSync(socketDir, { recursive: true, mode: SOCKET_DIR_MODE });
   assertSafeSocketDir(socketDir);
   if (process.platform !== 'win32') {
@@ -52,22 +55,28 @@ function ensureSocketDir(homeDir = os.homedir()) {
   return socketDir;
 }
 
-function getTaskSocketPath(taskId, homeDir = os.homedir()) {
+function ensureSocketDir(homeDir = resolveHomeDir()) {
+  const socketDir = getSocketDir(homeDir);
+  return ensureOwnedDirectory(socketDir);
+}
+
+function getTaskSocketPath(taskId, homeDir = resolveHomeDir()) {
   return path.join(ensureSocketDir(homeDir), `${taskId}.sock`);
 }
 
-function getAgentSocketPath(clusterId, agentId, homeDir = os.homedir()) {
+function getAgentSocketPath(clusterId, agentId, homeDir = resolveHomeDir()) {
   const clusterDir = path.join(ensureSocketDir(homeDir), clusterId);
-  fs.mkdirSync(clusterDir, { recursive: true, mode: SOCKET_DIR_MODE });
+  ensureOwnedDirectory(clusterDir);
   return path.join(clusterDir, `${agentId}.sock`);
 }
 
-function getClusterSocketPath(clusterId, homeDir = os.homedir()) {
+function getClusterSocketPath(clusterId, homeDir = resolveHomeDir()) {
   return path.join(ensureSocketDir(homeDir), `${clusterId}.sock`);
 }
 
 module.exports = {
   SOCKET_DIR_MODE,
+  resolveHomeDir,
   getSocketDir,
   ensureSocketDir,
   getTaskSocketPath,

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -5,10 +5,8 @@
  * Runs detached from parent, provides Unix socket for attach clients.
  */
 
-import { appendFileSync, existsSync, mkdirSync, unlinkSync } from 'fs';
+import { appendFileSync, unlinkSync } from 'fs';
 import { unlink } from 'fs/promises';
-import { join } from 'path';
-import { homedir } from 'os';
 import { updateTask } from './store.js';
 import {
   detectProviderFatalError,
@@ -72,6 +70,7 @@ process.on('unhandledRejection', (reason) => {
 
 const require = createRequire(import.meta.url);
 const { AttachServer } = require('../src/attach');
+const { getTaskSocketPath } = require('../src/attach/socket-paths');
 const { normalizeProviderName } = require('../lib/provider-names');
 
 const taskId = taskIdArg;
@@ -88,12 +87,7 @@ const commandSpec = config.commandSpec || {
 commandSpecCleanup = commandSpec.cleanup || [];
 let server = null;
 
-const SOCKET_DIR = join(homedir(), '.zeroshot', 'sockets');
-const socketPath = join(SOCKET_DIR, `${taskId}.sock`);
-
-if (!existsSync(SOCKET_DIR)) {
-  mkdirSync(SOCKET_DIR, { recursive: true });
-}
+const socketPath = getTaskSocketPath(taskId);
 
 function log(msg) {
   appendFileSync(logFile, msg);

--- a/tests/unit/socket-paths.test.js
+++ b/tests/unit/socket-paths.test.js
@@ -32,6 +32,32 @@ describe('attach socket paths', function () {
     assert(!first.includes(longHome));
   });
 
+  it('resolves Zeroshot home before generic process home variables', function () {
+    const sharedHome = '/tmp/shared-home';
+    const first = socketPaths.resolveHomeDir({
+      ZEROSHOT_HOME: '/tmp/zeroshot-home-a',
+      HOME: sharedHome,
+      USERPROFILE: sharedHome,
+    });
+    const second = socketPaths.resolveHomeDir({
+      ZEROSHOT_HOME: '/tmp/zeroshot-home-b',
+      HOME: sharedHome,
+      USERPROFILE: sharedHome,
+    });
+
+    assert.strictEqual(first, '/tmp/zeroshot-home-a');
+    assert.strictEqual(second, '/tmp/zeroshot-home-b');
+    assert.strictEqual(
+      socketPaths.resolveHomeDir({ HOME: sharedHome, USERPROFILE: '/tmp/profile-home' }),
+      sharedHome
+    );
+    assert.strictEqual(
+      socketPaths.resolveHomeDir({ USERPROFILE: '/tmp/profile-home' }),
+      '/tmp/profile-home'
+    );
+    assert.notStrictEqual(socketPaths.getSocketDir(first), socketPaths.getSocketDir(second));
+  });
+
   it('protects each per-user socket directory with owner-only permissions', function () {
     if (process.platform === 'win32') this.skip();
 
@@ -39,5 +65,37 @@ describe('attach socket paths', function () {
     const mode = fs.statSync(path.dirname(socketPath)).mode & 0o777;
 
     assert.strictEqual(mode, 0o700);
+  });
+
+  it('repairs permissive agent socket subdirectory permissions', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const homeDir = '/tmp/zeroshot-agent-permission-home';
+    const socketDir = socketPaths.ensureSocketDir(homeDir);
+    const clusterDir = path.join(socketDir, 'permission-cluster');
+    createdDirs.add(socketDir);
+    fs.mkdirSync(clusterDir, { mode: 0o755 });
+    fs.chmodSync(clusterDir, 0o755);
+
+    socketPaths.getAgentSocketPath('permission-cluster', 'worker', homeDir);
+
+    assert.strictEqual(fs.statSync(clusterDir).mode & 0o777, 0o700);
+  });
+
+  it('rejects symlinked agent socket subdirectories', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const homeDir = '/tmp/zeroshot-agent-symlink-home';
+    const socketDir = socketPaths.ensureSocketDir(homeDir);
+    const targetDir = fs.mkdtempSync('/tmp/zeroshot-agent-target-');
+    const clusterDir = path.join(socketDir, 'symlink-cluster');
+    createdDirs.add(socketDir);
+    createdDirs.add(targetDir);
+    fs.symlinkSync(targetDir, clusterDir);
+
+    assert.throws(
+      () => socketPaths.getAgentSocketPath('symlink-cluster', 'worker', homeDir),
+      /not a directory|symbolic link/
+    );
   });
 });

--- a/tests/unit/socket-paths.test.js
+++ b/tests/unit/socket-paths.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const socketPaths = require('../../src/attach/socket-paths');
+
+describe('attach socket paths', function () {
+  const createdDirs = new Set();
+
+  afterEach(() => {
+    for (const socketDir of createdDirs) {
+      fs.rmSync(socketDir, { recursive: true, force: true });
+    }
+    createdDirs.clear();
+  });
+
+  function taskPath(taskId, homeDir) {
+    const socketPath = socketPaths.getTaskSocketPath(taskId, homeDir);
+    createdDirs.add(path.dirname(socketPath));
+    return socketPath;
+  }
+
+  it('allocates deterministic short paths isolated by Zeroshot home', function () {
+    const longHome = path.join('/tmp', 'long-home-segment-'.repeat(20));
+    const first = taskPath('sparkling-fortress-99', longHome);
+    const repeated = taskPath('sparkling-fortress-99', longHome);
+    const otherHome = taskPath('sparkling-fortress-99', `${longHome}-other`);
+
+    assert.strictEqual(first, repeated);
+    assert.notStrictEqual(first, otherHome);
+    assert(Buffer.byteLength(first) < 100, `socket path is too long: ${first}`);
+    assert(!first.includes(longHome));
+  });
+
+  it('protects each per-user socket directory with owner-only permissions', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const socketPath = taskPath('secure-task', '/tmp/zeroshot-secure-home');
+    const mode = fs.statSync(path.dirname(socketPath)).mode & 0o777;
+
+    assert.strictEqual(mode, 0o700);
+  });
+});

--- a/tests/unit/task-attachable-selection.test.js
+++ b/tests/unit/task-attachable-selection.test.js
@@ -9,6 +9,7 @@ const { pathToFileURL } = require('url');
 const runnerUrl = pathToFileURL(path.resolve(__dirname, '../../task-lib/runner.js')).href;
 const storeUrl = pathToFileURL(path.resolve(__dirname, '../../task-lib/store.js')).href;
 const socketDiscoveryPath = path.resolve(__dirname, '../../src/attach/socket-discovery.js');
+const socketPaths = require('../../src/attach/socket-paths');
 
 function createFakeCodex(fakeBinDir) {
   const fakeCodex = path.join(fakeBinDir, 'codex');
@@ -108,14 +109,14 @@ process.stdout.write(JSON.stringify({ socketPath: attached.socketPath, log }) + 
   return harnessPath;
 }
 
-function runHarness(harnessPath, fakeBinDir, shortHome) {
+function runHarness(harnessPath, fakeBinDir, testHome, zeroshotHome = testHome) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [harnessPath], {
       env: {
         ...process.env,
-        HOME: shortHome,
-        USERPROFILE: shortHome,
-        ZEROSHOT_HOME: shortHome,
+        HOME: testHome,
+        USERPROFILE: testHome,
+        ZEROSHOT_HOME: zeroshotHome,
         PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -155,15 +156,20 @@ async function runAttachableRegression(options = {}) {
     ? `${'deliberately-long-home-segment-'.repeat(5)}${process.pid}-${Date.now()}`
     : `zeroshot-attach-${process.pid}-${Date.now()}`;
   const testHome = path.join('/tmp', homeSuffix);
+  const zeroshotHome =
+    options.zeroshotHome || path.join('/tmp', `zeroshot-runtime-${process.pid}-${Date.now()}`);
   fs.mkdirSync(testHome, { recursive: true });
+  fs.mkdirSync(zeroshotHome, { recursive: true });
   createFakeCodex(fakeBinDir);
   const harnessPath = createHarness(testHome);
 
   try {
-    return await runHarness(harnessPath, fakeBinDir, testHome);
+    return await runHarness(harnessPath, fakeBinDir, testHome, zeroshotHome);
   } finally {
     fs.rmSync(fakeBinDir, { recursive: true, force: true });
     fs.rmSync(testHome, { recursive: true, force: true });
+    fs.rmSync(zeroshotHome, { recursive: true, force: true });
+    fs.rmSync(socketPaths.getSocketDir(zeroshotHome), { recursive: true, force: true });
   }
 }
 
@@ -204,6 +210,15 @@ describe('task watcher attachment selection', function () {
     expect(result.socketPath).to.match(/\.sock$/);
     expect(result.socketPath.length).to.be.lessThan(100);
     expect(result.log).to.include('"type":"thread.started"');
+    expect(result.log).to.include('{\\"ok\\":true}');
+  });
+
+  it('uses ZEROSHOT_HOME consistently for watcher and discovery socket paths', async function () {
+    this.timeout(15000);
+    const zeroshotHome = path.join('/tmp', `zeroshot-explicit-home-${process.pid}-${Date.now()}`);
+    const result = await runAttachableRegression({ longHome: true, zeroshotHome });
+
+    expect(path.dirname(result.socketPath)).to.equal(socketPaths.getSocketDir(zeroshotHome));
     expect(result.log).to.include('{\\"ok\\":true}');
   });
 

--- a/tests/unit/task-attachable-selection.test.js
+++ b/tests/unit/task-attachable-selection.test.js
@@ -149,18 +149,21 @@ function runHarness(harnessPath, fakeBinDir, shortHome) {
   });
 }
 
-async function runAttachableRegression() {
+async function runAttachableRegression(options = {}) {
   const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-fake-codex-'));
-  const shortHome = `/tmp/zeroshot-attach-${process.pid}-${Date.now()}`;
-  fs.mkdirSync(shortHome, { recursive: true });
+  const homeSuffix = options.longHome
+    ? `${'deliberately-long-home-segment-'.repeat(5)}${process.pid}-${Date.now()}`
+    : `zeroshot-attach-${process.pid}-${Date.now()}`;
+  const testHome = path.join('/tmp', homeSuffix);
+  fs.mkdirSync(testHome, { recursive: true });
   createFakeCodex(fakeBinDir);
-  const harnessPath = createHarness(shortHome);
+  const harnessPath = createHarness(testHome);
 
   try {
-    return await runHarness(harnessPath, fakeBinDir, shortHome);
+    return await runHarness(harnessPath, fakeBinDir, testHome);
   } finally {
     fs.rmSync(fakeBinDir, { recursive: true, force: true });
-    fs.rmSync(shortHome, { recursive: true, force: true });
+    fs.rmSync(testHome, { recursive: true, force: true });
   }
 }
 
@@ -190,6 +193,16 @@ describe('task watcher attachment selection', function () {
     const result = await runAttachableRegression();
 
     expect(result.socketPath).to.match(/\.sock$/);
+    expect(result.log).to.include('"type":"thread.started"');
+    expect(result.log).to.include('{\\"ok\\":true}');
+  });
+
+  it('creates a live attach socket when HOME exceeds the Unix socket path limit', async function () {
+    this.timeout(15000);
+    const result = await runAttachableRegression({ longHome: true });
+
+    expect(result.socketPath).to.match(/\.sock$/);
+    expect(result.socketPath.length).to.be.lessThan(100);
     expect(result.log).to.include('"type":"thread.started"');
     expect(result.log).to.include('{\\"ok\\":true}');
   });


### PR DESCRIPTION
## Summary

- allocate attach sockets in a deterministic short runtime namespace keyed by OS user and Zeroshot home
- share that allocator between the attachable watcher and socket discovery/client fallbacks
- protect the runtime directory with owner-only permissions while retaining existing socket cleanup and task-registry paths
- add an end-to-end watcher regression with a deliberately overlong `HOME`

## Root cause

`task-lib/attachable-watcher.js` reconstructed sockets below
`$HOME/.zeroshot/sockets`. The E2E harness intentionally uses long isolated home
paths, which pushed macOS Unix-domain sockets past their 104-byte limit and caused
`listen EINVAL` before the provider process could start. Fixing only the watcher
would have left discovery and attach clients looking in a different location, so
path allocation now has one shared implementation.

## Validation

- RED before fix: long-HOME watcher regression failed with the issue's exact `listen EINVAL`
- focused attach, discovery, stdin, and guidance tests: 13 passing
- `npm run test:e2e`: 24 passing
- `npm run test:slow`: 143 passing, 18 pending Docker-dependent cases
- `npm run lint`: pass (existing warnings only)
- `npm run typecheck`: pass
- `opcore check --changed`: pass
- Opcore graph refresh remains degraded because its parser rejects the repository's JSONC `tsconfig.json` (`key must be a string at line 3 column 5`)

Closes #741.
