### PR TITLE
fix(cluster-protocol): align graph profile schema ordering

### DIFF
--- a/crates/openengine-cluster-protocol/src/graph_profile.rs
+++ b/crates/openengine-cluster-protocol/src/graph_profile.rs
@@ -95,10 +95,19 @@ impl<'de> Deserialize<'de> for GraphProfileSet {
 /// `schema_with` target for the `graphProfiles` field: `GraphProfileSet` has no standalone
 /// `JsonSchema` impl because its wire shape only ever appears inline on that field.
 pub fn graph_profile_set_schema(generator: &mut SchemaGenerator) -> Schema {
+    let full = GraphProfile::Full.as_str();
+    let single_worker = GraphProfile::SingleWorker.as_str();
     json_schema!({
         "type": "array",
         "maxItems": GRAPH_PROFILES.len(),
         "uniqueItems": true,
-        "items": generator.subschema_for::<GraphProfile>()
+        "items": generator.subschema_for::<GraphProfile>(),
+        "not": {
+            "minItems": 2,
+            "prefixItems": [
+                { "const": single_worker },
+                { "const": full }
+            ]
+        }
     })
 }

--- a/crates/openengine-cluster-protocol/tests/capabilities.rs
+++ b/crates/openengine-cluster-protocol/tests/capabilities.rs
@@ -72,6 +72,37 @@ fn unknown_profile_string_fails_deserialization() {
 }
 
 #[test]
+fn json_schema_matches_canonical_profile_order() {
+    let schema = serde_json::to_value(schemars::schema_for!(ServerCapabilities)).unwrap();
+    let validator = jsonschema::validator_for(&schema).unwrap();
+
+    for graph_profiles in [
+        json!([]),
+        json!(["openengine.graph.full/v1"]),
+        json!(["openengine.graph.single-worker/v1"]),
+        json!([
+            "openengine.graph.full/v1",
+            "openengine.graph.single-worker/v1"
+        ]),
+    ] {
+        let value = json!({ "graphProfiles": graph_profiles });
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+    }
+
+    for graph_profiles in [
+        json!([
+            "openengine.graph.single-worker/v1",
+            "openengine.graph.full/v1"
+        ]),
+        json!(["openengine.graph.full/v1", "openengine.graph.full/v1"]),
+        json!(["openengine.graph.unknown/v1"]),
+    ] {
+        let value = json!({ "graphProfiles": graph_profiles });
+        assert!(!validator.is_valid(&value), "schema accepted {value}");
+    }
+}
+
+#[test]
 fn missing_field_defaults_to_empty() {
     let value: ServerCapabilities = serde_json::from_value(json!({})).unwrap();
     assert_eq!(value, capabilities_of(vec![]));

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -1978,6 +1978,17 @@
             "$ref": "#/$defs/GraphProfile"
           },
           "maxItems": 2,
+          "not": {
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "const": "openengine.graph.single-worker/v1"
+              },
+              {
+                "const": "openengine.graph.full/v1"
+              }
+            ]
+          },
           "type": "array",
           "uniqueItems": true
         }


### PR DESCRIPTION
## Problem

Follow-up review of #776 found that Rust deserialization rejected reversed graph profile order while the generated JSON Schema accepted it. That violated #752's deterministic cross-client contract.

## Change

- Reject the only non-canonical two-profile ordering in the authoritative schema generator.
- Add schema parity coverage for every valid set plus reversed, duplicate, and unknown vectors.
- Regenerate the committed protocol schema.

## Verification

- cargo test -p openengine-cluster-protocol --test capabilities (9 passed)
- cargo test -p openengine-cluster-server --test initialize_capabilities (2 passed)
- cargo test -p openengine-cluster-testkit --test capability_vectors (4 passed)
- npm run rust:check
- npm run protocol:check
- npm run typecheck
- npm run lint
- npm run test:unit (1702 passing, 18 pending)
- opcore check --changed

Refs #752
