### PR TITLE
feat(opencode): allow configured external models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,9 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 - Configure non-catalog Opencode model IDs only through
   `providerSettings.opencode.levelOverrides.<level>.model`; direct agent model IDs remain
   catalog-validated.
+- Provider-level selections crossing nested `zeroshot task run` boundaries must retain their
+  level/config provenance in local and Docker launches; never flatten them into direct `--model`
+  requests.
 
 ### Logic Script API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,9 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 - Provider names use CLI identifiers: `claude`, `codex`, `gemini`, `opencode`, `pi`, `copilot` (legacy `anthropic`/`openai`/`google` map to these).
 - `model` remains a provider-specific escape hatch.
 - Claude/Codex/Opencode only: `reasoningEffort` (`low|medium|high|xhigh|max`).
+- Configure non-catalog Opencode model IDs only through
+  `providerSettings.opencode.levelOverrides.<level>.model`; direct agent model IDs remain
+  catalog-validated.
 
 ### Logic Script API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,9 +368,10 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
   `providerSettings.opencode.levelOverrides.<level>.model`; direct agent model IDs remain
   catalog-validated.
 - Provider-level selections crossing nested `zeroshot task run` boundaries carry only their level.
-  Local children re-resolve the concrete model from effective settings; Docker children receive a
-  settings snapshot and do the same. Never carry a configured model through a direct or hidden
-  model argument.
+  Local children re-resolve the concrete model from effective settings. Docker children receive a
+  temporary settings file containing only the requested OpenCode level and model; its path and
+  bootstrap marker are removed before provider spawn. Never trust a public environment overlay,
+  caller-supplied provenance, or a direct/hidden model argument for configured models.
 
 ### Logic Script API
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,9 +367,10 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 - Configure non-catalog Opencode model IDs only through
   `providerSettings.opencode.levelOverrides.<level>.model`; direct agent model IDs remain
   catalog-validated.
-- Provider-level selections crossing nested `zeroshot task run` boundaries must retain their
-  level/config provenance in local and Docker launches; never flatten them into direct `--model`
-  requests.
+- Provider-level selections crossing nested `zeroshot task run` boundaries carry only their level.
+  Local children re-resolve the concrete model from effective settings; Docker children receive a
+  settings snapshot and do the same. Never carry a configured model through a direct or hidden
+  model argument.
 
 ### Logic Script API
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -14,7 +14,7 @@
  * - export: Export cluster conversation
  */
 
-const { Option, program } = require('commander');
+const { program } = require('commander');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -2836,7 +2836,6 @@ taskCmd
   .option('--provider <provider>', `Provider to use (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
-  .addOption(new Option('--configured-model <model>').hideHelp())
   .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
   .option('-r, --resume <sessionId>', 'Resume a specific Claude session (claude only)')
   .option('-c, --continue', 'Continue the most recent Claude session (claude only)')

--- a/cli/index.js
+++ b/cli/index.js
@@ -14,7 +14,7 @@
  * - export: Export cluster conversation
  */
 
-const { program } = require('commander');
+const { Option, program } = require('commander');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -2836,6 +2836,7 @@ taskCmd
   .option('--provider <provider>', `Provider to use (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
+  .addOption(new Option('--configured-model <model>').hideHelp())
   .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
   .option('-r, --resume <sessionId>', 'Resume a specific Claude session (claude only)')
   .option('-c, --continue', 'Continue the most recent Claude session (claude only)')

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -103,7 +103,10 @@ zeroshot settings set providerSettings.opencode.levelOverrides.level2.model kimi
 Configured IDs must use Opencode's `provider/model` shape. Nested model paths
 such as `openrouter/anthropic/claude-sonnet-4` are accepted; whitespace and
 empty path segments are rejected before Opencode is started. Direct agent
-`model` fields remain limited to the built-in catalog.
+`model` fields remain limited to the built-in catalog. Nested Docker tasks
+receive only a temporary settings-file projection for the requested level and
+model; arbitrary provider settings and environment overlays are not trusted or
+forwarded to the provider process.
 
 ### Current explicit model IDs
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -91,6 +91,20 @@ Notes:
 - Opencode passes reasoning effort as `--variant`.
 - `model` is still supported as a provider-specific escape hatch.
 
+### External Opencode models
+
+Opencode models outside Zeroshot's built-in catalog must be configured in the
+Opencode provider's level overrides:
+
+```bash
+zeroshot settings set providerSettings.opencode.levelOverrides.level2.model kimi/kimi-k2-5
+```
+
+Configured IDs must use Opencode's `provider/model` shape. Nested model paths
+such as `openrouter/anthropic/claude-sonnet-4` are accepted; whitespace and
+empty path segments are rejected before Opencode is started. Direct agent
+`model` fields remain limited to the built-in catalog.
+
 ### Current explicit model IDs
 
 Zeroshot keeps provider-agnostic `modelLevel` defaults and also recognizes these

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -99,7 +99,7 @@ export function validateModelIdFromCatalog(
   modelId: string | null | undefined
 ): string | null | undefined {
   if (!modelId) return modelId;
-  if (catalog[modelId] !== undefined) return modelId;
+  if (Object.prototype.hasOwnProperty.call(catalog, modelId)) return modelId;
   const validModels = Object.keys(catalog).join(', ');
   throw new InvalidProviderModelError(
     `Invalid model "${modelId}" for provider "${provider}". Valid models: ${validModels}.`

--- a/src/agent-cli-provider/adapters/opencode-models.ts
+++ b/src/agent-cli-provider/adapters/opencode-models.ts
@@ -53,10 +53,7 @@ export const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
   level3: { rank: 3, model: null, reasoningEffort: 'high' },
 };
 
-export function resolveModelSpec(
-  level: ModelLevel,
-  overrides?: LevelOverrides
-): ResolvedModelSpec {
+export function resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec {
   const base = LEVEL_MAPPING[level] ?? LEVEL_MAPPING.level2;
   const override = overrides?.[level];
   const selectedModel = override?.model ?? base.model;
@@ -73,7 +70,7 @@ export function resolveModelSpec(
 export function validateConfiguredModelId(
   modelId: string | null | undefined
 ): string | null | undefined {
-  if (modelId && MODEL_CATALOG[modelId] !== undefined) return modelId;
+  if (modelId && Object.prototype.hasOwnProperty.call(MODEL_CATALOG, modelId)) return modelId;
   if (typeof modelId !== 'string') return validateModelId(modelId);
   const segments = modelId.split('/');
   if (segments.length >= 2 && segments.every(Boolean) && !/\s/u.test(modelId)) return modelId;
@@ -84,8 +81,6 @@ export function validateConfiguredModelId(
   );
 }
 
-export function validateModelId(
-  modelId: string | null | undefined
-): string | null | undefined {
+export function validateModelId(modelId: string | null | undefined): string | null | undefined {
   return validateModelIdFromCatalog('opencode', MODEL_CATALOG, modelId);
 }

--- a/src/agent-cli-provider/adapters/opencode-models.ts
+++ b/src/agent-cli-provider/adapters/opencode-models.ts
@@ -53,6 +53,13 @@ export const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
   level3: { rank: 3, model: null, reasoningEffort: 'high' },
 };
 
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f);
+  });
+}
+
 export function resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec {
   const base = LEVEL_MAPPING[level] ?? LEVEL_MAPPING.level2;
   const override = overrides?.[level];
@@ -73,11 +80,18 @@ export function validateConfiguredModelId(
   if (modelId && Object.prototype.hasOwnProperty.call(MODEL_CATALOG, modelId)) return modelId;
   if (typeof modelId !== 'string') return validateModelId(modelId);
   const segments = modelId.split('/');
-  if (segments.length >= 2 && segments.every(Boolean) && !/\s/u.test(modelId)) return modelId;
+  if (
+    segments.length >= 2 &&
+    segments.every(Boolean) &&
+    !/\s/u.test(modelId) &&
+    !containsControlCharacter(modelId)
+  ) {
+    return modelId;
+  }
   throw new InvalidProviderModelError(
     `Invalid configured model "${unknownToMessage(
       modelId
-    )}" for provider "opencode". Expected "provider/model" with no whitespace or empty path segments.`
+    )}" for provider "opencode". Expected "provider/model" with no whitespace, control characters, or empty path segments.`
   );
 }
 

--- a/src/agent-cli-provider/adapters/opencode-models.ts
+++ b/src/agent-cli-provider/adapters/opencode-models.ts
@@ -1,0 +1,91 @@
+import { unknownToMessage } from '../json';
+import {
+  InvalidProviderModelError,
+  type LevelModelSpec,
+  type LevelOverrides,
+  type ModelCatalogEntry,
+  type ModelLevel,
+  type ResolvedModelSpec,
+} from '../types';
+import { validateModelIdFromCatalog } from './common';
+
+export const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
+  'opencode/big-pickle': { rank: 1 },
+  'opencode/glm-4.7-free': { rank: 1 },
+  'opencode/gpt-5-nano': { rank: 1 },
+  'opencode/grok-code': { rank: 1 },
+  'opencode/minimax-m2.1-free': { rank: 1 },
+  'google/gemini-1.5-flash': { rank: 1 },
+  'google/gemini-1.5-flash-8b': { rank: 1 },
+  'google/gemini-1.5-pro': { rank: 1 },
+  'google/gemini-2.0-flash': { rank: 1 },
+  'google/gemini-2.0-flash-lite': { rank: 1 },
+  'google/gemini-2.5-flash': { rank: 1 },
+  'google/gemini-2.5-flash-image': { rank: 1 },
+  'google/gemini-2.5-flash-image-preview': { rank: 1 },
+  'google/gemini-2.5-flash-lite': { rank: 1 },
+  'google/gemini-2.5-flash-lite-preview-06-17': { rank: 1 },
+  'google/gemini-2.5-flash-lite-preview-09-2025': { rank: 1 },
+  'google/gemini-2.5-flash-preview-04-17': { rank: 1 },
+  'google/gemini-2.5-flash-preview-05-20': { rank: 1 },
+  'google/gemini-2.5-flash-preview-09-2025': { rank: 1 },
+  'google/gemini-2.5-flash-preview-tts': { rank: 1 },
+  'google/gemini-2.5-pro': { rank: 1 },
+  'google/gemini-2.5-pro-preview-05-06': { rank: 1 },
+  'google/gemini-2.5-pro-preview-06-05': { rank: 1 },
+  'google/gemini-2.5-pro-preview-tts': { rank: 1 },
+  'google/gemini-3-flash-preview': { rank: 1 },
+  'google/gemini-3-pro-preview': { rank: 1 },
+  'google/gemini-embedding-001': { rank: 1 },
+  'google/gemini-flash-latest': { rank: 1 },
+  'google/gemini-flash-lite-latest': { rank: 1 },
+  'google/gemini-live-2.5-flash': { rank: 1 },
+  'google/gemini-live-2.5-flash-preview-native-audio': { rank: 1 },
+  'openai/gpt-5.1-codex-max': { rank: 1 },
+  'openai/gpt-5.1-codex-mini': { rank: 1 },
+  'openai/gpt-5.2': { rank: 1 },
+  'openai/gpt-5.2-codex': { rank: 1 },
+};
+
+export const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
+  level1: { rank: 1, model: null, reasoningEffort: 'low' },
+  level2: { rank: 2, model: null, reasoningEffort: 'medium' },
+  level3: { rank: 3, model: null, reasoningEffort: 'high' },
+};
+
+export function resolveModelSpec(
+  level: ModelLevel,
+  overrides?: LevelOverrides
+): ResolvedModelSpec {
+  const base = LEVEL_MAPPING[level] ?? LEVEL_MAPPING.level2;
+  const override = overrides?.[level];
+  const selectedModel = override?.model ?? base.model;
+  return {
+    level,
+    model:
+      override?.model === undefined || override.model === null
+        ? (validateModelId(selectedModel) ?? null)
+        : (validateConfiguredModelId(selectedModel) ?? null),
+    reasoningEffort: override?.reasoningEffort ?? base.reasoningEffort,
+  };
+}
+
+export function validateConfiguredModelId(
+  modelId: string | null | undefined
+): string | null | undefined {
+  if (modelId && MODEL_CATALOG[modelId] !== undefined) return modelId;
+  if (typeof modelId !== 'string') return validateModelId(modelId);
+  const segments = modelId.split('/');
+  if (segments.length >= 2 && segments.every(Boolean) && !/\s/u.test(modelId)) return modelId;
+  throw new InvalidProviderModelError(
+    `Invalid configured model "${unknownToMessage(
+      modelId
+    )}" for provider "opencode". Expected "provider/model" with no whitespace or empty path segments.`
+  );
+}
+
+export function validateModelId(
+  modelId: string | null | undefined
+): string | null | undefined {
+  return validateModelIdFromCatalog('opencode', MODEL_CATALOG, modelId);
+}

