### PR TITLE
feat: reuse provider sessions per agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Gateway tools/policy         | `src/agent-cli-provider/gateway-tools.ts`                               |
 | Provider detection           | `lib/provider-detection.js`                                             |
 | Provider capabilities        | `src/providers/capabilities.js`                                         |
+| Provider session reuse       | `src/agent/provider-session.js`                                         |
 | Start-cluster helper         | `lib/start-cluster.js`                                                  |
 | Legacy worker facade         | `lib/cluster-worker/`                                                   |
 | Legacy worker executable     | `bin/zeroshot-cluster-worker.js`                                        |
@@ -331,6 +332,12 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 Provider task ownership: task watchers persist an owned termination boundary with each active task.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
+
+Provider session reuse is explicit-ID and agent-owned. Watchers may capture provider session IDs,
+but only the same logical `AgentWrapper` may resume them. Persist this state in that agent's
+`agentStates` entry, never select a cwd-wide "latest" session, never share across agents, and start
+fresh when provider capability, identity, task completion, or durable isolation semantics do not
+prove reuse is safe.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,11 +333,15 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
 
-Provider session reuse is explicit-ID and agent-owned. Watchers may capture provider session IDs,
-but only the same logical `AgentWrapper` may resume them. Persist this state in that agent's
-`agentStates` entry, never select a cwd-wide "latest" session, never share across agents, and start
-fresh when provider capability, identity, task completion, or durable isolation semantics do not
-prove reuse is safe.
+Provider session reuse is explicit-ID and agent-owned. Watcher-observed IDs are distinct from
+requested resume IDs. Commit continuation only after logical/structured success and bind it to the
+completed task, agent, generation, provider, cwd, and worktree. A resumed turn sends only new
+trigger/guidance context; it never replays static prompts or ISSUE_OPENED/PLAN_READY packs already in
+the provider session. Persist continuation in that agent's `agentStates` entry, never in native
+`ClusterLedger`, never select a cwd-wide "latest" session, and never share across agents. Durable
+restore fails closed unless the last lifecycle boundary is the exact matching `TASK_COMPLETED`;
+live, failed, retry/backoff, provider-switch, unsupported, Docker, and workspace-drift states start
+fresh.
 
 ### Guidance Messaging
 

