### PR TITLE
fix(cluster-protocol): harden watch boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,9 @@ predicate is a winner; correlate `raced=satisfied|no_satisfier` with those winne
 The admission coordinator provides stateful plan/apply/get semantics through injected ports.
 Testkit scripted approval and `running` phase mean admitted state, not native verification or a
 production full-graph executor.
+`AdmissionStore` and `ObservationStore` remain separate ports. A watch-capable
+`AdmissionCoordinator` requires both; never satisfy the observation boundary with a runtime
+placeholder that rejects every subscription.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait

--- a/crates/openengine-cluster-server/src/admission.rs
+++ b/crates/openengine-cluster-server/src/admission.rs
@@ -202,7 +202,7 @@ where
 impl<V, S> ClusterBackend for AdmissionCoordinator<V, S>
 where
     V: GraphVerifier,
-    S: AdmissionStore,
+    S: AdmissionStore + ObservationStore,
 {
     async fn initialize(
         &self,

--- a/crates/openengine-cluster-server/src/admission/ports.rs
+++ b/crates/openengine-cluster-server/src/admission/ports.rs
@@ -13,7 +13,6 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::lifecycle::{LifecycleSnapshot, LifecycleStore, MutationReceipt};
-use crate::watch::ObservationStore;
 
 #[derive(Clone, Default)]
 pub struct CancellationSignal(Arc<AtomicBool>);
@@ -223,7 +222,7 @@ pub trait VerifiedIoLedger: Send + Sync {
 /// check cancellation immediately before writing any effect.
 #[async_trait]
 pub trait AdmissionStore:
-    ControlJournal + VerifiedIoLedger + LifecycleStore + ObservationStore + Send + Sync + 'static
+    ControlJournal + VerifiedIoLedger + LifecycleStore + Send + Sync + 'static
 {
     async fn read_snapshot(&self) -> Result<AdmissionSnapshot, StoreError>;
     async fn read_aggregate(&self) -> Result<(AdmissionSnapshot, LifecycleSnapshot), StoreError>;

--- a/crates/openengine-cluster-testkit/tests/watch.rs
+++ b/crates/openengine-cluster-testkit/tests/watch.rs
@@ -1,6 +1,7 @@
+use openengine_cluster_client::{EventOrClosed, WatchClient};
 use openengine_cluster_protocol::{
-    GetParams, NodeAddress, NodeName, PositiveInteger, RunId, WatchEvent, WatchParams,
-    WorkerOutcome, GONE, NOT_FOUND,
+    GetParams, NodeAddress, NodeName, PositiveInteger, RunId, SubscriptionCloseReason, WatchEvent,
+    WatchParams, WorkerOutcome, DEFAULT_SUBSCRIPTION_QUEUE_CAPACITY, GONE, NOT_FOUND,
 };
 use openengine_cluster_server::watch::WatchStreamItem;
 use openengine_cluster_server::{ClusterBackend, ConnectionContext};
@@ -51,6 +52,73 @@ async fn watch_parks_while_empty_and_attaches_on_the_next_committed_run() {
             ..
         }
     ));
+}
+
+#[tokio::test]
+async fn parked_overflow_reconnect_stays_on_the_attached_run() {
+    let graph_a = graph_fixture("worker-a", json!({"kind":"null"}));
+    let compiled_a = compiled_from_graph_fixture(&graph_a);
+    let graph_b = graph_fixture("worker-b", json!({"kind":"null"}));
+    let compiled_b = compiled_from_graph_fixture(&graph_b);
+    let (admission_client, dispatcher, _backend, _verifier, store) = setup(vec![
+        ScriptedOutcome::approve(compiled_a, vec![]),
+        ScriptedOutcome::approve(compiled_b, vec![]),
+    ]);
+    let watch_client = WatchClient::new(dispatcher);
+
+    let (parked, mut stream, _handle) = watch_client.watch(WatchParams::default()).await.unwrap();
+    assert_eq!(parked.run_id, None);
+
+    let first = admission_client
+        .apply(committed(graph_a, Value::Null, 0, "create-parked-a"))
+        .await
+        .unwrap();
+    let first_run = first.run_id.unwrap();
+    let node = NodeAddress {
+        node: NodeName::new("worker-a").unwrap(),
+        attempt: PositiveInteger::new(1).unwrap(),
+    };
+    for _ in 0..DEFAULT_SUBSCRIPTION_QUEUE_CAPACITY {
+        store
+            .emit_node_event(
+                &first_run,
+                node.clone(),
+                NodeEventBody::Begin { input: Value::Null },
+            )
+            .await;
+    }
+
+    let second = admission_client
+        .apply(committed(
+            graph_b,
+            Value::Null,
+            first.generation.unwrap().get(),
+            "create-parked-b",
+        ))
+        .await
+        .unwrap();
+    assert_ne!(second.run_id.as_ref(), Some(&first_run));
+
+    loop {
+        match stream.next().await.unwrap() {
+            EventOrClosed::Event(record) => assert_eq!(record.run_id, first_run),
+            EventOrClosed::Closed {
+                reason,
+                last_delivered_cursor,
+            } => {
+                assert_eq!(reason, SubscriptionCloseReason::SlowConsumer);
+                assert!(last_delivered_cursor.is_some());
+                break;
+            }
+        }
+    }
+
+    let (reconnected, mut stream, _handle) = watch_client.reconnect(stream).await.unwrap();
+    assert_eq!(reconnected.run_id, Some(first_run.clone()));
+    let Some(EventOrClosed::Event(record)) = stream.next().await else {
+        panic!("expected the attached run's overflowed event on reconnect");
+    };
+    assert_eq!(record.run_id, first_run);
 }
 
 #[tokio::test]

--- a/zeroshot-rust/src/cluster_ledger/adapters.rs
+++ b/zeroshot-rust/src/cluster_ledger/adapters.rs
@@ -16,9 +16,6 @@ use openengine_cluster_server::lifecycle::{
     CompletionResult, DispatchPermit, LifecycleSnapshot, LifecycleStore, StopProposal,
     UpdateProposal, VerifiedCompletion,
 };
-use openengine_cluster_server::watch::{
-    ObservationStore, PublicEventRecord, ReplayPageRequest, ResolvedSubscription, SubscribeRequest,
-};
 
 use super::record::{CanonicalDigest, RecordPayload};
 use super::store::IdempotencyId;
@@ -419,32 +416,6 @@ impl AdmissionStore for ClusterLedgerAdapters {
             },
         )
         .await
