### PR TITLE
fix(cluster-protocol): replay resubmit before validation

### DIFF
--- a/crates/openengine-cluster-server/src/admission.rs
+++ b/crates/openengine-cluster-server/src/admission.rs
@@ -379,26 +379,6 @@ where
         params: ResubmitParams,
     ) -> Result<ResubmitResult, BackendError> {
         let fingerprint = resubmit_fingerprint(&params)?;
-        // Replacement-input schema validation is safe to fail fast on: unlike generation/run CAS,
-        // the admitted graph never changes as a side effect of resubmit, so this check's outcome
-        // cannot differ between a first call and its idempotent replay. Generation/run/phase/
-        // idempotency-replay checks are NOT duplicated here; they run once, atomically, inside
-        // `store.resubmit` (mirroring `retry`/`update`/`stop`) so a replay is judged against the
-        // request that was actually recorded rather than the coordinator's own pre-mutation read.
-        if let Some(replacement_input) = params.replacement_input.as_ref() {
-            let (snapshot, _) = self.read_valid_snapshot().await?;
-            let graph = snapshot.control.spec.as_ref().ok_or_else(|| {
-                BackendError::application(
-                    INVALID_PHASE,
-                    "Cluster has no admitted graph to validate replacement input against",
-                    None,
-                )
-            })?;
-            graph
-                .initial_input
-                .validate_value(replacement_input)
-                .map_err(|error| schema_error(&error.to_string()))?;
-        }
         if context.cancellation.is_cancelled() {
             return Err(cancelled_error());
         }

--- a/crates/openengine-cluster-testkit/tests/lifecycle_resubmit.rs
+++ b/crates/openengine-cluster-testkit/tests/lifecycle_resubmit.rs
@@ -5,7 +5,9 @@ use openengine_cluster_protocol::{
     INVALID_PHASE, RUN_CONFLICT, SCHEMA_VIOLATION,
 };
 use openengine_cluster_server::watch::{ObservationStore, SubscribeRequest};
-use openengine_cluster_testkit::admission::InMemoryAdmissionStore;
+use openengine_cluster_testkit::admission::{
+    compiled_from_graph_fixture, graph_fixture, InMemoryAdmissionStore, ScriptedOutcome,
+};
 use openengine_cluster_testkit::lifecycle::{resubmit, stop};
 use serde_json::json;
 
@@ -13,7 +15,7 @@ use serde_json::json;
 mod admission_support;
 #[path = "lifecycle_support/mod.rs"]
 mod lifecycle_support;
-use admission_support::{rpc_code, FixtureClient};
+use admission_support::{client, committed, rpc_code, FixtureClient};
 use lifecycle_support::running;
 
 /// A terminal run: `running()` immediately force-stopped, reaching `Phase::Finished` at
@@ -148,6 +150,39 @@ async fn resubmit_idempotent_replay_returns_original_receipt_no_second_run() {
         after.control_journal.len(),
         before.control_journal.len() + 1
     );
+}
+
+#[tokio::test]
+async fn resubmit_replay_precedes_current_graph_schema_validation() {
+    let first_graph = graph_fixture("worker", json!({"kind":"null"}));
+    let second_graph = graph_fixture("worker", json!({"kind":"integer"}));
+    let outcomes = vec![
+        ScriptedOutcome::approve(compiled_from_graph_fixture(&first_graph), vec![]),
+        ScriptedOutcome::approve(compiled_from_graph_fixture(&second_graph), vec![]),
+    ];
+    let (client, _, store) = client(outcomes);
+    client
+        .apply(committed(first_graph, json!(null), 0, "create-first"))
+        .await
+        .unwrap();
+    client
+        .stop(stop(StopMode::Force, 1, "finish-first"))
+        .await
+        .unwrap();
+
+    let params = resubmit(1, "run-1", "replay-across-generation", Some(json!(null)));
+    let first = client.resubmit(params.clone()).await.unwrap();
+    client
+        .apply(committed(second_graph, json!(1), 1, "create-second"))
+        .await
+        .unwrap();
+    let before_replay = store.inspect().await;
+
+    let replay = client.resubmit(params).await.unwrap();
+    assert!(replay.deduped);
+    assert_eq!(replay.run_id, first.run_id);
+    assert_eq!(replay.at_cursor, first.at_cursor);
+    assert_eq!(store.inspect().await, before_replay);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Post-merge review of #788 found that the coordinator validated `replacementInput` against the latest admitted graph before the store could resolve an existing idempotency receipt. After a later graph apply changed the input schema, an exact replay returned `SCHEMA_VIOLATION` instead of the original receipt.

## Fix

- Remove coordinator-side replacement-input prevalidation.
- Keep schema validation inside the atomic `AdmissionStore::resubmit` path, after idempotency lookup.
- Add a regression that resubmits generation 1 with `null`, applies an integer-input generation 2 graph, then replays the generation 1 request without mutation.

The native `ClusterLedgerAdapters::resubmit` implementation remains owned by #763, matching #746's explicit native-ledger non-goal.

## Verification

- 4 focused `lifecycle_resubmit` targets: 21 tests passed
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm run test:unit` (1702 passing, 18 pending)
- `opcore check --changed` (passed)