--- a/cli/commands/inspect.js
+++ b/cli/commands/inspect.js
@@ -140,6 +140,7 @@ function buildTaskSummary(task, details) {
     error: task.error || null,
     cwd: task.cwd || null,
     sessionId: task.sessionId || null,
+    requestedResumeSessionId: task.requestedResumeSessionId || null,
     attachable: Boolean(task.attachable),
     socketPath: details.socketPath.path,
     socketPathExists: details.socketPath.exists,

--- a/cli/index.js
+++ b/cli/index.js
@@ -2837,7 +2837,7 @@ taskCmd
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
   .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
-  .option('-r, --resume <sessionId>', 'Resume a specific Claude session (claude only)')
+  .option('-r, --resume <sessionId>', 'Resume a specific provider session (Claude or Codex)')
   .option('-c, --continue', 'Continue the most recent Claude session (claude only)')
   .option(
     '-o, --output-format <format>',

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -1,4 +1,4 @@
-import { stringifyJson } from '../json';
+import { getString, isRecord, stringifyJson, tryParseJson } from '../json';
 import {
   type BuildProviderCommandOptions,
   type ClaudeCliFeatures,
@@ -65,6 +65,7 @@ function detectCliFeatures(helpText?: string | null): ClaudeCliFeatures {
     supportsVerbose: unknown ? true : /--verbose/.test(help),
     supportsModel: unknown ? true : /--model/.test(help),
     supportsEffort: unknown ? true : /--effort/.test(help),
+    supportsResume: unknown ? true : /--resume/.test(help),
     unknown,
   };
 }
@@ -114,13 +115,21 @@ function addAutoApproveArgs(args: string[], options: BuildProviderCommandOptions
 }
 
 function addSessionArgs(args: string[], options: BuildProviderCommandOptions): void {
-  if (options.resumeSessionId) {
+  const features = optionFeatures(options);
+  if (options.resumeSessionId && features.supportsResume !== false) {
     args.push('--resume', options.resumeSessionId);
     return;
   }
-  if (options.continueSession) {
+  if (options.continueSession && features.supportsResume !== false) {
     args.push('--continue');
   }
+}
+
+function extractSessionId(line: string): string | null {
+  const event = tryParseJson(line.trim());
+  if (!isRecord(event)) return null;
+  const sessionId = getString(event, 'session_id');
+  return sessionId?.trim() || null;
 }
 
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
@@ -163,6 +172,18 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
         'claude',
         'claude-reasoning',
         'Claude CLI does not support --effort; skipping reasoningEffort.'
+      )
+    );
+  }
+  if (
+    (options.resumeSessionId || options.continueSession) &&
+    features.supportsResume === false
+  ) {
+    warnings.push(
+      warning(
+        'claude',
+        'claude-session-resume-unsupported',
+        'Claude CLI does not support session resume; starting a fresh session.'
       )
     );
   }
@@ -227,6 +248,7 @@ export const claudeAdapter: ProviderAdapter = {
   defaultMinLevel: 'level1',
   detectCliFeatures,
   buildCommand,
+  extractSessionId,
   parseEvent: parseClaudeEvent,
   createParserState: () => createParserState('claude'),
   resolveModelSpec,

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -1,3 +1,4 @@
+import { getString, isRecord, tryParseJson } from '../json';
 import { appendJsonSchemaPrompt, writeStrictOutputSchemaFile } from '../schema';
 import {
   type BuildProviderCommandOptions,
@@ -18,7 +19,6 @@ import {
   createParserState,
   optionFeatures,
   resolveModelSpecWithConfig,
-  unsupportedSessionControlWarnings,
   validateModelIdFromCatalog,
   warning,
 } from './common';
@@ -55,8 +55,16 @@ function detectCliFeatures(helpText?: string | null): CodexCliFeatures {
     supportsConfigOverride: supports(help, /--config\b/),
     supportsModel: supports(help, /\s-m\b/) || supports(help, /--model\b/),
     supportsSkipGitRepoCheck: supports(help, /--skip-git-repo-check\b/),
+    supportsResume: supports(help, /\bresume\b/),
     unknown,
   };
+}
+
+function extractSessionId(line: string): string | null {
+  const event = tryParseJson(line.trim());
+  if (!isRecord(event) || getString(event, 'type') !== 'thread.started') return null;
+  const sessionId = getString(event, 'thread_id');
+  return sessionId?.trim() || null;
 }
 
 function addOutputArgs(args: string[], options: BuildProviderCommandOptions): void {
@@ -118,7 +126,25 @@ function applySchemaArgs(
 
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
-  const warnings: WarningMetadata[] = unsupportedSessionControlWarnings('codex', options);
+  const warnings: WarningMetadata[] = [];
+  if (options.continueSession) {
+    warnings.push(
+      warning(
+        'codex',
+        'unsupported-session-control',
+        'Codex requires an explicit session ID; ignoring continueSession.'
+      )
+    );
+  }
+  if (options.resumeSessionId && features.supportsResume === false) {
+    warnings.push(
+      warning(
+        'codex',
+        'codex-session-resume-unsupported',
+        'Codex CLI does not support exec resume; starting a fresh session.'
+      )
+    );
+  }
   if (options.autoApprove && features.supportsAutoApprove === false) {
     warnings.push(
       warning(
@@ -152,14 +178,26 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
   const args: string[] = ['exec'];
   const cleanup: string[] = [];
+  const resumeSessionId =
+    options.resumeSessionId && optionFeatures(options).supportsResume !== false
+      ? options.resumeSessionId
+      : null;
+  if (resumeSessionId) {
+    args.push('resume');
+  }
 
   addOutputArgs(args, options);
   addModelArgs(args, options);
-  addCwdArgs(args, options);
+  if (!resumeSessionId) {
+    addCwdArgs(args, options);
+  }
   addAutoApproveArgs(args, options);
   addSkipGitArgs(args, options);
   const finalContext = applySchemaArgs(args, cleanup, context, options);
 
+  if (resumeSessionId) {
+    args.push(resumeSessionId);
+  }
   args.push(finalContext);
 
   return commandSpec({
@@ -213,6 +251,7 @@ export const codexAdapter: ProviderAdapter = {
   defaultMinLevel: 'level1',
   detectCliFeatures,
   buildCommand,
+  extractSessionId,
   parseEvent: parseCodexEvent,
   createParserState: () => createParserState('codex'),
   resolveModelSpec,

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -64,7 +64,7 @@ export function unsupportedSessionControlWarnings(
     warning(
       provider,
       'unsupported-session-control',
-      'resume/continue is only supported for Claude CLI; ignoring.'
+      `Provider ${provider} does not support resume/continue session control; ignoring.`
     ),
   ];
 }

--- a/src/agent-cli-provider/adapters/index.ts
+++ b/src/agent-cli-provider/adapters/index.ts
@@ -79,6 +79,16 @@ export function parseProviderChunk(
   return events;
 }
 
+export function extractProviderSessionId(
+  providerName: KnownProviderName | string,
+  line: string
+): string | null {
+  const adapter = getProviderAdapter(providerName || 'claude');
+  const content = stripTimestampPrefix(line);
+  if (!content || !adapter.extractSessionId) return null;
+  return adapter.extractSessionId(content);
+}
+
 export function resolveModelSpec(
   providerName: KnownProviderName | string,
   level: ModelLevel,

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -42,6 +42,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsNoAskUser',
   'supportsAddDir',
   'supportsMcpConfig',
+  'supportsResume',
   'supportsBundledRunner',
   'supportsAcpStdio',
   'supportsPromptImages',

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -3,6 +3,7 @@ export {
   classifyProviderError,
   detectProviderFatalError,
   detectProviderStreamingModeError,
+  extractProviderSessionId,
   getProviderAdapter,
   listProviderAdapters,
   parseProviderChunk,

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -19,6 +19,7 @@ export interface ProviderCapabilities {
   readonly streamJson: ProviderCapabilityState;
   readonly thinkingMode: ProviderCapabilityState;
   readonly reasoningEffort: ProviderCapabilityState;
+  readonly sessionResume: ProviderCapabilityState;
 }
 
 interface FixedProviderCommandSpec {
@@ -93,13 +94,22 @@ export interface ProviderRegistryEntry {
 }
 
 const STANDARD_CAPABILITIES: Readonly<
-  Pick<ProviderCapabilities, 'dockerIsolation' | 'worktreeIsolation' | 'mcpServers' | 'streamJson' | 'thinkingMode'>
+  Pick<
+    ProviderCapabilities,
+    | 'dockerIsolation'
+    | 'worktreeIsolation'
+    | 'mcpServers'
+    | 'streamJson'
+    | 'thinkingMode'
+    | 'sessionResume'
+  >
 > = {
   dockerIsolation: true,
   worktreeIsolation: true,
   mcpServers: true,
   streamJson: true,
   thinkingMode: true,
+  sessionResume: false,
 };
 
 const CLAUDE_DOCKER_ENV_PASSTHROUGH = [
@@ -161,6 +171,7 @@ export const providerRegistry = [
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
       reasoningEffort: true,
+      sessionResume: true,
     },
     docs: {
       label: 'Claude',
@@ -197,6 +208,7 @@ export const providerRegistry = [
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
       reasoningEffort: true,
+      sessionResume: true,
     },
     docs: {
       label: 'Codex',

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -96,6 +96,7 @@ export interface ClaudeCliFeatures extends BaseCliFeatures {
   readonly supportsVerbose: boolean;
   readonly supportsModel: boolean;
   readonly supportsEffort: boolean;
+  readonly supportsResume: boolean;
 }
 
 export interface CodexCliFeatures extends BaseCliFeatures {
@@ -107,6 +108,7 @@ export interface CodexCliFeatures extends BaseCliFeatures {
   readonly supportsConfigOverride: boolean;
   readonly supportsModel: boolean;
   readonly supportsSkipGitRepoCheck: boolean;
+  readonly supportsResume: boolean;
 }
 
 export interface GeminiCliFeatures extends BaseCliFeatures {
@@ -207,6 +209,7 @@ export interface CliFeatureOverrides {
   readonly supportsNoAskUser?: boolean;
   readonly supportsAddDir?: boolean;
   readonly supportsMcpConfig?: boolean;
+  readonly supportsResume?: boolean;
   readonly supportsBundledRunner?: boolean;
   readonly supportsAcpStdio?: boolean;
   readonly supportsPromptImages?: boolean;
@@ -363,6 +366,7 @@ export interface ProviderAdapter {
   readonly defaultMinLevel: ModelLevel;
   detectCliFeatures(helpText?: string | null): ProviderCliFeatures;
   buildCommand(context: string, options?: BuildProviderCommandOptions): CommandSpec;
+  extractSessionId?(line: string): string | null;
   parseEvent(line: string, state: ProviderParserState): ProviderParseResult;
   createParserState(): ProviderParserState;
   resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec;

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -66,6 +66,8 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
+    /** @type {{provider: string, sessionId: string} | null} */
+    this.providerSession = null; // Provider continuation state, owned by this logical agent only
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
     this.running = false;

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -17,6 +17,7 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { buildContext } = require('./agent/agent-context-builder');
 const { collectQueuedGuidance } = require('./agent/guidance-queue');
+const { resolveAgentResumeSessionId } = require('./agent/provider-session');
 const { findMatchingTrigger, evaluateTrigger } = require('./agent/agent-trigger-evaluator');
 const { executeHook } = require('./agent/agent-hook-executor');
 const { injectInput: injectAgentInput } = require('./agent/agent-input-injector');
@@ -66,7 +67,7 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
-    /** @type {{provider: string, sessionId: string} | null} */
+    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null} | null} */
     this.providerSession = null; // Provider continuation state, owned by this logical agent only
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
@@ -425,6 +426,8 @@ class AgentWrapper {
    */
   _buildContext(triggeringMessage) {
     const previousAgentStart = this.lastAgentStartTime;
+    const providerName = this._resolveProvider();
+    const contextMode = resolveAgentResumeSessionId(this, providerName) ? 'continuation' : 'full';
     const queuedGuidance = collectQueuedGuidance({
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
@@ -443,6 +446,7 @@ class AgentWrapper {
       triggeringMessage,
       selectedPrompt: this._selectPrompt(),
       queuedGuidance: queuedGuidance.guidanceBlock,
+      mode: contextMode,
       // Pass isolation state for conditional git restriction
       worktree: this.worktree,
       isolation: this.isolation,

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -138,6 +138,74 @@ function buildPacks(params) {
   return packs;
 }
 
+function buildContinuationPacks(params) {
+  const {
+    id,
+    iteration,
+    config,
+    selectedPrompt,
+    queuedGuidance,
+    triggeringMessage,
+    strategy,
+    messageBus,
+    cluster,
+    lastTaskEndTime,
+    lastAgentStartTime,
+  } = params;
+  const packs = [];
+  let order = 0;
+
+  order = pushStaticPack({
+    packs,
+    packId: 'continuationHeader',
+    section: 'continuationHeader',
+    text: `## Continuation Turn\n\nAgent: ${id}\nIteration: ${iteration}\n\nApply only the new material below while retaining the existing session instructions.\n\n`,
+    order,
+  });
+
+  // Iteration-rule prompts may intentionally change between turns. Static prompts,
+  // repository tooling, ISSUE_OPENED/PLAN_READY sources, and output contracts are
+  // already present in the provider session and must not be replayed.
+  if (config.promptConfig?.type === 'rules') {
+    order = pushStaticPack({
+      packs,
+      packId: 'iterationInstructions',
+      section: 'iterationInstructions',
+      text: buildInstructionsSection({ config, selectedPrompt, id }),
+      order,
+    });
+  }
+
+  order = pushStaticPack({
+    packs,
+    packId: 'queuedGuidance',
+    section: 'queuedGuidance',
+    text: queuedGuidance || '',
+    order,
+  });
+  order = appendSourcePacks(
+    packs,
+    {
+      sources: (strategy.sources || []).map((source) => ({
+        ...source,
+        since: 'last_agent_start',
+      })),
+    },
+    { messageBus, cluster, lastTaskEndTime, lastAgentStartTime },
+    order
+  );
+  pushStaticPack({
+    packs,
+    packId: 'triggeringMessage',
+    section: 'triggeringMessage',
+    text: buildTriggeringMessageSection(triggeringMessage),
+    order,
+    options: { preserve: true },
+  });
+
+  return packs;
+}
+
 /**
  * Build execution context for an agent
  * @param {object} params - Context building parameters
@@ -157,7 +225,10 @@ function buildPacks(params) {
  */
 function buildContext(params) {
   const strategy = params.config.contextStrategy || { sources: [] };
-  const packs = buildPacks({ ...params, strategy });
+  const continuation = params.mode === 'continuation';
+  const packs = continuation
+    ? buildContinuationPacks({ ...params, strategy })
+    : buildPacks({ ...params, strategy });
   const maxTokens = resolveLegacyMaxTokens(strategy);
   const packResult = buildContextPacks({
     packs,
@@ -171,7 +242,7 @@ function buildContext(params) {
     role: params.role,
     iteration: params.iteration,
     triggeringMessage: params.triggeringMessage,
-    strategy,
+    strategy: { ...strategy, contextMode: continuation ? 'continuation' : 'full' },
     packs: packResult.packDecisions,
     budget: packResult.budget,
     truncation: packResult.truncation,

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -442,6 +442,7 @@ function publishTaskCompleted(agent, result) {
     iteration: agent.iteration,
     success: true,
     taskId: agent.currentTaskId,
+    provider: agent._resolveProvider ? agent._resolveProvider() : 'claude',
     tokenUsage: result.tokenUsage || null,
   });
 }
@@ -574,11 +575,11 @@ async function runTaskAttempt(agent, triggeringMessage) {
     updateAgentProviderSession(agent, null);
     throw error;
   }
-  updateAgentProviderSession(agent, result.providerSession);
   attachResultMetadata(agent, result);
 
   // Check if task execution failed
   if (!result.success) {
+    updateAgentProviderSession(agent, null);
     const error = new Error(result.error || 'Task execution failed');
     error.code = result.code || result.errorType || null;
     error.taskId = result.taskId || null;
@@ -592,6 +593,10 @@ async function runTaskAttempt(agent, triggeringMessage) {
       `Validator platform mismatch detected (${fallbackReason}). Retrying in Docker isolation.`
     );
   }
+
+  // Commit continuation state only after provider completion, structured-output
+  // classification, and platform fallback checks all agree this logical turn succeeded.
+  updateAgentProviderSession(agent, result.providerSession);
 
   // Set state to idle BEFORE publishing lifecycle event
   // (so lifecycle message includes correct state)
@@ -981,6 +986,9 @@ async function executeTask(agent, triggeringMessage) {
       await runTaskAttempt(agent, triggeringMessage);
       return;
     } catch (error) {
+      // Any failed logical attempt invalidates continuation before TASK_FAILED is
+      // published and persisted. Retries must reconstruct a fresh full context.
+      updateAgentProviderSession(agent, null);
       if (!agent.running || agent.state === 'stopped') {
         agent._log(`[${agent.id}] Task interrupted during shutdown; skipping retry`);
         return;

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -22,6 +22,7 @@ const { normalizeProviderName } = require('../../lib/provider-names');
 const { loadSettings } = require('../../lib/settings');
 const { findPlatformMismatchReason } = require('./validation-platform');
 const { calculateRateLimitDelay, isRateLimitError } = require('./rate-limit-backoff');
+const { updateAgentProviderSession } = require('./provider-session');
 
 const DEFAULT_VALIDATOR_IMAGE = 'zeroshot-cluster-base';
 
@@ -566,7 +567,14 @@ async function runTaskAttempt(agent, triggeringMessage) {
   await applyValidatorJitter(agent);
   publishTaskStarted(agent, triggeringMessage);
 
-  const result = await agent._spawnClaudeTask(context);
+  let result;
+  try {
+    result = await agent._spawnClaudeTask(context);
+  } catch (error) {
+    updateAgentProviderSession(agent, null);
+    throw error;
+  }
+  updateAgentProviderSession(agent, result.providerSession);
   attachResultMetadata(agent, result);
 
   // Check if task execution failed
@@ -579,6 +587,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
 
   const fallbackReason = await maybeRetryValidatorInDocker(agent, result);
   if (fallbackReason) {
+    updateAgentProviderSession(agent, null);
     throw new Error(
       `Validator platform mismatch detected (${fallbackReason}). Retrying in Docker isolation.`
     );

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1217,7 +1217,15 @@ function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
   });
 }
 
-async function buildCompletionResult({ agent, taskId, providerName, state, stdout, success }) {
+async function buildCompletionResult({
+  agent,
+  taskId,
+  providerName,
+  state,
+  stdout,
+  success,
+  taskInfo = getTask(taskId),
+}) {
   const classified = await evaluateStructuredSuccess({ agent, taskId, state, success });
   let errorContext = classified.error;
   if (!errorContext && !classified.success) {
@@ -1232,7 +1240,8 @@ async function buildCompletionResult({ agent, taskId, providerName, state, stdou
     providerSession: providerSessionFromCompletedTask({
       agent,
       providerName,
-      taskInfo: getTask(taskId),
+      taskInfo,
+      logicalSuccess: classified.success,
     }),
   };
 }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -24,6 +24,10 @@ const {
   resolveRepoMcpConfigPath,
 } = require('../worktree-claude-config.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
+const {
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+} = require('./provider-session');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -750,6 +754,11 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
     args.push(mcpArg);
   }
 
+  const resumeSessionId = resolveAgentResumeSessionId(agent, providerName);
+  if (resumeSessionId) {
+    args.push('--resume', resumeSessionId);
+  }
+
   return args;
 }
 
@@ -1220,6 +1229,11 @@ async function buildCompletionResult({ agent, taskId, providerName, state, stdou
     output: state.output,
     error: errorContext,
     tokenUsage: extractTokenUsage(state.output, providerName),
+    providerSession: providerSessionFromCompletedTask({
+      agent,
+      providerName,
+      taskInfo: getTask(taskId),
+    }),
   };
 }
 
@@ -2366,5 +2380,6 @@ module.exports = {
   broadcastIsolatedLine,
   parseResultOutput,
   buildCompletionResult,
+  buildTaskRunArgs,
   killTask,
 };

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -1,7 +1,23 @@
+const path = require('path');
+
 const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
 
-function normalizeSessionId(value) {
+const DURABLE_SESSION_BOUNDARY_EVENTS = new Set([
+  'TASK_STARTED',
+  'TASK_COMPLETED',
+  'TASK_FAILED',
+  'RETRY_SCHEDULED',
+  'AGENT_RESTART_ATTEMPT',
+]);
+const RESTORABLE_AGENT_STATES = new Set(['idle', 'stopped', 'completed']);
+
+function normalizeNonEmptyString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeAbsolutePath(value) {
+  const normalized = normalizeNonEmptyString(value);
+  return normalized ? path.resolve(normalized) : null;
 }
 
 function supportsSessionResume(providerName) {
@@ -16,33 +32,87 @@ function normalizeProviderSession(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null;
   }
+
   const provider = normalizeProviderName(value.provider);
-  const sessionId = normalizeSessionId(value.sessionId);
-  if (!provider || !sessionId || !supportsSessionResume(provider)) {
+  const sessionId = normalizeNonEmptyString(value.sessionId);
+  const agentId = normalizeNonEmptyString(value.agentId);
+  const taskId = normalizeNonEmptyString(value.taskId);
+  const generation = value.generation;
+  const cwd = normalizeAbsolutePath(value.cwd);
+  const worktreePath =
+    value.worktreePath === null ? null : normalizeAbsolutePath(value.worktreePath);
+
+  if (
+    !provider ||
+    !sessionId ||
+    !agentId ||
+    !taskId ||
+    !Number.isInteger(generation) ||
+    generation < 1 ||
+    !cwd ||
+    !Object.hasOwn(value, 'worktreePath') ||
+    (value.worktreePath !== null && !worktreePath) ||
+    !supportsSessionResume(provider)
+  ) {
     return null;
   }
-  return { provider, sessionId };
+
+  return {
+    provider,
+    sessionId,
+    agentId,
+    taskId,
+    generation,
+    cwd,
+    worktreePath,
+  };
+}
+
+function agentWorkspaceProvenance(agent) {
+  const worktreePath = agent?.worktree?.enabled ? normalizeAbsolutePath(agent.worktree.path) : null;
+  const cwd = normalizeAbsolutePath(agent?.config?.cwd || worktreePath || process.cwd());
+  return { cwd, worktreePath };
 }
 
 function agentCanReuseSession(agent, providerName) {
   return !agent?.isolation?.enabled && supportsSessionResume(providerName);
 }
 
-function resolveAgentResumeSessionId(agent, providerName) {
+function sessionMatchesAgent(session, agent, providerName, expectedGeneration) {
   const provider = normalizeProviderName(providerName);
+  const workspace = agentWorkspaceProvenance(agent);
+  return (
+    agentCanReuseSession(agent, provider) &&
+    session.provider === provider &&
+    session.agentId === agent?.id &&
+    session.generation === expectedGeneration &&
+    session.cwd === workspace.cwd &&
+    session.worktreePath === workspace.worktreePath
+  );
+}
+
+function resolveAgentResumeSessionId(agent, providerName) {
   const stored = normalizeProviderSession(agent?.providerSession);
-  if (!agentCanReuseSession(agent, provider) || !stored || stored.provider !== provider) {
-    if (agent && stored) {
+  const expectedGeneration = Number.isInteger(agent?.iteration) ? agent.iteration - 1 : -1;
+
+  if (!stored || !sessionMatchesAgent(stored, agent, providerName, expectedGeneration)) {
+    if (agent) {
       agent.providerSession = null;
     }
     return null;
   }
+
   return stored.sessionId;
 }
 
-function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
+function providerSessionFromCompletedTask({
+  agent,
+  providerName,
+  taskInfo,
+  logicalSuccess = true,
+}) {
   const provider = normalizeProviderName(providerName);
-  if (!agentCanReuseSession(agent, provider)) {
+  if (!logicalSuccess || !agentCanReuseSession(agent, provider)) {
     return null;
   }
   if (!taskInfo || taskInfo.status !== 'completed') {
@@ -51,8 +121,20 @@ function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
   if (normalizeProviderName(taskInfo.provider) !== provider) {
     return null;
   }
-  const sessionId = normalizeSessionId(taskInfo.sessionId);
-  return sessionId ? { provider, sessionId } : null;
+
+  const sessionId = normalizeNonEmptyString(taskInfo.sessionId);
+  const taskId = normalizeNonEmptyString(taskInfo.id);
+  const generation = agent?.iteration;
+  const agentId = normalizeNonEmptyString(agent?.id);
+  const workspace = agentWorkspaceProvenance(agent);
+  return normalizeProviderSession({
+    provider,
+    sessionId,
+    agentId,
+    taskId,
+    generation,
+    ...workspace,
+  });
 }
 
 function updateAgentProviderSession(agent, value) {
@@ -61,10 +143,46 @@ function updateAgentProviderSession(agent, value) {
   return session;
 }
 
+function readLastDurableSessionBoundary(messageBus, clusterId, agentId) {
+  const lifecycle = messageBus.query({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agentId,
+  });
+  return lifecycle
+    .filter((message) => DURABLE_SESSION_BOUNDARY_EVENTS.has(message.content?.data?.event))
+    .at(-1);
+}
+
+function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId }) {
+  const session = normalizeProviderSession(savedState?.providerSession);
+  if (!session || !RESTORABLE_AGENT_STATES.has(savedState?.state || 'idle')) {
+    return null;
+  }
+  if (!sessionMatchesAgent(session, agent, session.provider, savedState.iteration)) {
+    return null;
+  }
+
+  const boundary = readLastDurableSessionBoundary(messageBus, clusterId, agent.id);
+  const data = boundary?.content?.data;
+  if (
+    data?.event !== 'TASK_COMPLETED' ||
+    data.taskId !== session.taskId ||
+    data.iteration !== session.generation ||
+    normalizeProviderName(data.provider) !== session.provider
+  ) {
+    return null;
+  }
+
+  return session;
+}
+
 module.exports = {
+  agentWorkspaceProvenance,
   normalizeProviderSession,
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
+  restoreAgentProviderSession,
   supportsSessionResume,
   updateAgentProviderSession,
 };

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -1,0 +1,70 @@
+const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
+
+function normalizeSessionId(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function supportsSessionResume(providerName) {
+  try {
+    return providerSupportsCapability(providerName, 'sessionResume');
+  } catch {
+    return false;
+  }
+}
+
+function normalizeProviderSession(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const provider = normalizeProviderName(value.provider);
+  const sessionId = normalizeSessionId(value.sessionId);
+  if (!provider || !sessionId || !supportsSessionResume(provider)) {
+    return null;
+  }
+  return { provider, sessionId };
+}
+
+function agentCanReuseSession(agent, providerName) {
+  return !agent?.isolation?.enabled && supportsSessionResume(providerName);
+}
+
+function resolveAgentResumeSessionId(agent, providerName) {
+  const provider = normalizeProviderName(providerName);
+  const stored = normalizeProviderSession(agent?.providerSession);
+  if (!agentCanReuseSession(agent, provider) || !stored || stored.provider !== provider) {
+    if (agent && stored) {
+      agent.providerSession = null;
+    }
+    return null;
+  }
+  return stored.sessionId;
+}
+
+function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
+  const provider = normalizeProviderName(providerName);
+  if (!agentCanReuseSession(agent, provider)) {
+    return null;
+  }
+  if (!taskInfo || taskInfo.status !== 'completed') {
+    return null;
+  }
+  if (normalizeProviderName(taskInfo.provider) !== provider) {
+    return null;
+  }
+  const sessionId = normalizeSessionId(taskInfo.sessionId);
+  return sessionId ? { provider, sessionId } : null;
+}
+
+function updateAgentProviderSession(agent, value) {
+  const session = normalizeProviderSession(value);
+  agent.providerSession = session;
+  return session;
+}
+
+module.exports = {
+  normalizeProviderSession,
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+  supportsSessionResume,
+  updateAgentProviderSession,
+};

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -52,6 +52,7 @@ const { isProcessRunning } = require('../lib/process-liveness');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
+const { normalizeProviderSession } = require('./agent/provider-session');
 const {
   commandProofsToQualityGates,
   mergeCommandProofs,
@@ -670,6 +671,7 @@ class Orchestrator {
     agent.currentTask = null;
     agent.currentTaskId = savedState.currentTaskId || null;
     agent.processPid = savedState.processPid || null;
+    agent.providerSession = normalizeProviderSession(savedState.providerSession);
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -888,6 +890,7 @@ class Orchestrator {
                 currentTask: a.currentTask ? true : false,
                 currentTaskId: a.currentTaskId,
                 processPid: a.processPid,
+                providerSession: normalizeProviderSession(a.providerSession),
               }))
             : null,
           setupLogPath: cluster.setupLogPath || null,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -52,7 +52,10 @@ const { isProcessRunning } = require('../lib/process-liveness');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
-const { normalizeProviderSession } = require('./agent/provider-session');
+const {
+  normalizeProviderSession,
+  restoreAgentProviderSession,
+} = require('./agent/provider-session');
 const {
   commandProofsToQualityGates,
   mergeCommandProofs,
@@ -229,6 +232,19 @@ function buildPrOptions(options, requiredQualityGates) {
     autoMerge,
     ...(requiredQualityGates.length > 0 ? { requiredQualityGates } : {}),
     cwd: options.cwd || process.cwd(),
+  };
+}
+
+function serializeWorktree(worktree) {
+  if (!worktree) {
+    return null;
+  }
+  return {
+    enabled: true,
+    path: worktree.path,
+    branch: worktree.branch,
+    repoRoot: worktree.repoRoot,
+    workDir: worktree.workDir,
   };
 }
 
@@ -646,6 +662,15 @@ class Orchestrator {
       };
     }
 
+    if (clusterData.worktree?.enabled) {
+      agentOptions.worktree = {
+        enabled: true,
+        path: clusterData.worktree.path,
+        branch: clusterData.worktree.branch,
+        repoRoot: clusterData.worktree.repoRoot,
+      };
+    }
+
     return agentOptions;
   }
 
@@ -657,7 +682,7 @@ class Orchestrator {
     return new AgentWrapper(agentConfig, messageBus, clusterContext, agentOptions);
   }
 
-  _restoreAgentState(agent, agentConfig, clusterData) {
+  _restoreAgentState(agent, agentConfig, clusterData, messageBus) {
     if (!clusterData.agentStates) return;
 
     const savedState = clusterData.agentStates.find((state) => state.id === agentConfig.id);
@@ -671,7 +696,12 @@ class Orchestrator {
     agent.currentTask = null;
     agent.currentTaskId = savedState.currentTaskId || null;
     agent.processPid = savedState.processPid || null;
-    agent.providerSession = normalizeProviderSession(savedState.providerSession);
+    agent.providerSession = restoreAgentProviderSession({
+      agent,
+      savedState,
+      messageBus,
+      clusterId: clusterData.id,
+    });
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -701,7 +731,7 @@ class Orchestrator {
         isolationManager
       );
       const agent = this._instantiateAgent(agentConfig, messageBus, clusterContext, agentOptions);
-      this._restoreAgentState(agent, agentConfig, clusterData);
+      this._restoreAgentState(agent, agentConfig, clusterData, messageBus);
       agents.push(agent);
     }
 
@@ -881,6 +911,7 @@ class Orchestrator {
                 workDir: cluster.isolation.workDir, // Required for resume
               }
             : null,
+          worktree: serializeWorktree(cluster.worktree),
           // Persist agent runtime states for accurate status display from other processes
           agentStates: cluster.agents
             ? cluster.agents.map((a) => ({
@@ -1588,6 +1619,8 @@ class Orchestrator {
         [
           'TASK_STARTED',
           'TASK_COMPLETED',
+          'TASK_FAILED',
+          'RETRY_SCHEDULED',
           'PROCESS_SPAWNED',
           'TASK_ID_ASSIGNED',
           'STARTED',

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -14,6 +14,7 @@ import {
   recoverProviderStructuredOutput,
   supportsProviderStructuredOutputRecovery,
 } from './provider-helper-runtime.js';
+import { createProviderSessionCapture } from './provider-session-capture.js';
 import { createRequire } from 'module';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -95,6 +96,12 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const maybeCaptureProviderSession = createProviderSessionCapture({
+  providerName,
+  taskId,
+  updateTask,
+  log,
+});
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -167,6 +174,7 @@ function maybeCaptureStructuredOutput(line) {
 function handleSilentJsonLines(lines, timestamp) {
   for (const line of lines) {
     if (!line.trim()) continue;
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -177,6 +185,7 @@ function handleSilentJsonLines(lines, timestamp) {
 
 function handleStreamingLines(lines, timestamp) {
   for (const line of lines) {
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -190,6 +199,7 @@ function flushOutputBuffer(timestamp) {
     return;
   }
 
+  maybeCaptureProviderSession(outputBuffer);
   if (!enableRecovery) {
     if (!silentJsonMode) {
       log(`[${timestamp}]${outputBuffer}\n`);

--- a/task-lib/commands/resume.js
+++ b/task-lib/commands/resume.js
@@ -1,6 +1,26 @@
 import chalk from 'chalk';
+import { createRequire } from 'module';
 import { getTask } from '../store.js';
 import { spawnTask } from '../runner.js';
+
+const require = createRequire(import.meta.url);
+const { providerSupportsCapability } = require('../../lib/provider-names.js');
+
+export function buildResumeTaskOptions(task) {
+  if (!providerSupportsCapability(task.provider, 'sessionResume')) {
+    throw new Error(`Provider ${task.provider} does not support safe session resume.`);
+  }
+  if (!task.sessionId) {
+    throw new Error(
+      `Task ${task.id} has no captured provider session ID; refusing cwd-wide continuation.`
+    );
+  }
+  return {
+    cwd: task.cwd,
+    resume: task.sessionId,
+    provider: task.provider,
+  };
+}
 
 export async function resumeTask(taskId, newPrompt) {
   const task = getTask(taskId);
@@ -23,12 +43,7 @@ export async function resumeTask(taskId, newPrompt) {
   console.log(chalk.dim(`Original prompt: ${task.prompt}`));
   console.log(chalk.dim(`Resume prompt: ${prompt}`));
 
-  const newTask = await spawnTask(prompt, {
-    cwd: task.cwd,
-    continue: true, // Use --continue to load most recent session in that directory
-    sessionId: task.sessionId,
-    provider: task.provider,
-  });
+  const newTask = await spawnTask(prompt, buildResumeTaskOptions(task));
 
   console.log(chalk.green(`\n✓ Resumed as new task: ${chalk.cyan(newTask.id)}`));
   console.log(chalk.dim(`  PID: ${newTask.pid}`));

--- a/task-lib/commands/status.js
+++ b/task-lib/commands/status.js
@@ -41,6 +41,9 @@ export function showStatus(taskId) {
   console.log(`${chalk.dim('PID:')}        ${task.pid || 'N/A'}`);
   console.log(`${chalk.dim('Exit Code:')}  ${task.exitCode ?? 'N/A'}`);
   console.log(`${chalk.dim('Session:')}    ${task.sessionId || 'N/A'}`);
+  if (task.requestedResumeSessionId) {
+    console.log(`${chalk.dim('Requested:')}  ${task.requestedResumeSessionId}`);
+  }
   console.log(`${chalk.dim('Log File:')}   ${task.logFile}`);
 
   console.log(`\n${chalk.dim('Prompt:')}`);

--- a/task-lib/provider-helper-runtime.js
+++ b/task-lib/provider-helper-runtime.js
@@ -19,6 +19,7 @@ export const {
   classifyProviderError,
   detectProviderFatalError,
   detectProviderStreamingModeError,
+  extractProviderSessionId,
   findProviderRegistryEntry,
   getProviderAdapter,
   getProviderRegistryEntry,

--- a/task-lib/provider-session-capture.js
+++ b/task-lib/provider-session-capture.js
@@ -1,0 +1,38 @@
+import { extractProviderSessionId } from './provider-helper-runtime.js';
+
+/**
+ * Capture a provider-owned session ID from one complete output line.
+ *
+ * The caller owns persistence so watcher variants can share parsing without
+ * importing each other's process lifecycle. Returning the prior ID for
+ * duplicate events avoids redundant task-store writes.
+ */
+export function captureProviderSessionLine({
+  providerName,
+  line,
+  currentSessionId = null,
+  onCapture,
+}) {
+  const sessionId = extractProviderSessionId(providerName, line);
+  if (!sessionId || sessionId === currentSessionId) {
+    return currentSessionId;
+  }
+  onCapture(sessionId);
+  return sessionId;
+}
+
+export function createProviderSessionCapture({ providerName, taskId, updateTask, log }) {
+  let currentSessionId = null;
+  return (line) => {
+    try {
+      currentSessionId = captureProviderSessionLine({
+        providerName,
+        line,
+        currentSessionId,
+        onCapture: (sessionId) => updateTask(taskId, { sessionId }),
+      });
+    } catch (error) {
+      log(`[${Date.now()}][SESSION] Failed to persist provider session: ${error.message}\n`);
+    }
+  };
+}

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -127,7 +127,7 @@ function resolveRequestedModelSpec(options) {
   return undefined;
 }
 
-function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {
+export function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {
   return {
     id,
     prompt: prompt.slice(0, 200) + (prompt.length > 200 ? '...' : ''),
@@ -135,7 +135,11 @@ function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, mode
     cwd,
     status: 'running',
     pid: null,
-    sessionId: options.resume || options.sessionId || null,
+    // Only watcher-observed provider output may populate sessionId. A requested
+    // resume ID is diagnostic input, not proof the resumed provider emitted or
+    // accepted that session identity.
+    sessionId: null,
+    requestedResumeSessionId: options.resume || null,
     logFile,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -41,6 +41,7 @@ function getDb() {
       status TEXT NOT NULL DEFAULT 'pending',
       pid INTEGER,
       session_id TEXT,
+      requested_resume_session_id TEXT,
       log_file TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -79,6 +80,7 @@ function getDb() {
 
   ensureTaskColumn(db, 'process_group_id', 'INTEGER');
   ensureTaskColumn(db, 'termination_strategy', 'TEXT');
+  ensureTaskColumn(db, 'requested_resume_session_id', 'TEXT');
 
   return db;
 }
@@ -88,6 +90,10 @@ function ensureTaskColumn(database, name, definition) {
   if (!columns.some((column) => column.name === name)) {
     database.exec(`ALTER TABLE tasks ADD COLUMN ${name} ${definition}`);
   }
+}
+
+function nullable(value) {
+  return value || null;
 }
 
 export function ensureDirs() {
@@ -112,6 +118,7 @@ function rowToTask(row) {
     status: row.status,
     pid: row.pid,
     sessionId: row.session_id,
+    requestedResumeSessionId: row.requested_resume_session_id,
     logFile: row.log_file,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -149,11 +156,11 @@ export function saveTasks(tasks) {
   const database = getDb();
   const insert = database.prepare(`
     INSERT OR REPLACE INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -172,6 +179,7 @@ export function saveTasks(tasks) {
         status: task.status || 'pending',
         pid: task.pid || null,
         sessionId: task.sessionId || null,
+        requestedResumeSessionId: nullable(task.requestedResumeSessionId),
         logFile: task.logFile || null,
         createdAt: task.createdAt || new Date().toISOString(),
         updatedAt: task.updatedAt || new Date().toISOString(),
@@ -240,6 +248,7 @@ export function updateTask(id, updates) {
       status = @status,
       pid = @pid,
       session_id = @sessionId,
+      requested_resume_session_id = @requestedResumeSessionId,
       log_file = @logFile,
       updated_at = @updatedAt,
       exit_code = @exitCode,
@@ -262,6 +271,7 @@ export function updateTask(id, updates) {
       status: updated.status || 'pending',
       pid: updated.pid || null,
       sessionId: updated.sessionId || null,
+      requestedResumeSessionId: nullable(updated.requestedResumeSessionId),
       logFile: updated.logFile || null,
       updatedAt: updated.updatedAt,
       exitCode: updated.exitCode ?? null,
@@ -295,11 +305,11 @@ export function addTask(task) {
     .prepare(
       `
     INSERT INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -313,6 +323,7 @@ export function addTask(task) {
       status: fullTask.status || 'pending',
       pid: fullTask.pid || null,
       sessionId: fullTask.sessionId || null,
+      requestedResumeSessionId: nullable(fullTask.requestedResumeSessionId),
       logFile: fullTask.logFile || null,
       createdAt: fullTask.createdAt,
       updatedAt: fullTask.updatedAt,

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -15,6 +15,7 @@ import {
   recoverProviderStructuredOutput,
   supportsProviderStructuredOutputRecovery,
 } from './provider-helper-runtime.js';
+import { createProviderSessionCapture } from './provider-session-capture.js';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -36,6 +37,12 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const maybeCaptureProviderSession = createProviderSessionCapture({
+  providerName,
+  taskId,
+  updateTask,
+  log,
+});
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -136,6 +143,7 @@ function maybeCaptureStructuredOutput(line) {
 function handleSilentJsonLines(lines, timestamp) {
   for (const line of lines) {
     if (!line.trim()) continue;
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -146,6 +154,7 @@ function handleSilentJsonLines(lines, timestamp) {
 
 function handleStreamingLines(lines, timestamp) {
   for (const line of lines) {
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -159,6 +168,7 @@ function flushStdoutBuffer(timestamp) {
     return;
   }
 
+  maybeCaptureProviderSession(stdoutBuffer);
   if (!enableRecovery) {
     if (!silentJsonMode) {
       log(`[${timestamp}]${stdoutBuffer}\n`);

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -80,6 +80,30 @@ test('build-command preserves Claude resume and continue options through JSON co
   assert.deepEqual(continued.envelope.result.commandSpec.args.slice(-2), ['--continue', 'ctx']);
 });
 
+test('build-command preserves Codex explicit session resume through JSON contract', () => {
+  const resumed = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'codex',
+    context: 'ctx',
+    options: {
+      resumeSessionId: 'thread-1',
+      cwd: '/tmp/project',
+      cliFeatures: {
+        supportsResume: true,
+        supportsCwd: true,
+      },
+    },
+  });
+
+  assert.equal(resumed.exitCode, 0);
+  assert.equal(resumed.envelope.ok, true);
+  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(0, 2), ['exec', 'resume']);
+  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(-2), ['thread-1', 'ctx']);
+  assert.equal(resumed.envelope.result.commandSpec.args.includes('-C'), false);
+  assert.equal(resumed.envelope.result.commandSpec.cwd, '/tmp/project');
+});
+
 test('build-command redacts adapter auth env values from command spec output', () => {
   const secret = 'plain-secret';
   const response = runExecutable({

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -430,9 +430,26 @@ test('feature probing is deterministic from injected help text', () => {
     supportsVerbose: true,
     supportsModel: true,
     supportsEffort: true,
+    supportsResume: true,
     unknown: true,
   });
 
+  assert.equal(
+    helper.getProviderAdapter('claude').detectCliFeatures('claude --resume').supportsResume,
+    true
+  );
+  assert.equal(
+    helper.getProviderAdapter('claude').detectCliFeatures('claude --print').supportsResume,
+    false
+  );
+  assert.equal(
+    helper.getProviderAdapter('codex').detectCliFeatures('codex exec resume').supportsResume,
+    true
+  );
+  assert.equal(
+    helper.getProviderAdapter('codex').detectCliFeatures('codex exec --json').supportsResume,
+    false
+  );
   assert.equal(
     helper
       .getProviderAdapter('codex')

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1900,6 +1900,10 @@ function defineLifecycleResumeTests() {
       agent.currentTask = { kill() {} };
       agent.currentTaskId = 'task-live';
       agent.processPid = 4242;
+      agent.providerSession = {
+        provider: 'claude',
+        sessionId: 'agent-owned-session',
+      };
 
       await lifecycleOrchestrator._saveClusters();
 
@@ -1916,6 +1920,10 @@ function defineLifecycleResumeTests() {
 
         assert.strictEqual(restoredAgent.currentTask, null);
         assert.strictEqual(restoredAgent.currentTaskId, 'task-live');
+        assert.deepStrictEqual(restoredAgent.providerSession, {
+          provider: 'claude',
+          sessionId: 'agent-owned-session',
+        });
         assert.strictEqual(restoredState.currentTask, false);
       } finally {
         reloaded.close();

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1886,7 +1886,7 @@ function defineLifecycleResumeTests() {
       assert.strictEqual(failureInfo.error, 'unresolved validator failure');
     });
 
-    it('should not restore serialized currentTask handles from disk', async function () {
+    it('restores a proven completed session without reviving currentTask handles', async function () {
       const config = createSimpleConfig();
       lifecycleMockRunner.when('worker').delays(1000, { done: true });
 
@@ -1903,7 +1903,26 @@ function defineLifecycleResumeTests() {
       agent.providerSession = {
         provider: 'claude',
         sessionId: 'agent-owned-session',
+        agentId: agent.id,
+        taskId: 'task-complete',
+        generation: agent.iteration,
+        cwd: path.resolve(agent.config.cwd || process.cwd()),
+        worktreePath: null,
       };
+      cluster.messageBus.publish({
+        cluster_id: result.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: agent.id,
+        content: {
+          text: `${agent.id}: TASK_COMPLETED`,
+          data: {
+            event: 'TASK_COMPLETED',
+            provider: 'claude',
+            taskId: 'task-complete',
+            iteration: agent.iteration,
+          },
+        },
+      });
 
       await lifecycleOrchestrator._saveClusters();
 
@@ -1923,8 +1942,78 @@ function defineLifecycleResumeTests() {
         assert.deepStrictEqual(restoredAgent.providerSession, {
           provider: 'claude',
           sessionId: 'agent-owned-session',
+          agentId: agent.id,
+          taskId: 'task-complete',
+          generation: agent.iteration,
+          cwd: path.resolve(agent.config.cwd || process.cwd()),
+          worktreePath: null,
         });
         assert.strictEqual(restoredState.currentTask, false);
+      } finally {
+        reloaded.close();
+      }
+    });
+
+    it('drops session state when a crash snapshot ends in a live or failed generation', async function () {
+      const config = createSimpleConfig();
+      lifecycleMockRunner.when('worker').delays(1000, { done: true });
+
+      const result = await lifecycleOrchestrator.start(config, { text: 'Task' });
+      const cluster = lifecycleOrchestrator.getCluster(result.id);
+      const agent = cluster.agents[0];
+      const cwd = path.resolve(agent.config.cwd || process.cwd());
+
+      cluster.state = 'stopped';
+      cluster.pid = null;
+      agent.state = 'executing_task';
+      agent.iteration = 2;
+      agent.currentTaskId = 'task-live-generation-2';
+      agent.providerSession = {
+        provider: 'claude',
+        sessionId: 'completed-generation-1',
+        agentId: agent.id,
+        taskId: 'task-complete-generation-1',
+        generation: 1,
+        cwd,
+        worktreePath: null,
+      };
+      for (const data of [
+        {
+          event: 'TASK_COMPLETED',
+          provider: 'claude',
+          taskId: 'task-complete-generation-1',
+          iteration: 1,
+        },
+        {
+          event: 'TASK_STARTED',
+          provider: 'claude',
+          taskId: 'task-live-generation-2',
+          iteration: 2,
+        },
+        {
+          event: 'TASK_FAILED',
+          provider: 'claude',
+          taskId: 'task-live-generation-2',
+          iteration: 2,
+        },
+      ]) {
+        cluster.messageBus.publish({
+          cluster_id: result.id,
+          topic: 'AGENT_LIFECYCLE',
+          sender: agent.id,
+          content: { text: `${agent.id}: ${data.event}`, data },
+        });
+      }
+
+      await lifecycleOrchestrator._saveClusters();
+      const reloaded = await Orchestrator.create({
+        taskRunner: new MockTaskRunner(),
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      try {
+        assert.strictEqual(reloaded.getCluster(result.id).agents[0].providerSession, null);
       } finally {
         reloaded.close();
       }

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -26,24 +26,33 @@ function buildCommand(provider, context, options = {}) {
 }
 
 describe('Codex provider helper builder', function () {
-  it('warns when unsupported session control options are ignored', function () {
+  it('resumes an explicit session without cwd-wide continuation', function () {
     const resumed = buildCommand('codex', 'test context', {
       resumeSessionId: 'session-123',
+      cwd: '/tmp/project',
     });
-    assert.ok(!resumed.args.includes('--resume'));
-    assert.ok(
-      resumed.warnings.some(
-        (warning) =>
-          warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
-      )
-    );
+    assert.deepStrictEqual(resumed.args.slice(0, 2), ['exec', 'resume']);
+    assert.deepStrictEqual(resumed.args.slice(-2), ['session-123', 'test context']);
+    assert.ok(!resumed.args.includes('-C'));
 
     const continued = buildCommand('codex', 'test context', {
       continueSession: true,
     });
     assert.ok(!continued.args.includes('--continue'));
     assert.ok(continued.warnings.some((warning) => warning.code === 'unsupported-session-control'));
+  });
+
+  it('starts fresh with a warning when the installed Codex CLI cannot resume', function () {
+    const resumed = buildCommand('codex', 'test context', {
+      resumeSessionId: 'session-123',
+      cliFeatures: { supportsResume: false },
+    });
+
+    assert.deepStrictEqual(resumed.args.slice(0, 1), ['exec']);
+    assert.ok(!resumed.args.includes('resume'));
+    assert.ok(
+      resumed.warnings.some((warning) => warning.code === 'codex-session-resume-unsupported')
+    );
   });
 
   it('passes --output-schema when CLI supports it', function () {
@@ -122,7 +131,8 @@ describe('Gemini provider helper builder', function () {
       resumed.warnings.some(
         (warning) =>
           warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
+          warning.message ===
+            'Provider gemini does not support resume/continue session control; ignoring.'
       )
     );
 
@@ -189,7 +199,8 @@ describe('Opencode provider helper builder', function () {
       resumed.warnings.some(
         (warning) =>
           warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
+          warning.message ===
+            'Provider opencode does not support resume/continue session control; ignoring.'
       )
     );
 
@@ -361,6 +372,18 @@ describe('Claude provider helper builder', function () {
       continueSession: true,
     });
     assert.deepStrictEqual(continued.args.slice(-2), ['--continue', 'test context']);
+  });
+
+  it('starts fresh with a warning when the installed Claude CLI cannot resume', function () {
+    const resumed = buildCommand('claude', 'test context', {
+      resumeSessionId: 'session-123',
+      cliFeatures: { supportsResume: false },
+    });
+
+    assert.ok(!resumed.args.includes('--resume'));
+    assert.ok(
+      resumed.warnings.some((warning) => warning.code === 'claude-session-resume-unsupported')
+    );
   });
 
   it('honors configured Claude executable selection inside the helper', function () {

--- a/tests/unit/provider-session-capture.test.js
+++ b/tests/unit/provider-session-capture.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+describe('provider session capture', function () {
+  it('captures Claude and Codex session IDs from provider JSONL', async function () {
+    const { captureProviderSessionLine } =
+      await import('../../task-lib/provider-session-capture.js');
+    const captured = [];
+
+    let currentSessionId = captureProviderSessionLine({
+      providerName: 'claude',
+      line: JSON.stringify({ type: 'system', subtype: 'init', session_id: 'claude-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    const duplicateSessionId = captureProviderSessionLine({
+      providerName: 'claude',
+      line: JSON.stringify({ type: 'result', session_id: 'claude-1' }),
+      currentSessionId,
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    assert.strictEqual(duplicateSessionId, 'claude-1');
+    currentSessionId = captureProviderSessionLine({
+      providerName: 'codex',
+      line: JSON.stringify({ type: 'thread.started', thread_id: 'codex-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+
+    assert.strictEqual(currentSessionId, 'codex-1');
+    assert.deepStrictEqual(captured, ['claude-1', 'codex-1']);
+  });
+
+  it('ignores malformed output and providers without safe resume semantics', async function () {
+    const { captureProviderSessionLine } =
+      await import('../../task-lib/provider-session-capture.js');
+    const captured = [];
+
+    const malformed = captureProviderSessionLine({
+      providerName: 'claude',
+      line: '{not-json',
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    const unsupported = captureProviderSessionLine({
+      providerName: 'gemini',
+      line: JSON.stringify({ type: 'init', session_id: 'gemini-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+
+    assert.strictEqual(malformed, null);
+    assert.strictEqual(unsupported, null);
+    assert.deepStrictEqual(captured, []);
+  });
+});

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -1,0 +1,205 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const AgentWrapper = require('../../src/agent-wrapper');
+const Ledger = require('../../src/ledger');
+const MessageBus = require('../../src/message-bus');
+
+describe('provider-session continuation context', function () {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let priorSettingsFile;
+
+  beforeEach(function () {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-session-context-'));
+    priorSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(tempDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+    );
+    ledger = new Ledger(path.join(tempDir, 'ledger.db'));
+    messageBus = new MessageBus(ledger);
+  });
+
+  afterEach(function () {
+    ledger.close();
+    if (priorSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = priorSettingsFile;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('sends static context once and only the new turn delta after resume', function () {
+    const cluster = {
+      id: 'session-context-cluster',
+      createdAt: Date.now(),
+      agents: [],
+    };
+    const agent = new AgentWrapper(
+      {
+        id: 'worker',
+        role: 'implementation',
+        provider: 'claude',
+        prompt: 'STATIC-WORKER-INSTRUCTIONS',
+        timeout: 0,
+        contextStrategy: {
+          sources: [
+            { topic: 'ISSUE_OPENED', limit: 1 },
+            { topic: 'PLAN_READY', limit: 1 },
+            { topic: 'VALIDATION_RESULT', limit: 5 },
+          ],
+        },
+      },
+      messageBus,
+      cluster,
+      {
+        testMode: true,
+        mockSpawnFn: () => ({ success: true, output: '{}' }),
+      }
+    );
+    const cwd = path.resolve(agent.config.cwd || process.cwd());
+
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'STATIC-ISSUE-OPENED' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'PLAN_READY',
+      sender: 'planner',
+      content: { text: 'STATIC-PLAN-READY' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-old',
+      content: { text: 'OLD-VALIDATION-RESULT' },
+    });
+
+    agent.iteration = 1;
+    const firstContext = agent._buildContext({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'FIRST-TURN-TRIGGER' },
+    });
+    assert.match(firstContext, /STATIC-WORKER-INSTRUCTIONS/);
+    assert.match(firstContext, /STATIC-ISSUE-OPENED/);
+    assert.match(firstContext, /STATIC-PLAN-READY/);
+
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'session-generation-1',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd,
+      worktreePath: null,
+    };
+    const deltaTimestamp = agent.lastAgentStartTime + 10;
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-a',
+      timestamp: deltaTimestamp,
+      content: { text: 'NEW-VALIDATION-A' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-b',
+      timestamp: deltaTimestamp + 1,
+      content: { text: 'NEW-VALIDATION-B' },
+    });
+    agent.iteration = 2;
+    const secondContext = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      timestamp: deltaTimestamp + 2,
+      content: { text: 'NEW-REJECTION-DELTA' },
+    });
+
+    assert.match(secondContext, /Continuation Turn/);
+    assert.match(secondContext, /NEW-REJECTION-DELTA/);
+    assert.match(secondContext, /NEW-VALIDATION-A/);
+    assert.match(secondContext, /NEW-VALIDATION-B/);
+    assert.doesNotMatch(secondContext, /STATIC-WORKER-INSTRUCTIONS/);
+    assert.doesNotMatch(secondContext, /STATIC-ISSUE-OPENED/);
+    assert.doesNotMatch(secondContext, /STATIC-PLAN-READY/);
+    assert.doesNotMatch(secondContext, /FIRST-TURN-TRIGGER/);
+    assert.doesNotMatch(secondContext, /OLD-VALIDATION-RESULT/);
+  });
+
+  it('clears a failed logical result before the retry is constructed', async function () {
+    const cluster = { id: 'retry-cluster', createdAt: Date.now(), agents: [] };
+    let attempts = 0;
+    let agent;
+
+    agent = new AgentWrapper(
+      {
+        id: 'worker',
+        role: 'implementation',
+        provider: 'claude',
+        prompt: 'STATIC-RETRY-INSTRUCTIONS',
+        outputFormat: 'text',
+        maxRetries: 2,
+        timeout: 0,
+        contextStrategy: { sources: [] },
+      },
+      messageBus,
+      cluster,
+      {
+        testMode: true,
+        quiet: true,
+        mockSpawnFn: (args, { context }) => {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              success: false,
+              error: 'logical schema failure',
+              providerSession: {
+                provider: 'claude',
+                sessionId: 'must-not-resume',
+                agentId: 'worker',
+                taskId: 'failed-task',
+                generation: 1,
+                cwd: path.resolve(agent.config.cwd || process.cwd()),
+                worktreePath: null,
+              },
+            };
+          }
+
+          assert.strictEqual(agent.providerSession, null);
+          assert.ok(!args.includes('--resume'));
+          assert.match(context, /STATIC-RETRY-INSTRUCTIONS/);
+          return { success: true, output: 'done', providerSession: null };
+        },
+      }
+    );
+    agent.running = true;
+
+    await agent._executeTask({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'retry me' },
+    });
+
+    assert.strictEqual(attempts, 2);
+    assert.strictEqual(agent.providerSession, null);
+    const failed = messageBus
+      .query({
+        cluster_id: cluster.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+      })
+      .find((message) => message.content?.data?.event === 'TASK_FAILED');
+    assert.ok(failed, 'failed attempt must be durable before retry');
+  });
+});

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+
+const {
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+  updateAgentProviderSession,
+} = require('../../src/agent/provider-session');
+const { buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+
+function buildAgent(overrides = {}) {
+  return {
+    config: { cwd: process.cwd(), ...overrides.config },
+    cluster: { id: 'cluster-1' },
+    providerSession: overrides.providerSession || null,
+    isolation: overrides.isolation || null,
+    worktree: overrides.worktree || null,
+  };
+}
+
+function taskArgs(agent, providerName) {
+  return buildTaskRunArgs({
+    agent,
+    providerName,
+    modelSpec: {},
+    runOutputFormat: 'stream-json',
+  });
+}
+
+describe('agent-owned provider session reuse', function () {
+  it('reuses explicit Claude and Codex IDs for the same logical agent', function () {
+    const claude = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
+    });
+    const codex = buildAgent({
+      providerSession: { provider: 'codex', sessionId: 'codex-thread-1' },
+    });
+
+    assert.deepStrictEqual(taskArgs(claude, 'claude').slice(-2), ['--resume', 'claude-session-1']);
+    assert.deepStrictEqual(taskArgs(codex, 'codex').slice(-2), ['--resume', 'codex-thread-1']);
+  });
+
+  it('starts fresh for unsupported providers, Docker isolation, and provider switches', function () {
+    const unsupported = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
+    });
+    assert.ok(!taskArgs(unsupported, 'gemini').includes('--resume'));
+    assert.strictEqual(unsupported.providerSession, null);
+
+    const isolated = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-2' },
+      isolation: { enabled: true },
+    });
+    assert.ok(!taskArgs(isolated, 'claude').includes('--resume'));
+    assert.strictEqual(isolated.providerSession, null);
+  });
+
+  it('captures completed tasks and invalidates failed retry boundaries', function () {
+    const agent = buildAgent();
+    const completed = providerSessionFromCompletedTask({
+      agent,
+      providerName: 'codex',
+      taskInfo: {
+        provider: 'codex',
+        status: 'completed',
+        sessionId: 'thread-complete',
+      },
+    });
+    updateAgentProviderSession(agent, completed);
+    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), 'thread-complete');
+
+    const failed = providerSessionFromCompletedTask({
+      agent,
+      providerName: 'codex',
+      taskInfo: {
+        provider: 'codex',
+        status: 'failed',
+        sessionId: 'thread-failed',
+      },
+    });
+    updateAgentProviderSession(agent, failed);
+    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), null);
+  });
+
+  it('never leaks one agent session into another agent', function () {
+    const worker = buildAgent();
+    const validator = buildAgent();
+    updateAgentProviderSession(worker, {
+      provider: 'claude',
+      sessionId: 'worker-session',
+    });
+
+    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'worker-session');
+    assert.strictEqual(resolveAgentResumeSessionId(validator, 'claude'), null);
+    assert.strictEqual(validator.providerSession, null);
+  });
+});

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -1,17 +1,36 @@
 const assert = require('assert');
+const path = require('path');
 
 const {
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
+  restoreAgentProviderSession,
   updateAgentProviderSession,
 } = require('../../src/agent/provider-session');
-const { buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+const { buildCompletionResult, buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+
+const TEST_CWD = path.resolve('/tmp/provider-session-project');
+
+function buildSession(overrides = {}) {
+  return {
+    provider: 'claude',
+    sessionId: 'claude-session-1',
+    agentId: 'worker',
+    taskId: 'task-generation-1',
+    generation: 1,
+    cwd: TEST_CWD,
+    worktreePath: null,
+    ...overrides,
+  };
+}
 
 function buildAgent(overrides = {}) {
   return {
-    config: { cwd: process.cwd(), ...overrides.config },
+    id: overrides.id || 'worker',
+    iteration: overrides.iteration ?? 2,
+    config: { cwd: TEST_CWD, ...overrides.config },
     cluster: { id: 'cluster-1' },
-    providerSession: overrides.providerSession || null,
+    providerSession: overrides.providerSession ?? null,
     isolation: overrides.isolation || null,
     worktree: overrides.worktree || null,
   };
@@ -26,71 +45,188 @@ function taskArgs(agent, providerName) {
   });
 }
 
+function lifecycleBus(messages) {
+  return {
+    query: () =>
+      messages.map((data, index) => ({
+        timestamp: index + 1,
+        content: { data },
+      })),
+  };
+}
+
 describe('agent-owned provider session reuse', function () {
-  it('reuses explicit Claude and Codex IDs for the same logical agent', function () {
-    const claude = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
-    });
+  it('reuses an explicit ID only for the next generation of the same logical agent', function () {
+    const claude = buildAgent({ providerSession: buildSession() });
     const codex = buildAgent({
-      providerSession: { provider: 'codex', sessionId: 'codex-thread-1' },
+      providerSession: buildSession({
+        provider: 'codex',
+        sessionId: 'codex-thread-1',
+      }),
     });
 
     assert.deepStrictEqual(taskArgs(claude, 'claude').slice(-2), ['--resume', 'claude-session-1']);
     assert.deepStrictEqual(taskArgs(codex, 'codex').slice(-2), ['--resume', 'codex-thread-1']);
+
+    const staleGeneration = buildAgent({
+      iteration: 3,
+      providerSession: buildSession(),
+    });
+    assert.ok(!taskArgs(staleGeneration, 'claude').includes('--resume'));
+    assert.strictEqual(staleGeneration.providerSession, null);
   });
 
-  it('starts fresh for unsupported providers, Docker isolation, and provider switches', function () {
-    const unsupported = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
-    });
+  it('starts fresh for unsupported providers, Docker, provider switches, and worktree drift', function () {
+    const unsupported = buildAgent({ providerSession: buildSession() });
     assert.ok(!taskArgs(unsupported, 'gemini').includes('--resume'));
-    assert.strictEqual(unsupported.providerSession, null);
 
     const isolated = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-2' },
+      providerSession: buildSession(),
       isolation: { enabled: true },
     });
     assert.ok(!taskArgs(isolated, 'claude').includes('--resume'));
-    assert.strictEqual(isolated.providerSession, null);
+
+    const moved = buildAgent({
+      providerSession: buildSession({ worktreePath: '/tmp/old-worktree' }),
+      worktree: { enabled: true, path: '/tmp/new-worktree' },
+    });
+    assert.ok(!taskArgs(moved, 'claude').includes('--resume'));
   });
 
-  it('captures completed tasks and invalidates failed retry boundaries', function () {
-    const agent = buildAgent();
+  it('captures only logically successful completed tasks with full provenance', function () {
+    const agent = buildAgent({ iteration: 1 });
+    const taskInfo = {
+      id: 'task-generation-1',
+      provider: 'codex',
+      status: 'completed',
+      sessionId: 'thread-complete',
+    };
     const completed = providerSessionFromCompletedTask({
       agent,
       providerName: 'codex',
-      taskInfo: {
-        provider: 'codex',
-        status: 'completed',
-        sessionId: 'thread-complete',
-      },
+      taskInfo,
+      logicalSuccess: true,
     });
-    updateAgentProviderSession(agent, completed);
-    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), 'thread-complete');
 
-    const failed = providerSessionFromCompletedTask({
+    assert.deepStrictEqual(completed, {
+      provider: 'codex',
+      sessionId: 'thread-complete',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd: TEST_CWD,
+      worktreePath: null,
+    });
+
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo,
+        logicalSuccess: false,
+      }),
+      null
+    );
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo: { ...taskInfo, status: 'failed' },
+      }),
+      null
+    );
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo: { ...taskInfo, sessionId: null },
+      }),
+      null
+    );
+  });
+
+  it('discards a provider-completed session when structured output is invalid', async function () {
+    const agent = {
+      ...buildAgent({ iteration: 1 }),
+      _parseResultOutput: () => Promise.reject(new Error('schema mismatch')),
+    };
+    const result = await buildCompletionResult({
       agent,
-      providerName: 'codex',
+      taskId: 'task-generation-1',
+      providerName: 'claude',
+      state: { output: '{"wrong":true}', logFilePath: null },
+      stdout: 'Status: completed',
+      success: true,
       taskInfo: {
-        provider: 'codex',
-        status: 'failed',
-        sessionId: 'thread-failed',
+        id: 'task-generation-1',
+        provider: 'claude',
+        status: 'completed',
+        sessionId: 'must-be-discarded',
       },
     });
-    updateAgentProviderSession(agent, failed);
-    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), null);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.providerSession, null);
+    assert.match(result.error, /schema mismatch/);
   });
 
   it('never leaks one agent session into another agent', function () {
-    const worker = buildAgent();
-    const validator = buildAgent();
-    updateAgentProviderSession(worker, {
-      provider: 'claude',
-      sessionId: 'worker-session',
+    const worker = buildAgent({ providerSession: buildSession() });
+    const validator = buildAgent({
+      id: 'validator',
+      providerSession: buildSession(),
     });
 
-    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'worker-session');
+    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'claude-session-1');
     assert.strictEqual(resolveAgentResumeSessionId(validator, 'claude'), null);
     assert.strictEqual(validator.providerSession, null);
+  });
+
+  it('restores only the exact last completed task boundary', function () {
+    const agent = buildAgent({ iteration: 1 });
+    const savedState = {
+      state: 'idle',
+      iteration: 1,
+      providerSession: buildSession(),
+    };
+    const completed = {
+      event: 'TASK_COMPLETED',
+      provider: 'claude',
+      taskId: 'task-generation-1',
+      iteration: 1,
+    };
+
+    const restored = restoreAgentProviderSession({
+      agent,
+      savedState,
+      messageBus: lifecycleBus([completed]),
+      clusterId: 'cluster-1',
+    });
+    assert.deepStrictEqual(restored, buildSession());
+
+    for (const boundary of [
+      { event: 'TASK_STARTED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'TASK_FAILED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'RETRY_SCHEDULED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+    ]) {
+      assert.strictEqual(
+        restoreAgentProviderSession({
+          agent,
+          savedState,
+          messageBus: lifecycleBus([completed, boundary]),
+          clusterId: 'cluster-1',
+        }),
+        null
+      );
+    }
+  });
+
+  it('drops legacy session-only state because its task provenance is ambiguous', function () {
+    const agent = buildAgent({ iteration: 1 });
+    updateAgentProviderSession(agent, {
+      provider: 'claude',
+      sessionId: 'legacy-session',
+    });
+    assert.strictEqual(agent.providerSession, null);
   });
 });

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+
+describe('single-task session resume', function () {
+  it('uses the captured explicit provider session ID', async function () {
+    const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
+    assert.deepStrictEqual(
+      buildResumeTaskOptions({
+        id: 'task-1',
+        provider: 'codex',
+        sessionId: 'thread-1',
+        cwd: '/tmp/project',
+      }),
+      {
+        provider: 'codex',
+        resume: 'thread-1',
+        cwd: '/tmp/project',
+      }
+    );
+  });
+
+  it('fails deterministically instead of selecting another task or agent session', async function () {
+    const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
+
+    assert.throws(
+      () =>
+        buildResumeTaskOptions({
+          id: 'task-without-session',
+          provider: 'claude',
+          sessionId: null,
+          cwd: '/tmp/project',
+        }),
+      /no captured provider session ID/
+    );
+    assert.throws(
+      () =>
+        buildResumeTaskOptions({
+          id: 'unsupported-task',
+          provider: 'gemini',
+          sessionId: 'gemini-session',
+          cwd: '/tmp/project',
+        }),
+      /does not support safe session resume/
+    );
+  });
+});

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -1,6 +1,22 @@
 const assert = require('assert');
 
 describe('single-task session resume', function () {
+  it('keeps a requested resume ID separate from watcher-captured identity', async function () {
+    const { buildTaskRecord } = await import('../../task-lib/runner.js');
+    const task = buildTaskRecord({
+      id: 'task-resumed',
+      prompt: 'continue',
+      cwd: '/tmp/project',
+      options: { resume: 'requested-thread' },
+      logFile: '/tmp/task-resumed.log',
+      providerName: 'codex',
+      modelSpec: {},
+    });
+
+    assert.strictEqual(task.requestedResumeSessionId, 'requested-thread');
+    assert.strictEqual(task.sessionId, null);
+  });
+
   it('uses the captured explicit provider session ID', async function () {
     const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
     assert.deepStrictEqual(


### PR DESCRIPTION
## Summary

- capture Claude session IDs and Codex thread IDs from provider JSONL output
- persist continuation state on the owning logical agent and restore it with cluster state
- resume only that same agent by explicit session ID; never use cwd-wide latest-session selection
- fail closed to a fresh session on provider changes, failed tasks, unsupported CLI versions, or Docker isolation
- make manual task resume use the captured explicit provider session for Claude and Codex

This follows the revised scope in #482: provider-side session reuse rather than direct API `cache_control` plumbing.

## Validation

- `npm run check`
- `npm run check:agent-cli-provider:ci` (135 passing)
- focused provider/session/persistence tests (24 passing)
- `opcore check --changed --json`
- `npm test`: 1705 passing, 18 pending; 7 local attach/PTTY tests fail with the environment-level `node-pty` error `posix_spawnp failed`

Fixes #482