-    }
-}
-
-/// The native ledger does not yet project durable watch history; that projection is owned by a
-/// later issue, which must consume the merged watch types unchanged. This adapter only satisfies
-/// the additive `AdmissionStore: ObservationStore` supertrait bound so the workspace continues to
-/// build; it declines every call rather than approximating native projection.
-#[async_trait]
-impl ObservationStore for ClusterLedgerAdapters {
-    async fn subscribe(
-        &self,
-        _request: SubscribeRequest,
-        _queue_capacity: usize,
-    ) -> Result<ResolvedSubscription, ProtocolStoreError> {
-        Err(ProtocolStoreError::Internal(
-            "native ledger observation projection is not implemented yet".into(),
-        ))
-    }
-
-    async fn replay_page(
-        &self,
-        _request: ReplayPageRequest<'_>,
-    ) -> Result<Vec<PublicEventRecord>, ProtocolStoreError> {
-        Err(ProtocolStoreError::Internal(
-            "native ledger observation projection is not implemented yet".into(),
-        ))
     }
 }
 


### PR DESCRIPTION
## Problem

Post-merge review of #780 found that `ClusterLedgerAdapters` satisfied `ObservationStore` with methods that always returned internal errors, making a future native coordinator fail at runtime instead of refusing construction. The second review concern claimed a parked overflow could lose its attached run; the bounded channel retains queued records before emitting `SLOW_CONSUMER`, so the client learns the run first. This PR adds the exact regression scenario to lock that invariant down.

## Fix

- Keep `AdmissionStore` and `ObservationStore` as separate ports.
- Require both only for the watch-capable `AdmissionCoordinator` backend implementation.
- Remove the native runtime placeholder observation adapter.
- Add a parked-subscription overflow regression that supersedes the current run before reconnect and proves reconnect stays pinned to the attached run.
- Record the boundary in `AGENTS.md`.

## Verification

- `cargo test -p openengine-cluster-testkit --test watch` (8 passed)
- `cargo test -p openengine-cluster-server --test watch` (4 passed)
- `cargo test -p openengine-cluster-client --test reconnect` (1 passed)
- `cargo test -p openengine-cluster-protocol --test watch` (11 passed)
- `cargo test -p zeroshot-rust --test cluster_ledger_replay` (22 passed)
- `npm run rust:check`
- `npm run protocol:check`

Follow-up to #780 and #647.