### PR TITLE
fix(cluster-protocol): harden manual retry frontier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,10 +208,13 @@ by the shared transport, never by individual watch-client facades.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait
-for resume. Drain waits without inventing graph hooks; force cancels and voids leases without
-fabricating output. Each stopped run has one final `finished` event. Stop acknowledgements never
-claim rollback or absence of external side effects. These are deterministic scripted-backend
-semantics, not a native graph scheduler or worker executor.
+for resume. Manual retry admits only a retryable settled frontier after every peer lease settles;
+exhausted authored attempts never create a frontier. An accepted retry intent reserves its next
+single-use turn and rejects a stale error-successor until that reserved turn begins. Drain waits
+without inventing graph hooks and terminalizes after the final verified or failed settlement; force
+cancels and voids leases without fabricating output. Each stopped run has one final `finished`
+event. Stop acknowledgements never claim rollback or absence of external side effects. These are
+deterministic scripted-backend semantics, not a native graph scheduler or worker executor.
 
 The TUI is not included in this release. Use `zeroshot list`, `zeroshot status <id>`,
 and `zeroshot logs <id> -f` or `zeroshot logs <id> -w` for monitoring.

--- a/crates/openengine-cluster-protocol/src/lifecycle.rs
+++ b/crates/openengine-cluster-protocol/src/lifecycle.rs
@@ -99,6 +99,33 @@ pub enum TurnFailureKind {
     Crash,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NoRetryableFrontierReason {
+    Exhausted,
+    Success,
+    Active,
+    Consumed,
+}
+
+impl NoRetryableFrontierReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exhausted => "exhausted",
+            Self::Success => "success",
+            Self::Active => "active",
+            Self::Consumed => "consumed",
+        }
+    }
+}
+
+impl std::fmt::Display for NoRetryableFrontierReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OperationalStatus {

--- a/crates/openengine-cluster-protocol/tests/lifecycle_retry.rs
+++ b/crates/openengine-cluster-protocol/tests/lifecycle_retry.rs
@@ -1,4 +1,6 @@
-use openengine_cluster_protocol::{Generation, IdempotencyKey, RetryParams, TurnFailureKind};
+use openengine_cluster_protocol::{
+    Generation, IdempotencyKey, NoRetryableFrontierReason, RetryParams, TurnFailureKind,
+};
 use serde_json::json;
 
 #[test]
@@ -33,6 +35,23 @@ fn retry_wire_is_closed_and_carries_no_execution_selector() {
             "schema accepted {invalid}"
         );
     }
+}
+
+#[test]
+fn no_retryable_frontier_reasons_are_closed_wire_values() {
+    for (reason, wire) in [
+        (NoRetryableFrontierReason::Exhausted, "exhausted"),
+        (NoRetryableFrontierReason::Success, "success"),
+        (NoRetryableFrontierReason::Active, "active"),
+        (NoRetryableFrontierReason::Consumed, "consumed"),
+    ] {
+        assert_eq!(serde_json::to_value(reason).unwrap(), json!(wire));
+        assert_eq!(
+            serde_json::from_value::<NoRetryableFrontierReason>(json!(wire)).unwrap(),
+            reason
+        );
+    }
+    assert!(serde_json::from_value::<NoRetryableFrontierReason>(json!("unknown")).is_err());
 }
 
 #[test]

--- a/crates/openengine-cluster-server/src/admission/ports.rs
+++ b/crates/openengine-cluster-server/src/admission/ports.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
     ApplyResult, ClusterStatus, CompiledGraphIr, Cursor, DispatchState, Generation,
-    GraphDiagnostic, GraphSpec, IdempotencyKey, Phase, RequestFingerprint, RunId,
+    GraphDiagnostic, GraphSpec, IdempotencyKey, NoRetryableFrontierReason, Phase,
+    RequestFingerprint, RunId,
 };
 use serde_json::Value;
 use thiserror::Error;
