### PR TITLE
fix: support non-origin git remotes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,6 +609,10 @@ git switch <branch>                            # Instead of git checkout
 git restore <file>                             # Instead of git checkout --
 ```
 
+Bind issue context before inserting shell-quoted Git configuration into prompt commands. Never run
+global placeholder replacement over a completed command prompt: Git-valid names can contain
+placeholder-like text.
+
 ### Test-First Workflow
 
 Write tests BEFORE or WITH code:

--- a/lib/git-remote-utils.js
+++ b/lib/git-remote-utils.js
@@ -140,19 +140,39 @@ function detectGitContext(cwd = process.cwd()) {
   }
 
   try {
-    // Try to get remote URL (origin by default)
-    const remoteUrl = execSync('git remote get-url origin', {
+    const remoteOutput = execSync('git remote -v', {
       cwd,
       stdio: 'pipe',
       encoding: 'utf8',
-    }).trim();
+    });
 
-    if (!remoteUrl) {
-      return null;
+    const supportedRemotes = new Map();
+    for (const line of remoteOutput.split(/\r?\n/)) {
+      const match = line.match(/^(\S+)\s+(.+)\s+\(fetch\)$/);
+      if (!match) {
+        continue;
+      }
+
+      const [, remote, remoteUrl] = match;
+      const context = parseGitRemoteUrl(remoteUrl);
+      if (context && !supportedRemotes.has(remote)) {
+        supportedRemotes.set(remote, { ...context, remote });
+      }
     }
 
-    // Parse the remote URL to extract provider context
-    return parseGitRemoteUrl(remoteUrl);
+    // Preserve existing behavior whenever origin is usable. Without origin,
+    // select a remote only when there is exactly one supported target. Guessing
+    // between multiple repositories could push code or create a PR in the wrong
+    // place, so ambiguous configurations deliberately fail closed.
+    if (supportedRemotes.has('origin')) {
+      return supportedRemotes.get('origin');
+    }
+
+    if (supportedRemotes.size === 1) {
+      return supportedRemotes.values().next().value;
+    }
+
+    return null;
   } catch {
     // No remote configured or command failed
     return null;

--- a/lib/git-remote-utils.js
+++ b/lib/git-remote-utils.js
@@ -5,6 +5,63 @@
 
 const { execSync } = require('../src/lib/safe-exec');
 
+function hasInvalidGitRefCharacter(value) {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint <= 0x20 || codePoint === 0x7f || '~^:?*[\\'.includes(character)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Normalize a Git remote name using the same ref-format rules Git applies to
+ * refs/remotes/<name>. Keeping this next to detection prevents a discovered
+ * remote from being rejected later by a narrower consumer-specific allowlist.
+ *
+ * @param {unknown} value - Candidate remote name
+ * @returns {string|null} Normalized remote name, or null when invalid
+ */
+function normalizeGitRemoteName(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const name = value.trim();
+  if (
+    name.length === 0 ||
+    name.endsWith('.') ||
+    name.includes('..') ||
+    name.includes('@{') ||
+    hasInvalidGitRefCharacter(name)
+  ) {
+    return null;
+  }
+
+  const components = name.split('/');
+  if (
+    components.some(
+      (component) =>
+        component.length === 0 || component.startsWith('.') || component.endsWith('.lock')
+    )
+  ) {
+    return null;
+  }
+
+  return name;
+}
+
+/**
+ * Quote one argument for the POSIX shell snippets embedded in agent prompts.
+ *
+ * @param {string} value - Argument to quote
+ * @returns {string} Single-quoted shell argument
+ */
+function quoteShellArgument(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
 /**
  * Parse git remote URL into structured provider context.
  * Supports GitHub, GitLab, and Azure DevOps (cloud + self-hosted).
@@ -153,7 +210,11 @@ function detectGitContext(cwd = process.cwd()) {
         continue;
       }
 
-      const [, remote, remoteUrl] = match;
+      const [, remoteCandidate, remoteUrl] = match;
+      const remote = normalizeGitRemoteName(remoteCandidate);
+      if (!remote) {
+        continue;
+      }
       const context = parseGitRemoteUrl(remoteUrl);
       if (context && !supportedRemotes.has(remote)) {
         supportedRemotes.set(remote, { ...context, remote });
@@ -180,6 +241,8 @@ function detectGitContext(cwd = process.cwd()) {
 }
 
 module.exports = {
+  normalizeGitRemoteName,
+  quoteShellArgument,
   parseGitRemoteUrl,
   detectGitContext,
 };

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -275,6 +275,7 @@ const hasSufficientEvidence = latestValidatorMessages.every((r) => {
 return hasSufficientEvidence;`;
 
 const { readRepoSettings } = require('../../lib/repo-settings');
+const { normalizeGitRemoteName, quoteShellArgument } = require('../../lib/git-remote-utils');
 const { resolveRequiredQualityGates } = require('../quality-gates');
 
 function getSafeBranchName(value) {
@@ -292,25 +293,6 @@ function getSafeBranchName(value) {
     return null;
   }
 
-  return trimmed;
-}
-
-function getSafeGitRemote(value) {
-  if (value === undefined || value === null) {
-    return 'origin';
-  }
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (
-    trimmed.length === 0 ||
-    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(trimmed) ||
-    trimmed.includes('..')
-  ) {
-    return null;
-  }
   return trimmed;
 }
 
