### PR TITLE
fix(cluster-protocol): harden NDJSON multiplexing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,10 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Watch minimal test fixture   | `crates/openengine-cluster-server/src/watch/fixtures.rs`                |
 | Watch wire types/framing     | `crates/openengine-cluster-protocol/src/watch.rs`                       |
 | Client watch/reconnect       | `crates/openengine-cluster-client/src/watch.rs`                         |
+| NDJSON stdio binding         | `crates/openengine-cluster-server/src/stdio.rs`                         |
+| NDJSON watch client          | `crates/openengine-cluster-client/src/ndjson_watch.rs`                  |
+| NDJSON task admission        | `crates/openengine-cluster-server/src/stdio/admission.rs`               |
+| NDJSON response pump         | `crates/openengine-cluster-client/src/ndjson_pump.rs`                   |
 | Cluster typed transports     | `crates/openengine-cluster-client/`                                     |
 | Cluster fixtures/artifacts   | `crates/openengine-cluster-testkit/`                                    |
 | Scripted admission fixtures  | `crates/openengine-cluster-testkit/src/admission.rs`                    |
@@ -196,6 +200,11 @@ production full-graph executor.
 `AdmissionStore` and `ObservationStore` remain separate ports. A watch-capable
 `AdmissionCoordinator` requires both; never satisfy the observation boundary with a runtime
 placeholder that rejects every subscription.
+The NDJSON server caps and continuously reaps per-connection request/subscription tasks;
+`subscription/cancel` bypasses admission. The client response pump must never await a
+per-subscription consumer: local queue overflow closes that stream as `SLOW_CONSUMER` from its
+exact caller-delivered cursor and cancels the server subscription. Watch request IDs are allocated
+by the shared transport, never by individual watch-client facades.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "async-trait",
  "openengine-cluster-protocol",
  "openengine-cluster-server",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror",
@@ -763,6 +764,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "openengine-cluster-protocol",
+ "parking_lot",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/the-open-engine/zeroshot"
 async-trait = "0.1.89"
 fs2 = "0.4.3"
 libc = "0.2.177"
+parking_lot = "0.12.5"
 rust_decimal = { version = "1.39.0", features = ["serde"] }
 schemars = "1.1.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/openengine-cluster-client/Cargo.toml
+++ b/crates/openengine-cluster-client/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 async-trait.workspace = true
 openengine-cluster-protocol.workspace = true
 openengine-cluster-server.workspace = true
+parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/openengine-cluster-client/src/lib.rs
+++ b/crates/openengine-cluster-client/src/lib.rs
@@ -1,14 +1,19 @@
 //! Typed transport-neutral Cluster Protocol client.
 