--- a/src/agent-cli-provider/adapters/opencode.ts
+++ b/src/agent-cli-provider/adapters/opencode.ts
@@ -11,14 +11,9 @@ import {
   type BuildProviderCommandOptions,
   type CommandSpec,
   type ErrorClassification,
-  type LevelModelSpec,
-  type LevelOverrides,
-  type ModelCatalogEntry,
-  type ModelLevel,
   type OpencodeCliFeatures,
   type OutputEvent,
   type ProviderAdapter,
-  type ResolvedModelSpec,
   type WarningMetadata,
 } from '../types';
 import {
@@ -26,55 +21,16 @@ import {
   commandSpec,
   createParserState,
   optionFeatures,
-  resolveModelSpecWithConfig,
   unsupportedSessionControlWarnings,
-  validateModelIdFromCatalog,
   warning,
 } from './common';
-
-const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
-  'opencode/big-pickle': { rank: 1 },
-  'opencode/glm-4.7-free': { rank: 1 },
-  'opencode/gpt-5-nano': { rank: 1 },
-  'opencode/grok-code': { rank: 1 },
-  'opencode/minimax-m2.1-free': { rank: 1 },
-  'google/gemini-1.5-flash': { rank: 1 },
-  'google/gemini-1.5-flash-8b': { rank: 1 },
-  'google/gemini-1.5-pro': { rank: 1 },
-  'google/gemini-2.0-flash': { rank: 1 },
-  'google/gemini-2.0-flash-lite': { rank: 1 },
-  'google/gemini-2.5-flash': { rank: 1 },
-  'google/gemini-2.5-flash-image': { rank: 1 },
-  'google/gemini-2.5-flash-image-preview': { rank: 1 },
-  'google/gemini-2.5-flash-lite': { rank: 1 },
-  'google/gemini-2.5-flash-lite-preview-06-17': { rank: 1 },
-  'google/gemini-2.5-flash-lite-preview-09-2025': { rank: 1 },
-  'google/gemini-2.5-flash-preview-04-17': { rank: 1 },
-  'google/gemini-2.5-flash-preview-05-20': { rank: 1 },
-  'google/gemini-2.5-flash-preview-09-2025': { rank: 1 },
-  'google/gemini-2.5-flash-preview-tts': { rank: 1 },
-  'google/gemini-2.5-pro': { rank: 1 },
-  'google/gemini-2.5-pro-preview-05-06': { rank: 1 },
-  'google/gemini-2.5-pro-preview-06-05': { rank: 1 },
-  'google/gemini-2.5-pro-preview-tts': { rank: 1 },
-  'google/gemini-3-flash-preview': { rank: 1 },
-  'google/gemini-3-pro-preview': { rank: 1 },
-  'google/gemini-embedding-001': { rank: 1 },
-  'google/gemini-flash-latest': { rank: 1 },
-  'google/gemini-flash-lite-latest': { rank: 1 },
-  'google/gemini-live-2.5-flash': { rank: 1 },
-  'google/gemini-live-2.5-flash-preview-native-audio': { rank: 1 },
-  'openai/gpt-5.1-codex-max': { rank: 1 },
-  'openai/gpt-5.1-codex-mini': { rank: 1 },
-  'openai/gpt-5.2': { rank: 1 },
-  'openai/gpt-5.2-codex': { rank: 1 },
-};
-
-const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {
-  level1: { rank: 1, model: null, reasoningEffort: 'low' },
-  level2: { rank: 2, model: null, reasoningEffort: 'medium' },
-  level3: { rank: 3, model: null, reasoningEffort: 'high' },
-};
+import {
+  LEVEL_MAPPING,
+  MODEL_CATALOG,
+  resolveModelSpec,
+  validateConfiguredModelId,
+  validateModelId,
+} from './opencode-models';
 
 function detectCliFeatures(helpText?: string | null): OpencodeCliFeatures {
   const help = helpText ?? '';
@@ -244,20 +200,6 @@ function parseEvent(line: string): OutputEvent | null {
   return null;
 }
 
-function resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec {
-  return resolveModelSpecWithConfig({
-    mapping: LEVEL_MAPPING,
-    defaultLevel: 'level2',
-    level,
-    overrides,
-    validateModelId,
-  });
-}
-
-function validateModelId(modelId: string | null | undefined): string | null | undefined {
-  return validateModelIdFromCatalog('opencode', MODEL_CATALOG, modelId);
-}
-
 function classifyError(error: unknown): ErrorClassification {
   return classifyBaseProviderError(error, [], []);
 }
@@ -285,5 +227,6 @@ export const opencodeAdapter: ProviderAdapter = {
   createParserState: () => createParserState('opencode'),
   resolveModelSpec,
   validateModelId,
+  validateConfiguredModelId,
   classifyError,
 };

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -250,7 +250,7 @@ function resolveRuntimeModelSpec(
   providerSettings: RuntimeProviderSettings
 ): ModelSpec {
   if (explicit?.model !== undefined) {
-    adapter.validateModelId(explicit.model);
+    validateRuntimeModelId(adapter, explicit.model, providerSettings.levelOverrides);
     return explicit;
   }
 
@@ -259,6 +259,21 @@ function resolveRuntimeModelSpec(
   const modelSpec = modelSpecFromResolved(resolved);
   if (explicit?.reasoningEffort === undefined) return modelSpec;
   return { ...modelSpec, reasoningEffort: explicit.reasoningEffort };
+}
+
+function validateRuntimeModelId(
+  adapter: ProviderAdapter,
+  modelId: string | null,
+  levelOverrides: LevelOverrides
+): void {
+  const isConfigured = Object.values(levelOverrides).some(
+    (override) => override?.model === modelId
+  );
+  if (isConfigured && adapter.validateConfiguredModelId) {
+    adapter.validateConfiguredModelId(modelId);
+    return;
+  }
+  adapter.validateModelId(modelId);
 }
 
 function modelSpecFromResolved(resolved: {

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -250,7 +250,7 @@ function resolveRuntimeModelSpec(
   providerSettings: RuntimeProviderSettings
 ): ModelSpec {
   if (explicit?.model !== undefined) {
-    validateRuntimeModelId(adapter, explicit.model, providerSettings.levelOverrides);
+    adapter.validateModelId(explicit.model);
     return explicit;
   }
 
@@ -259,21 +259,6 @@ function resolveRuntimeModelSpec(
   const modelSpec = modelSpecFromResolved(resolved);
   if (explicit?.reasoningEffort === undefined) return modelSpec;
   return { ...modelSpec, reasoningEffort: explicit.reasoningEffort };
-}
-
-function validateRuntimeModelId(
-  adapter: ProviderAdapter,
-  modelId: string | null,
-  levelOverrides: LevelOverrides
-): void {
-  const isConfigured = Object.values(levelOverrides).some(
-    (override) => override?.model === modelId
-  );
-  if (isConfigured && adapter.validateConfiguredModelId) {
-    adapter.validateConfiguredModelId(modelId);
-    return;
-  }
-  adapter.validateModelId(modelId);
 }
 
 function modelSpecFromResolved(resolved: {

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -37,13 +37,11 @@ interface RuntimeProviderSettings {
 interface RuntimeCommandContext {
   readonly cliFeatures: CliFeatureOverrides;
   readonly authEnv: Readonly<Record<string, string>>;
-  readonly modelSpecSource: 'direct' | 'provider-level';
 }
 
 export interface SingleAgentProviderCommandInput {
   readonly provider?: string | null;
   readonly context: string;
-  readonly modelSpecSource?: 'direct' | 'provider-level';
   readonly options?: BuildProviderCommandOptions;
 }
 
@@ -83,6 +81,7 @@ const resolveClaudeAuthFn = moduleFunction(claudeAuthModule, 'resolveClaudeAuth'
 export function prepareSingleAgentProviderCommand(
   input: SingleAgentProviderCommandInput
 ): PreparedSingleAgentProviderCommand {
+  rejectCallerSuppliedModelProvenance(input);
   const baseOptions = input.options ?? {};
   const settings = loadRuntimeSettings();
   const adapter = adapterForRuntimeInput(input.provider, settings);
@@ -96,7 +95,6 @@ export function prepareSingleAgentProviderCommand(
   const options = buildRuntimeOptions(baseOptions, adapter, providerSettings, {
     cliFeatures,
     authEnv,
-    modelSpecSource: input.modelSpecSource ?? 'direct',
   });
   return {
     adapter,
@@ -191,12 +189,7 @@ function buildRuntimeOptions(
   providerSettings: RuntimeProviderSettings,
   runtime: RuntimeCommandContext
 ): BuildProviderCommandOptions {
-  const modelSpec = resolveRuntimeModelSpec(
-    adapter,
-    baseOptions.modelSpec,
-    providerSettings,
-    runtime.modelSpecSource
-  );
+  const modelSpec = resolveRuntimeModelSpec(adapter, baseOptions.modelSpec, providerSettings);
   const gateway = resolveRuntimeGatewayOptions(
     adapter.id,
     baseOptions,
@@ -259,19 +252,9 @@ function shouldIncludeAuthEnv(
 function resolveRuntimeModelSpec(
   adapter: ProviderAdapter,
   explicit: ModelSpec | undefined,
-  providerSettings: RuntimeProviderSettings,
-  modelSpecSource: 'direct' | 'provider-level'
+  providerSettings: RuntimeProviderSettings
 ): ModelSpec {
   if (explicit?.model !== undefined) {
-    if (modelSpecSource === 'provider-level') {
-      if (explicit.level === undefined) {
-        throw new Error('Provider-level task model selections require a model level.');
-      }
-      const validateConfiguredModelId =
-        adapter.validateConfiguredModelId ?? adapter.validateModelId;
-      validateConfiguredModelId(explicit.model);
-      return explicit;
-    }
     adapter.validateModelId(explicit.model);
     return explicit;
   }
@@ -376,8 +359,37 @@ function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
 }
 
 function loadRuntimeSettings(): Record<string, unknown> {
-  const settings = loadSettingsFn();
-  return requiredRecord(settings, 'loadSettings');
+  const settings = requiredRecord(loadSettingsFn(), 'loadSettings');
+  const snapshotJson = process.env.ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON;
+  if (snapshotJson === undefined) return settings;
+
+  const snapshot = isolatedProviderSettingsFromJson(snapshotJson);
+  const configured = optionalRecord(settings.providerSettings, 'settings.providerSettings') ?? {};
+  return {
+    ...settings,
+    providerSettings: {
+      ...configured,
+      ...snapshot,
+    },
+  };
+}
+
+function isolatedProviderSettingsFromJson(value: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error('ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON must be valid JSON.');
+  }
+  return requiredRecord(parsed, 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON');
+}
+
+function rejectCallerSuppliedModelProvenance(input: SingleAgentProviderCommandInput): void {
+  if (Object.prototype.hasOwnProperty.call(input, 'modelSpecSource')) {
+    throw new Error(
+      'modelSpecSource is not accepted at the child provider boundary; use modelLevel and effective provider settings.'
+    );
+  }
 }
 
 function moduleFunction(moduleValue: unknown, field: string): UnknownFunction {

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -34,9 +34,16 @@ interface RuntimeProviderSettings {
   readonly gateway?: GatewayBuildOptions;
 }
 
+interface RuntimeCommandContext {
+  readonly cliFeatures: CliFeatureOverrides;
+  readonly authEnv: Readonly<Record<string, string>>;
+  readonly modelSpecSource: 'direct' | 'provider-level';
+}
+
 export interface SingleAgentProviderCommandInput {
   readonly provider?: string | null;
   readonly context: string;
+  readonly modelSpecSource?: 'direct' | 'provider-level';
   readonly options?: BuildProviderCommandOptions;
 }
 
@@ -86,7 +93,11 @@ export function prepareSingleAgentProviderCommand(
   );
   const cliFeatures = resolveRuntimeCliFeatures(adapter.id, baseOptions.cliFeatures);
   const authEnv = baseOptions.authEnv ?? resolveRuntimeAuthEnv(adapter.id, settings);
-  const options = buildRuntimeOptions(baseOptions, adapter, providerSettings, cliFeatures, authEnv);
+  const options = buildRuntimeOptions(baseOptions, adapter, providerSettings, {
+    cliFeatures,
+    authEnv,
+    modelSpecSource: input.modelSpecSource ?? 'direct',
+  });
   return {
     adapter,
     options,
@@ -128,8 +139,7 @@ function mergeAcpFailClosedCliFeatures(
     ...detected,
     ...overrides,
     supportsAcpStdio: detected.supportsAcpStdio && overrides.supportsAcpStdio !== false,
-    supportsPromptImages:
-      detected.supportsPromptImages && overrides.supportsPromptImages !== false,
+    supportsPromptImages: detected.supportsPromptImages && overrides.supportsPromptImages !== false,
     supportsLoadSession: detected.supportsLoadSession && overrides.supportsLoadSession !== false,
     supportsSessionCancel:
       detected.supportsSessionCancel && overrides.supportsSessionCancel !== false,
@@ -162,7 +172,9 @@ export function probeRuntimeProviderCli(provider: string): RuntimeProviderProbe 
   }
 
   const helpText = stringResult(getHelpOutputFn(helpCommand.command, helpCommand.args)).trim();
-  const versionText = stringResult(getVersionOutputFn(helpCommand.command, helpCommand.args)).trim();
+  const versionText = stringResult(
+    getVersionOutputFn(helpCommand.command, helpCommand.args)
+  ).trim();
   const availabilityProbe = getProviderRegistryEntry(adapter.id).availabilityProbe ?? 'command';
 
   return {
@@ -177,10 +189,14 @@ function buildRuntimeOptions(
   baseOptions: BuildProviderCommandOptions,
   adapter: ProviderAdapter,
   providerSettings: RuntimeProviderSettings,
-  cliFeatures: CliFeatureOverrides,
-  authEnv: Readonly<Record<string, string>>
+  runtime: RuntimeCommandContext
 ): BuildProviderCommandOptions {
-  const modelSpec = resolveRuntimeModelSpec(adapter, baseOptions.modelSpec, providerSettings);
+  const modelSpec = resolveRuntimeModelSpec(
+    adapter,
+    baseOptions.modelSpec,
+    providerSettings,
+    runtime.modelSpecSource
+  );
   const gateway = resolveRuntimeGatewayOptions(
     adapter.id,
     baseOptions,
@@ -191,16 +207,16 @@ function buildRuntimeOptions(
     ...baseOptions,
     modelSpec,
     ...(gateway === undefined ? {} : { gateway }),
-    cliFeatures,
+    cliFeatures: runtime.cliFeatures,
   };
   if (baseOptions.jsonSchema && !supportsProviderCapability(adapter.id, 'jsonSchema')) {
-    if (!shouldIncludeAuthEnv(baseOptions, authEnv)) {
+    if (!shouldIncludeAuthEnv(baseOptions, runtime.authEnv)) {
       return { ...resolved, strictSchema: false };
     }
-    return { ...resolved, authEnv, strictSchema: false };
+    return { ...resolved, authEnv: runtime.authEnv, strictSchema: false };
   }
-  if (!shouldIncludeAuthEnv(baseOptions, authEnv)) return resolved;
-  return { ...resolved, authEnv };
+  if (!shouldIncludeAuthEnv(baseOptions, runtime.authEnv)) return resolved;
+  return { ...resolved, authEnv: runtime.authEnv };
 }
 
 function resolveRuntimeGatewayOptions(
@@ -218,23 +234,19 @@ function resolveRuntimeGatewayOptions(
       ? settingsGateway.headers
       : { ...(settingsGateway.headers ?? {}), ...requestGateway.headers };
   const mergedGateway: GatewayBuildOptions = {
-    ...(requestGateway.baseUrl ?? settingsGateway.baseUrl
+    ...((requestGateway.baseUrl ?? settingsGateway.baseUrl)
       ? { baseUrl: requestGateway.baseUrl ?? settingsGateway.baseUrl }
       : {}),
-    ...(requestGateway.apiKey ?? settingsGateway.apiKey
+    ...((requestGateway.apiKey ?? settingsGateway.apiKey)
       ? { apiKey: requestGateway.apiKey ?? settingsGateway.apiKey }
       : {}),
     ...(mergedHeaders === undefined ? {} : { headers: mergedHeaders }),
     model: requestGateway.model ?? modelSpec.model ?? settingsGateway.model ?? null,
-    ...(requestGateway.toolPolicy ?? settingsGateway.toolPolicy
+    ...((requestGateway.toolPolicy ?? settingsGateway.toolPolicy)
       ? { toolPolicy: requestGateway.toolPolicy ?? settingsGateway.toolPolicy }
       : {}),
   };
-  return resolveGatewayConfiguration(
-    mergedGateway,
-    'options.gateway',
-    cwd
-  );
+  return resolveGatewayConfiguration(mergedGateway, 'options.gateway', cwd);
 }
 
 function shouldIncludeAuthEnv(
@@ -247,9 +259,19 @@ function shouldIncludeAuthEnv(
 function resolveRuntimeModelSpec(
   adapter: ProviderAdapter,
   explicit: ModelSpec | undefined,
-  providerSettings: RuntimeProviderSettings
+  providerSettings: RuntimeProviderSettings,
+  modelSpecSource: 'direct' | 'provider-level'
 ): ModelSpec {
   if (explicit?.model !== undefined) {
+    if (modelSpecSource === 'provider-level') {
+      if (explicit.level === undefined) {
+        throw new Error('Provider-level task model selections require a model level.');
+      }
+      const validateConfiguredModelId =
+        adapter.validateConfiguredModelId ?? adapter.validateModelId;
+      validateConfiguredModelId(explicit.model);
+      return explicit;
+    }
     adapter.validateModelId(explicit.model);
     return explicit;
   }
@@ -286,7 +308,8 @@ function adapterForRuntimeInput(
   provider: string | null | undefined,
   settings: Record<string, unknown>
 ): ProviderAdapter {
-  const configured = provider ?? optionalString(settings.defaultProvider, 'settings.defaultProvider');
+  const configured =
+    provider ?? optionalString(settings.defaultProvider, 'settings.defaultProvider');
   return getProviderAdapter(configured ?? 'claude');
 }
 
@@ -309,16 +332,14 @@ function runtimeProviderSettings(
   );
   const gateway =
     provider === 'gateway'
-      ? normalizeGatewayBuildOptions(
-          providerSettings,
-          'settings.providerSettings.gateway',
-          cwd
-        )
+      ? normalizeGatewayBuildOptions(providerSettings, 'settings.providerSettings.gateway', cwd)
       : undefined;
   if (defaultLevel === undefined) {
     return gateway === undefined ? { levelOverrides } : { levelOverrides, gateway };
   }
-  return gateway === undefined ? { defaultLevel, levelOverrides } : { defaultLevel, levelOverrides, gateway };
+  return gateway === undefined
+    ? { defaultLevel, levelOverrides }
+    : { defaultLevel, levelOverrides, gateway };
 }
 
 function runtimeHelpCommand(provider: ProviderId): CommandParts {
@@ -333,7 +354,11 @@ function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
   try {
     const settings = loadRuntimeSettings();
     const providerSettings = runtimeProviderSettings(settings, 'gateway', process.cwd());
-    resolveGatewayConfiguration(providerSettings.gateway, 'settings.providerSettings.gateway', process.cwd());
+    resolveGatewayConfiguration(
+      providerSettings.gateway,
+      'settings.providerSettings.gateway',
+      process.cwd()
+    );
     return {
       available: true,
       helpText: 'Bundled gateway runner',
@@ -456,10 +481,7 @@ function requiredRecord(value: unknown, field: string): Record<string, unknown> 
   throw new Error(`${field} must be an object.`);
 }
 
-function stringRecordFromUnknown(
-  value: unknown,
-  field: string
-): Readonly<Record<string, string>> {
+function stringRecordFromUnknown(value: unknown, field: string): Readonly<Record<string, string>> {
   if (value === undefined || value === null) return {};
   const record = requiredRecord(value, field);
   const result: Record<string, string> = {};

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -67,6 +67,7 @@ type MutableModelSpec = {
 
 const MODEL_LEVELS: readonly ModelLevel[] = ['level1', 'level2', 'level3'];
 const REASONING_EFFORTS: readonly ReasoningEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+const LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV = 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON';
 const settingsModule: unknown = require('../../lib/settings');
 const providerDetectionModule: unknown = require('../../lib/provider-detection');
 const claudeAuthModule: unknown = require('../../lib/settings/claude-auth');
@@ -359,29 +360,12 @@ function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
 }
 
 function loadRuntimeSettings(): Record<string, unknown> {
-  const settings = requiredRecord(loadSettingsFn(), 'loadSettings');
-  const snapshotJson = process.env.ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON;
-  if (snapshotJson === undefined) return settings;
-
-  const snapshot = isolatedProviderSettingsFromJson(snapshotJson);
-  const configured = optionalRecord(settings.providerSettings, 'settings.providerSettings') ?? {};
-  return {
-    ...settings,
-    providerSettings: {
-      ...configured,
-      ...snapshot,
-    },
-  };
-}
-
-function isolatedProviderSettingsFromJson(value: string): Record<string, unknown> {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error('ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON must be valid JSON.');
+  if (Object.prototype.hasOwnProperty.call(process.env, LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV)) {
+    throw new Error(
+      `${LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV} is not a trusted settings channel; use the settings file.`
+    );
   }
-  return requiredRecord(parsed, 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON');
+  return requiredRecord(loadSettingsFn(), 'loadSettings');
 }
 
 function rejectCallerSuppliedModelProvenance(input: SingleAgentProviderCommandInput): void {

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -367,6 +367,7 @@ export interface ProviderAdapter {
   createParserState(): ProviderParserState;
   resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec;
   validateModelId(modelId: string | null | undefined): string | null | undefined;
+  validateConfiguredModelId?(modelId: string | null | undefined): string | null | undefined;
   classifyError(error: unknown): ErrorClassification;
 }
 

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -103,11 +103,11 @@ class AgentWrapper {
       const taskRunner = options.taskRunner;
       this.mockSpawnFn = (args, { context }) => {
         const spec = this._resolveModelSpec();
+        const source = this._resolveModelSpecSource();
         return taskRunner.run(context, {
           agentId: this.id,
-          model: this._selectModel(),
-          modelSpec: spec,
-          modelSpecSource: this._resolveModelSpecSource(),
+          ...(source === 'direct' ? { model: spec.model } : { modelLevel: spec.level }),
+          ...(spec.reasoningEffort ? { reasoningEffort: spec.reasoningEffort } : {}),
           provider: this._resolveProvider(),
           cwd: this.config.cwd || process.cwd(),
           worktreePath: this.worktree?.path || null,

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -107,6 +107,7 @@ class AgentWrapper {
           agentId: this.id,
           model: this._selectModel(),
           modelSpec: spec,
+          modelSpecSource: this._resolveModelSpecSource(),
           provider: this._resolveProvider(),
           cwd: this.config.cwd || process.cwd(),
           worktreePath: this.worktree?.path || null,
@@ -220,6 +221,17 @@ class AgentWrapper {
     const level = provider.validateLevel(defaultLevel, minLevel, maxLevel);
     const spec = provider.resolveModelSpec(level, levelOverrides);
     return applyReasoningOverride({ ...spec, level }, this.config.reasoningEffort);
+  }
+
+  _resolveModelSpecSource() {
+    if (this.modelConfig.type === 'rules') {
+      for (const rule of this.modelConfig.rules) {
+        if (this._matchesIterationRange(rule.iterations)) {
+          return rule.model ? 'direct' : 'provider-level';
+        }
+      }
+    }
+    return this.modelConfig.model ? 'direct' : 'provider-level';
   }
 
   /**

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -23,6 +23,7 @@ const {
   prepareClaudeConfigDir,
   resolveRepoMcpConfigPath,
 } = require('../worktree-claude-config.js');
+const { appendTaskRunModelArgs } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
@@ -722,14 +723,10 @@ function resolveOutputFormatConfig(agent) {
 
 function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
   const args = ['task', 'run', '--output-format', runOutputFormat, '--provider', providerName];
-
-  if (modelSpec?.model) {
-    args.push('--model', modelSpec.model);
-  }
-
-  if (modelSpec?.reasoningEffort) {
-    args.push('--reasoning-effort', modelSpec.reasoningEffort);
-  }
+  const modelSpecSource = agent._resolveModelSpecSource
+    ? agent._resolveModelSpecSource()
+    : 'direct';
+  appendTaskRunModelArgs(args, modelSpec, modelSpecSource);
 
   // Add verification mode flag if configured
   if (agent.config.verificationMode) {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -25,7 +25,7 @@ const {
 } = require('../worktree-claude-config.js');
 const {
   appendTaskRunModelArgs,
-  buildIsolatedProviderSettingsEnv,
+  wrapTaskRunWithIsolatedSettings,
 } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 
@@ -1516,7 +1516,7 @@ async function spawnClaudeTaskIsolated(agent, context) {
   agent._log(`📦 Agent ${agent.id}: Running task in isolated container using zeroshot task run...`);
 
   const { desiredOutputFormat, runOutputFormat } = resolveOutputFormatConfig(agent);
-  const command = [
+  let command = [
     'zeroshot',
     ...buildTaskRunArgs({
       agent,
@@ -1534,15 +1534,19 @@ async function spawnClaudeTaskIsolated(agent, context) {
   });
 
   command.push(finalContext);
+  command = wrapTaskRunWithIsolatedSettings(command, {
+    providerName,
+    settings: loadSettings(),
+    modelSpecSource,
+    modelSpec,
+  });
 
   // STEP 1: Spawn task and extract task ID (same as non-isolated mode)
   // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it
   const SPAWN_TIMEOUT_MS = 30000; // 30 seconds to spawn task
   // Note: Auth env vars are injected by IsolationManager, we only need model mapping here
-  const isolatedEnv = {
-    ...buildIsolatedProviderSettingsEnv(providerName, loadSettings(), modelSpecSource, modelSpec),
-    ...(providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {}),
-  };
+  const isolatedEnv =
+    providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {};
 
   const taskId = await new Promise((resolve, reject) => {
     const proc = manager.spawnInContainer(clusterId, command, {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -23,7 +23,10 @@ const {
   prepareClaudeConfigDir,
   resolveRepoMcpConfigPath,
 } = require('../worktree-claude-config.js');
-const { appendTaskRunModelArgs } = require('../task-run-model-args.js');
+const {
+  appendTaskRunModelArgs,
+  buildIsolatedProviderSettingsEnv,
+} = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
@@ -1506,6 +1509,9 @@ async function spawnClaudeTaskIsolated(agent, context) {
   const { manager, clusterId } = agent.isolation;
   const providerName = agent._resolveProvider ? agent._resolveProvider() : 'claude';
   const modelSpec = resolveAgentModelSpec(agent);
+  const modelSpecSource = agent._resolveModelSpecSource
+    ? agent._resolveModelSpecSource()
+    : 'direct';
 
   agent._log(`📦 Agent ${agent.id}: Running task in isolated container using zeroshot task run...`);
 
@@ -1533,8 +1539,10 @@ async function spawnClaudeTaskIsolated(agent, context) {
   // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it
   const SPAWN_TIMEOUT_MS = 30000; // 30 seconds to spawn task
   // Note: Auth env vars are injected by IsolationManager, we only need model mapping here
-  const isolatedEnv =
-    providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {};
+  const isolatedEnv = {
+    ...buildIsolatedProviderSettingsEnv(providerName, loadSettings(), modelSpecSource, modelSpec),
+    ...(providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {}),
+  };
 
   const taskId = await new Promise((resolve, reject) => {
     const proc = manager.spawnInContainer(clusterId, command, {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -13,6 +13,7 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 const { prepareClaudeConfigDir } = require('./worktree-claude-config');
+const { appendTaskRunModelArgs } = require('./task-run-model-args');
 
 function runCommand(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -170,6 +171,7 @@ class ClaudeTaskRunner extends TaskRunner {
       providerName,
       runOutputFormat,
       resolvedModelSpec,
+      modelSpecSource,
       jsonSchema,
     });
 
@@ -267,16 +269,16 @@ class ClaudeTaskRunner extends TaskRunner {
     return jsonSchema && outputFormat === 'json' && !strictSchema ? 'stream-json' : outputFormat;
   }
 
-  _buildRunArgs({ context, providerName, runOutputFormat, resolvedModelSpec, jsonSchema }) {
+  _buildRunArgs({
+    context,
+    providerName,
+    runOutputFormat,
+    resolvedModelSpec,
+    modelSpecSource = 'direct',
+    jsonSchema,
+  }) {
     const args = ['task', 'run', '--output-format', runOutputFormat, '--provider', providerName];
-
-    if (resolvedModelSpec?.model) {
-      args.push('--model', resolvedModelSpec.model);
-    }
-
-    if (resolvedModelSpec?.reasoningEffort) {
-      args.push('--reasoning-effort', resolvedModelSpec.reasoningEffort);
-    }
+    appendTaskRunModelArgs(args, resolvedModelSpec, modelSpecSource);
 
     // Pass schema to CLI only when using json output (strictSchema=true or no conflict)
     if (jsonSchema && runOutputFormat === 'json') {
@@ -585,6 +587,7 @@ class ClaudeTaskRunner extends TaskRunner {
       agentId = 'unknown',
       provider = 'claude',
       modelSpec = null,
+      modelSpecSource = 'direct',
       outputFormat = 'stream-json',
       jsonSchema = null,
       strictSchema = false,
@@ -610,13 +613,7 @@ class ClaudeTaskRunner extends TaskRunner {
       provider,
     ];
 
-    if (modelSpec?.model) {
-      command.push('--model', modelSpec.model);
-    }
-
-    if (modelSpec?.reasoningEffort) {
-      command.push('--reasoning-effort', modelSpec.reasoningEffort);
-    }
+    appendTaskRunModelArgs(command, modelSpec, modelSpecSource);
 
     if (jsonSchema && runOutputFormat === 'json') {
       command.push('--json-schema', JSON.stringify(jsonSchema));

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -112,7 +112,7 @@ class ClaudeTaskRunner extends TaskRunner {
    * Execute a task via zeroshot CLI
    *
    * @param {string} context - Full prompt/context
-   * @param {{agentId?: string, model?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, worktreePath?: string|null, isolation?: any}} options - Execution options
+   * @param {{agentId?: string, model?: string, modelLevel?: string, modelSpec?: Object|null, modelSpecSource?: 'direct'|'provider-level', reasoningEffort?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, worktreePath?: string|null, isolation?: any}} options - Execution options
    * @returns {Promise<{success: boolean, output: string, error: string|null, taskId?: string}>}
    */
   async run(context, options = {}) {
@@ -122,6 +122,7 @@ class ClaudeTaskRunner extends TaskRunner {
       model = null,
       modelLevel = null,
       modelSpec: explicitModelSpec = null,
+      modelSpecSource = 'direct',
       reasoningEffort = null,
       outputFormat = 'stream-json',
       jsonSchema = null,
@@ -139,6 +140,7 @@ class ClaudeTaskRunner extends TaskRunner {
     );
     const resolvedModelSpec = this._resolveModelSpec({
       explicitModelSpec,
+      modelSpecSource,
       model,
       reasoningEffort,
       modelLevel,
@@ -197,6 +199,7 @@ class ClaudeTaskRunner extends TaskRunner {
 
   _resolveModelSpec({
     explicitModelSpec,
+    modelSpecSource,
     model,
     reasoningEffort,
     modelLevel,
@@ -204,25 +207,26 @@ class ClaudeTaskRunner extends TaskRunner {
     providerSettings,
     levelOverrides,
   }) {
-    const validateModelId = (modelId) => {
-      const isConfigured = Object.values(levelOverrides).some(
-        (override) => override?.model === modelId
-      );
-      if (isConfigured) {
-        return providerModule.validateConfiguredModelId(modelId);
-      }
-      return providerModule.validateModelId(modelId);
-    };
+    if (modelSpecSource === 'provider-level') {
+      return this._resolveProviderLevelModelSpec({
+        explicitModelSpec,
+        modelLevel,
+        reasoningEffort,
+        providerModule,
+        providerSettings,
+        levelOverrides,
+      });
+    }
 
     if (explicitModelSpec) {
       if (explicitModelSpec.model !== undefined) {
-        validateModelId(explicitModelSpec.model);
+        providerModule.validateModelId(explicitModelSpec.model);
       }
       return explicitModelSpec;
     }
 
     if (model) {
-      validateModelId(model);
+      providerModule.validateModelId(model);
       return { model, reasoningEffort };
     }
 
@@ -233,6 +237,27 @@ class ClaudeTaskRunner extends TaskRunner {
     }
 
     return resolvedModelSpec;
+  }
+
+  _resolveProviderLevelModelSpec({
+    explicitModelSpec,
+    modelLevel,
+    reasoningEffort,
+    providerModule,
+    providerSettings,
+    levelOverrides,
+  }) {
+    const level =
+      explicitModelSpec?.level ||
+      modelLevel ||
+      providerSettings.defaultLevel ||
+      providerModule.getDefaultLevel();
+    const resolvedModelSpec = providerModule.resolveModelSpec(level, levelOverrides);
+    const resolvedReasoningEffort = explicitModelSpec?.reasoningEffort || reasoningEffort;
+
+    return resolvedReasoningEffort
+      ? { ...resolvedModelSpec, reasoningEffort: resolvedReasoningEffort }
+      : resolvedModelSpec;
   }
 
   _resolveOutputFormat({ outputFormat, jsonSchema, strictSchema }) {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -13,7 +13,10 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 const { prepareClaudeConfigDir } = require('./worktree-claude-config');
-const { appendTaskRunModelArgs } = require('./task-run-model-args');
+const {
+  appendTaskRunModelArgs,
+  buildIsolatedProviderSettingsEnv,
+} = require('./task-run-model-args');
 
 function runCommand(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -255,6 +258,16 @@ class ClaudeTaskRunner extends TaskRunner {
       providerSettings.defaultLevel ||
       providerModule.getDefaultLevel();
     const resolvedModelSpec = providerModule.resolveModelSpec(level, levelOverrides);
+    if (
+      explicitModelSpec?.model !== undefined &&
+      explicitModelSpec.model !== resolvedModelSpec.model
+    ) {
+      const error = new Error(
+        `Provider-level model "${explicitModelSpec.model}" does not match the configured ${level} model "${resolvedModelSpec.model}".`
+      );
+      error.permanent = true;
+      throw error;
+    }
     const resolvedReasoningEffort = explicitModelSpec?.reasoningEffort || reasoningEffort;
 
     return resolvedReasoningEffort
@@ -635,10 +648,12 @@ class ClaudeTaskRunner extends TaskRunner {
       let resolved = false;
 
       const proc = manager.spawnInContainer(clusterId, command, {
-        env:
-          provider === 'claude' && modelSpec?.model
+        env: {
+          ...buildIsolatedProviderSettingsEnv(provider, loadSettings(), modelSpecSource, modelSpec),
+          ...(provider === 'claude' && modelSpec?.model
             ? { ANTHROPIC_MODEL: modelSpec.model, ZEROSHOT_BLOCK_ASK_USER: '1' }
-            : {},
+            : {}),
+        },
       });
 
       proc.stdout.on('data', (/** @type {Buffer} */ data) => {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -15,8 +15,16 @@ const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 const { prepareClaudeConfigDir } = require('./worktree-claude-config');
 const {
   appendTaskRunModelArgs,
-  buildIsolatedProviderSettingsEnv,
+  wrapTaskRunWithIsolatedSettings,
 } = require('./task-run-model-args');
+
+function rejectCallerSuppliedModelProvenance(options) {
+  if (Object.prototype.hasOwnProperty.call(options, 'modelSpecSource')) {
+    throw new Error(
+      'modelSpecSource is derived from model versus modelLevel/default and cannot be supplied.'
+    );
+  }
+}
 
 function runCommand(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -116,17 +124,17 @@ class ClaudeTaskRunner extends TaskRunner {
    * Execute a task via zeroshot CLI
    *
    * @param {string} context - Full prompt/context
-   * @param {{agentId?: string, model?: string, modelLevel?: string, modelSpec?: Object|null, modelSpecSource?: 'direct'|'provider-level', reasoningEffort?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, worktreePath?: string|null, isolation?: any}} options - Execution options
+   * @param {{agentId?: string, model?: string, modelLevel?: string, modelSpec?: Object|null, reasoningEffort?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, cwd?: string, worktreePath?: string|null, isolation?: any}} options - Execution options
    * @returns {Promise<{success: boolean, output: string, error: string|null, taskId?: string}>}
    */
   async run(context, options = {}) {
+    rejectCallerSuppliedModelProvenance(options);
     const {
       agentId = 'unknown',
       provider,
       model = null,
       modelLevel = null,
       modelSpec: explicitModelSpec = null,
-      modelSpecSource = 'direct',
       reasoningEffort = null,
       outputFormat = 'stream-json',
       jsonSchema = null,
@@ -142,9 +150,8 @@ class ClaudeTaskRunner extends TaskRunner {
       providerName,
       settings
     );
-    const resolvedModelSpec = this._resolveModelSpec({
+    const modelSelection = this._resolveModelSelection({
       explicitModelSpec,
-      modelSpecSource,
       model,
       reasoningEffort,
       modelLevel,
@@ -152,13 +159,13 @@ class ClaudeTaskRunner extends TaskRunner {
       providerSettings,
       levelOverrides,
     });
+    const resolvedModelSpec = modelSelection.modelSpec;
 
     // Isolation mode delegates to separate method
     if (isolation?.enabled) {
       return this._runIsolated(context, {
         ...options,
         provider: providerName,
-        modelSpec: resolvedModelSpec,
       });
     }
 
@@ -174,7 +181,7 @@ class ClaudeTaskRunner extends TaskRunner {
       providerName,
       runOutputFormat,
       resolvedModelSpec,
-      modelSpecSource,
+      modelSpecSource: modelSelection.source,
       jsonSchema,
     });
 
@@ -204,7 +211,6 @@ class ClaudeTaskRunner extends TaskRunner {
 
   _resolveModelSpec({
     explicitModelSpec,
-    modelSpecSource,
     model,
     reasoningEffort,
     modelLevel,
@@ -212,36 +218,53 @@ class ClaudeTaskRunner extends TaskRunner {
     providerSettings,
     levelOverrides,
   }) {
-    if (modelSpecSource === 'provider-level') {
-      return this._resolveProviderLevelModelSpec({
+    return this._resolveModelSelection({
+      explicitModelSpec,
+      model,
+      reasoningEffort,
+      modelLevel,
+      providerModule,
+      providerSettings,
+      levelOverrides,
+    }).modelSpec;
+  }
+
+  _resolveModelSelection({
+    explicitModelSpec,
+    model,
+    reasoningEffort,
+    modelLevel,
+    providerModule,
+    providerSettings,
+    levelOverrides,
+  }) {
+    if (model) {
+      providerModule.validateModelId(model);
+      return {
+        source: 'direct',
+        modelSpec: { model, reasoningEffort },
+      };
+    }
+
+    if (explicitModelSpec?.model !== undefined) {
+      providerModule.validateModelId(explicitModelSpec.model);
+      return {
+        source: 'direct',
+        modelSpec: explicitModelSpec,
+      };
+    }
+
+    return {
+      source: 'provider-level',
+      modelSpec: this._resolveProviderLevelModelSpec({
         explicitModelSpec,
         modelLevel,
         reasoningEffort,
         providerModule,
         providerSettings,
         levelOverrides,
-      });
-    }
-
-    if (explicitModelSpec) {
-      if (explicitModelSpec.model !== undefined) {
-        providerModule.validateModelId(explicitModelSpec.model);
-      }
-      return explicitModelSpec;
-    }
-
-    if (model) {
-      providerModule.validateModelId(model);
-      return { model, reasoningEffort };
-    }
-
-    const level = modelLevel || providerSettings.defaultLevel || providerModule.getDefaultLevel();
-    let resolvedModelSpec = providerModule.resolveModelSpec(level, levelOverrides);
-    if (reasoningEffort) {
-      resolvedModelSpec = { ...resolvedModelSpec, reasoningEffort };
-    }
-
-    return resolvedModelSpec;
+      }),
+    };
   }
 
   _resolveProviderLevelModelSpec({
@@ -258,16 +281,6 @@ class ClaudeTaskRunner extends TaskRunner {
       providerSettings.defaultLevel ||
       providerModule.getDefaultLevel();
     const resolvedModelSpec = providerModule.resolveModelSpec(level, levelOverrides);
-    if (
-      explicitModelSpec?.model !== undefined &&
-      explicitModelSpec.model !== resolvedModelSpec.model
-    ) {
-      const error = new Error(
-        `Provider-level model "${explicitModelSpec.model}" does not match the configured ${level} model "${resolvedModelSpec.model}".`
-      );
-      error.permanent = true;
-      throw error;
-    }
     const resolvedReasoningEffort = explicitModelSpec?.reasoningEffort || reasoningEffort;
 
     return resolvedReasoningEffort
@@ -592,21 +605,40 @@ class ClaudeTaskRunner extends TaskRunner {
   /**
    * Run task in isolated Docker container
    * @param {string} context
-   * @param {{agentId?: string, model?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, isolation?: any}} options
+   * @param {{agentId?: string, provider?: string, model?: string, modelLevel?: string, modelSpec?: Object|null, reasoningEffort?: string, outputFormat?: string, jsonSchema?: any, strictSchema?: boolean, isolation?: any}} options
    * @returns {Promise<{success: boolean, output: string, error: string|null}>}
    */
   _runIsolated(context, options) {
+    rejectCallerSuppliedModelProvenance(options);
     const {
       agentId = 'unknown',
       provider = 'claude',
-      modelSpec = null,
-      modelSpecSource = 'direct',
+      model = null,
+      modelLevel = null,
+      modelSpec: explicitModelSpec = null,
+      reasoningEffort = null,
       outputFormat = 'stream-json',
       jsonSchema = null,
       strictSchema = false,
       isolation,
     } = options;
     const { manager, clusterId } = isolation;
+    const settings = loadSettings();
+    const { providerModule, providerSettings, levelOverrides } = this._getProviderContext(
+      provider,
+      settings
+    );
+    const modelSelection = this._resolveModelSelection({
+      explicitModelSpec,
+      model,
+      reasoningEffort,
+      modelLevel,
+      providerModule,
+      providerSettings,
+      levelOverrides,
+    });
+    const modelSpec = modelSelection.modelSpec;
+    const modelSpecSource = modelSelection.source;
 
     this._log(`📦 [${agentId}]: Running task in isolated container...`);
 
@@ -616,7 +648,7 @@ class ClaudeTaskRunner extends TaskRunner {
         ? 'stream-json'
         : desiredOutputFormat;
 
-    const command = [
+    let command = [
       'zeroshot',
       'task',
       'run',
@@ -642,6 +674,12 @@ class ClaudeTaskRunner extends TaskRunner {
     }
 
     command.push(finalContext);
+    command = wrapTaskRunWithIsolatedSettings(command, {
+      providerName: provider,
+      settings,
+      modelSpecSource,
+      modelSpec,
+    });
 
     return new Promise((resolve, reject) => {
       let output = '';
@@ -649,7 +687,6 @@ class ClaudeTaskRunner extends TaskRunner {
 
       const proc = manager.spawnInContainer(clusterId, command, {
         env: {
-          ...buildIsolatedProviderSettingsEnv(provider, loadSettings(), modelSpecSource, modelSpec),
           ...(provider === 'claude' && modelSpec?.model
             ? { ANTHROPIC_MODEL: modelSpec.model, ZEROSHOT_BLOCK_ASK_USER: '1' }
             : {}),

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -204,15 +204,25 @@ class ClaudeTaskRunner extends TaskRunner {
     providerSettings,
     levelOverrides,
   }) {
+    const validateModelId = (modelId) => {
+      const isConfigured = Object.values(levelOverrides).some(
+        (override) => override?.model === modelId
+      );
+      if (isConfigured) {
+        return providerModule.validateConfiguredModelId(modelId);
+      }
+      return providerModule.validateModelId(modelId);
+    };
+
     if (explicitModelSpec) {
-      if (explicitModelSpec.model) {
-        providerModule.validateModelId(explicitModelSpec.model);
+      if (explicitModelSpec.model !== undefined) {
+        validateModelId(explicitModelSpec.model);
       }
       return explicitModelSpec;
     }
 
     if (model) {
-      providerModule.validateModelId(model);
+      validateModelId(model);
       return { model, reasoningEffort };
     }
 

--- a/src/config-validator.js
+++ b/src/config-validator.js
@@ -2053,8 +2053,8 @@ function validateProviderSettings(provider, providerSettings) {
         `Invalid model override (must be non-empty string) for provider "${provider}"`
       );
     }
-    if (override?.model) {
-      providerModule.validateModelId(override.model);
+    if (override?.model || (provider === 'opencode' && override?.model === '')) {
+      providerModule.resolveModelSpec(level, { [level]: override });
     }
     if (override?.reasoningEffort && !providerSupportsCapability(provider, 'reasoningEffort')) {
       throw new Error(

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -129,6 +129,11 @@ class RuntimeProvider extends BaseProvider {
     return this._adapter.validateModelId(modelId);
   }
 
+  validateConfiguredModelId(modelId) {
+    const validator = this._adapter.validateConfiguredModelId || this._adapter.validateModelId;
+    return validator(modelId);
+  }
+
   isRetryableError(err) {
     return helper.classifyProviderError(this.name, err).retryable;
   }

--- a/src/task-run-model-args.js
+++ b/src/task-run-model-args.js
@@ -1,0 +1,33 @@
+/**
+ * Append a resolved model selection to a nested `zeroshot task run` invocation.
+ *
+ * Direct requests use the public, catalog-strict `--model` channel.
+ * Provider-level selections retain their level and carry the already validated
+ * configured value through the internal `--configured-model` channel.
+ *
+ * @param {string[]} args
+ * @param {Object|null|undefined} modelSpec
+ * @param {'direct'|'provider-level'} [modelSpecSource]
+ * @returns {string[]}
+ */
+function appendTaskRunModelArgs(args, modelSpec, modelSpecSource = 'direct') {
+  if (modelSpecSource === 'provider-level') {
+    if (!modelSpec?.level) {
+      throw new Error('Provider-level task model selections require a model level');
+    }
+    args.push('--model-level', modelSpec.level);
+    if (modelSpec.model) {
+      args.push('--configured-model', modelSpec.model);
+    }
+  } else if (modelSpec?.model) {
+    args.push('--model', modelSpec.model);
+  }
+
+  if (modelSpec?.reasoningEffort) {
+    args.push('--reasoning-effort', modelSpec.reasoningEffort);
+  }
+
+  return args;
+}
+
+module.exports = { appendTaskRunModelArgs };

--- a/src/task-run-model-args.js
+++ b/src/task-run-model-args.js
@@ -2,8 +2,8 @@
  * Append a resolved model selection to a nested `zeroshot task run` invocation.
  *
  * Direct requests use the public, catalog-strict `--model` channel.
- * Provider-level selections retain their level and carry the already validated
- * configured value through the internal `--configured-model` channel.
+ * Provider-level selections carry only their level. The child must resolve the
+ * concrete model again from its effective provider settings.
  *
  * @param {string[]} args
  * @param {Object|null|undefined} modelSpec
@@ -16,9 +16,6 @@ function appendTaskRunModelArgs(args, modelSpec, modelSpecSource = 'direct') {
       throw new Error('Provider-level task model selections require a model level');
     }
     args.push('--model-level', modelSpec.level);
-    if (modelSpec.model) {
-      args.push('--configured-model', modelSpec.model);
-    }
   } else if (modelSpec?.model) {
     args.push('--model', modelSpec.model);
   }
@@ -30,4 +27,39 @@ function appendTaskRunModelArgs(args, modelSpec, modelSpecSource = 'direct') {
   return args;
 }
 
-module.exports = { appendTaskRunModelArgs };
+const ISOLATED_PROVIDER_SETTINGS_ENV = 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON';
+
+/**
+ * Serialize the effective configured-model settings needed by an isolated
+ * child. Only providers that support settings-owned external model IDs need a
+ * snapshot; direct models continue through the strict public channel.
+ *
+ * @param {string} providerName
+ * @param {Object} settings
+ * @param {'direct'|'provider-level'} modelSpecSource
+ * @param {Object|null|undefined} modelSpec
+ * @returns {Record<string, string>}
+ */
+function buildIsolatedProviderSettingsEnv(providerName, settings, modelSpecSource, modelSpec) {
+  if (providerName !== 'opencode' || modelSpecSource !== 'provider-level') return {};
+  const providerSettings = settings.providerSettings?.[providerName] || {};
+  const configuredModel = providerSettings.levelOverrides?.[modelSpec?.level]?.model ?? null;
+  if (modelSpec?.model !== configuredModel) {
+    const error = new Error(
+      `Provider-level model "${modelSpec?.model}" does not match the effective isolated ${modelSpec?.level} model "${configuredModel}".`
+    );
+    error.permanent = true;
+    throw error;
+  }
+  return {
+    [ISOLATED_PROVIDER_SETTINGS_ENV]: JSON.stringify({
+      [providerName]: providerSettings,
+    }),
+  };
+}
+
+module.exports = {
+  ISOLATED_PROVIDER_SETTINGS_ENV,
+  appendTaskRunModelArgs,
+  buildIsolatedProviderSettingsEnv,
+};

--- a/src/task-run-model-args.js
+++ b/src/task-run-model-args.js
@@ -27,39 +27,129 @@ function appendTaskRunModelArgs(args, modelSpec, modelSpecSource = 'direct') {
   return args;
 }
 
-const ISOLATED_PROVIDER_SETTINGS_ENV = 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON';
+const ISOLATED_SETTINGS_FILE_ENV = 'ZEROSHOT_SETTINGS_FILE';
+const ISOLATED_SETTINGS_FILE_MARKER = 'ZEROSHOT_DOCKER_SETTINGS_FILE';
+const LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV = 'ZEROSHOT_ISOLATED_PROVIDER_SETTINGS_JSON';
+const SETTINGS_BOOTSTRAP_SCRIPT = String.raw`
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const snapshot = process.argv[1];
+const command = process.argv[2];
+const args = process.argv.slice(3);
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-isolated-settings-'));
+const settingsFile = path.join(directory, 'settings.json');
+
+try {
+  fs.writeFileSync(settingsFile, snapshot, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+  const result = childProcess.spawnSync(command, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ${ISOLATED_SETTINGS_FILE_ENV}: settingsFile,
+      ${ISOLATED_SETTINGS_FILE_MARKER}: '1',
+    },
+  });
+  if (result.error) throw result.error;
+  process.exitCode = result.status === null ? 1 : result.status;
+} finally {
+  fs.rmSync(directory, { recursive: true, force: true });
+}
+`.trim();
 
 /**
- * Serialize the effective configured-model settings needed by an isolated
- * child. Only providers that support settings-owned external model IDs need a
- * snapshot; direct models continue through the strict public channel.
+ * Wrap an isolated task command with a Docker-only, temporary settings-file
+ * bootstrap. The snapshot is a closed projection containing only the selected
+ * OpenCode level and its model. It never contains arbitrary provider settings,
+ * credentials, or caller-owned keys.
  *
- * @param {string} providerName
- * @param {Object} settings
- * @param {'direct'|'provider-level'} modelSpecSource
- * @param {Object|null|undefined} modelSpec
- * @returns {Record<string, string>}
+ * @param {string[]} command
+ * @param {{providerName: string, settings: Object, modelSpecSource: 'direct'|'provider-level', modelSpec: Object|null|undefined}} context
+ * @returns {string[]}
  */
-function buildIsolatedProviderSettingsEnv(providerName, settings, modelSpecSource, modelSpec) {
-  if (providerName !== 'opencode' || modelSpecSource !== 'provider-level') return {};
-  const providerSettings = settings.providerSettings?.[providerName] || {};
-  const configuredModel = providerSettings.levelOverrides?.[modelSpec?.level]?.model ?? null;
+function wrapTaskRunWithIsolatedSettings(command, context) {
+  const { providerName, settings, modelSpecSource, modelSpec } = context;
+  if (providerName !== 'opencode' || modelSpecSource !== 'provider-level') return command;
+  const snapshot = buildIsolatedSettingsSnapshot(settings, modelSpec);
+  if (snapshot === null) return command;
+  return ['node', '-e', SETTINGS_BOOTSTRAP_SCRIPT, snapshot, ...command];
+}
+
+function buildIsolatedSettingsSnapshot(settings, modelSpec) {
+  const level = modelSpec?.level;
+  if (!['level1', 'level2', 'level3'].includes(level)) {
+    throw permanentError(
+      'Provider-level isolated OpenCode selections require a valid model level.'
+    );
+  }
+
+  const providerSettings = ownRecordValue(settings, 'providerSettings', 'settings') ?? {};
+  const opencodeSettings = ownRecordValue(
+    providerSettings,
+    'opencode',
+    'settings.providerSettings'
+  );
+  const levelOverrides = ownRecordValue(
+    opencodeSettings,
+    'levelOverrides',
+    'settings.providerSettings.opencode'
+  );
+  const levelOverride = ownRecordValue(
+    levelOverrides,
+    level,
+    'settings.providerSettings.opencode.levelOverrides'
+  );
+  const configuredModel =
+    levelOverride && Object.prototype.hasOwnProperty.call(levelOverride, 'model')
+      ? levelOverride.model
+      : null;
+  if (configuredModel !== null && typeof configuredModel !== 'string') {
+    throw permanentError(`Configured isolated OpenCode ${level} model must be a string or null.`);
+  }
   if (modelSpec?.model !== configuredModel) {
-    const error = new Error(
+    throw permanentError(
       `Provider-level model "${modelSpec?.model}" does not match the effective isolated ${modelSpec?.level} model "${configuredModel}".`
     );
-    error.permanent = true;
-    throw error;
   }
-  return {
-    [ISOLATED_PROVIDER_SETTINGS_ENV]: JSON.stringify({
-      [providerName]: providerSettings,
-    }),
-  };
+  if (configuredModel === null) return null;
+
+  return JSON.stringify({
+    providerSettings: {
+      opencode: {
+        levelOverrides: {
+          [level]: { model: configuredModel },
+        },
+      },
+    },
+  });
+}
+
+function ownRecordValue(record, key, field) {
+  if (record === null || record === undefined) return undefined;
+  if (typeof record !== 'object' || Array.isArray(record)) {
+    throw permanentError(`${field} must be an object.`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(record, key)) return undefined;
+  const value = record[key];
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw permanentError(`${field}.${key} must be an object.`);
+  }
+  return value;
+}
+
+function permanentError(message) {
+  const error = new Error(message);
+  error.permanent = true;
+  return error;
 }
 
 module.exports = {
-  ISOLATED_PROVIDER_SETTINGS_ENV,
+  ISOLATED_SETTINGS_FILE_ENV,
+  ISOLATED_SETTINGS_FILE_MARKER,
+  LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV,
   appendTaskRunModelArgs,
-  buildIsolatedProviderSettingsEnv,
+  wrapTaskRunWithIsolatedSettings,
 };

--- a/task-lib/commands/run.js
+++ b/task-lib/commands/run.js
@@ -32,7 +32,6 @@ export async function runTask(prompt, options = {}) {
     cwd: options.cwd || process.cwd(),
     model: options.model,
     modelLevel: options.modelLevel,
-    configuredModel: options.configuredModel,
     reasoningEffort: options.reasoningEffort,
     provider: options.provider,
     resume: options.resume,

--- a/task-lib/commands/run.js
+++ b/task-lib/commands/run.js
@@ -32,6 +32,7 @@ export async function runTask(prompt, options = {}) {
     cwd: options.cwd || process.cwd(),
     model: options.model,
     modelLevel: options.modelLevel,
+    configuredModel: options.configuredModel,
     reasoningEffort: options.reasoningEffort,
     provider: options.provider,
     resume: options.resume,

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -86,7 +86,6 @@ function prepareTaskProviderCommandFromResolved(prompt, options, runtime) {
   return prepareSingleAgentProviderCommand({
     provider: options.provider || null,
     context: prompt,
-    modelSpecSource: modelSelection?.source,
     options: buildProviderOptions(options, runtime, modelSelection),
   });
 }
@@ -124,19 +123,14 @@ function mcpConfigOption(options) {
 }
 
 function resolveRequestedModelSelection(options) {
-  if (options.model && options.configuredModel) {
-    throw new Error('--model and --configured-model cannot be used together');
-  }
-  if (options.configuredModel && !options.modelLevel) {
-    throw new Error('--configured-model requires --model-level');
+  if (Object.prototype.hasOwnProperty.call(options, 'configuredModel')) {
+    throw new Error(
+      '--configured-model is not supported; configure providerSettings levelOverrides instead'
+    );
   }
 
   if (options.model) {
     return directModelSelection(options);
-  }
-
-  if (options.configuredModel) {
-    return configuredModelSelection(options);
   }
 
   return providerLevelSelection(options);
@@ -145,16 +139,7 @@ function resolveRequestedModelSelection(options) {
 function directModelSelection(options) {
   const modelSpec = { model: options.model };
   if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
-  return { source: 'direct', modelSpec };
-}
-
-function configuredModelSelection(options) {
-  const modelSpec = {
-    level: options.modelLevel,
-    model: options.configuredModel,
-  };
-  if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
-  return { source: 'provider-level', modelSpec };
+  return { modelSpec };
 }
 
 function providerLevelSelection(options) {
@@ -162,7 +147,7 @@ function providerLevelSelection(options) {
   const modelSpec = {};
   if (options.modelLevel) modelSpec.level = options.modelLevel;
   if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
-  return { source: 'provider-level', modelSpec };
+  return { modelSpec };
 }
 
 function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -25,10 +25,10 @@ export function spawnTask(prompt, options = {}) {
 
   const outputFormat = resolveOutputFormat(options);
   const jsonSchema = resolveJsonSchema(options, outputFormat);
-  const prepared = prepareSingleAgentProviderCommand({
-    provider: options.provider || null,
-    context: prompt,
-    options: buildProviderOptions(options, outputFormat, jsonSchema, cwd),
+  const prepared = prepareTaskProviderCommandFromResolved(prompt, options, {
+    outputFormat,
+    jsonSchema,
+    cwd,
   });
   const providerName = prepared.adapter.id;
   const modelSpec = prepared.options.modelSpec;
@@ -72,6 +72,25 @@ export function spawnTask(prompt, options = {}) {
   return task;
 }
 
+export function prepareTaskProviderCommand(prompt, options = {}) {
+  const outputFormat = resolveOutputFormat(options);
+  return prepareTaskProviderCommandFromResolved(prompt, options, {
+    outputFormat,
+    jsonSchema: resolveJsonSchema(options, outputFormat),
+    cwd: options.cwd || process.cwd(),
+  });
+}
+
+function prepareTaskProviderCommandFromResolved(prompt, options, runtime) {
+  const modelSelection = resolveRequestedModelSelection(options);
+  return prepareSingleAgentProviderCommand({
+    provider: options.provider || null,
+    context: prompt,
+    modelSpecSource: modelSelection?.source,
+    options: buildProviderOptions(options, runtime, modelSelection),
+  });
+}
+
 function resolveOutputFormat(options) {
   return options.outputFormat || 'stream-json';
 }
@@ -85,13 +104,13 @@ function resolveJsonSchema(options, outputFormat) {
   return jsonSchema;
 }
 
-function buildProviderOptions(options, outputFormat, jsonSchema, cwd) {
+function buildProviderOptions(options, runtime, modelSelection) {
   return {
-    outputFormat,
-    jsonSchema,
-    cwd,
+    outputFormat: runtime.outputFormat,
+    jsonSchema: runtime.jsonSchema,
+    cwd: runtime.cwd,
     autoApprove: true,
-    ...modelSpecOption(options),
+    ...(modelSelection === undefined ? {} : { modelSpec: modelSelection.modelSpec }),
     ...mcpConfigOption(options),
     ...(options.resume ? { resumeSessionId: options.resume } : {}),
     ...(options.continue ? { continueSession: true } : {}),
@@ -104,27 +123,46 @@ function mcpConfigOption(options) {
   return { mcpConfig: entries };
 }
 
-function modelSpecOption(options) {
-  const modelSpec = resolveRequestedModelSpec(options);
-  return modelSpec === undefined ? {} : { modelSpec };
+function resolveRequestedModelSelection(options) {
+  if (options.model && options.configuredModel) {
+    throw new Error('--model and --configured-model cannot be used together');
+  }
+  if (options.configuredModel && !options.modelLevel) {
+    throw new Error('--configured-model requires --model-level');
+  }
+
+  if (options.model) {
+    return directModelSelection(options);
+  }
+
+  if (options.configuredModel) {
+    return configuredModelSelection(options);
+  }
+
+  return providerLevelSelection(options);
 }
 
-function resolveRequestedModelSpec(options) {
-  if (options.model) {
-    return {
-      model: options.model,
-      ...(options.reasoningEffort ? { reasoningEffort: options.reasoningEffort } : {}),
-    };
-  }
+function directModelSelection(options) {
+  const modelSpec = { model: options.model };
+  if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
+  return { source: 'direct', modelSpec };
+}
 
-  if (options.reasoningEffort) {
-    return {
-      ...(options.modelLevel ? { level: options.modelLevel } : {}),
-      reasoningEffort: options.reasoningEffort,
-    };
-  }
-  if (options.modelLevel) return { level: options.modelLevel };
-  return undefined;
+function configuredModelSelection(options) {
+  const modelSpec = {
+    level: options.modelLevel,
+    model: options.configuredModel,
+  };
+  if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
+  return { source: 'provider-level', modelSpec };
+}
+
+function providerLevelSelection(options) {
+  if (!options.reasoningEffort && !options.modelLevel) return undefined;
+  const modelSpec = {};
+  if (options.modelLevel) modelSpec.level = options.modelLevel;
+  if (options.reasoningEffort) modelSpec.reasoningEffort = options.reasoningEffort;
+  return { source: 'provider-level', modelSpec };
 }
 
 function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -7,6 +7,11 @@ import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { prepareSingleAgentProviderCommand } = require('./provider-helper-runtime.js');
+const {
+  ISOLATED_SETTINGS_FILE_ENV,
+  ISOLATED_SETTINGS_FILE_MARKER,
+  LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV,
+} = require('../src/task-run-model-args.js');
 export {
   isOwnedProcessTreeRunning,
   isProcessRunning,
@@ -212,6 +217,7 @@ function resolveWatcherScript(options, providerName) {
 }
 
 function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfig }) {
+  const watcherEnv = buildWatcherEnv();
   const watcher = fork(
     watcherScript,
     [id, cwd, logFile, JSON.stringify(finalArgs), JSON.stringify(watcherConfig)],
@@ -219,9 +225,20 @@ function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfi
       detached: true,
       stdio: 'ignore',
       windowsHide: true,
+      env: watcherEnv,
     }
   );
 
   watcher.unref();
   watcher.disconnect(); // Close IPC channel so parent can exit
+}
+
+export function buildWatcherEnv(sourceEnv = process.env) {
+  const watcherEnv = { ...sourceEnv };
+  delete watcherEnv[LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV];
+  if (watcherEnv[ISOLATED_SETTINGS_FILE_MARKER] === '1') {
+    delete watcherEnv[ISOLATED_SETTINGS_FILE_ENV];
+    delete watcherEnv[ISOLATED_SETTINGS_FILE_MARKER];
+  }
+  return watcherEnv;
 }

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -61,6 +61,25 @@ function assertRuntimeCommandParity(provider, context, options) {
   return direct;
 }
 
+function withTempSettings(settings, callback) {
+  const settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-provider-settings-'));
+  const settingsFile = path.join(settingsDir, 'settings.json');
+  const previousSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+  if (settings !== undefined) fs.writeFileSync(settingsFile, JSON.stringify(settings));
+  process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+
+  try {
+    return callback();
+  } finally {
+    if (previousSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = previousSettingsFile;
+    }
+    fs.rmSync(settingsDir, { recursive: true, force: true });
+  }
+}
+
 test('runtime Claude command facade delegates to helper', () => {
   assertRuntimeCommandParity('claude', 'test context', {
     authEnv: { ANTHROPIC_API_KEY: 'sk-ant-test' },
@@ -127,6 +146,127 @@ test('runtime Opencode command facade delegates to helper', () => {
       supportsCwd: true,
     },
   });
+});
+
+test('runtime Opencode command parity preserves the CLI default model', () => {
+  withTempSettings(undefined, () => {
+    const context = 'opencode default context';
+    const runtimeOptions = {
+      outputFormat: 'json',
+      cliFeatures: {
+        supportsJson: true,
+        supportsVariant: true,
+        supportsDir: true,
+        supportsCwd: true,
+      },
+    };
+    const runtime = runtimeProviders.getProvider('opencode').buildCommand(context, runtimeOptions);
+    const direct = helper.buildProviderCommand('opencode', context, {
+      ...runtimeOptions,
+      modelSpec: helper.resolveModelSpec('opencode', 'level2'),
+    });
+
+    assert.deepEqual(normalizeCommand(runtime), normalizeCommand(direct));
+    assert.equal(direct.args.includes('--model'), false);
+  });
+});
+
+test('runtime Opencode command parity accepts an external model configured in Opencode settings', () => {
+  withTempSettings(
+    {
+      providerSettings: {
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {
+            level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+          },
+        },
+      },
+    },
+    () => {
+      const context = 'opencode external context';
+      const runtimeOptions = {
+        outputFormat: 'json',
+        cliFeatures: {
+          supportsJson: true,
+          supportsVariant: true,
+          supportsDir: true,
+          supportsCwd: true,
+        },
+      };
+      const runtime = runtimeProviders
+        .getProvider('opencode')
+        .buildCommand(context, runtimeOptions);
+      const direct = helper.buildProviderCommand('opencode', context, {
+        ...runtimeOptions,
+        modelSpec: helper.resolveModelSpec('opencode', 'level2', {
+          level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+        }),
+      });
+
+      assert.deepEqual(normalizeCommand(runtime), normalizeCommand(direct));
+      assert.deepEqual(direct.args.slice(0, 7), [
+        'run',
+        '--format',
+        'json',
+        '--model',
+        'kimi/kimi-k2-5',
+        '--variant',
+        'high',
+      ]);
+    }
+  );
+});
+
+test('runtime Opencode rejects an unconfigured external model before command construction', () => {
+  withTempSettings(
+    {
+      providerSettings: {
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {},
+        },
+      },
+    },
+    () => {
+      assert.throws(
+        () =>
+          runtimeProviders.getProvider('opencode').buildCommand('opencode external context', {
+            modelSpec: { level: 'level2', model: 'kimi/kimi-k2-5' },
+            cliFeatures: { supportsJson: true, supportsModel: true },
+          }),
+        (error) =>
+          error.permanent === true &&
+          /Invalid model "kimi\/kimi-k2-5" for provider "opencode"/.test(error.message)
+      );
+    }
+  );
+});
+
+test('runtime Opencode rejects a malformed configured model before command construction', () => {
+  withTempSettings(
+    {
+      providerSettings: {
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {
+            level2: { model: 'kimi/' },
+          },
+        },
+      },
+    },
+    () => {
+      assert.throws(
+        () =>
+          runtimeProviders.getProvider('opencode').buildCommand('opencode malformed context', {
+            cliFeatures: { supportsJson: true, supportsModel: true },
+          }),
+        (error) =>
+          error.permanent === true &&
+          /Invalid configured model "kimi\/" for provider "opencode"/.test(error.message)
+      );
+    }
+  );
 });
 
 test('runtime Pi command facade delegates to helper', () => {
@@ -285,10 +425,19 @@ test('model resolution and invalid-model permanence match helper', () => {
       );
     }
 
-    assert.deepEqual(
-      helper.resolveModelSpec(provider, 'level2', { level2: { model: '' } }),
-      current.resolveModelSpec('level2', { level2: { model: '' } })
-    );
+    if (provider === 'opencode') {
+      assert.throws(() => helper.resolveModelSpec(provider, 'level2', { level2: { model: '' } }), {
+        permanent: true,
+      });
+      assert.throws(() => current.resolveModelSpec('level2', { level2: { model: '' } }), {
+        permanent: true,
+      });
+    } else {
+      assert.deepEqual(
+        helper.resolveModelSpec(provider, 'level2', { level2: { model: '' } }),
+        current.resolveModelSpec('level2', { level2: { model: '' } })
+      );
+    }
 
     if (provider === 'pi' || provider === 'copilot' || provider === 'gateway') {
       assert.deepEqual(

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -243,6 +243,33 @@ test('runtime Opencode rejects an unconfigured external model before command con
   );
 });
 
+test('runtime Opencode rejects a direct external model even when a configured override matches', () => {
+  withTempSettings(
+    {
+      providerSettings: {
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {
+            level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+          },
+        },
+      },
+    },
+    () => {
+      assert.throws(
+        () =>
+          runtimeProviders.getProvider('opencode').buildCommand('opencode direct context', {
+            modelSpec: { level: 'level2', model: 'kimi/kimi-k2-5' },
+            cliFeatures: { supportsJson: true, supportsModel: true },
+          }),
+        (error) =>
+          error.permanent === true &&
+          /Invalid model "kimi\/kimi-k2-5" for provider "opencode"/.test(error.message)
+      );
+    }
+  );
+});
+
 test('runtime Opencode rejects a malformed configured model before command construction', () => {
   withTempSettings(
     {

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -16,6 +16,12 @@ const {
 const runtimeProviders = require('../../src/providers');
 
 const createdTempFiles = new Set();
+const CONTROL_MODEL_IDS = [
+  'kimi/model\0suffix',
+  'kimi/model\u0001suffix',
+  'kimi/model\u001fsuffix',
+  'kimi/model\u007fsuffix',
+];
 
 afterEach(() => {
   for (const file of createdTempFiles) {
@@ -294,6 +300,41 @@ test('runtime Opencode rejects a malformed configured model before command const
       );
     }
   );
+});
+
+test('runtime Opencode rejects control bytes in configured and direct models before command construction', () => {
+  const opencode = runtimeProviders.getProvider('opencode');
+
+  for (const model of CONTROL_MODEL_IDS) {
+    withTempSettings(
+      {
+        providerSettings: {
+          opencode: {
+            defaultLevel: 'level2',
+            levelOverrides: { level2: { model } },
+          },
+        },
+      },
+      () => {
+        assert.throws(
+          () =>
+            opencode.buildCommand('configured control byte', {
+              cliFeatures: { supportsJson: true, supportsModel: true },
+            }),
+          { name: 'InvalidProviderModelError', permanent: true }
+        );
+      }
+    );
+
+    assert.throws(
+      () =>
+        opencode.buildCommand('direct control byte', {
+          modelSpec: { level: 'level2', model },
+          cliFeatures: { supportsJson: true, supportsModel: true },
+        }),
+      { name: 'InvalidProviderModelError', permanent: true }
+    );
+  }
 });
 
 test('runtime Pi command facade delegates to helper', () => {

--- a/tests/model-selection.test.js
+++ b/tests/model-selection.test.js
@@ -64,6 +64,55 @@ function registerStaticModelTests() {
   });
 }
 
+function registerModelSpecSourceTests() {
+  describe('Task runner model provenance', () => {
+    function captureTaskRunnerOptions(agentConfig, iteration = 0) {
+      let capturedOptions;
+      const agent = new AgentWrapper(agentConfig, mockMessageBus, mockCluster, {
+        testMode: true,
+        taskRunner: {
+          run(_context, options) {
+            capturedOptions = options;
+            return { success: true };
+          },
+        },
+      });
+
+      agent.iteration = iteration;
+      agent.mockSpawnFn([], { context: 'test context' });
+      return capturedOptions;
+    }
+
+    it('marks static direct models separately from provider-level selections', () => {
+      assert.strictEqual(
+        captureTaskRunnerOptions({ id: 'direct', model: 'opus', timeout: 0 }).modelSpecSource,
+        'direct'
+      );
+      assert.strictEqual(
+        captureTaskRunnerOptions({ id: 'level', modelLevel: 'level2', timeout: 0 }).modelSpecSource,
+        'provider-level'
+      );
+    });
+
+    it('tracks the matching rule source for each iteration', () => {
+      const agentConfig = {
+        id: 'rules',
+        timeout: 0,
+        modelRules: [
+          { iterations: '1', model: 'haiku' },
+          { iterations: '2+', modelLevel: 'level2' },
+        ],
+      };
+
+      assert.strictEqual(captureTaskRunnerOptions(agentConfig, 1).modelSpecSource, 'direct');
+      assert.strictEqual(
+        captureTaskRunnerOptions(agentConfig, 2).modelSpecSource,
+        'provider-level'
+      );
+    });
+  });
+}
+
 function registerDynamicModelRulesTests() {
   describe('Dynamic model rules', () => {
     it('should match exact iteration', () => {
@@ -210,6 +259,7 @@ function registerRealWorldUseCaseTests() {
 describe('Model Selection', () => {
   registerModelSelectionHooks();
   registerStaticModelTests();
+  registerModelSpecSourceTests();
   registerDynamicModelRulesTests();
   registerErrorHandlingTests();
   registerRealWorldUseCaseTests();

--- a/tests/model-selection.test.js
+++ b/tests/model-selection.test.js
@@ -83,14 +83,18 @@ function registerModelSpecSourceTests() {
       return capturedOptions;
     }
 
-    it('marks static direct models separately from provider-level selections', () => {
+    it('passes direct models and provider levels through separate structural fields', () => {
       assert.strictEqual(
-        captureTaskRunnerOptions({ id: 'direct', model: 'opus', timeout: 0 }).modelSpecSource,
-        'direct'
+        captureTaskRunnerOptions({ id: 'direct', model: 'opus', timeout: 0 }).model,
+        'opus'
+      );
+      assert.strictEqual(
+        captureTaskRunnerOptions({ id: 'level', modelLevel: 'level2', timeout: 0 }).modelLevel,
+        'level2'
       );
       assert.strictEqual(
         captureTaskRunnerOptions({ id: 'level', modelLevel: 'level2', timeout: 0 }).modelSpecSource,
-        'provider-level'
+        undefined
       );
     });
 
@@ -104,11 +108,8 @@ function registerModelSpecSourceTests() {
         ],
       };
 
-      assert.strictEqual(captureTaskRunnerOptions(agentConfig, 1).modelSpecSource, 'direct');
-      assert.strictEqual(
-        captureTaskRunnerOptions(agentConfig, 2).modelSpecSource,
-        'provider-level'
-      );
+      assert.strictEqual(captureTaskRunnerOptions(agentConfig, 1).model, 'haiku');
+      assert.strictEqual(captureTaskRunnerOptions(agentConfig, 2).modelLevel, 'level2');
     });
   });
 }

--- a/tests/opencode-docker-settings-boundary.test.js
+++ b/tests/opencode-docker-settings-boundary.test.js
@@ -1,0 +1,145 @@
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
+const {
+  ISOLATED_SETTINGS_FILE_ENV,
+  ISOLATED_SETTINGS_FILE_MARKER,
+  LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV,
+  wrapTaskRunWithIsolatedSettings,
+} = require('../src/task-run-model-args');
+
+const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
+const MISMATCHED_MODEL = 'attacker/other-model';
+
+function configuredSettings(model = EXTERNAL_MODEL) {
+  return {
+    defaultProvider: 'opencode',
+    providerSettings: {
+      opencode: {
+        defaultLevel: 'level2',
+        levelOverrides: {
+          level2: { model, reasoningEffort: 'high' },
+        },
+      },
+    },
+  };
+}
+
+describe('Docker provider settings trust boundary', function () {
+  it('rejects an agent model that does not match the effective settings snapshot', async function () {
+    let spawnCount = 0;
+    const agent = {
+      id: 'mismatched-docker',
+      config: { outputFormat: 'json', strictSchema: true },
+      isolation: {
+        enabled: true,
+        clusterId: 'test-cluster',
+        manager: {
+          spawnInContainer() {
+            spawnCount += 1;
+            throw new Error('must not spawn');
+          },
+        },
+      },
+      _resolveProvider: () => 'opencode',
+      _resolveModelSpec: () => ({
+        level: 'level2',
+        model: EXTERNAL_MODEL,
+        reasoningEffort: 'high',
+      }),
+      _resolveModelSpecSource: () => 'provider-level',
+      _log() {},
+    };
+
+    await assert.rejects(
+      spawnClaudeTaskIsolated(agent, 'test context'),
+      /does not match the effective isolated level2 model/
+    );
+    assert.strictEqual(spawnCount, 0);
+  });
+
+  it('rejects empty and mismatched snapshots before spawning', function () {
+    const command = ['zeroshot', 'task', 'run'];
+    for (const settings of [{}, configuredSettings(MISMATCHED_MODEL)]) {
+      assert.throws(
+        () =>
+          wrapTaskRunWithIsolatedSettings(command, {
+            providerName: 'opencode',
+            settings,
+            modelSpecSource: 'provider-level',
+            modelSpec: { level: 'level2', model: EXTERNAL_MODEL },
+          }),
+        /does not match the effective isolated level2 model/
+      );
+    }
+  });
+
+  it('transports only the requested level and model, never arbitrary settings or secrets', function () {
+    const settings = configuredSettings();
+    settings.providerSettings.opencode.apiKey = 'secret-opencode-key';
+    settings.providerSettings.opencode.unknown = { nested: true };
+    settings.providerSettings.codex = { apiKey: 'secret-codex-key' };
+    settings.unknownRoot = 'not-transported';
+
+    const wrapped = wrapTaskRunWithIsolatedSettings(
+      ['zeroshot', 'task', 'run', '--model-level', 'level2'],
+      {
+        providerName: 'opencode',
+        settings,
+        modelSpecSource: 'provider-level',
+        modelSpec: {
+          level: 'level2',
+          model: EXTERNAL_MODEL,
+          reasoningEffort: 'high',
+        },
+      }
+    );
+    assert.deepStrictEqual(JSON.parse(wrapped[3]), {
+      providerSettings: {
+        opencode: {
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL },
+          },
+        },
+      },
+    });
+    assert.strictEqual(wrapped.join(' ').includes('secret-'), false);
+    assert.strictEqual(wrapped.join(' ').includes('unknown'), false);
+  });
+
+  it('stages a legitimate minimal snapshot through the temporary settings file', function () {
+    const readSettingsScript = String.raw`
+const fs = require('node:fs');
+process.stdout.write(fs.readFileSync(process.env.ZEROSHOT_SETTINGS_FILE, 'utf8'));
+`.trim();
+    const wrapped = wrapTaskRunWithIsolatedSettings(['node', '-e', readSettingsScript], {
+      providerName: 'opencode',
+      settings: configuredSettings(),
+      modelSpecSource: 'provider-level',
+      modelSpec: { level: 'level2', model: EXTERNAL_MODEL },
+    });
+    const result = childProcess.spawnSync(wrapped[0], wrapped.slice(1), { encoding: 'utf8' });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      providerSettings: {
+        opencode: {
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL },
+          },
+        },
+      },
+    });
+  });
+
+  it('strips the isolated settings path and markers before the provider watcher', async function () {
+    const { buildWatcherEnv } = await import('../task-lib/runner.js');
+    const env = buildWatcherEnv({
+      KEEP_ME: 'yes',
+      [ISOLATED_SETTINGS_FILE_ENV]: '/tmp/private-settings.json',
+      [ISOLATED_SETTINGS_FILE_MARKER]: '1',
+      [LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV]: '{"spoofed":true}',
+    });
+    assert.deepStrictEqual(env, { KEEP_ME: 'yes' });
+  });
+});

--- a/tests/opencode-external-models.test.js
+++ b/tests/opencode-external-models.test.js
@@ -82,32 +82,29 @@ describe('Opencode external model task runner boundary', function () {
     );
   });
 
-  it('re-resolves provider-level selections instead of trusting a supplied model value', function () {
+  it('rejects provider-level selections whose supplied model does not match settings', function () {
     const providerModule = getProvider('opencode');
     const levelOverrides = {
       level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
     };
     const runner = new ClaudeTaskRunner({ quiet: true });
 
-    assert.deepStrictEqual(
-      runner._resolveModelSpec({
-        explicitModelSpec: {
-          level: 'level2',
-          model: 'untrusted/external-model',
-        },
-        modelSpecSource: 'provider-level',
-        model: null,
-        reasoningEffort: null,
-        modelLevel: null,
-        providerModule,
-        providerSettings: { defaultLevel: 'level2', levelOverrides },
-        levelOverrides,
-      }),
-      {
-        level: 'level2',
-        model: 'kimi/kimi-k2-5',
-        reasoningEffort: 'high',
-      }
+    assert.throws(
+      () =>
+        runner._resolveModelSpec({
+          explicitModelSpec: {
+            level: 'level2',
+            model: 'untrusted/external-model',
+          },
+          modelSpecSource: 'provider-level',
+          model: null,
+          reasoningEffort: null,
+          modelLevel: null,
+          providerModule,
+          providerSettings: { defaultLevel: 'level2', levelOverrides },
+          levelOverrides,
+        }),
+      /does not match the configured level2 model/
     );
   });
 });

--- a/tests/opencode-external-models.test.js
+++ b/tests/opencode-external-models.test.js
@@ -34,7 +34,7 @@ describe('Opencode external model configuration', function () {
 });
 
 describe('Opencode external model task runner boundary', function () {
-  it('carries configured external models through the task runner boundary', function () {
+  it('derives configured external models from modelLevel without a source flag', function () {
     const providerModule = getProvider('opencode');
     const levelOverrides = {
       level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
@@ -43,15 +43,10 @@ describe('Opencode external model task runner boundary', function () {
 
     assert.deepStrictEqual(
       runner._resolveModelSpec({
-        explicitModelSpec: {
-          level: 'level2',
-          model: 'kimi/kimi-k2-5',
-          reasoningEffort: 'high',
-        },
-        modelSpecSource: 'provider-level',
+        explicitModelSpec: null,
         model: null,
         reasoningEffort: null,
-        modelLevel: null,
+        modelLevel: 'level2',
         providerModule,
         providerSettings: { defaultLevel: 'level2', levelOverrides },
         levelOverrides,
@@ -70,7 +65,6 @@ describe('Opencode external model task runner boundary', function () {
             level: 'level2',
             model: 'kimi/kimi-k2-5',
           },
-          modelSpecSource: 'direct',
           model: null,
           reasoningEffort: null,
           modelLevel: null,
@@ -82,7 +76,7 @@ describe('Opencode external model task runner boundary', function () {
     );
   });
 
-  it('rejects provider-level selections whose supplied model does not match settings', function () {
+  it('treats every caller-supplied concrete model as direct and catalog-strict', function () {
     const providerModule = getProvider('opencode');
     const levelOverrides = {
       level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
@@ -96,7 +90,6 @@ describe('Opencode external model task runner boundary', function () {
             level: 'level2',
             model: 'untrusted/external-model',
           },
-          modelSpecSource: 'provider-level',
           model: null,
           reasoningEffort: null,
           modelLevel: null,
@@ -104,7 +97,19 @@ describe('Opencode external model task runner boundary', function () {
           providerSettings: { defaultLevel: 'level2', levelOverrides },
           levelOverrides,
         }),
-      /does not match the configured level2 model/
+      { permanent: true }
+    );
+  });
+
+  it('rejects caller-supplied model provenance', async function () {
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    await assert.rejects(
+      runner.run('spoofed source', {
+        provider: 'opencode',
+        modelLevel: 'level2',
+        modelSpecSource: 'provider-level',
+      }),
+      /modelSpecSource is derived/
     );
   });
 });
@@ -123,6 +128,22 @@ describe('Opencode malformed external model validation', function () {
           error.permanent === true &&
           error.message.includes(`Invalid configured model "${model}" for provider "opencode"`)
       );
+    }
+  });
+
+  it('rejects prototype-inherited names for direct and configured models', function () {
+    const opencode = getProvider('opencode');
+    const codex = getProvider('codex');
+
+    for (const model of ['constructor', 'toString', '__proto__']) {
+      assert.throws(() => opencode.validateModelId(model), { permanent: true });
+      assert.throws(() => codex.validateModelId(model), { permanent: true });
+      assert.throws(() => opencode.resolveModelSpec('level2', { level2: { model } }), {
+        permanent: true,
+      });
+      assert.throws(() => codex.resolveModelSpec('level2', { level2: { model } }), {
+        permanent: true,
+      });
     }
   });
 });

--- a/tests/opencode-external-models.test.js
+++ b/tests/opencode-external-models.test.js
@@ -48,6 +48,7 @@ describe('Opencode external model task runner boundary', function () {
           model: 'kimi/kimi-k2-5',
           reasoningEffort: 'high',
         },
+        modelSpecSource: 'provider-level',
         model: null,
         reasoningEffort: null,
         modelLevel: null,
@@ -69,14 +70,44 @@ describe('Opencode external model task runner boundary', function () {
             level: 'level2',
             model: 'kimi/kimi-k2-5',
           },
+          modelSpecSource: 'direct',
           model: null,
           reasoningEffort: null,
           modelLevel: null,
           providerModule,
-          providerSettings: { defaultLevel: 'level2', levelOverrides: {} },
-          levelOverrides: {},
+          providerSettings: { defaultLevel: 'level2', levelOverrides },
+          levelOverrides,
         }),
       { permanent: true }
+    );
+  });
+
+  it('re-resolves provider-level selections instead of trusting a supplied model value', function () {
+    const providerModule = getProvider('opencode');
+    const levelOverrides = {
+      level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+    };
+    const runner = new ClaudeTaskRunner({ quiet: true });
+
+    assert.deepStrictEqual(
+      runner._resolveModelSpec({
+        explicitModelSpec: {
+          level: 'level2',
+          model: 'untrusted/external-model',
+        },
+        modelSpecSource: 'provider-level',
+        model: null,
+        reasoningEffort: null,
+        modelLevel: null,
+        providerModule,
+        providerSettings: { defaultLevel: 'level2', levelOverrides },
+        levelOverrides,
+      }),
+      {
+        level: 'level2',
+        model: 'kimi/kimi-k2-5',
+        reasoningEffort: 'high',
+      }
     );
   });
 });

--- a/tests/opencode-external-models.test.js
+++ b/tests/opencode-external-models.test.js
@@ -3,6 +3,13 @@ const ClaudeTaskRunner = require('../src/claude-task-runner');
 const { validateProviderSettings } = require('../src/config-validator');
 const { getProvider } = require('../src/providers');
 
+const CONTROL_MODEL_IDS = [
+  'kimi/model\0suffix',
+  'kimi/model\u0001suffix',
+  'kimi/model\u001fsuffix',
+  'kimi/model\u007fsuffix',
+];
+
 describe('Opencode external model configuration', function () {
   it('accepts well-formed external models only through level overrides', function () {
     const opencode = getProvider('opencode');
@@ -142,6 +149,28 @@ describe('Opencode malformed external model validation', function () {
         permanent: true,
       });
       assert.throws(() => codex.resolveModelSpec('level2', { level2: { model } }), {
+        permanent: true,
+      });
+    }
+  });
+
+  it('rejects C0 and DEL bytes through configured settings as permanent model errors', function () {
+    const opencode = getProvider('opencode');
+
+    for (const model of CONTROL_MODEL_IDS) {
+      assert.throws(
+        () =>
+          validateProviderSettings('opencode', {
+            defaultLevel: 'level2',
+            levelOverrides: { level2: { model } },
+          }),
+        (error) =>
+          error.name === 'InvalidProviderModelError' &&
+          error.permanent === true &&
+          error.message.includes('Invalid configured model')
+      );
+      assert.throws(() => opencode.validateModelId(model), {
+        name: 'InvalidProviderModelError',
         permanent: true,
       });
     }

--- a/tests/opencode-external-models.test.js
+++ b/tests/opencode-external-models.test.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const ClaudeTaskRunner = require('../src/claude-task-runner');
+const { validateProviderSettings } = require('../src/config-validator');
+const { getProvider } = require('../src/providers');
+
+describe('Opencode external model configuration', function () {
+  it('accepts well-formed external models only through level overrides', function () {
+    const opencode = getProvider('opencode');
+    const levelOverrides = {
+      level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+    };
+
+    assert.deepStrictEqual(opencode.resolveModelSpec('level2', levelOverrides), {
+      level: 'level2',
+      model: 'kimi/kimi-k2-5',
+      reasoningEffort: 'high',
+    });
+    assert.doesNotThrow(() =>
+      validateProviderSettings('opencode', {
+        minLevel: 'level1',
+        maxLevel: 'level3',
+        defaultLevel: 'level2',
+        levelOverrides,
+      })
+    );
+
+    assert.throws(
+      () => opencode.validateModelId('kimi/kimi-k2-5'),
+      (error) =>
+        error.permanent === true &&
+        /Invalid model "kimi\/kimi-k2-5" for provider "opencode"/.test(error.message)
+    );
+  });
+});
+
+describe('Opencode external model task runner boundary', function () {
+  it('carries configured external models through the task runner boundary', function () {
+    const providerModule = getProvider('opencode');
+    const levelOverrides = {
+      level2: { model: 'kimi/kimi-k2-5', reasoningEffort: 'high' },
+    };
+    const runner = new ClaudeTaskRunner({ quiet: true });
+
+    assert.deepStrictEqual(
+      runner._resolveModelSpec({
+        explicitModelSpec: {
+          level: 'level2',
+          model: 'kimi/kimi-k2-5',
+          reasoningEffort: 'high',
+        },
+        model: null,
+        reasoningEffort: null,
+        modelLevel: null,
+        providerModule,
+        providerSettings: { defaultLevel: 'level2', levelOverrides },
+        levelOverrides,
+      }),
+      {
+        level: 'level2',
+        model: 'kimi/kimi-k2-5',
+        reasoningEffort: 'high',
+      }
+    );
+
+    assert.throws(
+      () =>
+        runner._resolveModelSpec({
+          explicitModelSpec: {
+            level: 'level2',
+            model: 'kimi/kimi-k2-5',
+          },
+          model: null,
+          reasoningEffort: null,
+          modelLevel: null,
+          providerModule,
+          providerSettings: { defaultLevel: 'level2', levelOverrides: {} },
+          levelOverrides: {},
+        }),
+      { permanent: true }
+    );
+  });
+});
+
+describe('Opencode malformed external model validation', function () {
+  it('rejects malformed configured model ids as permanent errors', function () {
+    const opencode = getProvider('opencode');
+
+    for (const model of ['', 'kimi', '/kimi-k2-5', 'kimi/', 'kimi//kimi-k2-5', 'kimi/kimi k2']) {
+      assert.throws(
+        () =>
+          opencode.resolveModelSpec('level2', {
+            level2: { model },
+          }),
+        (error) =>
+          error.permanent === true &&
+          error.message.includes(`Invalid configured model "${model}" for provider "opencode"`)
+      );
+    }
+  });
+});

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -1,0 +1,250 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { PassThrough } = require('stream');
+const AgentWrapper = require('../src/agent-wrapper');
+const ClaudeTaskRunner = require('../src/claude-task-runner');
+const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
+const { appendTaskRunModelArgs } = require('../src/task-run-model-args');
+
+const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
+const CATALOG_MODEL = 'openai/gpt-5.2-codex';
+let settingsDir;
+let settingsFile;
+let previousSettingsFile;
+
+function assertConfiguredModelArgs(args) {
+  assert.deepStrictEqual(
+    args.slice(args.indexOf('--model-level'), args.indexOf('--model-level') + 2),
+    ['--model-level', 'level2']
+  );
+  assert.deepStrictEqual(
+    args.slice(args.indexOf('--configured-model'), args.indexOf('--configured-model') + 2),
+    ['--configured-model', EXTERNAL_MODEL]
+  );
+  assert.strictEqual(args.includes('--model'), false);
+}
+
+function createClosingProcess(code = 1) {
+  const proc = new EventEmitter();
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.pid = 12345;
+  proc.kill = () => {};
+  setImmediate(() => proc.emit('close', code, null));
+  return proc;
+}
+
+before(function () {
+  settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-opencode-model-boundary-'));
+  settingsFile = path.join(settingsDir, 'settings.json');
+  previousSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({
+      defaultProvider: 'opencode',
+      providerSettings: {
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL, reasoningEffort: 'high' },
+          },
+        },
+      },
+    })
+  );
+  process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+});
+
+after(function () {
+  if (previousSettingsFile === undefined) {
+    delete process.env.ZEROSHOT_SETTINGS_FILE;
+  } else {
+    process.env.ZEROSHOT_SETTINGS_FILE = previousSettingsFile;
+  }
+  fs.rmSync(settingsDir, { recursive: true, force: true });
+});
+
+describe('Nested task model argument encoding', function () {
+  it('keeps provider-level models off the direct model channel', function () {
+    const args = [];
+    appendTaskRunModelArgs(
+      args,
+      { level: 'level2', model: EXTERNAL_MODEL, reasoningEffort: 'high' },
+      'provider-level'
+    );
+    assertConfiguredModelArgs(args);
+  });
+
+  it('preserves provider-level provenance in actual local agent arguments', async function () {
+    let capturedArgs;
+    const agent = new AgentWrapper(
+      { id: 'configured-local', provider: 'opencode', modelLevel: 'level2', timeout: 0 },
+      { publish() {}, subscribe() {} },
+      { id: 'test-cluster', agents: [] },
+      {
+        testMode: true,
+        mockSpawnFn(args) {
+          capturedArgs = args;
+          return { success: true };
+        },
+      }
+    );
+
+    await agent._spawnClaudeTask('test context');
+    assertConfiguredModelArgs(capturedArgs);
+  });
+
+  it('keeps direct local agent models on the catalog-strict channel', async function () {
+    let capturedArgs;
+    const agent = new AgentWrapper(
+      { id: 'direct-local', provider: 'opencode', model: CATALOG_MODEL, timeout: 0 },
+      { publish() {}, subscribe() {} },
+      { id: 'test-cluster', agents: [] },
+      {
+        testMode: true,
+        mockSpawnFn(args) {
+          capturedArgs = args;
+          return { success: true };
+        },
+      }
+    );
+
+    await agent._spawnClaudeTask('test context');
+    assert.deepStrictEqual(
+      capturedArgs.slice(capturedArgs.indexOf('--model'), capturedArgs.indexOf('--model') + 2),
+      ['--model', CATALOG_MODEL]
+    );
+    assert.strictEqual(capturedArgs.includes('--configured-model'), false);
+  });
+});
+
+describe('Nested Docker agent model arguments', function () {
+  it('preserves provider-level provenance in the spawned command', async function () {
+    let capturedCommand;
+    const agent = {
+      id: 'configured-docker',
+      config: { outputFormat: 'json', strictSchema: true },
+      isolation: {
+        enabled: true,
+        clusterId: 'test-cluster',
+        manager: {
+          spawnInContainer(_clusterId, command) {
+            capturedCommand = command;
+            return createClosingProcess();
+          },
+        },
+      },
+      enableLivenessCheck: false,
+      _resolveProvider: () => 'opencode',
+      _resolveModelSpec: () => ({
+        level: 'level2',
+        model: EXTERNAL_MODEL,
+        reasoningEffort: 'high',
+      }),
+      _resolveModelSpecSource: () => 'provider-level',
+      _log() {},
+      _publishLifecycle() {},
+    };
+
+    await assert.rejects(
+      spawnClaudeTaskIsolated(agent, 'test context'),
+      /zeroshot task run failed with code 1/
+    );
+    assertConfiguredModelArgs(capturedCommand);
+  });
+});
+
+describe('Nested ClaudeTaskRunner model arguments', function () {
+  it('preserves provider-level provenance locally and in Docker', async function () {
+    const runner = new ClaudeTaskRunner({ quiet: true, timeout: 20 });
+    const modelSpec = {
+      level: 'level2',
+      model: EXTERNAL_MODEL,
+      reasoningEffort: 'high',
+    };
+    const localArgs = runner._buildRunArgs({
+      context: 'test context',
+      providerName: 'opencode',
+      runOutputFormat: 'json',
+      resolvedModelSpec: modelSpec,
+      modelSpecSource: 'provider-level',
+      jsonSchema: null,
+    });
+    assertConfiguredModelArgs(localArgs);
+
+    let capturedCommand;
+    const result = await runner._runIsolated('test context', {
+      agentId: 'configured-runner-docker',
+      provider: 'opencode',
+      modelSpec,
+      modelSpecSource: 'provider-level',
+      outputFormat: 'json',
+      isolation: {
+        clusterId: 'test-cluster',
+        manager: {
+          spawnInContainer(_clusterId, command) {
+            capturedCommand = command;
+            return createClosingProcess();
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(result.success, false);
+    assertConfiguredModelArgs(capturedCommand);
+  });
+});
+
+describe('Nested task-lib model preparation', function () {
+  it('uses passed configured intent without Docker-local settings', async function () {
+    const { prepareTaskProviderCommand } = await import('../task-lib/runner.js');
+    const dockerSettingsFile = path.join(settingsDir, 'docker-settings.json');
+    fs.writeFileSync(dockerSettingsFile, JSON.stringify({ defaultProvider: 'opencode' }));
+    process.env.ZEROSHOT_SETTINGS_FILE = dockerSettingsFile;
+
+    try {
+      const prepared = prepareTaskProviderCommand('test context', {
+        provider: 'opencode',
+        modelLevel: 'level2',
+        configuredModel: EXTERNAL_MODEL,
+        reasoningEffort: 'high',
+      });
+      assert.deepStrictEqual(prepared.options.modelSpec, {
+        level: 'level2',
+        model: EXTERNAL_MODEL,
+        reasoningEffort: 'high',
+      });
+      assert.throws(
+        () =>
+          prepareTaskProviderCommand('test context', {
+            provider: 'opencode',
+            model: EXTERNAL_MODEL,
+          }),
+        { permanent: true }
+      );
+      assert.throws(
+        () =>
+          prepareTaskProviderCommand('test context', {
+            provider: 'opencode',
+            configuredModel: EXTERNAL_MODEL,
+          }),
+        /--configured-model requires --model-level/
+      );
+      assert.throws(
+        () =>
+          prepareTaskProviderCommand('test context', {
+            provider: 'opencode',
+            model: CATALOG_MODEL,
+            modelLevel: 'level2',
+            configuredModel: EXTERNAL_MODEL,
+          }),
+        /--model and --configured-model cannot be used together/
+      );
+    } finally {
+      process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+    }
+  });
+});

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -7,7 +7,11 @@ const { PassThrough } = require('stream');
 const AgentWrapper = require('../src/agent-wrapper');
 const ClaudeTaskRunner = require('../src/claude-task-runner');
 const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
-const { appendTaskRunModelArgs } = require('../src/task-run-model-args');
+const { loadSettings } = require('../lib/settings');
+const {
+  ISOLATED_PROVIDER_SETTINGS_ENV,
+  appendTaskRunModelArgs,
+} = require('../src/task-run-model-args');
 
 const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
 const CATALOG_MODEL = 'openai/gpt-5.2-codex';
@@ -20,10 +24,7 @@ function assertConfiguredModelArgs(args) {
     args.slice(args.indexOf('--model-level'), args.indexOf('--model-level') + 2),
     ['--model-level', 'level2']
   );
-  assert.deepStrictEqual(
-    args.slice(args.indexOf('--configured-model'), args.indexOf('--configured-model') + 2),
-    ['--configured-model', EXTERNAL_MODEL]
-  );
+  assert.strictEqual(args.includes('--configured-model'), false);
   assert.strictEqual(args.includes('--model'), false);
 }
 
@@ -124,6 +125,7 @@ describe('Nested task model argument encoding', function () {
 describe('Nested Docker agent model arguments', function () {
   it('preserves provider-level provenance in the spawned command', async function () {
     let capturedCommand;
+    let capturedOptions;
     const agent = {
       id: 'configured-docker',
       config: { outputFormat: 'json', strictSchema: true },
@@ -131,8 +133,9 @@ describe('Nested Docker agent model arguments', function () {
         enabled: true,
         clusterId: 'test-cluster',
         manager: {
-          spawnInContainer(_clusterId, command) {
+          spawnInContainer(_clusterId, command, options) {
             capturedCommand = command;
+            capturedOptions = options;
             return createClosingProcess();
           },
         },
@@ -154,6 +157,9 @@ describe('Nested Docker agent model arguments', function () {
       /zeroshot task run failed with code 1/
     );
     assertConfiguredModelArgs(capturedCommand);
+    assert.deepStrictEqual(JSON.parse(capturedOptions.env[ISOLATED_PROVIDER_SETTINGS_ENV]), {
+      opencode: loadSettings().providerSettings.opencode,
+    });
   });
 });
 
@@ -176,6 +182,7 @@ describe('Nested ClaudeTaskRunner model arguments', function () {
     assertConfiguredModelArgs(localArgs);
 
     let capturedCommand;
+    let capturedOptions;
     const result = await runner._runIsolated('test context', {
       agentId: 'configured-runner-docker',
       provider: 'opencode',
@@ -185,8 +192,9 @@ describe('Nested ClaudeTaskRunner model arguments', function () {
       isolation: {
         clusterId: 'test-cluster',
         manager: {
-          spawnInContainer(_clusterId, command) {
+          spawnInContainer(_clusterId, command, options) {
             capturedCommand = command;
+            capturedOptions = options;
             return createClosingProcess();
           },
         },
@@ -195,21 +203,19 @@ describe('Nested ClaudeTaskRunner model arguments', function () {
 
     assert.strictEqual(result.success, false);
     assertConfiguredModelArgs(capturedCommand);
+    assert.ok(capturedOptions.env[ISOLATED_PROVIDER_SETTINGS_ENV]);
   });
 });
 
 describe('Nested task-lib model preparation', function () {
-  it('uses passed configured intent without Docker-local settings', async function () {
+  it('derives configured intent from settings and rejects caller-supplied model provenance', async function () {
     const { prepareTaskProviderCommand } = await import('../task-lib/runner.js');
     const dockerSettingsFile = path.join(settingsDir, 'docker-settings.json');
-    fs.writeFileSync(dockerSettingsFile, JSON.stringify({ defaultProvider: 'opencode' }));
-    process.env.ZEROSHOT_SETTINGS_FILE = dockerSettingsFile;
 
     try {
       const prepared = prepareTaskProviderCommand('test context', {
         provider: 'opencode',
         modelLevel: 'level2',
-        configuredModel: EXTERNAL_MODEL,
         reasoningEffort: 'high',
       });
       assert.deepStrictEqual(prepared.options.modelSpec, {
@@ -217,6 +223,24 @@ describe('Nested task-lib model preparation', function () {
         model: EXTERNAL_MODEL,
         reasoningEffort: 'high',
       });
+
+      const snapshot = JSON.stringify({
+        opencode: {
+          defaultLevel: 'level2',
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL, reasoningEffort: 'high' },
+          },
+        },
+      });
+      fs.writeFileSync(dockerSettingsFile, JSON.stringify({ defaultProvider: 'opencode' }));
+      process.env.ZEROSHOT_SETTINGS_FILE = dockerSettingsFile;
+      process.env[ISOLATED_PROVIDER_SETTINGS_ENV] = snapshot;
+      const isolatedPrepared = prepareTaskProviderCommand('test context', {
+        provider: 'opencode',
+        modelLevel: 'level2',
+      });
+      assert.strictEqual(isolatedPrepared.options.modelSpec.model, EXTERNAL_MODEL);
+
       assert.throws(
         () =>
           prepareTaskProviderCommand('test context', {
@@ -229,21 +253,13 @@ describe('Nested task-lib model preparation', function () {
         () =>
           prepareTaskProviderCommand('test context', {
             provider: 'opencode',
-            configuredModel: EXTERNAL_MODEL,
-          }),
-        /--configured-model requires --model-level/
-      );
-      assert.throws(
-        () =>
-          prepareTaskProviderCommand('test context', {
-            provider: 'opencode',
-            model: CATALOG_MODEL,
             modelLevel: 'level2',
             configuredModel: EXTERNAL_MODEL,
           }),
-        /--model and --configured-model cannot be used together/
+        /--configured-model is not supported/
       );
     } finally {
+      delete process.env[ISOLATED_PROVIDER_SETTINGS_ENV];
       process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
     }
   });

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -7,11 +7,7 @@ const { PassThrough } = require('stream');
 const AgentWrapper = require('../src/agent-wrapper');
 const ClaudeTaskRunner = require('../src/claude-task-runner');
 const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
-const { loadSettings } = require('../lib/settings');
-const {
-  ISOLATED_PROVIDER_SETTINGS_ENV,
-  appendTaskRunModelArgs,
-} = require('../src/task-run-model-args');
+const { appendTaskRunModelArgs } = require('../src/task-run-model-args');
 
 const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
 const CATALOG_MODEL = 'openai/gpt-5.2-codex';
@@ -157,9 +153,16 @@ describe('Nested Docker agent model arguments', function () {
       /zeroshot task run failed with code 1/
     );
     assertConfiguredModelArgs(capturedCommand);
-    assert.deepStrictEqual(JSON.parse(capturedOptions.env[ISOLATED_PROVIDER_SETTINGS_ENV]), {
-      opencode: loadSettings().providerSettings.opencode,
+    assert.deepStrictEqual(JSON.parse(capturedCommand[3]), {
+      providerSettings: {
+        opencode: {
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL },
+          },
+        },
+      },
     });
+    assert.deepStrictEqual(capturedOptions.env, {});
   });
 });
 
@@ -186,8 +189,8 @@ describe('Nested ClaudeTaskRunner model arguments', function () {
     const result = await runner._runIsolated('test context', {
       agentId: 'configured-runner-docker',
       provider: 'opencode',
-      modelSpec,
-      modelSpecSource: 'provider-level',
+      modelLevel: 'level2',
+      reasoningEffort: 'high',
       outputFormat: 'json',
       isolation: {
         clusterId: 'test-cluster',
@@ -203,7 +206,16 @@ describe('Nested ClaudeTaskRunner model arguments', function () {
 
     assert.strictEqual(result.success, false);
     assertConfiguredModelArgs(capturedCommand);
-    assert.ok(capturedOptions.env[ISOLATED_PROVIDER_SETTINGS_ENV]);
+    assert.deepStrictEqual(JSON.parse(capturedCommand[3]), {
+      providerSettings: {
+        opencode: {
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL },
+          },
+        },
+      },
+    });
+    assert.deepStrictEqual(capturedOptions.env, {});
   });
 });
 
@@ -224,17 +236,20 @@ describe('Nested task-lib model preparation', function () {
         reasoningEffort: 'high',
       });
 
-      const snapshot = JSON.stringify({
-        opencode: {
-          defaultLevel: 'level2',
-          levelOverrides: {
-            level2: { model: EXTERNAL_MODEL, reasoningEffort: 'high' },
+      fs.writeFileSync(
+        dockerSettingsFile,
+        JSON.stringify({
+          defaultProvider: 'opencode',
+          providerSettings: {
+            opencode: {
+              levelOverrides: {
+                level2: { model: EXTERNAL_MODEL },
+              },
+            },
           },
-        },
-      });
-      fs.writeFileSync(dockerSettingsFile, JSON.stringify({ defaultProvider: 'opencode' }));
+        })
+      );
       process.env.ZEROSHOT_SETTINGS_FILE = dockerSettingsFile;
-      process.env[ISOLATED_PROVIDER_SETTINGS_ENV] = snapshot;
       const isolatedPrepared = prepareTaskProviderCommand('test context', {
         provider: 'opencode',
         modelLevel: 'level2',
@@ -259,7 +274,6 @@ describe('Nested task-lib model preparation', function () {
         /--configured-model is not supported/
       );
     } finally {
-      delete process.env[ISOLATED_PROVIDER_SETTINGS_ENV];
       process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
     }
   });

--- a/tests/opencode-nested-model-trust.test.js
+++ b/tests/opencode-nested-model-trust.test.js
@@ -5,11 +5,9 @@ const os = require('node:os');
 const path = require('node:path');
 const ClaudeTaskRunner = require('../src/claude-task-runner');
 const { loadSettings } = require('../lib/settings');
-const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
-const { ISOLATED_PROVIDER_SETTINGS_ENV } = require('../src/task-run-model-args');
+const { LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV } = require('../src/task-run-model-args');
 
 const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
-const MISMATCHED_MODEL = 'attacker/other-model';
 let settingsDir;
 let settingsFile;
 let previousSettingsFile;
@@ -32,20 +30,15 @@ function configuredSettings(model = EXTERNAL_MODEL) {
   };
 }
 
-function resolveRunnerProviderLevel(model) {
+function resolveRunnerProviderLevel() {
   const runner = new ClaudeTaskRunner({ quiet: true });
   const settings = loadSettings();
   const context = runner._getProviderContext('opencode', settings);
   return runner._resolveModelSpec({
-    explicitModelSpec: {
-      level: 'level2',
-      model,
-      reasoningEffort: 'high',
-    },
-    modelSpecSource: 'provider-level',
+    explicitModelSpec: null,
     model: null,
     reasoningEffort: null,
-    modelLevel: null,
+    modelLevel: 'level2',
     ...context,
   });
 }
@@ -67,31 +60,59 @@ after(function () {
 });
 
 afterEach(function () {
-  delete process.env[ISOLATED_PROVIDER_SETTINGS_ENV];
+  delete process.env[LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV];
 });
 
 describe('ClaudeTaskRunner provider-level model trust', function () {
-  it('accepts a model only when it matches the effective level override', function () {
+  it('resolves an ordinary configured selection without a source flag', function () {
     writeSettings(configuredSettings());
-    assert.strictEqual(resolveRunnerProviderLevel(EXTERNAL_MODEL).model, EXTERNAL_MODEL);
-
-    assert.throws(
-      () => resolveRunnerProviderLevel(MISMATCHED_MODEL),
-      /does not match the configured level2 model/
-    );
+    assert.strictEqual(resolveRunnerProviderLevel().model, EXTERNAL_MODEL);
   });
 
-  it('rejects claimed external models with empty or nonexistent settings', function () {
-    writeSettings({ defaultProvider: 'opencode' });
-    assert.throws(
-      () => resolveRunnerProviderLevel(EXTERNAL_MODEL),
-      /does not match the configured level2 model/
-    );
+  it('runs an ordinary configured external selection without caller provenance', async function () {
+    writeSettings(configuredSettings());
+    let capturedArgs;
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    runner._spawnAndGetTaskId = (_command, args) => {
+      capturedArgs = args;
+      return Promise.resolve('task-test');
+    };
+    runner._waitForTaskReady = () => Promise.resolve();
+    runner._followLogs = () => Promise.resolve({ success: true, output: 'ok', error: null });
 
-    fs.unlinkSync(settingsFile);
+    const result = await runner.run('configured task', {
+      provider: 'opencode',
+      modelLevel: 'level2',
+      reasoningEffort: 'high',
+      outputFormat: 'json',
+    });
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(
+      capturedArgs.slice(
+        capturedArgs.indexOf('--model-level'),
+        capturedArgs.indexOf('--model-level') + 2
+      ),
+      ['--model-level', 'level2']
+    );
+    assert.strictEqual(capturedArgs.includes('--model'), false);
+  });
+
+  it('rejects a concrete external model even when it equals the configured override', function () {
+    writeSettings(configuredSettings());
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    const settings = loadSettings();
+    const context = runner._getProviderContext('opencode', settings);
     assert.throws(
-      () => resolveRunnerProviderLevel(EXTERNAL_MODEL),
-      /does not match the configured level2 model/
+      () =>
+        runner._resolveModelSpec({
+          explicitModelSpec: { level: 'level2', model: EXTERNAL_MODEL },
+          model: null,
+          reasoningEffort: null,
+          modelLevel: null,
+          ...context,
+        }),
+      { permanent: true }
     );
   });
 });
@@ -124,7 +145,7 @@ describe('Child provider command trust boundary', function () {
     );
   });
 
-  it('keeps non-Opencode direct model validation strict', function () {
+  it('rejects the legacy overlay locally and keeps non-OpenCode models strict', function () {
     const { prepareSingleAgentProviderCommand } = require('../task-lib/provider-helper-runtime.js');
     assert.throws(
       () =>
@@ -136,7 +157,7 @@ describe('Child provider command trust boundary', function () {
       { permanent: true }
     );
 
-    process.env[ISOLATED_PROVIDER_SETTINGS_ENV] = JSON.stringify({
+    process.env[LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV] = JSON.stringify({
       codex: {
         defaultLevel: 'level2',
         levelOverrides: {
@@ -151,7 +172,7 @@ describe('Child provider command trust boundary', function () {
           context: 'configured context',
           options: { modelSpec: { level: 'level2' } },
         }),
-      { permanent: true }
+      /is not a trusted settings channel/
     );
   });
 
@@ -171,70 +192,5 @@ describe('Child provider command trust boundary', function () {
     );
     assert.notStrictEqual(result.status, 0);
     assert.match(result.stderr, /unknown option '--configured-model'/);
-  });
-});
-
-describe('Docker provider settings trust boundary', function () {
-  it('rejects an agent model that does not match the effective settings snapshot', async function () {
-    writeSettings({ defaultProvider: 'opencode' });
-    let spawnCount = 0;
-    const agent = {
-      id: 'mismatched-docker',
-      config: { outputFormat: 'json', strictSchema: true },
-      isolation: {
-        enabled: true,
-        clusterId: 'test-cluster',
-        manager: {
-          spawnInContainer() {
-            spawnCount += 1;
-            throw new Error('must not spawn');
-          },
-        },
-      },
-      _resolveProvider: () => 'opencode',
-      _resolveModelSpec: () => ({
-        level: 'level2',
-        model: EXTERNAL_MODEL,
-        reasoningEffort: 'high',
-      }),
-      _resolveModelSpecSource: () => 'provider-level',
-      _log() {},
-    };
-
-    await assert.rejects(
-      spawnClaudeTaskIsolated(agent, 'test context'),
-      /does not match the effective isolated level2 model/
-    );
-    assert.strictEqual(spawnCount, 0);
-  });
-
-  it('rejects ClaudeTaskRunner mismatches before spawning in Docker', async function () {
-    writeSettings(configuredSettings());
-    let spawnCount = 0;
-    const runner = new ClaudeTaskRunner({ quiet: true, timeout: 20 });
-
-    await assert.rejects(
-      runner._runIsolated('test context', {
-        provider: 'opencode',
-        modelSpec: {
-          level: 'level2',
-          model: MISMATCHED_MODEL,
-          reasoningEffort: 'high',
-        },
-        modelSpecSource: 'provider-level',
-        outputFormat: 'json',
-        isolation: {
-          clusterId: 'test-cluster',
-          manager: {
-            spawnInContainer() {
-              spawnCount += 1;
-              throw new Error('must not spawn');
-            },
-          },
-        },
-      }),
-      /does not match the effective isolated level2 model/
-    );
-    assert.strictEqual(spawnCount, 0);
   });
 });

--- a/tests/opencode-nested-model-trust.test.js
+++ b/tests/opencode-nested-model-trust.test.js
@@ -1,0 +1,240 @@
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const ClaudeTaskRunner = require('../src/claude-task-runner');
+const { loadSettings } = require('../lib/settings');
+const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
+const { ISOLATED_PROVIDER_SETTINGS_ENV } = require('../src/task-run-model-args');
+
+const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
+const MISMATCHED_MODEL = 'attacker/other-model';
+let settingsDir;
+let settingsFile;
+let previousSettingsFile;
+
+function writeSettings(value) {
+  fs.writeFileSync(settingsFile, JSON.stringify(value));
+}
+
+function configuredSettings(model = EXTERNAL_MODEL) {
+  return {
+    defaultProvider: 'opencode',
+    providerSettings: {
+      opencode: {
+        defaultLevel: 'level2',
+        levelOverrides: {
+          level2: { model, reasoningEffort: 'high' },
+        },
+      },
+    },
+  };
+}
+
+function resolveRunnerProviderLevel(model) {
+  const runner = new ClaudeTaskRunner({ quiet: true });
+  const settings = loadSettings();
+  const context = runner._getProviderContext('opencode', settings);
+  return runner._resolveModelSpec({
+    explicitModelSpec: {
+      level: 'level2',
+      model,
+      reasoningEffort: 'high',
+    },
+    modelSpecSource: 'provider-level',
+    model: null,
+    reasoningEffort: null,
+    modelLevel: null,
+    ...context,
+  });
+}
+
+before(function () {
+  settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-opencode-model-trust-'));
+  settingsFile = path.join(settingsDir, 'settings.json');
+  previousSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+  process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+});
+
+after(function () {
+  if (previousSettingsFile === undefined) {
+    delete process.env.ZEROSHOT_SETTINGS_FILE;
+  } else {
+    process.env.ZEROSHOT_SETTINGS_FILE = previousSettingsFile;
+  }
+  fs.rmSync(settingsDir, { recursive: true, force: true });
+});
+
+afterEach(function () {
+  delete process.env[ISOLATED_PROVIDER_SETTINGS_ENV];
+});
+
+describe('ClaudeTaskRunner provider-level model trust', function () {
+  it('accepts a model only when it matches the effective level override', function () {
+    writeSettings(configuredSettings());
+    assert.strictEqual(resolveRunnerProviderLevel(EXTERNAL_MODEL).model, EXTERNAL_MODEL);
+
+    assert.throws(
+      () => resolveRunnerProviderLevel(MISMATCHED_MODEL),
+      /does not match the configured level2 model/
+    );
+  });
+
+  it('rejects claimed external models with empty or nonexistent settings', function () {
+    writeSettings({ defaultProvider: 'opencode' });
+    assert.throws(
+      () => resolveRunnerProviderLevel(EXTERNAL_MODEL),
+      /does not match the configured level2 model/
+    );
+
+    fs.unlinkSync(settingsFile);
+    assert.throws(
+      () => resolveRunnerProviderLevel(EXTERNAL_MODEL),
+      /does not match the configured level2 model/
+    );
+  });
+});
+
+describe('Child provider command trust boundary', function () {
+  it('rejects caller-supplied provenance and keeps direct models strict', function () {
+    writeSettings(configuredSettings());
+    const { prepareSingleAgentProviderCommand } = require('../task-lib/provider-helper-runtime.js');
+
+    assert.throws(
+      () =>
+        prepareSingleAgentProviderCommand({
+          provider: 'opencode',
+          context: 'attacker context',
+          modelSpecSource: 'provider-level',
+          options: {
+            modelSpec: { level: 'level2', model: EXTERNAL_MODEL },
+          },
+        }),
+      /modelSpecSource is not accepted/
+    );
+    assert.throws(
+      () =>
+        prepareSingleAgentProviderCommand({
+          provider: 'opencode',
+          context: 'direct context',
+          options: { modelSpec: { model: EXTERNAL_MODEL } },
+        }),
+      { permanent: true }
+    );
+  });
+
+  it('keeps non-Opencode direct model validation strict', function () {
+    const { prepareSingleAgentProviderCommand } = require('../task-lib/provider-helper-runtime.js');
+    assert.throws(
+      () =>
+        prepareSingleAgentProviderCommand({
+          provider: 'codex',
+          context: 'direct context',
+          options: { modelSpec: { model: 'attacker/external-model' } },
+        }),
+      { permanent: true }
+    );
+
+    process.env[ISOLATED_PROVIDER_SETTINGS_ENV] = JSON.stringify({
+      codex: {
+        defaultLevel: 'level2',
+        levelOverrides: {
+          level2: { model: 'attacker/external-model' },
+        },
+      },
+    });
+    assert.throws(
+      () =>
+        prepareSingleAgentProviderCommand({
+          provider: 'codex',
+          context: 'configured context',
+          options: { modelSpec: { level: 'level2' } },
+        }),
+      { permanent: true }
+    );
+  });
+
+  it('does not expose the removed configured-model CLI option', function () {
+    writeSettings({ autoCheckUpdates: false });
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [
+        path.join(__dirname, '..', 'cli', 'index.js'),
+        'task',
+        'run',
+        'test',
+        '--configured-model',
+        EXTERNAL_MODEL,
+      ],
+      { encoding: 'utf8', env: { ...process.env, CI: 'true' } }
+    );
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /unknown option '--configured-model'/);
+  });
+});
+
+describe('Docker provider settings trust boundary', function () {
+  it('rejects an agent model that does not match the effective settings snapshot', async function () {
+    writeSettings({ defaultProvider: 'opencode' });
+    let spawnCount = 0;
+    const agent = {
+      id: 'mismatched-docker',
+      config: { outputFormat: 'json', strictSchema: true },
+      isolation: {
+        enabled: true,
+        clusterId: 'test-cluster',
+        manager: {
+          spawnInContainer() {
+            spawnCount += 1;
+            throw new Error('must not spawn');
+          },
+        },
+      },
+      _resolveProvider: () => 'opencode',
+      _resolveModelSpec: () => ({
+        level: 'level2',
+        model: EXTERNAL_MODEL,
+        reasoningEffort: 'high',
+      }),
+      _resolveModelSpecSource: () => 'provider-level',
+      _log() {},
+    };
+
+    await assert.rejects(
+      spawnClaudeTaskIsolated(agent, 'test context'),
+      /does not match the effective isolated level2 model/
+    );
+    assert.strictEqual(spawnCount, 0);
+  });
+
+  it('rejects ClaudeTaskRunner mismatches before spawning in Docker', async function () {
+    writeSettings(configuredSettings());
+    let spawnCount = 0;
+    const runner = new ClaudeTaskRunner({ quiet: true, timeout: 20 });
+
+    await assert.rejects(
+      runner._runIsolated('test context', {
+        provider: 'opencode',
+        modelSpec: {
+          level: 'level2',
+          model: MISMATCHED_MODEL,
+          reasoningEffort: 'high',
+        },
+        modelSpecSource: 'provider-level',
+        outputFormat: 'json',
+        isolation: {
+          clusterId: 'test-cluster',
+          manager: {
+            spawnInContainer() {
+              spawnCount += 1;
+              throw new Error('must not spawn');
+            },
+          },
+        },
+      }),
+      /does not match the effective isolated level2 model/
+    );
+    assert.strictEqual(spawnCount, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- allow non-catalog OpenCode model IDs only when configured through `providerSettings.opencode.levelOverrides`
- reject malformed configured IDs before provider command construction with permanent model errors
- preserve strict direct/catalog validation and document the configuration path
- add runtime/helper parity coverage for OpenCode defaults and configured external IDs

## Validation

- `npm run check`
- `npm test` (1705 passing, 18 pending)
- `opcore check --changed --json`
- focused provider/config/task-runner suites

Fixes #390