@@ -201,7 +202,7 @@ pub enum StoreError {
     #[error("run history was deleted")]
     RunGone { tombstoned_at: Option<Cursor> },
     #[error("no retryable failed frontier is pending: {reason}")]
-    NoRetryableFrontier { reason: &'static str },
+    NoRetryableFrontier { reason: NoRetryableFrontierReason },
 }
 
 /// Logical durable control-journal view.

--- a/crates/openengine-cluster-server/src/admission/snapshot.rs
+++ b/crates/openengine-cluster-server/src/admission/snapshot.rs
@@ -5,7 +5,7 @@ use openengine_cluster_protocol::{
 };
 
 use crate::admission::AdmissionSnapshot;
-use crate::lifecycle::{LifecycleEvent, LifecycleSnapshot};
+use crate::lifecycle::{FailureRetryability, LifecycleEvent, LifecycleSnapshot};
 use crate::BackendError;
 
 pub(super) fn validate_snapshot(
@@ -113,11 +113,13 @@ fn stop_state_matches(operational: &openengine_cluster_protocol::OperationalStat
 
 #[derive(Default)]
 struct LifecycleFold {
+    dispatched: std::collections::BTreeSet<crate::lifecycle::TurnId>,
     in_flight: std::collections::BTreeSet<crate::lifecycle::TurnId>,
     outcomes: std::collections::BTreeSet<crate::lifecycle::TurnId>,
     operational: OperationalStatus,
     finished: bool,
     pending_failed_frontier: Option<crate::lifecycle::TurnId>,
+    pending_retry_turn: Option<crate::lifecycle::TurnId>,
 }
 
 fn lifecycle_record_fold_is_valid(lifecycle: &LifecycleSnapshot) -> bool {
@@ -149,7 +151,11 @@ fn fold_record(
             accepted_mode,
             effective_mode,
         } => fold_stop_request(fold, *accepted_mode, *effective_mode),
-        LifecycleEvent::Failed { turn_id, kind: _ } => fold_failed(fold, turn_id),
+        LifecycleEvent::Failed {
+            turn_id,
+            kind: _,
+            retryability,
+        } => fold_failed(fold, turn_id, *retryability),
         LifecycleEvent::Retried {
             failed_turn_id,
             retry_turn_id,
@@ -159,18 +165,28 @@ fn fold_record(
 
 fn fold_dispatch(fold: &mut LifecycleFold, turn_id: &crate::lifecycle::TurnId) -> bool {
     if fold.operational.dispatch_state != DispatchState::Active
-        || fold.outcomes.contains(turn_id)
+        || !fold.dispatched.insert(turn_id.clone())
         || !fold.in_flight.insert(turn_id.clone())
+        || fold
+            .pending_retry_turn
+            .as_ref()
+            .is_some_and(|pending| pending != turn_id)
     {
         return false;
     }
-    // A new dispatch (e.g. an error-successor continuation) supersedes any pending failed
-    // frontier, mirroring the store's un-recorded `acquire_dispatch` clear.
-    fold.pending_failed_frontier = None;
+    if fold.pending_retry_turn.as_ref() == Some(turn_id) {
+        fold.pending_retry_turn = None;
+    } else {
+        fold.pending_failed_frontier = None;
+    }
     sync_in_flight(fold)
 }
 
-fn fold_failed(fold: &mut LifecycleFold, turn_id: &crate::lifecycle::TurnId) -> bool {
+fn fold_failed(
+    fold: &mut LifecycleFold,
+    turn_id: &crate::lifecycle::TurnId,
+    retryability: FailureRetryability,
+) -> bool {
     if matches!(
         fold.operational.dispatch_state,
         DispatchState::ForceStopping | DispatchState::Stopped
@@ -178,7 +194,10 @@ fn fold_failed(fold: &mut LifecycleFold, turn_id: &crate::lifecycle::TurnId) -> 
     {
         return false;
     }
-    fold.pending_failed_frontier = Some(turn_id.clone());
+    fold.pending_failed_frontier = match retryability {
+        FailureRetryability::Retryable => Some(turn_id.clone()),
+        FailureRetryability::AttemptsExhausted => None,
+    };
     sync_in_flight(fold)
 }
 
@@ -188,11 +207,14 @@ fn fold_retried(
     retry_turn_id: &crate::lifecycle::TurnId,
 ) -> bool {
     if fold.pending_failed_frontier.as_ref() != Some(failed_turn_id)
+        || fold.pending_retry_turn.is_some()
         || failed_turn_id == retry_turn_id
+        || fold.dispatched.contains(retry_turn_id)
     {
         return false;
     }
     fold.pending_failed_frontier = None;
+    fold.pending_retry_turn = Some(retry_turn_id.clone());
     true
 }
 
@@ -298,6 +320,8 @@ fn fold_finished(fold: &mut LifecycleFold, mode: StopMode) -> bool {
     fold.operational.dispatch_state = DispatchState::Stopped;
     fold.operational.in_flight = 0;
     fold.finished = true;
+    fold.pending_failed_frontier = None;
+    fold.pending_retry_turn = None;
     true
 }
 
@@ -322,6 +346,7 @@ fn fold_counts_match(fold: &LifecycleFold, lifecycle: &LifecycleSnapshot) -> boo
     count_matches
         && fold.outcomes.len() == outcome_count
         && lifecycle.pending_failed_frontier == fold.pending_failed_frontier
+        && lifecycle.pending_retry_turn == fold.pending_retry_turn
         && lifecycle
             .operational
             .as_ref()

--- a/crates/openengine-cluster-server/src/lifecycle/ports.rs
+++ b/crates/openengine-cluster-server/src/lifecycle/ports.rs
@@ -62,10 +62,17 @@ pub struct VerifiedCompletion {
     pub output: Value,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FailureRetryability {
+    Retryable,
+    AttemptsExhausted,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FailedCompletion {
     pub lease_id: LeaseId,
     pub kind: TurnFailureKind,
+    pub retryability: FailureRetryability,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -120,6 +127,7 @@ pub enum LifecycleEvent {
     Failed {
         turn_id: TurnId,
         kind: TurnFailureKind,
+        retryability: FailureRetryability,
     },
     Retried {
         failed_turn_id: TurnId,
@@ -135,6 +143,7 @@ pub struct LifecycleSnapshot {
     pub verified_turns: Vec<VerifiedTurn>,
     pub void_turns: Vec<VoidTurn>,
     pub pending_failed_frontier: Option<TurnId>,
+    pub pending_retry_turn: Option<TurnId>,
 }
 
 impl LifecycleSnapshot {

--- a/crates/openengine-cluster-testkit/src/admission.rs
+++ b/crates/openengine-cluster-testkit/src/admission.rs
@@ -208,6 +208,7 @@ impl StoreState {
             verified_turns: Vec::new(),
             void_turns: Vec::new(),
             pending_failed_frontier: None,
+            pending_retry_turn: None,
         };
         self.control_journal.push(ControlReceipt {
             generation,

--- a/crates/openengine-cluster-testkit/src/admission/inspection.rs
+++ b/crates/openengine-cluster-testkit/src/admission/inspection.rs
@@ -109,6 +109,7 @@ impl InMemoryAdmissionStore {
                 verified_turns: Vec::new(),
                 void_turns: Vec::new(),
                 pending_failed_frontier: None,
+                pending_retry_turn: None,
             }
         };
     }

--- a/crates/openengine-cluster-testkit/src/lifecycle.rs
+++ b/crates/openengine-cluster-testkit/src/lifecycle.rs
@@ -15,7 +15,7 @@ use crate::admission::{append, enforce_generation, AppendKind, InMemoryAdmission
 
 mod dispatch;
 mod params;
-pub use params::{fail, resume, retry, stop, suspend};
+pub use params::{fail, fail_exhausted, resume, retry, stop, suspend};
 
 fn dispatch_state_for_suspension(suspended: bool) -> DispatchState {
     if suspended {
@@ -327,6 +327,8 @@ impl StoreState {
         }
         self.control.phase = Phase::Finished;
         self.append_lifecycle(LifecycleEvent::Finished { mode });
+        self.lifecycle.pending_failed_frontier = None;
+        self.lifecycle.pending_retry_turn = None;
     }
 }
 

--- a/crates/openengine-cluster-testkit/src/lifecycle/dispatch.rs
+++ b/crates/openengine-cluster-testkit/src/lifecycle/dispatch.rs
@@ -1,10 +1,13 @@
 //! Per-turn dispatch lease lifecycle: acquire, verified/void/failed completion, and retry.
 
-use openengine_cluster_protocol::{Cursor, DispatchState, Phase, RetryResult, StopMode};
+use openengine_cluster_protocol::{
+    Cursor, DispatchState, NoRetryableFrontierReason, Phase, RetryResult, StopMode,
+};
 use openengine_cluster_server::admission::{CancellationSignal, StoreError};
 use openengine_cluster_server::lifecycle::{
-    CompletionResult, DispatchPermit, FailedCompletion, LeaseId, LifecycleEvent, MutationReceipt,
-    RetryProposal, TurnId, VerifiedCompletion, VerifiedTurn, VoidTurn,
+    CompletionResult, DispatchPermit, FailedCompletion, FailureRetryability, LeaseId,
+    LifecycleEvent, MutationReceipt, RetryProposal, TurnId, VerifiedCompletion, VerifiedTurn,
+    VoidTurn,
 };
 
 use crate::admission::{
@@ -24,18 +27,17 @@ impl StoreState {
         if self.control.phase != Phase::Running || current != DispatchState::Active {
             return Err(StoreError::DispatchDenied { current });
         }
-        let turn_exists = self.leases.values().any(|lease| lease.turn_id == turn_id)
-            || self
-                .lifecycle
-                .verified_turns
-                .iter()
-                .any(|turn| turn.turn_id == turn_id)
-            || self
-                .lifecycle
-                .void_turns
-                .iter()
-                .any(|turn| turn.turn_id == turn_id);
-        if turn_exists {
+        if self
+            .lifecycle
+            .pending_retry_turn
+            .as_ref()
+            .is_some_and(|pending| pending != &turn_id)
+        {
+            return Err(StoreError::SchemaViolation(
+                "a pending retry intent must dispatch before another turn".into(),
+            ));
+        }
+        if self.turn_was_dispatched(&turn_id) {
             return Err(StoreError::SchemaViolation(
                 "turn id has already been dispatched".into(),
             ));
@@ -56,9 +58,14 @@ impl StoreState {
             .expect("active lifecycle metadata exists")
             .in_flight = u32::try_from(self.leases.len())
             .map_err(|_| StoreError::Internal("in-flight count exceeds u32".into()))?;
-        // A fresh dispatch (e.g. an error-successor continuation) supersedes any pending failed
-        // frontier left behind by an earlier failure on a different turn.
-        self.lifecycle.pending_failed_frontier = None;
+        if self.lifecycle.pending_retry_turn.as_ref() == Some(&turn_id) {
+            self.lifecycle.pending_retry_turn = None;
+        } else {
+            // A fresh error-successor dispatch wins the frontier CAS against manual retry.
+            if self.lifecycle.pending_failed_frontier.take().is_some() {
+                self.retryable_history = RetryableHistory::Consumed;
+            }
+        }
         let cursor = self.append_lifecycle(LifecycleEvent::Dispatched {
             turn_id: turn_id.clone(),
         });
@@ -81,30 +88,47 @@ impl StoreState {
         let cursor = self.append_lifecycle(LifecycleEvent::Failed {
             turn_id: lease.turn_id.clone(),
             kind: failure.kind,
+            retryability: failure.retryability,
         });
-        self.lifecycle.pending_failed_frontier = Some(lease.turn_id.clone());
+        match failure.retryability {
+            FailureRetryability::Retryable => {
+                self.lifecycle.pending_failed_frontier = Some(lease.turn_id.clone());
+            }
+            FailureRetryability::AttemptsExhausted => {
+                self.lifecycle.pending_failed_frontier = None;
+                self.retryable_history = RetryableHistory::Exhausted;
+            }
+        }
         let remaining = u32::try_from(self.leases.len())
             .map_err(|_| StoreError::Internal("in-flight count exceeds u32".into()))?;
-        self.lifecycle
-            .operational
-            .as_mut()
-            .ok_or_else(|| StoreError::Internal("lifecycle metadata is absent".into()))?
-            .in_flight = remaining;
+        let draining = {
+            let operational = self
+                .lifecycle
+                .operational
+                .as_mut()
+                .ok_or_else(|| StoreError::Internal("lifecycle metadata is absent".into()))?;
+            operational.in_flight = remaining;
+            operational.dispatch_state == DispatchState::Draining
+        };
+        let terminalized = draining && remaining == 0;
+        if terminalized {
+            self.finish(StopMode::Drain);
+        }
         Ok(CompletionResult {
             turn_id: lease.turn_id,
             at_cursor: cursor,
-            terminalized: false,
+            terminalized,
         })
     }
 
-    fn no_retryable_frontier_reason(&self) -> &'static str {
+    fn no_retryable_frontier_reason(&self) -> NoRetryableFrontierReason {
         if !self.leases.is_empty() {
-            "active"
+            NoRetryableFrontierReason::Active
         } else {
             match self.retryable_history {
-                RetryableHistory::Exhausted => "exhausted",
-                RetryableHistory::Success => "success",
-                RetryableHistory::Consumed => "consumed",
+                RetryableHistory::Exhausted => NoRetryableFrontierReason::Exhausted,
+                RetryableHistory::Success => NoRetryableFrontierReason::Success,
+                RetryableHistory::Consumed => NoRetryableFrontierReason::Consumed,
             }
         }
     }
@@ -130,14 +154,24 @@ impl StoreState {
         if current != DispatchState::Active {
             return Err(StoreError::DispatchDenied { current });
         }
+        if !self.leases.is_empty() {
+            return Err(StoreError::NoRetryableFrontier {
+                reason: NoRetryableFrontierReason::Active,
+            });
+        }
+        if self.lifecycle.pending_retry_turn.is_some() {
+            return Err(StoreError::NoRetryableFrontier {
+                reason: NoRetryableFrontierReason::Consumed,
+            });
+        }
         let Some(failed_turn_id) = self.lifecycle.pending_failed_frontier.clone() else {
             return Err(StoreError::NoRetryableFrontier {
                 reason: self.no_retryable_frontier_reason(),
             });
         };
-        self.next_retry_turn += 1;
-        let retry_turn_id = TurnId::new(format!("retry-{}", self.next_retry_turn));
+        let retry_turn_id = self.next_retry_turn_id();
         self.lifecycle.pending_failed_frontier = None;
+        self.lifecycle.pending_retry_turn = Some(retry_turn_id.clone());
         self.retryable_history = RetryableHistory::Consumed;
         let cursor = self.append_lifecycle(LifecycleEvent::Retried {
             failed_turn_id: failed_turn_id.clone(),
@@ -150,6 +184,29 @@ impl StoreState {
             MutationReceipt::Retry(result.clone()),
         );
         Ok(result)
+    }
+
+    fn turn_was_dispatched(&self, turn_id: &TurnId) -> bool {
+        self.lifecycle.records.iter().any(|record| {
+            matches!(
+                &record.event,
+                LifecycleEvent::Dispatched {
+                    turn_id: dispatched
+                } if dispatched == turn_id
+            )
+        })
+    }
+
+    fn next_retry_turn_id(&mut self) -> TurnId {
+        loop {
+            self.next_retry_turn += 1;
+            let candidate = TurnId::new(format!("retry-{}", self.next_retry_turn));
+            if !self.turn_was_dispatched(&candidate)
+                && self.lifecycle.pending_retry_turn.as_ref() != Some(&candidate)
+            {
+                return candidate;
+            }
+        }
     }
 
     fn replay_retry(&self, proposal: &RetryProposal) -> Result<Option<RetryResult>, StoreError> {

--- a/crates/openengine-cluster-testkit/src/lifecycle/params.rs
+++ b/crates/openengine-cluster-testkit/src/lifecycle/params.rs
@@ -3,7 +3,7 @@
 use openengine_cluster_protocol::{
     Generation, IdempotencyKey, RetryParams, StopMode, StopParams, TurnFailureKind, UpdateParams,
 };
-use openengine_cluster_server::lifecycle::{FailedCompletion, LeaseId};
+use openengine_cluster_server::lifecycle::{FailedCompletion, FailureRetryability, LeaseId};
 
 #[must_use]
 pub fn suspend(generation: u64, key: &str) -> UpdateParams {
@@ -44,9 +44,23 @@ pub fn retry(generation: u64, key: &str) -> RetryParams {
 
 #[must_use]
 pub fn fail(kind: TurnFailureKind, lease_id: &str) -> FailedCompletion {
+    failed_completion(kind, lease_id, FailureRetryability::Retryable)
+}
+
+#[must_use]
+pub fn fail_exhausted(kind: TurnFailureKind, lease_id: &str) -> FailedCompletion {
+    failed_completion(kind, lease_id, FailureRetryability::AttemptsExhausted)
+}
+
+fn failed_completion(
+    kind: TurnFailureKind,
+    lease_id: &str,
+    retryability: FailureRetryability,
+) -> FailedCompletion {
     FailedCompletion {
         lease_id: LeaseId::new(lease_id),
         kind,
+        retryability,
     }
 }
 

--- a/crates/openengine-cluster-testkit/src/lifecycle_artifacts.rs
+++ b/crates/openengine-cluster-testkit/src/lifecycle_artifacts.rs
@@ -27,6 +27,7 @@ pub(crate) async fn generate_lifecycle_goldens() -> Vec<Artifact> {
         .fail_dispatch(FailedCompletion {
             lease_id: permit.lease_id,
             kind: TurnFailureKind::Timeout,
+            retryability: openengine_cluster_server::lifecycle::FailureRetryability::Retryable,
         })
         .await
         .expect("golden dispatch failure succeeds");

--- a/crates/openengine-cluster-testkit/tests/lifecycle_retry.rs
+++ b/crates/openengine-cluster-testkit/tests/lifecycle_retry.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use openengine_cluster_client::ClientError;
 use openengine_cluster_protocol::{
-    Generation, IdempotencyKey, RetryParams, StopMode, TurnFailureKind, GENERATION_CONFLICT,
-    IDEMPOTENCY_REUSE, INVALID_PHASE, NO_RETRYABLE_FRONTIER,
+    DispatchState, Generation, IdempotencyKey, Phase, RetryParams, StopMode, TurnFailureKind,
+    GENERATION_CONFLICT, IDEMPOTENCY_REUSE, INVALID_PHASE, NO_RETRYABLE_FRONTIER,
 };
 use openengine_cluster_server::lifecycle::{LifecycleEvent, TurnId, VerifiedCompletion};
-use openengine_cluster_testkit::lifecycle::{fail, retry, stop, suspend};
+use openengine_cluster_testkit::lifecycle::{fail, fail_exhausted, retry, stop, suspend};
 use serde_json::json;
 
 #[path = "admission_support/mod.rs"]
@@ -63,6 +63,28 @@ async fn retry_before_any_failure_reports_exhausted() {
     let (code, reason) = rpc_error_parts(error);
     assert_eq!(code, NO_RETRYABLE_FRONTIER);
     assert_eq!(reason, "exhausted");
+}
+
+#[tokio::test]
+async fn retry_after_authored_attempts_are_exhausted_fails_closed() {
+    let (client, store) = running().await;
+    let permit = store.acquire_dispatch(TurnId::new("turn-1")).await.unwrap();
+    store
+        .fail_dispatch(fail_exhausted(
+            TurnFailureKind::Timeout,
+            permit.lease_id.as_str(),
+        ))
+        .await
+        .unwrap();
+
+    let error = client
+        .retry(retry(1, "attempts-exhausted"))
+        .await
+        .unwrap_err();
+    let (code, reason) = rpc_error_parts(error);
+    assert_eq!(code, NO_RETRYABLE_FRONTIER);
+    assert_eq!(reason, "exhausted");
+    assert!(store.inspect().await.lifecycle.pending_retry_turn.is_none());
 }
 
 #[tokio::test]
@@ -186,7 +208,7 @@ async fn retry_cas_and_idempotency_are_atomic_and_never_starts_a_new_run() {
 }
 
 #[tokio::test]
-async fn retry_races_a_concurrent_new_dispatch_and_exactly_one_side_consumes_the_frontier() {
+async fn retry_races_a_concurrent_error_successor_and_exactly_one_mutation_is_accepted() {
     let (client, store) = running().await;
     let client = Arc::new(client);
     let permit = store.acquire_dispatch(TurnId::new("turn-1")).await.unwrap();
@@ -206,7 +228,11 @@ async fn retry_races_a_concurrent_new_dispatch_and_exactly_one_side_consumes_the
     let retry_result = retry_call.await.unwrap();
     let dispatch_result = dispatch_call.await.unwrap();
 
-    assert!(dispatch_result.is_ok(), "a fresh dispatch always succeeds");
+    assert_ne!(
+        retry_result.is_ok(),
+        dispatch_result.is_ok(),
+        "only retry or its competing error-successor may be accepted"
+    );
     let effects = store.inspect().await;
     let retried_count = effects
         .lifecycle
@@ -216,14 +242,23 @@ async fn retry_races_a_concurrent_new_dispatch_and_exactly_one_side_consumes_the
         .count();
     match retry_result {
         Ok(result) => {
-            assert!(!result.deduped);
             assert_eq!(retried_count, 1);
+            assert_eq!(
+                effects
+                    .lifecycle
+                    .pending_retry_turn
+                    .as_ref()
+                    .unwrap()
+                    .as_str(),
+                result.retry_turn_id
+            );
         }
         Err(error) => {
             let (code, reason) = rpc_error_parts(error);
             assert_eq!(code, NO_RETRYABLE_FRONTIER);
             assert_eq!(reason, "active");
             assert_eq!(retried_count, 0);
+            assert!(effects.lifecycle.pending_retry_turn.is_none());
         }
     }
 }
@@ -242,4 +277,118 @@ async fn retry_never_allocates_a_new_run_id() {
     assert_eq!(result.run_id, before.control.run_id.unwrap());
     assert_eq!(result.generation, before.control.generation.unwrap());
     assert_eq!(store.inspect().await.control.run_id, Some(result.run_id));
+}
+
+#[tokio::test]
+async fn accepted_retry_intent_must_dispatch_before_any_error_successor() {
+    let (client, store) = running().await;
+    let permit = store.acquire_dispatch(TurnId::new("turn-1")).await.unwrap();
+    store
+        .fail_dispatch(fail(TurnFailureKind::Failed, permit.lease_id.as_str()))
+        .await
+        .unwrap();
+
+    let retried = client.retry(retry(1, "retry-intent")).await.unwrap();
+    assert!(
+        store
+            .acquire_dispatch(TurnId::new("stale-error-successor"))
+            .await
+            .is_err()
+    );
+    let retry_turn = TurnId::new(retried.retry_turn_id);
+    store.acquire_dispatch(retry_turn.clone()).await.unwrap();
+    assert!(store.acquire_dispatch(retry_turn).await.is_err());
+}
+
+#[tokio::test]
+async fn a_failed_turn_identity_can_never_be_dispatched_again() {
+    let (_client, store) = running().await;
+    let turn = TurnId::new("turn-1");
+    let permit = store.acquire_dispatch(turn.clone()).await.unwrap();
+    store
+        .fail_dispatch(fail(TurnFailureKind::Failed, permit.lease_id.as_str()))
+        .await
+        .unwrap();
+
+    assert!(store.acquire_dispatch(turn).await.is_err());
+}
+
+#[tokio::test]
+async fn retry_turn_identity_skips_an_existing_dispatch_identity() {
+    let (client, store) = running().await;
+    let collision = store
+        .acquire_dispatch(TurnId::new("retry-1"))
+        .await
+        .unwrap();
+    store
+        .complete_dispatch(VerifiedCompletion {
+            lease_id: collision.lease_id,
+            output: json!({"ok": true}),
+        })
+        .await
+        .unwrap();
+    let failed = store.acquire_dispatch(TurnId::new("turn-2")).await.unwrap();
+    store
+        .fail_dispatch(fail(TurnFailureKind::Crash, failed.lease_id.as_str()))
+        .await
+        .unwrap();
+
+    let retried = client.retry(retry(1, "unique-retry-turn")).await.unwrap();
+    assert_eq!(retried.retry_turn_id, "retry-2");
+}
+
+#[tokio::test]
+async fn retry_waits_until_every_concurrent_lease_has_settled() {
+    let (client, store) = running().await;
+    let failed = store.acquire_dispatch(TurnId::new("failed")).await.unwrap();
+    let active = store.acquire_dispatch(TurnId::new("active")).await.unwrap();
+    store
+        .fail_dispatch(fail(TurnFailureKind::Refused, failed.lease_id.as_str()))
+        .await
+        .unwrap();
+
+    let error = client
+        .retry(retry(1, "while-peer-active"))
+        .await
+        .unwrap_err();
+    let (code, reason) = rpc_error_parts(error);
+    assert_eq!(code, NO_RETRYABLE_FRONTIER);
+    assert_eq!(reason, "active");
+    store
+        .complete_dispatch(VerifiedCompletion {
+            lease_id: active.lease_id,
+            output: json!({"ok": true}),
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn final_failed_lease_finishes_a_draining_run() {
+    let (client, store) = running().await;
+    let permit = store.acquire_dispatch(TurnId::new("turn-1")).await.unwrap();
+    let acknowledged = client
+        .stop(stop(StopMode::Drain, 1, "drain-failed"))
+        .await
+        .unwrap();
+    assert_eq!(
+        acknowledged.operational.dispatch_state,
+        DispatchState::Draining
+    );
+
+    let result = store
+        .fail_dispatch(fail(TurnFailureKind::Crash, permit.lease_id.as_str()))
+        .await
+        .unwrap();
+    assert!(result.terminalized);
+    let state = store.inspect().await;
+    assert_eq!(state.control.phase, Phase::Finished);
+    assert!(state.lifecycle.pending_failed_frontier.is_none());
+    assert!(state.lifecycle.pending_retry_turn.is_none());
+    assert!(matches!(
+        state.lifecycle.records.last().unwrap().event,
+        LifecycleEvent::Finished {
+            mode: StopMode::Drain
+        }
+    ));
 }

--- a/docs/openengine-cluster-protocol/v1/lifecycle.md
+++ b/docs/openengine-cluster-protocol/v1/lifecycle.md
@@ -30,9 +30,10 @@ from the latest durable cursor.
 
 `stop({mode, ifGeneration, idempotencyKey})` accepts `drain` or `force`.
 
-- Drain closes the dispatch gate and waits for every existing lease. The final verified completion
-  atomically appends the single terminal `finished` record. With no in-flight lease, stop finishes
-  immediately. Drain invokes no `onComplete` or other hook absent from the authored graph contract.
+- Drain closes the dispatch gate and waits for every existing lease. The final verified or failed
+  settlement atomically appends the single terminal `finished` record. With no in-flight lease,
+  stop finishes immediately. Drain invokes no `onComplete` or other hook absent from the authored
+  graph contract.
 - Force closes the gate, signals every lease cancellation token, records each cancelled turn as
   structural void state with no outcome, and appends the single terminal `finished` record. A force
   request escalates an existing drain; a drain request never downgrades force.
@@ -49,21 +50,22 @@ record.
 targets its own store-tracked latest unconsumed failed dispatch frontier. A closed request rejects
 `mode`, `turnId`, `executionId`, `session`, `workspacePath`, `provider`, and any other unknown field.
 
-Only a pending failed frontier admits retry. Every other observable state fails closed with
-`NO_RETRYABLE_FRONTIER` and a `reason`: `exhausted` (no turn has ever failed), `success` (the
-frontier turn already completed), `active` (a turn is currently leased — either the original turn
-or a superseding dispatch), or `consumed` (the frontier was already retried). A stale generation
+Only a pending retryable failed frontier admits retry. Every other observable state fails closed
+with `NO_RETRYABLE_FRONTIER` and a closed `reason`: `exhausted` (no turn has failed or the authored
+attempt allowance is exhausted), `success` (the frontier turn already completed), `active` (one or
+more turns are still leased), or `consumed` (the frontier was already retried). A stale generation
 returns `GENERATION_CONFLICT`; a terminal graph or a non-`active` dispatch state (suspended,
 draining, force-stopping, stopped) returns `INVALID_PHASE`.
 
 Retry reuses the exact recorded verified input, admitted target, workspace policy, and deadline of
 the original run; it never accepts caller-supplied replacement data and never allocates a new run
-ID or generation. It mints one new internal turn identity for the retried attempt and atomically
-races any competing error-successor continuation: a concurrent new dispatch (`acquire_dispatch`)
-silently supersedes — clears — a pending failed frontier it did not consume, so at most one side of
-that race ever wins the frontier. Retry is a same-run intent record only; it does not itself
-establish a new dispatch lease or invoke a worker, and no automatic or background code path in this
-protocol ever calls it.
+ID or generation. It mints and durably reserves one new internal turn identity for the retried
+attempt. Until that reserved retry turn is dispatched, a stale error-successor dispatch is rejected.
+A concurrent error-successor may instead win first by atomically clearing the failed frontier, in
+which case retry fails closed; exactly one side is accepted. Dispatching the reserved retry turn
+consumes the intent, and every turn identity remains single-use across failures as well as successes.
+Retry is a same-run intent record only; it does not itself establish a new dispatch lease or invoke
+a worker, and no automatic or background code path in this protocol ever calls it.
 
 ## CAS, idempotency, and acknowledgements
 


### PR DESCRIPTION
## Problem

Post-merge review of #785 found that a failed final drain lease never finished the run, stale error-successor dispatch could still be accepted after retry won, failed turn IDs could be reused, authored attempt exhaustion was not represented, retry turn IDs could collide, and retry error reasons were open strings.

## Fix

- terminalize drain after the final failed settlement
- reserve accepted retry intents and reject stale successors until the reserved turn begins
- enforce single-use and collision-free turn identities
- represent authored-attempt exhaustion explicitly
- close the retry error-reason algebra
- strengthen lifecycle snapshot replay validation and regression coverage

## Verification

- all four focused lifecycle_retry suites (23 tests)
- openengine-cluster-server package tests (103)
- openengine-cluster-testkit package tests (90)
- npm run rust:check
- npm run protocol:check
- npm run typecheck
- npm run lint (0 errors)
- npm run test:unit (1702 passing, 18 pending)
- opcore check --changed (passed)