+mod ndjson_pump;
+
+use ndjson_pump::forward_notification;
+
 pub mod ndjson_watch;
 pub mod watch;
 pub use ndjson_watch::*;
 pub use watch::*;
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::collections::{hash_map::Entry, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::Arc;
 
+use parking_lot::Mutex as ParkingMutex;
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
     ApplyParams, ApplyResult, GetParams, GetResult, InitializeParams, InitializeResult,
@@ -81,9 +86,8 @@ where
 const MAX_FRAME_BYTES: usize = 1_048_576;
 
 /// Bounded per-subscription local buffer of raw notification lines awaiting
-/// [`NdjsonReconnectingEventStream::next`]. Independent of (and smaller-scoped than) the server's
-/// own per-subscription delivery queue: this only smooths delivery on the client side of an
-/// already-accepted subscription.
+/// [`NdjsonReconnectingEventStream::next`]. Delivery into this queue is non-blocking so one
+/// abandoned subscription cannot stall the connection's sole response pump.
 const SUBSCRIPTION_QUEUE_CAPACITY: usize = 1024;
 
 /// One demultiplexed unary response: the raw response line plus, only for a successful `watch`
@@ -91,20 +95,32 @@ const SUBSCRIPTION_QUEUE_CAPACITY: usize = 1024;
 /// notifications.
 struct PumpedResponse {
     line: String,
-    subscription: Option<mpsc::Receiver<String>>,
+    subscription: Option<PumpedSubscription>,
 }
 
-type PendingMap = Arc<StdMutex<HashMap<RequestId, oneshot::Sender<PumpedResponse>>>>;
-type SubscriptionMap = Arc<StdMutex<HashMap<SubscriptionId, mpsc::Sender<String>>>>;
+pub(crate) struct PumpedSubscription {
+    pub(crate) receiver: mpsc::Receiver<String>,
+    pub(crate) overflowed: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+struct SubscriptionRegistration {
+    sender: mpsc::Sender<String>,
+    overflowed: Arc<AtomicBool>,
+}
+
+type PendingMap = Arc<ParkingMutex<HashMap<RequestId, oneshot::Sender<PumpedResponse>>>>;
+type SubscriptionMap = Arc<ParkingMutex<HashMap<SubscriptionId, SubscriptionRegistration>>>;
 
 /// NDJSON stdio transport that demultiplexes unary request/response traffic and generic `watch`
 /// subscription notifications sharing one connection, correlating by request id and subscription
 /// id respectively. A background pump task owns the read half; [`Self::request`] and the
 /// subscription-establishing/cancelling methods below only ever take the write half's lock.
 pub struct NdjsonTransport<R, W> {
-    writer: Mutex<W>,
+    writer: Arc<Mutex<W>>,
     pending: PendingMap,
     pump: JoinHandle<()>,
+    next_watch_id: AtomicU64,
     _reader: std::marker::PhantomData<fn() -> R>,
 }
 
@@ -115,23 +131,26 @@ where
 {
     #[must_use]
     pub fn new(reader: R, writer: W) -> Self {
-        let pending: PendingMap = Arc::new(StdMutex::new(HashMap::new()));
-        let subscriptions: SubscriptionMap = Arc::new(StdMutex::new(HashMap::new()));
-        let pump = tokio::spawn(run_pump(reader, Arc::clone(&pending), subscriptions));
+        let pending: PendingMap = Arc::new(ParkingMutex::new(HashMap::new()));
+        let subscriptions: SubscriptionMap = Arc::new(ParkingMutex::new(HashMap::new()));
+        let writer = Arc::new(Mutex::new(writer));
+        let pump = tokio::spawn(run_pump(
+            reader,
+            Arc::clone(&pending),
+            subscriptions,
+            Arc::clone(&writer),
+        ));
         Self {
-            writer: Mutex::new(writer),
+            writer,
             pending,
             pump,
+            next_watch_id: AtomicU64::new(1),
             _reader: std::marker::PhantomData,
         }
     }
 
     async fn write_line(&self, line: &str) -> Result<(), TransportError> {
-        let mut writer = self.writer.lock().await;
-        writer.write_all(line.as_bytes()).await?;
-        writer.write_all(b"\n").await?;
-        writer.flush().await?;
-        Ok(())
+        write_shared_line(&self.writer, line).await
     }
 
     /// Registers `id` as pending, writes `request`, and awaits its demultiplexed response.
@@ -141,9 +160,21 @@ where
         id: RequestId,
     ) -> Result<PumpedResponse, TransportError> {
         let (sender, receiver) = oneshot::channel();
-        self.pending.lock().unwrap().insert(id.clone(), sender);
+        {
+            let mut pending = self.pending.lock();
+            match pending.entry(id.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(sender);
+                }
+                Entry::Occupied(_) => {
+                    return Err(TransportError::Protocol(format!(
+                        "request id is already pending: {id:?}"
+                    )));
+                }
+            }
+        }
         if let Err(error) = self.write_line(&request).await {
-            self.pending.lock().unwrap().remove(&id);
+            self.pending.lock().remove(&id);
             return Err(error);
         }
         receiver.await.map_err(|_| {
@@ -154,16 +185,23 @@ where
     /// Sends a `watch` request and returns its response line plus the receiver registered for its
     /// subscription's notifications. Errors if the response carried no `subscriptionId` (either a
     /// backend error, or a malformed/unexpected response).
-    pub async fn open_subscription(
+    pub(crate) async fn open_subscription(
         &self,
         request: String,
         id: RequestId,
-    ) -> Result<(String, mpsc::Receiver<String>), TransportError> {
+    ) -> Result<(String, PumpedSubscription), TransportError> {
         let response = self.send_request(request, id).await?;
         let subscription = response.subscription.ok_or_else(|| {
             TransportError::Protocol("watch response carried no subscriptionId".to_owned())
         })?;
         Ok((response.line, subscription))
+    }
+
+    pub(crate) fn next_watch_request_id(&self) -> RequestId {
+        RequestId::String(format!(
+            "watch-{}",
+            self.next_watch_id.fetch_add(1, Ordering::Relaxed)
+        ))
     }
 
     /// Sends a `subscription/cancel` notification. Fire-and-forget: cancellation has no response
@@ -222,9 +260,14 @@ fn extract_request_id(request: &str) -> RequestId {
 /// response carrying a `result.subscriptionId` registers that subscription's channel before
 /// resolving the pending oneshot, so no `event` racing the response can be missed. On stream end
 /// every pending request fails and every open subscription ends (dropping its sender).
-async fn run_pump<R>(reader: R, pending: PendingMap, subscriptions: SubscriptionMap)
-where
+async fn run_pump<R, W>(
+    reader: R,
+    pending: PendingMap,
+    subscriptions: SubscriptionMap,
+    writer: Arc<Mutex<W>>,
+) where
     R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
 {
     let mut lines = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_FRAME_BYTES));
     while let Some(Ok(line)) = lines.next().await {
@@ -232,13 +275,15 @@ where
             continue;
         };
         if value.get("method").is_some() {
-            forward_notification(&value, line, &subscriptions).await;
+            if let Some(subscription_id) = forward_notification(&value, line, &subscriptions) {
+                let _ = write_subscription_cancel(&writer, subscription_id).await;
+            }
             continue;
         }
         let Some(id) = value.get("id").and_then(RequestId::from_json_value) else {
             continue;
         };
-        let Some(sender) = pending.lock().unwrap().remove(&id) else {
+        let Some(sender) = pending.lock().remove(&id) else {
             continue;
         };
         let subscription = value
@@ -246,40 +291,53 @@ where
             .and_then(|result| result.get("subscriptionId"))
             .and_then(Value::as_str)
             .map(|subscription_id| {
-                let (tx, rx) = mpsc::channel(SUBSCRIPTION_QUEUE_CAPACITY);
-                subscriptions
-                    .lock()
-                    .unwrap()
-                    .insert(SubscriptionId::new(subscription_id), tx);
-                rx
+                let (sender, receiver) = mpsc::channel(SUBSCRIPTION_QUEUE_CAPACITY);
+                let overflowed = Arc::new(AtomicBool::new(false));
+                subscriptions.lock().insert(
+                    SubscriptionId::new(subscription_id),
+                    SubscriptionRegistration {
+                        sender,
+                        overflowed: Arc::clone(&overflowed),
+                    },
+                );
+                PumpedSubscription {
+                    receiver,
+                    overflowed,
+                }
             });
         let _ = sender.send(PumpedResponse { line, subscription });
     }
-    for (_, sender) in pending.lock().unwrap().drain() {
+    for (_, sender) in pending.lock().drain() {
         drop(sender);
     }
-    subscriptions.lock().unwrap().clear();
+    subscriptions.lock().clear();
 }
 
-/// Forwards one `event`/`subscription/closed` notification line to its subscription's registered
-/// channel, if still open. Removes the registration on `subscription/closed` (the terminal
-/// notification for that subscription).
-async fn forward_notification(value: &Value, line: String, subscriptions: &SubscriptionMap) {
-    let Some(subscription_id) = value
-        .get("params")
-        .and_then(|params| params.get("subscriptionId"))
-        .and_then(Value::as_str)
-    else {
-        return;
-    };
-    let subscription_id = SubscriptionId::new(subscription_id);
-    let sender = subscriptions.lock().unwrap().get(&subscription_id).cloned();
-    if let Some(sender) = sender {
-        let _ = sender.send(line).await;
-    }
-    if value.get("method").and_then(Value::as_str) == Some("subscription/closed") {
-        subscriptions.lock().unwrap().remove(&subscription_id);
-    }
+async fn write_subscription_cancel<W>(
+    writer: &Arc<Mutex<W>>,
+    subscription_id: SubscriptionId,
+) -> Result<(), TransportError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let notification = serde_json::to_string(&JsonRpcNotification {
+        jsonrpc: JSON_RPC_VERSION.to_owned(),
+        method: "subscription/cancel".to_owned(),
+        params: SubscriptionCancelParams { subscription_id },
+    })
+    .expect("subscription cancel notification serialization must succeed");
+    write_shared_line(writer, &notification).await
+}
+
+async fn write_shared_line<W>(writer: &Arc<Mutex<W>>, line: &str) -> Result<(), TransportError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut writer = writer.lock().await;
+    writer.write_all(line.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
 }
 
 pub struct ClusterClient<T> {

--- a/crates/openengine-cluster-client/src/ndjson_pump.rs
+++ b/crates/openengine-cluster-client/src/ndjson_pump.rs
@@ -1,0 +1,45 @@
+//! Non-blocking notification routing for the shared NDJSON response pump.
+
+use std::sync::atomic::Ordering;
+
+use openengine_cluster_protocol::SubscriptionId;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use super::SubscriptionMap;
+
+/// Forwards one `event`/`subscription/closed` notification without waiting on a consumer.
+/// Returns the subscription id when the local receiver is full or gone and the server must be
+/// cancelled. A full receiver retains its buffered events; once drained, the stream emits one
+/// local `SLOW_CONSUMER` close from its exact last caller-delivered cursor.
+pub(super) fn forward_notification(
+    value: &Value,
+    line: String,
+    subscriptions: &SubscriptionMap,
+) -> Option<SubscriptionId> {
+    let subscription_id = value
+        .get("params")
+        .and_then(|params| params.get("subscriptionId"))
+        .and_then(Value::as_str)?;
+    let subscription_id = SubscriptionId::new(subscription_id);
+    let terminal = value.get("method").and_then(Value::as_str) == Some("subscription/closed");
+    let registration = subscriptions.lock().get(&subscription_id).cloned()?;
+
+    match registration.sender.try_send(line) {
+        Ok(()) => {
+            if terminal {
+                subscriptions.lock().remove(&subscription_id);
+            }
+            None
+        }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            registration.overflowed.store(true, Ordering::Release);
+            subscriptions.lock().remove(&subscription_id);
+            (!terminal).then_some(subscription_id)
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            subscriptions.lock().remove(&subscription_id);
+            (!terminal).then_some(subscription_id)
+        }
+    }
+}

--- a/crates/openengine-cluster-client/src/ndjson_watch.rs
+++ b/crates/openengine-cluster-client/src/ndjson_watch.rs
@@ -4,12 +4,12 @@
 //! `subscription/closed` notifications instead of the in-process [`Dispatcher`] passthrough.
 
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::Ordering;
 
 use openengine_cluster_protocol::{
     Cursor, EventNotification, JsonRpcErrorResponse, JsonRpcNotification, JsonRpcRequest,
-    JsonRpcSuccess, RequestId, RunId, SubscriptionClosedNotification, SubscriptionId, WatchParams,
-    WatchResult, JSON_RPC_VERSION,
+    JsonRpcSuccess, RequestId, RunId, SubscriptionCloseReason, SubscriptionClosedNotification,
+    SubscriptionId, WatchParams, WatchResult, JSON_RPC_VERSION,
 };
 use openengine_cluster_server::watch::PublicEventRecord;
 use serde_json::Value;
@@ -17,15 +17,14 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 
 use crate::watch::admit_event;
+use crate::PumpedSubscription;
 use crate::{validate_response_identity, ClientError, EventOrClosed, NdjsonTransport};
 
-/// Typed NDJSON watch client. Uses its own `watch-<n>` string request-id namespace (distinct
-/// from [`crate::ClusterClient`]'s integer ids) so `watch` requests issued on one connection can
-/// never collide with concurrent unary requests issued by a [`crate::ClusterClient`] sharing the
-/// same [`NdjsonTransport`].
+/// Typed NDJSON watch client. Request ids come from the shared [`NdjsonTransport`] rather than a
+/// client-local counter, so independently constructed watch clients on one connection cannot
+/// replace each other's pending response waiters.
 pub struct NdjsonWatchClient<'a, R, W> {
     transport: &'a NdjsonTransport<R, W>,
-    next_id: AtomicI64,
 }
 
 impl<'a, R, W> NdjsonWatchClient<'a, R, W>
@@ -35,10 +34,7 @@ where
 {
     #[must_use]
     pub const fn new(transport: &'a NdjsonTransport<R, W>) -> Self {
-        Self {
-            transport,
-            next_id: AtomicI64::new(1),
-        }
+        Self { transport }
     }
 
     pub async fn watch(
@@ -52,14 +48,19 @@ where
             method: "watch".to_owned(),
             params: params.clone(),
         })?;
-        let (line, receiver) = self
+        let (line, subscription) = self
             .transport
             .open_subscription(request, id.clone())
             .await?;
         let result = parse_watch_response(&line, &id)?;
+        let PumpedSubscription {
+            receiver,
+            overflowed,
+        } = subscription;
         let stream = NdjsonReconnectingEventStream {
             transport: self.transport,
             receiver,
+            overflowed,
             subscription_id: result.subscription_id.clone(),
             seen: HashSet::new(),
             last_delivered: params.from_cursor,
@@ -69,10 +70,7 @@ where
     }
 
     fn next_request_id(&self) -> RequestId {
-        RequestId::String(format!(
-            "watch-{}",
-            self.next_id.fetch_add(1, Ordering::Relaxed)
-        ))
+        self.transport.next_watch_request_id()
     }
 }
 
@@ -97,6 +95,7 @@ fn parse_watch_response(line: &str, expected_id: &RequestId) -> Result<WatchResu
 pub struct NdjsonReconnectingEventStream<'a, R, W> {
     transport: &'a NdjsonTransport<R, W>,
     receiver: mpsc::Receiver<String>,
+    overflowed: std::sync::Arc<std::sync::atomic::AtomicBool>,
     subscription_id: SubscriptionId,
     seen: HashSet<(RunId, Cursor)>,
     last_delivered: Option<Cursor>,
@@ -113,7 +112,16 @@ where
     /// (cancelled locally, or the transport's connection ended).
     pub async fn next(&mut self) -> Option<EventOrClosed> {
         loop {
-            let line = self.receiver.recv().await?;
+            let line = match self.receiver.recv().await {
+                Some(line) => line,
+                None if self.overflowed.swap(false, Ordering::AcqRel) => {
+                    return Some(EventOrClosed::Closed {
+                        reason: SubscriptionCloseReason::SlowConsumer,
+                        last_delivered_cursor: self.last_delivered.clone(),
+                    });
+                }
+                None => return None,
+            };
             let value: Value =
                 serde_json::from_str(&line).expect("subscription notification must be valid JSON");
             match value.get("method").and_then(Value::as_str) {

--- a/crates/openengine-cluster-client/tests/subscription_ndjson.rs
+++ b/crates/openengine-cluster-client/tests/subscription_ndjson.rs
@@ -7,11 +7,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use openengine_cluster_client::{ClusterClient, EventOrClosed, NdjsonTransport, NdjsonWatchClient};
-use openengine_cluster_protocol::{Cursor, GetParams, RunId, WatchEvent, WatchParams};
+use openengine_cluster_client::{
+    ClusterClient, EventOrClosed, JsonRpcTransport, NdjsonTransport, NdjsonWatchClient,
+};
+use openengine_cluster_protocol::{
+    Cursor, GetParams, RunId, SubscriptionCloseReason, WatchEvent, WatchParams,
+};
 use openengine_cluster_server::watch::fixtures::{
     await_ndjson_shutdown, spawn_ndjson, FixtureBackend, FixtureStore,
 };
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream};
 
 #[path = "reconnect_support/mod.rs"]
 mod reconnect_support;
@@ -105,4 +111,163 @@ async fn cancel_stops_further_delivery() {
     drop(stream);
     drop(transport);
     await_ndjson_shutdown(server).await;
+}
+
+async fn write_json_line(writer: &mut DuplexStream, value: Value) {
+    writer
+        .write_all(value.to_string().as_bytes())
+        .await
+        .unwrap();
+    writer.write_all(b"\n").await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+async fn read_json_line(reader: &mut BufReader<DuplexStream>) -> Value {
+    let mut line = String::new();
+    assert!(reader.read_line(&mut line).await.unwrap() > 0);
+    serde_json::from_str(&line).unwrap()
+}
+
+#[tokio::test]
+async fn independent_watch_clients_share_one_collision_free_request_id_source() {
+    let (client_write, server_read) = tokio::io::duplex(1 << 16);
+    let (mut server_write, client_read) = tokio::io::duplex(1 << 16);
+    let server = tokio::spawn(async move {
+        let mut server_read = BufReader::new(server_read);
+        let first = read_json_line(&mut server_read).await;
+        let second = read_json_line(&mut server_read).await;
+        let first_id = first["id"].clone();
+        let second_id = second["id"].clone();
+        assert_ne!(first_id, second_id);
+
+        write_json_line(
+            &mut server_write,
+            json!({
+                "jsonrpc": "2.0",
+                "id": second_id,
+                "result": {"subscriptionId": "sub-2", "runId": null, "atCursor": null}
+            }),
+        )
+        .await;
+        write_json_line(
+            &mut server_write,
+            json!({
+                "jsonrpc": "2.0",
+                "id": first_id,
+                "result": {"subscriptionId": "sub-1", "runId": null, "atCursor": null}
+            }),
+        )
+        .await;
+    });
+
+    let transport = NdjsonTransport::new(client_read, client_write);
+    let first = NdjsonWatchClient::new(&transport);
+    let second = NdjsonWatchClient::new(&transport);
+    let (first_result, second_result) = tokio::join!(
+        first.watch(WatchParams::default()),
+        second.watch(WatchParams::default())
+    );
+    assert_ne!(
+        first_result.unwrap().0.subscription_id,
+        second_result.unwrap().0.subscription_id
+    );
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn unread_subscription_overflow_does_not_block_unary_responses() {
+    const CLIENT_QUEUE_CAPACITY: usize = 1024;
+
+    let (client_write, server_read) = tokio::io::duplex(1 << 20);
+    let (mut server_write, client_read) = tokio::io::duplex(1 << 20);
+    let server = tokio::spawn(async move {
+        let mut server_read = BufReader::new(server_read);
+        let watch = read_json_line(&mut server_read).await;
+        write_json_line(
+            &mut server_write,
+            json!({
+                "jsonrpc": "2.0",
+                "id": watch["id"],
+                "result": {
+                    "subscriptionId": "slow-subscription",
+                    "runId": "run-1",
+                    "atCursor": null
+                }
+            }),
+        )
+        .await;
+
+        for index in 1..=CLIENT_QUEUE_CAPACITY + 1 {
+            write_json_line(
+                &mut server_write,
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "event",
+                    "params": {
+                        "subscriptionId": "slow-subscription",
+                        "runId": "run-1",
+                        "cursor": format!("cursor-{index}"),
+                        "event": {"type": "bookmark"}
+                    }
+                }),
+            )
+            .await;
+        }
+
+        let mut saw_cancel = false;
+        let mut saw_unary = false;
+        while !(saw_cancel && saw_unary) {
+            let request = read_json_line(&mut server_read).await;
+            if request["method"] == "subscription/cancel" {
+                assert_eq!(request["params"]["subscriptionId"], "slow-subscription");
+                saw_cancel = true;
+            } else {
+                assert_eq!(request["method"], "get");
+                write_json_line(
+                    &mut server_write,
+                    json!({"jsonrpc": "2.0", "id": request["id"], "result": {}}),
+                )
+                .await;
+                saw_unary = true;
+            }
+        }
+    });
+
+    let transport = NdjsonTransport::new(client_read, client_write);
+    let watch_client = NdjsonWatchClient::new(&transport);
+    let (_result, mut stream) = watch_client.watch(WatchParams::default()).await.unwrap();
+
+    let unary =
+        json!({"jsonrpc": "2.0", "id": "unary-1", "method": "get", "params": {}}).to_string();
+    let response = tokio::time::timeout(Duration::from_secs(2), transport.request(unary))
+        .await
+        .expect("an unread subscription must not block the shared response pump")
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<Value>(&response).unwrap()["id"],
+        "unary-1"
+    );
+
+    server.await.unwrap();
+    let (events, closed_cursor) = tokio::time::timeout(Duration::from_secs(2), async {
+        let mut events = 0;
+        loop {
+            match stream.next().await {
+                Some(EventOrClosed::Event(_)) => events += 1,
+                Some(EventOrClosed::Closed {
+                    reason,
+                    last_delivered_cursor,
+                }) => {
+                    assert_eq!(reason, SubscriptionCloseReason::SlowConsumer);
+                    break (events, last_delivered_cursor);
+                }
+                None => panic!("local overflow ended without a SLOW_CONSUMER close"),
+            }
+        }
+    })
+    .await
+    .expect("buffered notifications and the local overflow close must drain");
+    assert_eq!(events, CLIENT_QUEUE_CAPACITY);
+    assert_eq!(closed_cursor, Some(Cursor::new("cursor-1024")));
+    assert_eq!(stream.last_delivered_cursor(), closed_cursor.as_ref());
 }

--- a/crates/openengine-cluster-server/Cargo.toml
+++ b/crates/openengine-cluster-server/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 async-trait.workspace = true
 openengine-cluster-protocol.workspace = true
+parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/openengine-cluster-server/src/stdio.rs
+++ b/crates/openengine-cluster-server/src/stdio.rs
@@ -1,19 +1,24 @@
 //! NDJSON stdio transport: multiplexes unary JSON-RPC request/response traffic and generic
 //! `watch` subscription notifications over one bounded-frame connection.
 
+mod admission;
+
+use admission::{acquire_task_slot, reject_duplicate, run_writer, InFlightIds, MAX_CONNECTION_TASKS};
+
 use std::collections::{HashMap, HashSet};
 use std::io;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::time::Duration;
 
+use parking_lot::Mutex;
 use openengine_cluster_protocol::{
     DomainErrorData, EventNotification, JsonRpcNotification, JsonRpcRequest, RequestId,
     SubscriptionCancelParams, SubscriptionClosedNotification, SubscriptionId, WatchParams,
-    INVALID_PARAMS, INVALID_REQUEST, JSON_RPC_VERSION, PARSE_ERROR, SCHEMA_VIOLATION,
+    INVALID_PARAMS, JSON_RPC_VERSION, PARSE_ERROR, SCHEMA_VIOLATION,
 };
 use serde_json::Value;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::{mpsc, Notify, Semaphore};
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Framed, LinesCodec, LinesCodecError};
@@ -30,26 +35,17 @@ const MAX_FRAME_BYTES: usize = 1_048_576;
 /// than growing memory without bound.
 const OUTBOUND_QUEUE_CAPACITY: usize = 256;
 
-/// Grace period given to already-spawned tasks to finish on their own once the connection is
-/// shutting down (EOF or fatal I/O error). Bounded unary/watch-establishment dispatches finish
-/// well within this window and get their response flushed; a `watch` subscription's streaming
-/// loop has no natural end once its live channel goes idle (cancellation is only observed on the
-/// stream's next poll, and nothing left will ever poll it), so once the grace period elapses
-/// whatever tasks remain are assumed stuck and force-aborted rather than awaited forever.
+/// Grace period given to already-spawned bounded backend dispatches to finish once the connection
+/// closes. Subscription tasks are notified through their cancellation handles before shutdown;
+/// any backend operation that does not finish inside this bound is force-aborted.
 const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(200);
-
-/// Domain error code for a request id reused while its first request is still in flight. Specific
-/// to this multiplexed NDJSON binding: an unmultiplexed unary transport has no concept of two
-/// requests in flight at once.
-const DUPLICATE_REQUEST_ID: &str = "DUPLICATE_REQUEST_ID";
 
 /// Per-subscription cancellation signal: notifying it wakes `run_watch_subscription`'s streaming
 /// loop immediately, even while parked awaiting the next live event, instead of relying solely on
 /// `WatchEventStream`'s own cancelled flag, which is only re-checked at the top of `next()` and so
 /// never observed on an idle run once the task is parked inside `next_live`'s
 /// `receiver.recv().await`.
-type SubscriptionMap = Arc<StdMutex<HashMap<SubscriptionId, Arc<Notify>>>>;
-type InFlightIds = Arc<StdMutex<HashSet<RequestId>>>;
+type SubscriptionMap = Arc<Mutex<HashMap<SubscriptionId, Arc<Notify>>>>;
 
 /// Per-connection state shared by every spawned request/subscription task: the outbound write
 /// queue and the tracking maps used for cancellation and duplicate-id rejection.
@@ -75,8 +71,9 @@ where
     let (outbound_tx, outbound_rx) = mpsc::channel::<String>(OUTBOUND_QUEUE_CAPACITY);
     let writer_task = tokio::spawn(run_writer(writer, outbound_rx));
 
-    let subscriptions: SubscriptionMap = Arc::new(StdMutex::new(HashMap::new()));
-    let in_flight_ids: InFlightIds = Arc::new(StdMutex::new(HashSet::new()));
+    let subscriptions: SubscriptionMap = Arc::new(Mutex::new(HashMap::new()));
+    let in_flight_ids: InFlightIds = Arc::new(Mutex::new(HashSet::new()));
+    let task_slots = Arc::new(Semaphore::new(MAX_CONNECTION_TASKS));
     let mut tasks: JoinSet<()> = JoinSet::new();
     let state = ConnectionState {
         outbound_tx: outbound_tx.clone(),
@@ -86,7 +83,17 @@ where
 
     let mut lines = Framed::new(reader, LinesCodec::new_with_max_length(MAX_FRAME_BYTES));
     loop {
-        let line = match lines.next().await {
+        // Reap completed request tasks even while the connection remains idle. A concurrency cap
+        // alone is insufficient: `JoinSet` retains every completed output until it is joined.
+        let next_line = loop {
+            tokio::select! {
+                completed = tasks.join_next(), if !tasks.is_empty() => {
+                    let _ = completed;
+                }
+                line = lines.next() => break line,
+            }
+        };
+        let line = match next_line {
             Some(Ok(line)) => line,
             Some(Err(LinesCodecError::MaxLineLengthExceeded)) => {
                 let _ = outbound_tx
@@ -116,7 +123,7 @@ where
 
         match classify_ndjson_line(&line) {
             NdjsonLineKind::Cancel(subscription_id) => {
-                if let Some(cancel) = subscriptions.lock().unwrap().remove(&subscription_id) {
+                if let Some(cancel) = subscriptions.lock().remove(&subscription_id) {
                     cancel.notify_one();
                 }
             }
@@ -124,12 +131,18 @@ where
                 if reject_duplicate(&in_flight_ids, &outbound_tx, id.clone()).await {
                     continue;
                 }
-                tasks.spawn(run_watch_subscription(
-                    dispatcher.clone(),
-                    id,
-                    params,
-                    state.clone(),
-                ));
+                let Some(permit) =
+                    acquire_task_slot(&task_slots, &outbound_tx, Some(id.clone())).await
+                else {
+                    in_flight_ids.lock().remove(&id);
+                    continue;
+                };
+                let task_dispatcher = dispatcher.clone();
+                let task_state = state.clone();
+                tasks.spawn(async move {
+                    let _permit = permit;
+                    run_watch_subscription(task_dispatcher, id, params, task_state).await;
+                });
             }
             NdjsonLineKind::Passthrough { id } => {
                 if let Some(id) = id.clone() {
@@ -137,14 +150,25 @@ where
                         continue;
                     }
                 }
-                tasks.spawn(run_passthrough_request(
-                    dispatcher.clone(),
-                    id,
-                    line,
-                    state.clone(),
-                ));
+                let Some(permit) = acquire_task_slot(&task_slots, &outbound_tx, id.clone()).await
+                else {
+                    if let Some(id) = id {
+                        in_flight_ids.lock().remove(&id);
+                    }
+                    continue;
+                };
+                let task_dispatcher = dispatcher.clone();
+                let task_state = state.clone();
+                tasks.spawn(async move {
+                    let _permit = permit;
+                    run_passthrough_request(task_dispatcher, id, line, task_state).await;
+                });
             }
         }
+    }
+
+    for cancel in subscriptions.lock().drain().map(|(_, cancel)| cancel) {
+        cancel.notify_one();
     }
 
     let drain_naturally = async { while tasks.join_next().await.is_some() {} };
@@ -161,47 +185,6 @@ where
     Ok(())
 }
 
-/// Registers `id` as in flight, or sends a `DUPLICATE_REQUEST_ID` error and returns `true` if it
-/// was already in flight.
-async fn reject_duplicate(
-    in_flight_ids: &InFlightIds,
-    outbound_tx: &mpsc::Sender<String>,
-    id: RequestId,
-) -> bool {
-    let inserted = in_flight_ids.lock().unwrap().insert(id.clone());
-    if inserted {
-        return false;
-    }
-    let _ = outbound_tx
-        .send(serialize_error(
-            Some(id),
-            INVALID_REQUEST,
-            "Invalid Request",
-            Some(DomainErrorData::new(DUPLICATE_REQUEST_ID)),
-        ))
-        .await;
-    true
-}
-
-/// Drains the bounded outbound queue, writing one NDJSON line per queued frame. Stops on the
-/// first write failure (the peer is gone) or once every sender half is dropped.
-async fn run_writer<W>(mut writer: W, mut outbound_rx: mpsc::Receiver<String>)
-where
-    W: AsyncWrite + Unpin,
-{
-    while let Some(line) = outbound_rx.recv().await {
-        if writer.write_all(line.as_bytes()).await.is_err() {
-            break;
-        }
-        if writer.write_all(b"\n").await.is_err() {
-            break;
-        }
-        if writer.flush().await.is_err() {
-            break;
-        }
-    }
-}
-
 /// Dispatches a non-`watch` request or notification line, releasing its in-flight id (if any)
 /// once the backend call returns and before the response is enqueued.
 async fn run_passthrough_request<B>(
@@ -214,7 +197,7 @@ async fn run_passthrough_request<B>(
 {
     let response = dispatcher.dispatch(&line).await;
     if let Some(id) = id {
-        state.in_flight_ids.lock().unwrap().remove(&id);
+        state.in_flight_ids.lock().remove(&id);
     }
     let _ = state.outbound_tx.send(response).await;
 }
@@ -242,7 +225,7 @@ async fn run_watch_subscription<B>(
         in_flight_ids,
     } = state;
     let (response, established) = dispatcher.dispatch_watch(id.clone(), params).await;
-    in_flight_ids.lock().unwrap().remove(&id);
+    in_flight_ids.lock().remove(&id);
     let Some((subscription_id, mut stream, _handle)) = established else {
         let _ = outbound_tx.send(response).await;
         return;
@@ -254,10 +237,9 @@ async fn run_watch_subscription<B>(
     // register-before-resolve ordering in `NdjsonTransport::run_pump`).
     subscriptions
         .lock()
-        .unwrap()
         .insert(subscription_id.clone(), Arc::clone(&cancel));
     if outbound_tx.send(response).await.is_err() {
-        subscriptions.lock().unwrap().remove(&subscription_id);
+        subscriptions.lock().remove(&subscription_id);
         return;
     }
 
@@ -308,7 +290,7 @@ async fn run_watch_subscription<B>(
             break;
         }
     }
-    subscriptions.lock().unwrap().remove(&subscription_id);
+    subscriptions.lock().remove(&subscription_id);
 }
 
 pub async fn serve_stdio<B>(dispatcher: Dispatcher<B>) -> io::Result<()>
@@ -425,11 +407,11 @@ mod tests {
         let (outbound_tx, mut outbound_rx) = mpsc::channel::<String>(1);
         outbound_tx.send("occupied".to_owned()).await.unwrap();
 
-        let subscriptions: SubscriptionMap = Arc::new(StdMutex::new(HashMap::new()));
+        let subscriptions: SubscriptionMap = Arc::new(Mutex::new(HashMap::new()));
         let state = ConnectionState {
             outbound_tx,
             subscriptions: Arc::clone(&subscriptions),
-            in_flight_ids: Arc::new(StdMutex::new(HashSet::new())),
+            in_flight_ids: Arc::new(Mutex::new(HashSet::new())),
         };
 
         tokio::spawn(run_watch_subscription(
@@ -446,7 +428,7 @@ mod tests {
         // full `cargo test --workspace` run; yielding is deterministic regardless of load and the
         // attempt cap still fails the test if registration never happens.
         let mut attempts = 0;
-        while subscriptions.lock().unwrap().len() != 1 {
+        while subscriptions.lock().len() != 1 {
             attempts += 1;
             assert!(
                 attempts < 100_000,

--- a/crates/openengine-cluster-server/src/stdio/admission.rs
+++ b/crates/openengine-cluster-server/src/stdio/admission.rs
@@ -1,0 +1,79 @@
+//! Bounded per-connection NDJSON admission and outbound writing.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use openengine_cluster_protocol::{DomainErrorData, RequestId, APPLICATION_ERROR, INVALID_REQUEST};
+use parking_lot::Mutex;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
+
+use super::serialize_error;
+
+/// Maximum concurrent backend dispatch/subscription tasks per connection.
+pub(super) const MAX_CONNECTION_TASKS: usize = 256;
+const DUPLICATE_REQUEST_ID: &str = "DUPLICATE_REQUEST_ID";
+const SERVER_BUSY: &str = "SERVER_BUSY";
+
+pub(super) type InFlightIds = Arc<Mutex<HashSet<RequestId>>>;
+
+/// Registers `id` as in flight, or reports that it was already in flight.
+pub(super) async fn reject_duplicate(
+    in_flight_ids: &InFlightIds,
+    outbound_tx: &mpsc::Sender<String>,
+    id: RequestId,
+) -> bool {
+    let inserted = in_flight_ids.lock().insert(id.clone());
+    if inserted {
+        return false;
+    }
+    let _ = outbound_tx
+        .send(serialize_error(
+            Some(id),
+            INVALID_REQUEST,
+            "Invalid Request",
+            Some(DomainErrorData::new(DUPLICATE_REQUEST_ID)),
+        ))
+        .await;
+    true
+}
+
+/// Acquires one task slot. Excess requests receive a deterministic application error;
+/// notifications have no JSON-RPC response and are dropped.
+pub(super) async fn acquire_task_slot(
+    task_slots: &Arc<Semaphore>,
+    outbound_tx: &mpsc::Sender<String>,
+    id: Option<RequestId>,
+) -> Option<OwnedSemaphorePermit> {
+    match Arc::clone(task_slots).try_acquire_owned() {
+        Ok(permit) => Some(permit),
+        Err(_) => {
+            if let Some(id) = id {
+                let _ = outbound_tx
+                    .send(serialize_error(
+                        Some(id),
+                        APPLICATION_ERROR,
+                        "Server busy",
+                        Some(DomainErrorData::new(SERVER_BUSY)),
+                    ))
+                    .await;
+            }
+            None
+        }
+    }
+}
+
+/// Drains the bounded outbound queue until the peer closes or every sender is dropped.
+pub(super) async fn run_writer<W>(mut writer: W, mut outbound_rx: mpsc::Receiver<String>)
+where
+    W: AsyncWrite + Unpin,
+{
+    while let Some(line) = outbound_rx.recv().await {
+        if writer.write_all(line.as_bytes()).await.is_err()
+            || writer.write_all(b"\n").await.is_err()
+            || writer.flush().await.is_err()
+        {
+            break;
+        }
+    }
+}

--- a/crates/openengine-cluster-server/tests/subscription_ndjson.rs
+++ b/crates/openengine-cluster-server/tests/subscription_ndjson.rs
@@ -216,6 +216,31 @@ async fn duplicate_request_ids_are_rejected() {
     shut_down(harness).await;
 }
 
+#[tokio::test]
+async fn excess_requests_are_rejected_without_unbounded_task_admission() {
+    const MAX_CONNECTION_TASKS: i64 = 256;
+
+    let store = Arc::new(FixtureStore::new(RunId::new("run-1"), Vec::new(), 8));
+    let gate = Arc::new(Notify::new());
+    let mut harness = spawn_server(GatedBackend {
+        inner: FixtureBackend::new(store),
+        gate,
+    });
+
+    for id in 1..=MAX_CONNECTION_TASKS + 1 {
+        write_line(&mut harness.write, &request_line(id, "get", json!({}))).await;
+    }
+
+    let rejected = tokio::time::timeout(Duration::from_secs(1), read_value(&mut harness.read))
+        .await
+        .expect("the bounded admission rejection must not wait for blocked backend calls");
+    assert_eq!(rejected["id"], MAX_CONNECTION_TASKS + 1);
+    assert_eq!(rejected["error"]["code"], -32000);
+    assert_eq!(rejected["error"]["data"]["code"], "SERVER_BUSY");
+
+    shut_down(harness).await;
+}
+
 /// Publishes one bookmark event and asserts both `sub_a` and `sub_b` observe it as `cursor-1`.
 async fn assert_shared_bookmark_delivered(
     harness: &mut Harness,


### PR DESCRIPTION
## Problem

Post-merge review of #782 found that the NDJSON binding could accumulate completed `JoinSet` entries without bound and that the client response pump awaited bounded per-subscription queues. The watch facade also allocated request IDs independently per facade, so two facades over one transport could collide.

## Fix

- cap and continuously reap per-connection server tasks; reject excess requests with `SERVER_BUSY`
- keep `subscription/cancel` outside task admission and retain bounded shutdown
- allocate watch request IDs through the shared `NdjsonTransport`
- route notifications with `try_send`; on local queue overflow, retain buffered events, emit local `SLOW_CONSUMER` from the exact delivered cursor, and cancel the server subscription
- serialize all client writes behind one async mutex
- add real NDJSON regressions for server admission, shared transport IDs, slow-consumer isolation, exact cursor recovery, and client cancel behavior
- split task admission and pump routing into focused modules to preserve repository file-size policy

## Verification

- `cargo test -p openengine-cluster-server --test subscription_ndjson`
- `cargo test -p openengine-cluster-client --test subscription_ndjson`
- `cargo test -p openengine-cluster-testkit --test protocol_ndjson`
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` (1702 passing, 18 pending)
- `opcore check --changed`

Follow-up to #745 and #782.