@@ -347,7 +329,7 @@ function resolveGitHubConfig(options = {}) {
   const repoSettingsResult = readRepoSettings(options.cwd || process.cwd());
   const repoSettings = repoSettingsResult.settings || {};
   const repoGithub = repoSettings.github || {};
-  const gitRemote = getSafeGitRemote(options.gitRemote);
+  const gitRemote = normalizeGitRemoteName(options.gitRemote ?? 'origin');
   if (!gitRemote) {
     throw new Error(`Invalid git remote name '${options.gitRemote}'`);
   }
@@ -466,6 +448,7 @@ function generateReviewModePrompt(config) {
     requiresPrIdExtraction,
     gitRemote,
   } = config;
+  const gitRemoteArgument = quoteShellArgument(gitRemote);
 
   return `CRITICAL: ALL VALIDATORS APPROVED. YOU ARE A TRANSPORT-ONLY GIT PUSHER.
 
@@ -507,7 +490,7 @@ Run this command. Do not skip it.
 
 ### STEP 4: Push to ${gitRemote} (MANDATORY)
 \`\`\`bash
-git push -u ${gitRemote} HEAD
+git push -u -- ${gitRemoteArgument} HEAD
 \`\`\`
 Run this. If it fails, do not edit files, rebase, or resolve conflicts. Output blocked JSON with the failure summary.
 
@@ -579,6 +562,7 @@ function generatePrompt(config) {
     autoMerge,
     gitRemote,
   } = config;
+  const gitRemoteArgument = quoteShellArgument(gitRemote);
 
   if (!autoMerge) {
     return generateReviewModePrompt(config);
@@ -668,7 +652,7 @@ Run this command. Do not skip it.
 
 ### STEP 4: Push to ${gitRemote} (MANDATORY)
 \`\`\`bash
-git push -u ${gitRemote} HEAD
+git push -u -- ${gitRemoteArgument} HEAD
 \`\`\`
 Run this. If it fails, do not edit files, rebase, or resolve conflicts. Output blocked JSON with the failure summary.
 

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -314,6 +314,35 @@ function normalizeCloseIssueMode(value) {
   return null;
 }
 
+function normalizeIssueNumber(value) {
+  const candidate = typeof value === 'number' ? String(value) : value;
+  if (typeof candidate !== 'string') return 'unknown';
+  const trimmed = candidate.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) ? trimmed : 'unknown';
+}
+
+function normalizeIssueTitle(value) {
+  if (typeof value !== 'string' || value.trim() === '') return 'Implementation';
+  const normalized = [...value]
+    .map((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint < 0x20 || codePoint === 0x7f ? ' ' : character;
+    })
+    .join('')
+    .trim();
+  return normalized || 'Implementation';
+}
+
+function resolveIssueContext(options) {
+  const issueNumber = normalizeIssueNumber(options.issueNumber);
+  const issueTitle = normalizeIssueTitle(options.issueTitle);
+  const issueReference =
+    options.includeIssueReference === false || issueNumber === 'unknown'
+      ? ''
+      : `Closes #${issueNumber}`;
+  return { issueNumber, issueTitle, issueReference };
+}
+
 /**
  * Resolve GitHub configuration from CLI options and repo settings.
  * Priority: CLI options > repo settings (.zeroshot/settings.json) > defaults
@@ -323,6 +352,9 @@ function normalizeCloseIssueMode(value) {
  * @param {boolean} [options.mergeQueue] - Use GitHub merge queue
  * @param {string} [options.closeIssue] - When to close issue: auto|always|never
  * @param {string} [options.gitRemote=origin] - Remote to push the implementation branch to
+ * @param {string|number} [options.issueNumber] - Typed issue identifier for prompt commands
+ * @param {string} [options.issueTitle] - Typed issue title for prompt commands
+ * @param {boolean} [options.includeIssueReference] - Include the closing reference in PR text
  * @returns {Object} Resolved configuration
  */
 function resolveGitHubConfig(options = {}) {
@@ -353,7 +385,14 @@ function resolveGitHubConfig(options = {}) {
     options.autoMerge === true ||
     (options.autoMerge !== false && parseBool(repoGithub.autoMerge) === true);
 
-  return { prBase, useMergeQueue, closeIssueMode, autoMerge, gitRemote };
+  return {
+    prBase,
+    useMergeQueue,
+    closeIssueMode,
+    autoMerge,
+    gitRemote,
+    issueContext: resolveIssueContext(options),
+  };
 }
 
 /**
@@ -365,12 +404,15 @@ function resolveGitHubConfig(options = {}) {
  */
 function getPlatformConfig(platform, config = {}) {
   const { prBase, useMergeQueue, closeIssueMode, autoMerge, gitRemote } = config;
+  const issueContext = config.issueContext || resolveIssueContext({});
+  const issueTitleArgument = quoteShellArgument(`feat: ${issueContext.issueTitle}`);
+  const issueReferenceArgument = quoteShellArgument(issueContext.issueReference);
 
   const PLATFORM_CONFIGS = {
     github: {
       prName: 'PR',
       prNameLower: 'pull request',
-      createCmd: `gh pr create${prBase ? ` --base ${prBase}` : ''} --title "feat: {{issue_title}}" --body "Closes #{{issue_number}}"`,
+      createCmd: `gh pr create${prBase ? ` --base ${prBase}` : ''} --title ${issueTitleArgument} --body ${issueReferenceArgument}`,
       mergeCmd: useMergeQueue
         ? `PR_ID="$(timeout 30 gh pr view --json id --jq .id)"
 gh api graphql -f query='mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){mergeQueueEntry{state}}}' -f id="$PR_ID"
@@ -387,12 +429,12 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
       gitRemote,
+      issueContext,
     },
     gitlab: {
       prName: 'MR',
       prNameLower: 'merge request',
-      createCmd:
-        'glab mr create --title "feat: {{issue_title}}" --description "Closes #{{issue_number}}"',
+      createCmd: `glab mr create --title ${issueTitleArgument} --description ${issueReferenceArgument}`,
       mergeCmd: 'glab mr merge --auto-merge',
       mergeFallbackCmd: 'glab mr merge',
       prUrlExample: 'https://gitlab.com/owner/repo/-/merge_requests/123',
@@ -400,12 +442,12 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
       gitRemote,
+      issueContext,
     },
     'azure-devops': {
       prName: 'PR',
       prNameLower: 'pull request',
-      createCmd:
-        'az repos pr create --title "feat: {{issue_title}}" --description "Closes #{{issue_number}}"',
+      createCmd: `az repos pr create --title ${issueTitleArgument} --description ${issueReferenceArgument}`,
       mergeCmd: 'az repos pr update --id <PR_ID> --auto-complete true',
       mergeFallbackCmd: 'az repos pr update --id <PR_ID> --status completed',
       prUrlExample: 'https://dev.azure.com/org/project/_git/repo/pullrequest/123',
@@ -420,6 +462,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
       gitRemote,
+      issueContext,
     },
   };
 
@@ -447,8 +490,12 @@ function generateReviewModePrompt(config) {
     outputFields,
     requiresPrIdExtraction,
     gitRemote,
+    issueContext,
   } = config;
   const gitRemoteArgument = quoteShellArgument(gitRemote);
+  const commitMessageArgument = quoteShellArgument(
+    `feat: implement #${issueContext.issueNumber} - ${issueContext.issueTitle}`
+  );
 
   return `CRITICAL: ALL VALIDATORS APPROVED. YOU ARE A TRANSPORT-ONLY GIT PUSHER.
 
@@ -484,7 +531,7 @@ Run this. If nothing to commit, output JSON with ${outputFields.urlField}: null 
 
 ### STEP 3: Commit the changes (MANDATORY if there are changes)
 \`\`\`bash
-git commit -m "feat: implement #{{issue_number}} - {{issue_title}}"
+git commit -m ${commitMessageArgument}
 \`\`\`
 Run this command. Do not skip it.
 
@@ -561,8 +608,13 @@ function generatePrompt(config) {
     closeIssueMode,
     autoMerge,
     gitRemote,
+    issueContext,
   } = config;
   const gitRemoteArgument = quoteShellArgument(gitRemote);
+  const issueNumberArgument = quoteShellArgument(issueContext.issueNumber);
+  const commitMessageArgument = quoteShellArgument(
+    `feat: implement #${issueContext.issueNumber} - ${issueContext.issueTitle}`
+  );
 
   if (!autoMerge) {
     return generateReviewModePrompt(config);
@@ -646,7 +698,7 @@ Run this. If nothing to commit, output JSON with ${outputFields.urlField}: null 
 
 ### STEP 3: Commit the changes (MANDATORY if there are changes)
 \`\`\`bash
-git commit -m "feat: implement #{{issue_number}} - {{issue_title}}"
+git commit -m ${commitMessageArgument}
 \`\`\`
 Run this command. Do not skip it.
 
@@ -684,8 +736,8 @@ ${
   closeIssueMode !== 'never'
     ? `### STEP 7: Close the issue (MANDATORY)
 \`\`\`bash
-if [ "{{issue_number}}" != "unknown" ]; then
-  ISSUE_STATE="$(gh issue view {{issue_number}} --json state --jq .state 2>/dev/null || true)"
+if [ ${issueNumberArgument} != "unknown" ]; then
+  ISSUE_STATE="$(gh issue view ${issueNumberArgument} --json state --jq .state 2>/dev/null || true)"
   if [ "$ISSUE_STATE" = "OPEN" ]; then
     BASE_BRANCH="${rebaseBranch || 'main'}"
     DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null || true)"
@@ -701,9 +753,9 @@ if [ "{{issue_number}}" != "unknown" ]; then
     if [ "$SHOULD_CLOSE" = "1" ]; then
   PR_URL="$(gh pr view --json url --jq .url 2>/dev/null || true)"
   if [ -n "$PR_URL" ]; then
-    gh issue close {{issue_number}} --comment "Implemented in $PR_URL"
+    gh issue close ${issueNumberArgument} --comment "Implemented in $PR_URL"
   else
-    gh issue close {{issue_number}} --comment "Implemented"
+    gh issue close ${issueNumberArgument} --comment "Implemented"
   fi
     fi
   fi
@@ -748,6 +800,9 @@ If blocked before creating a ${prName}, output:
  * @param {boolean} [options.mergeQueue] - Use GitHub merge queue
  * @param {string} [options.closeIssue] - When to close issue: auto|always|never
  * @param {string} [options.gitRemote=origin] - Remote to push the implementation branch to
+ * @param {string|number} [options.issueNumber] - Typed issue identifier for prompt commands
+ * @param {string} [options.issueTitle] - Typed issue title for prompt commands
+ * @param {boolean} [options.includeIssueReference] - Include the closing reference in PR text
  * @param {Array} [options.requiredQualityGates] - Required handoff quality gates
  * @param {boolean} [options.autoMerge] - Merge the PR (--ship). False stops after PR creation (--pr).
  * @returns {Object} Agent configuration object

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -295,6 +295,25 @@ function getSafeBranchName(value) {
   return trimmed;
 }
 
+function getSafeGitRemote(value) {
+  if (value === undefined || value === null) {
+    return 'origin';
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (
+    trimmed.length === 0 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(trimmed) ||
+    trimmed.includes('..')
+  ) {
+    return null;
+  }
+  return trimmed;
+}
+
 function parseBool(value) {
   if (typeof value === 'boolean') return value;
   if (typeof value !== 'string') return null;
@@ -321,12 +340,17 @@ function normalizeCloseIssueMode(value) {
  * @param {string} [options.prBase] - Target branch for PRs
  * @param {boolean} [options.mergeQueue] - Use GitHub merge queue
  * @param {string} [options.closeIssue] - When to close issue: auto|always|never
+ * @param {string} [options.gitRemote=origin] - Remote to push the implementation branch to
  * @returns {Object} Resolved configuration
  */
 function resolveGitHubConfig(options = {}) {
   const repoSettingsResult = readRepoSettings(options.cwd || process.cwd());
   const repoSettings = repoSettingsResult.settings || {};
   const repoGithub = repoSettings.github || {};
+  const gitRemote = getSafeGitRemote(options.gitRemote);
+  if (!gitRemote) {
+    throw new Error(`Invalid git remote name '${options.gitRemote}'`);
+  }
 
   // CLI options override repo settings
   const prBase = getSafeBranchName(options.prBase) || getSafeBranchName(repoGithub.prBase);
@@ -347,7 +371,7 @@ function resolveGitHubConfig(options = {}) {
     options.autoMerge === true ||
     (options.autoMerge !== false && parseBool(repoGithub.autoMerge) === true);
 
-  return { prBase, useMergeQueue, closeIssueMode, autoMerge };
+  return { prBase, useMergeQueue, closeIssueMode, autoMerge, gitRemote };
 }
 
 /**
@@ -358,7 +382,7 @@ function resolveGitHubConfig(options = {}) {
  * @returns {Object|null} Platform configuration or null if unsupported
  */
 function getPlatformConfig(platform, config = {}) {
-  const { prBase, useMergeQueue, closeIssueMode, autoMerge } = config;
+  const { prBase, useMergeQueue, closeIssueMode, autoMerge, gitRemote } = config;
 
   const PLATFORM_CONFIGS = {
     github: {
@@ -380,6 +404,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       usesMergeQueue: useMergeQueue,
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
+      gitRemote,
     },
     gitlab: {
       prName: 'MR',
@@ -392,6 +417,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       outputFields: { urlField: 'mr_url', numberField: 'mr_number', mergedField: 'merged' },
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
+      gitRemote,
     },
     'azure-devops': {
       prName: 'PR',
@@ -411,6 +437,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
       requiresPrIdExtraction: true,
       closeIssueMode: closeIssueMode || 'never',
       autoMerge: Boolean(autoMerge),
+      gitRemote,
     },
   };
 
@@ -430,8 +457,15 @@ const SUPPORTED_PLATFORMS = ['github', 'gitlab', 'azure-devops'];
  * @returns {string} The complete review-mode prompt
  */
 function generateReviewModePrompt(config) {
-  const { prName, prNameLower, createCmd, prUrlExample, outputFields, requiresPrIdExtraction } =
-    config;
+  const {
+    prName,
+    prNameLower,
+    createCmd,
+    prUrlExample,
+    outputFields,
+    requiresPrIdExtraction,
+    gitRemote,
+  } = config;
 
   return `CRITICAL: ALL VALIDATORS APPROVED. YOU ARE A TRANSPORT-ONLY GIT PUSHER.
 
@@ -471,9 +505,9 @@ git commit -m "feat: implement #{{issue_number}} - {{issue_title}}"
 \`\`\`
 Run this command. Do not skip it.
 
-### STEP 4: Push to origin (MANDATORY)
+### STEP 4: Push to ${gitRemote} (MANDATORY)
 \`\`\`bash
-git push -u origin HEAD
+git push -u ${gitRemote} HEAD
 \`\`\`
 Run this. If it fails, do not edit files, rebase, or resolve conflicts. Output blocked JSON with the failure summary.
 
@@ -543,6 +577,7 @@ function generatePrompt(config) {
     usesMergeQueue,
     closeIssueMode,
     autoMerge,
+    gitRemote,
   } = config;
 
   if (!autoMerge) {
@@ -631,9 +666,9 @@ git commit -m "feat: implement #{{issue_number}} - {{issue_title}}"
 \`\`\`
 Run this command. Do not skip it.
 
-### STEP 4: Push to origin (MANDATORY)
+### STEP 4: Push to ${gitRemote} (MANDATORY)
 \`\`\`bash
-git push -u origin HEAD
+git push -u ${gitRemote} HEAD
 \`\`\`
 Run this. If it fails, do not edit files, rebase, or resolve conflicts. Output blocked JSON with the failure summary.
 
@@ -728,6 +763,7 @@ If blocked before creating a ${prName}, output:
  * @param {string} [options.prBase] - Target branch for PRs
  * @param {boolean} [options.mergeQueue] - Use GitHub merge queue
  * @param {string} [options.closeIssue] - When to close issue: auto|always|never
+ * @param {string} [options.gitRemote=origin] - Remote to push the implementation branch to
  * @param {Array} [options.requiredQualityGates] - Required handoff quality gates
  * @param {boolean} [options.autoMerge] - Merge the PR (--ship). False stops after PR creation (--pr).
  * @returns {Object} Agent configuration object

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -83,6 +83,7 @@ function fetchFreshRemoteBase(repoRoot, remoteName, branch) {
         '--no-tags',
         '--no-write-fetch-head',
         '--refmap=',
+        '--',
         remoteName,
         `+refs/heads/${branch}:${temporaryRef}`,
       ],
@@ -1634,7 +1635,7 @@ class IsolationManager {
         try {
           runSync(
             'git',
-            ['fetch', '--no-tags', remoteName, `+refs/heads/${branch}:${remoteTrackingRef}`],
+            ['fetch', '--no-tags', '--', remoteName, `+refs/heads/${branch}:${remoteTrackingRef}`],
             {
               cwd: repoRoot,
               encoding: 'utf8',

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -71,7 +71,7 @@ function deleteTemporaryBaseRef(repoRoot, temporaryRef) {
   }
 }
 
-function fetchFreshRemoteBase(repoRoot, branch) {
+function fetchFreshRemoteBase(repoRoot, remoteName, branch) {
   const temporaryRef = `${FRESH_BASE_REF_PREFIX}/${crypto.randomBytes(16).toString('hex')}`;
 
   try {
@@ -83,7 +83,7 @@ function fetchFreshRemoteBase(repoRoot, branch) {
         '--no-tags',
         '--no-write-fetch-head',
         '--refmap=',
-        'origin',
+        remoteName,
         `+refs/heads/${branch}:${temporaryRef}`,
       ],
       {
@@ -1540,6 +1540,7 @@ class IsolationManager {
    * @param {string} workDir - Original working directory
    * @param {object} [options] - Worktree creation options
    * @param {string} [options.baseRef] - Git ref to base the worktree branch on
+   * @param {string} [options.remoteName=origin] - Remote used by a remote base ref
    * @param {boolean} [options.requireFreshBase=false] - Require a freshly fetched remote base
    * @param {number} [options.worktreeSetupTimeoutMs] - Setup command timeout in milliseconds
    * @returns {{ path: string, branch: string, repoRoot: string, baseRef: string, baseSha: string }}
@@ -1617,22 +1618,23 @@ class IsolationManager {
     const worktreeSetupTimeoutMs = resolveWorktreeSetupTimeoutMs(repoSettings, options);
 
     const baseRef = worktreeBaseRef || 'HEAD';
+    const remoteName = options.remoteName || 'origin';
     let baseSha;
     let temporaryBaseRef = null;
 
-    if (worktreeBaseRef && worktreeBaseRef.startsWith('origin/')) {
-      const branch = worktreeBaseRef.slice('origin/'.length);
-      const remoteTrackingRef = `refs/remotes/origin/${branch}`;
+    if (worktreeBaseRef && worktreeBaseRef.startsWith(`${remoteName}/`)) {
+      const branch = worktreeBaseRef.slice(remoteName.length + 1);
+      const remoteTrackingRef = `refs/remotes/${remoteName}/${branch}`;
 
       if (options.requireFreshBase === true) {
-        const freshBase = fetchFreshRemoteBase(repoRoot, branch);
+        const freshBase = fetchFreshRemoteBase(repoRoot, remoteName, branch);
         baseSha = freshBase.baseSha;
         temporaryBaseRef = freshBase.temporaryRef;
       } else {
         try {
           runSync(
             'git',
-            ['fetch', '--no-tags', 'origin', `+refs/heads/${branch}:${remoteTrackingRef}`],
+            ['fetch', '--no-tags', remoteName, `+refs/heads/${branch}:${remoteTrackingRef}`],
             {
               cwd: repoRoot,
               encoding: 'utf8',

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -224,6 +224,7 @@ function buildPrOptions(options, requiredQualityGates) {
     prBase: options.prBase || null,
     mergeQueue: options.mergeQueue || false,
     closeIssue: options.closeIssue || null,
+    gitRemote: options.gitRemote || null,
     autoMerge,
     ...(requiredQualityGates.length > 0 ? { requiredQualityGates } : {}),
     cwd: options.cwd || process.cwd(),
@@ -1266,6 +1267,8 @@ class Orchestrator {
         const { detectGitContext } = require('../lib/git-remote-utils');
         const gitContext = detectGitContext(options.cwd);
         cluster.gitPlatform = gitContext?.provider || null;
+        options.gitRemote = gitContext?.remote || options.gitRemote || null;
+        cluster.prOptions = buildPrOptions(options, requiredQualityGates);
 
         if (cluster.gitPlatform) {
           this._log(`[Orchestrator] Git platform detected: ${cluster.gitPlatform.toUpperCase()}`);
@@ -1796,11 +1799,21 @@ class Orchestrator {
       const workDir = options.cwd || process.cwd();
 
       isolationManager = new IsolationManager({});
+      const { detectGitContext } = require('../lib/git-remote-utils');
+      const gitContext = detectGitContext(workDir);
+      if (gitContext?.remote) {
+        options.gitRemote = gitContext.remote;
+      }
+
       // `prBase` is the PR target branch. Base isolated work on its refreshed
       // remote-tracking ref so a stale local branch cannot change the plan.
       const worktreeOptions = {};
       if (options.prBase) {
-        worktreeOptions.baseRef = `origin/${options.prBase}`;
+        const remoteName = options.gitRemote || 'origin';
+        worktreeOptions.baseRef = `${remoteName}/${options.prBase}`;
+        if (remoteName !== 'origin') {
+          worktreeOptions.remoteName = remoteName;
+        }
         worktreeOptions.requireFreshBase = true;
         this._log(`[Orchestrator] Using worktree base ref: ${worktreeOptions.baseRef}`);
       }
@@ -1872,6 +1885,7 @@ class Orchestrator {
       closeIssue: options.closeIssue,
       requiredQualityGates: options.requiredQualityGates,
       autoMerge: resolveRunPlan(options).autoMerge,
+      gitRemote: gitContext?.remote || options.gitRemote,
       cwd: options.cwd,
     });
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1886,15 +1886,11 @@ class Orchestrator {
       requiredQualityGates: options.requiredQualityGates,
       autoMerge: resolveRunPlan(options).autoMerge,
       gitRemote: gitContext?.remote || options.gitRemote,
+      issueNumber: inputData.number,
+      issueTitle: inputData.title,
+      includeIssueReference: !skipCloseIssue,
       cwd: options.cwd,
     });
-
-    // Template replacement for issue context
-    const issueRef = skipCloseIssue ? '' : `Closes #${inputData.number || 'unknown'}`;
-    gitPusherConfig.prompt = gitPusherConfig.prompt
-      .replace(/\{\{issue_number\}\}/g, inputData.number || 'unknown')
-      .replace(/\{\{issue_title\}\}/g, inputData.title || 'Implementation')
-      .replace(/Closes #\{\{issue_number\}\}/g, issueRef);
 
     config.agents.push(gitPusherConfig);
     this._log(
@@ -4049,7 +4045,6 @@ Continue from where you left off. Review your previous output to understand what
         }
       }
 
-      // Generate platform-specific git-pusher agent from template
       const {
         generateGitPusherAgent,
         isPlatformSupported,
@@ -4061,18 +4056,19 @@ Continue from where you left off. Review your previous output to understand what
         );
       }
 
-      // Use persisted PR options from cluster state (or empty for repo settings fallback)
-      const gitPusherConfig = generateGitPusherAgent(platform, cluster.prOptions || {});
-
       // Get issue context from ledger
       const issueMsg = cluster.messageBus.ledger.findLast({ topic: 'ISSUE_OPENED' });
       const issueNumber = issueMsg?.content?.data?.number || 'unknown';
       const issueTitle = issueMsg?.content?.data?.title || 'Implementation';
 
-      // Inject issue context into prompt
-      gitPusherConfig.prompt = gitPusherConfig.prompt
-        .replace(/\{\{issue_number\}\}/g, issueNumber)
-        .replace(/\{\{issue_title\}\}/g, issueTitle);
+      // Generate the final prompt in one typed assembly pass. Issue values are
+      // resolved before the shell-quoted remote is inserted, so placeholder-like
+      // remote names cannot be rewritten by issue context.
+      const gitPusherConfig = generateGitPusherAgent(platform, {
+        ...(cluster.prOptions || {}),
+        issueNumber,
+        issueTitle,
+      });
 
       await this._opAddAgents(cluster, { agents: [gitPusherConfig] }, context);
       this._log(`    [--pr mode] Injected ${platform}-git-pusher agent`);

--- a/tests/git-pusher-placeholder-safety.test.js
+++ b/tests/git-pusher-placeholder-safety.test.js
@@ -1,0 +1,94 @@
+const assert = require('node:assert');
+const { execFileSync, execSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const Orchestrator = require('../src/orchestrator');
+
+function writeCommandRecorder(binDir, commandName) {
+  const commandPath = path.join(binDir, commandName);
+  fs.writeFileSync(
+    commandPath,
+    '#!/bin/sh\nprintf \'%s\\n\' "$@" >> "$ZEROSHOT_COMMAND_LOG"\n',
+    'utf8'
+  );
+  fs.chmodSync(commandPath, 0o755);
+}
+
+function findPromptCommand(prompt, prefix) {
+  return prompt.split('\n').find((line) => line.startsWith(prefix));
+}
+
+describe('git-pusher typed prompt assembly', function () {
+  it('does not reinterpret issue placeholders inside a quoted remote', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-git-pusher-safety-'));
+    const gitRemote = 'remote-{{issue_number}}-{{issue_title}}';
+    const injectedFile = path.join(cwd, 'PWNED');
+    const issueTitle = `safe'; printf PWNED > ${injectedFile}; #`;
+    execSync('git init', { cwd, stdio: 'ignore' });
+    execFileSync('git', ['remote', 'add', gitRemote, 'https://github.com/acme/widgets.git'], {
+      cwd,
+      stdio: 'ignore',
+    });
+    const orchestrator = new Orchestrator({
+      storageDir: path.join(cwd, 'storage'),
+    });
+    const config = { agents: [{ id: 'completion-detector' }] };
+
+    try {
+      orchestrator._applyAutoPrConfig(
+        config,
+        {
+          number: 448,
+          title: issueTitle,
+          url: 'https://github.com/acme/widgets/issues/448',
+        },
+        {
+          autoPr: true,
+          cwd,
+          requiredQualityGates: [],
+        }
+      );
+
+      const prompt = config.agents.find((agent) => agent.id === 'git-pusher').prompt;
+      const commands = [
+        findPromptCommand(prompt, 'git commit -m '),
+        findPromptCommand(prompt, 'git push -u -- '),
+        findPromptCommand(prompt, 'gh pr create'),
+      ];
+      assert(commands.every(Boolean), 'expected commit, push, and PR creation commands');
+      assert.match(commands[1], /remote-\{\{issue_number\}\}-\{\{issue_title\}\}/);
+
+      const binDir = path.join(cwd, 'bin');
+      const commandLog = path.join(cwd, 'commands.log');
+      fs.mkdirSync(binDir);
+      writeCommandRecorder(binDir, 'git');
+      writeCommandRecorder(binDir, 'gh');
+
+      for (const command of commands) {
+        execFileSync('/bin/sh', ['-c', command], {
+          cwd,
+          env: {
+            ...process.env,
+            PATH: `${binDir}:${process.env.PATH}`,
+            ZEROSHOT_COMMAND_LOG: commandLog,
+          },
+        });
+      }
+
+      const recordedArguments = fs.readFileSync(commandLog, 'utf8').split('\n');
+      assert(recordedArguments.includes(gitRemote), 'push remote must remain byte-for-byte intact');
+      assert(
+        recordedArguments.some((argument) => argument.includes(issueTitle)),
+        'the issue title must remain one literal command argument'
+      );
+      assert.strictEqual(fs.existsSync(injectedFile), false, 'issue title must not execute');
+    } finally {
+      orchestrator.close();
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/git-pusher-pr-mode.test.js
+++ b/tests/git-pusher-pr-mode.test.js
@@ -11,7 +11,7 @@ const assert = require('node:assert');
 const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const { execFileSync, execSync } = require('node:child_process');
 
 const { generateGitPusherAgent } = require('../src/agents/git-pusher-template');
 const Orchestrator = require('../src/orchestrator');
@@ -33,9 +33,9 @@ function writeRepoSettings(cwd, settings) {
   fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(settings, null, 2));
 }
 
-function addUpstreamRemote(cwd) {
+function addGitRemote(cwd, name = 'upstream') {
   execSync('git init', { cwd, stdio: 'ignore' });
-  execSync('git remote add upstream https://github.com/acme/widgets.git', {
+  execFileSync('git', ['remote', 'add', name, 'https://github.com/acme/widgets.git'], {
     cwd,
     stdio: 'ignore',
   });
@@ -100,14 +100,14 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
         cwd,
       });
 
-      assert.match(agentConfig.prompt, /git push -u upstream HEAD/);
-      assert.doesNotMatch(agentConfig.prompt, /git push -u origin HEAD/);
+      assert.match(agentConfig.prompt, /git push -u -- 'upstream' HEAD/);
+      assert.doesNotMatch(agentConfig.prompt, /git push -u -- 'origin' HEAD/);
     });
   });
 
   it('threads an auto-detected non-origin remote into the PR agent', function () {
     withTmpCwd((cwd) => {
-      addUpstreamRemote(cwd);
+      addGitRemote(cwd);
       const orchestrator = new Orchestrator({
         storageDir: path.join(cwd, 'storage'),
       });
@@ -130,7 +130,43 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
 
         const gitPusher = config.agents.find((agent) => agent.id === 'git-pusher');
         assert.ok(gitPusher);
-        assert.match(gitPusher.prompt, /git push -u upstream HEAD/);
+        assert.match(gitPusher.prompt, /git push -u -- 'upstream' HEAD/);
+      } finally {
+        orchestrator.close();
+      }
+    });
+  });
+
+  it('supports and shell-quotes a Git-valid remote outside the old allowlist', function () {
+    withTmpCwd((cwd) => {
+      addGitRemote(cwd, "my@remote's");
+      const orchestrator = new Orchestrator({
+        storageDir: path.join(cwd, 'storage'),
+      });
+      const config = { agents: [{ id: 'completion-detector' }] };
+
+      try {
+        orchestrator._applyAutoPrConfig(
+          config,
+          {
+            number: 448,
+            title: 'Support non-origin remotes',
+            url: 'https://github.com/acme/widgets/issues/448',
+          },
+          {
+            autoPr: true,
+            cwd,
+            requiredQualityGates: [],
+          }
+        );
+
+        const gitPusher = config.agents.find((agent) => agent.id === 'git-pusher');
+        assert.ok(gitPusher);
+        assert.match(gitPusher.prompt, /Push to my@remote's/);
+        assert.ok(
+          gitPusher.prompt.includes(`git push -u -- 'my@remote'"'"'s' HEAD`),
+          'remote must be passed as one shell-quoted argument'
+        );
       } finally {
         orchestrator.close();
       }

--- a/tests/git-pusher-pr-mode.test.js
+++ b/tests/git-pusher-pr-mode.test.js
@@ -33,6 +33,14 @@ function writeRepoSettings(cwd, settings) {
   fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(settings, null, 2));
 }
 
+function addUpstreamRemote(cwd) {
+  execSync('git init', { cwd, stdio: 'ignore' });
+  execSync('git remote add upstream https://github.com/acme/widgets.git', {
+    cwd,
+    stdio: 'ignore',
+  });
+}
+
 describe('git-pusher --pr vs --ship (autoMerge)', function () {
   it('review mode (autoMerge=false): prompt has no merge step, output template is merged:false', function () {
     withTmpCwd((cwd) => {
@@ -84,6 +92,51 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
     });
   });
 
+  it('pushes to the selected non-origin remote', function () {
+    withTmpCwd((cwd) => {
+      const agentConfig = generateGitPusherAgent('github', {
+        autoMerge: false,
+        gitRemote: 'upstream',
+        cwd,
+      });
+
+      assert.match(agentConfig.prompt, /git push -u upstream HEAD/);
+      assert.doesNotMatch(agentConfig.prompt, /git push -u origin HEAD/);
+    });
+  });
+
+  it('threads an auto-detected non-origin remote into the PR agent', function () {
+    withTmpCwd((cwd) => {
+      addUpstreamRemote(cwd);
+      const orchestrator = new Orchestrator({
+        storageDir: path.join(cwd, 'storage'),
+      });
+      const config = { agents: [{ id: 'completion-detector' }] };
+
+      try {
+        orchestrator._applyAutoPrConfig(
+          config,
+          {
+            number: 448,
+            title: 'Support non-origin remotes',
+            url: 'https://github.com/acme/widgets/issues/448',
+          },
+          {
+            autoPr: true,
+            cwd,
+            requiredQualityGates: [],
+          }
+        );
+
+        const gitPusher = config.agents.find((agent) => agent.id === 'git-pusher');
+        assert.ok(gitPusher);
+        assert.match(gitPusher.prompt, /git push -u upstream HEAD/);
+      } finally {
+        orchestrator.close();
+      }
+    });
+  });
+
   it('--pr review mode overrides repo github.autoMerge=true', function () {
     withTmpCwd((cwd) => {
       writeRepoSettings(cwd, { github: { autoMerge: true } });
@@ -120,6 +173,12 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
     // Persisted even when no other PR fields were passed (--pr with all defaults),
     // otherwise the distinction is lost on `zeroshot resume`.
     assert.notStrictEqual(prOptionsForPr, null);
+  });
+
+  it('buildPrOptions persists the selected remote for resume', function () {
+    const prOptions = Orchestrator.buildPrOptions({ pr: true, gitRemote: 'upstream' }, []);
+
+    assert.strictEqual(prOptions.gitRemote, 'upstream');
   });
 
   it('resolveRunPlan is the single source for the autoMerge decision', function () {

--- a/tests/integration/worktree-isolation.test.js
+++ b/tests/integration/worktree-isolation.test.js
@@ -508,6 +508,31 @@ function registerRemotePrBaseTests() {
     }
   });
 
+  it('refreshes a PR base from a selected non-origin remote', function () {
+    const fixture = createStaleRemoteBaseFixture('zs-upstream-pr-base-');
+    const clusterId = `test-upstream-remote-pr-base-${Date.now()}`;
+    const remoteManager = new IsolationManager();
+
+    try {
+      runGit(['remote', 'rename', 'origin', 'upstream'], { cwd: fixture.sourceDir });
+
+      const info = remoteManager.createWorktreeIsolation(clusterId, fixture.sourceDir, {
+        baseRef: 'upstream/dev',
+        remoteName: 'upstream',
+        requireFreshBase: true,
+      });
+      const worktreeSha = runGit(['rev-parse', 'HEAD'], { cwd: info.path }).trim();
+
+      assert.strictEqual(info.baseRef, 'upstream/dev');
+      assert.strictEqual(info.baseSha, fixture.remoteSha);
+      assert.strictEqual(worktreeSha, fixture.remoteSha);
+      assert.deepStrictEqual(listTemporaryBaseRefs(fixture.sourceDir), []);
+    } finally {
+      remoteManager.cleanupWorktreeIsolation(clusterId);
+      fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when the requested remote base cannot be refreshed', function () {
     const fixture = createStaleRemoteBaseFixture('zs-unavailable-pr-base-');
     const clusterId = `test-unavailable-remote-pr-base-${Date.now()}`;

--- a/tests/unit/git-remote-utils.test.js
+++ b/tests/unit/git-remote-utils.test.js
@@ -8,7 +8,11 @@
  * - Graceful error handling
  */
 
-const assert = require('assert');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const { parseGitRemoteUrl, detectGitContext } = require('../../lib/git-remote-utils');
 
 describe('Git Remote Utils', function () {
@@ -211,11 +215,60 @@ function registerDetectGitContextTests() {
       assert.strictEqual(result, null);
     });
 
-    // NOTE: Additional integration-style tests for detectGitContext
-    // would require mocking git commands or setting up test fixtures.
-    // These are better suited for integration tests.
-    //
-    // Unit tests above verify the core URL parsing logic in isolation.
-    // Provider integration tests will verify the full workflow.
+    it('should detect the only supported remote when origin is absent', function () {
+      withGitRemotes(
+        {
+          upstream: 'git@github.com:the-open-engine/zeroshot.git',
+        },
+        (cwd) => {
+          const result = detectGitContext(cwd);
+
+          assert.strictEqual(result.provider, 'github');
+          assert.strictEqual(result.fullRepo, 'the-open-engine/zeroshot');
+          assert.strictEqual(result.remote, 'upstream');
+        }
+      );
+    });
+
+    it('should preserve origin as the deterministic preference when it is supported', function () {
+      withGitRemotes(
+        {
+          upstream: 'https://gitlab.com/upstream/project.git',
+          origin: 'https://github.com/fork/project.git',
+        },
+        (cwd) => {
+          const result = detectGitContext(cwd);
+
+          assert.strictEqual(result.provider, 'github');
+          assert.strictEqual(result.fullRepo, 'fork/project');
+          assert.strictEqual(result.remote, 'origin');
+        }
+      );
+    });
+
+    it('should fail closed when multiple supported non-origin remotes are ambiguous', function () {
+      withGitRemotes(
+        {
+          fork: 'https://github.com/fork/project.git',
+          upstream: 'https://github.com/upstream/project.git',
+        },
+        (cwd) => {
+          assert.strictEqual(detectGitContext(cwd), null);
+        }
+      );
+    });
   });
+}
+
+function withGitRemotes(remotes, fn) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-git-remotes-'));
+  try {
+    execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+    for (const [name, url] of Object.entries(remotes)) {
+      execFileSync('git', ['remote', 'add', name, url], { cwd, stdio: 'ignore' });
+    }
+    return fn(cwd);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 }

--- a/tests/unit/git-remote-utils.test.js
+++ b/tests/unit/git-remote-utils.test.js
@@ -13,9 +13,27 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { parseGitRemoteUrl, detectGitContext } = require('../../lib/git-remote-utils');
+const {
+  normalizeGitRemoteName,
+  quoteShellArgument,
+  parseGitRemoteUrl,
+  detectGitContext,
+} = require('../../lib/git-remote-utils');
 
 describe('Git Remote Utils', function () {
+  describe('remote names', function () {
+    it('accepts Git-valid punctuation and quotes it for shell prompts', function () {
+      assert.strictEqual(normalizeGitRemoteName("my@remote's"), "my@remote's");
+      assert.strictEqual(quoteShellArgument("my@remote's"), `'my@remote'"'"'s'`);
+    });
+
+    it('rejects names Git cannot map into remote-tracking refs', function () {
+      for (const name of ['', 'has space', 'two..dots', '.hidden', 'name.lock', 'bad?name']) {
+        assert.strictEqual(normalizeGitRemoteName(name), null, name);
+      }
+    });
+  });
+
   registerParseGitRemoteUrlTests();
   registerDetectGitContextTests();
 });


### PR DESCRIPTION
## Summary

- detect a sole supported non-`origin` remote while preserving `origin` as the backward-compatible preference
- fail closed when multiple supported non-origin targets are ambiguous
- carry the selected remote through PR-agent pushes, resume state, and fresh `--pr-base` worktree fetching

## Validation

- `npm test` — 1,707 passing, 18 pending
- `npm run check` — passes (repository warning baseline only)
- `npx mocha tests/unit/git-remote-utils.test.js tests/git-pusher-pr-mode.test.js tests/integration/worktree-isolation.test.js --timeout 180000` — 67 passing
- `opcore check --changed --json` — passes

Fixes #448