### PR TITLE
feat: reuse provider sessions per agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Gateway tools/policy         | `src/agent-cli-provider/gateway-tools.ts`                               |
 | Provider detection           | `lib/provider-detection.js`                                             |
 | Provider capabilities        | `src/providers/capabilities.js`                                         |
+| Provider session reuse       | `src/agent/provider-session.js`                                         |
 | Start-cluster helper         | `lib/start-cluster.js`                                                  |
 | Legacy worker facade         | `lib/cluster-worker/`                                                   |
 | Legacy worker executable     | `bin/zeroshot-cluster-worker.js`                                        |
@@ -331,6 +332,12 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 Provider task ownership: task watchers persist an owned termination boundary with each active task.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
+
+Provider session reuse is explicit-ID and agent-owned. Watchers may capture provider session IDs,
+but only the same logical `AgentWrapper` may resume them. Persist this state in that agent's
+`agentStates` entry, never select a cwd-wide "latest" session, never share across agents, and start
+fresh when provider capability, identity, task completion, or durable isolation semantics do not
+prove reuse is safe.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,11 +333,15 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
 
-Provider session reuse is explicit-ID and agent-owned. Watchers may capture provider session IDs,
-but only the same logical `AgentWrapper` may resume them. Persist this state in that agent's
-`agentStates` entry, never select a cwd-wide "latest" session, never share across agents, and start
-fresh when provider capability, identity, task completion, or durable isolation semantics do not
-prove reuse is safe.
+Provider session reuse is explicit-ID and agent-owned. Watcher-observed IDs are distinct from
+requested resume IDs. Commit continuation only after logical/structured success and bind it to the
+completed task, agent, generation, provider, cwd, and worktree. A resumed turn sends only new
+trigger/guidance context; it never replays static prompts or ISSUE_OPENED/PLAN_READY packs already in
+the provider session. Persist continuation in that agent's `agentStates` entry, never in native
+`ClusterLedger`, never select a cwd-wide "latest" session, and never share across agents. Durable
+restore fails closed unless the last lifecycle boundary is the exact matching `TASK_COMPLETED`;
+live, failed, retry/backoff, provider-switch, unsupported, Docker, and workspace-drift states start
+fresh.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,12 +333,17 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
 Provider continuation is agent- and generation-owned and becomes durable only after logical output
-validation and the `onComplete` hook succeed. Persist the exact ledger high-water cursor, applied
-guidance cursor, and selected prompt identity with the observed provider session; restored
+validation and the `onComplete` hook succeed. A requested resume is successful only when the
+watcher captures that exact same nonempty provider session ID; absent or forked identity fails the
+attempt before hooks and forces the retry to rebuild full context. Persist the exact SQLite rowid
+high-water sequence, applied guidance sequence, and bounded SHA-256 selected-prompt identity with
+the observed provider session; never persist the selected prompt text. Restored
 continuations fail closed unless the final durable `TASK_COMPLETED` boundary and all provenance
-match. Continuation sources query strictly after that cursor and de-duplicate the exact triggering
-message by ledger ID. If the installed CLI cannot resume, rebuild full context or fail before
-launch—never send a continuation delta to a fresh provider session.
+match. Full and continuation source/guidance reads are bounded through the captured high-water;
+continuations query strictly after their prior sequence and de-duplicate the exact triggering
+message by ledger ID. Timestamps are display/filter metadata, not continuation cursors: concurrent
+writers can share one millisecond. If the installed CLI cannot resume, rebuild full context or fail
+before launch—never send a continuation delta to a fresh provider session.
 
 Provider session reuse is explicit-ID and agent-owned. Watcher-observed IDs are distinct from
 requested resume IDs. Commit continuation only after logical/structured success and bind it to the
@@ -355,7 +360,7 @@ fresh.
 - Topics: `USER_GUIDANCE_CLUSTER`, `USER_GUIDANCE_AGENT` (see `src/guidance-topics.js`).
 - Mailbox helper: `ledger.queryGuidanceMailbox()` with `messageBus.queryGuidanceMailbox()` passthrough.
 - Live injection: `Orchestrator.sendGuidanceToAgent()` uses `agent.injectInput()` to attempt PTY stdin; always persists `USER_GUIDANCE_AGENT` with `metadata.delivery` (`status: injected|unsupported`, `method: pty`, `taskId`, `reason`).
-- Safe-point queue fallback: `AgentWrapper._buildContext()` pulls queued guidance via `collectQueuedGuidance()` and injects a delimited block in `agent-context-builder` between Instructions and Output Schema. Cursor: `agent.lastGuidanceAppliedAt`.
+- Safe-point queue fallback: `AgentWrapper._buildContext()` pulls queued guidance via `collectQueuedGuidance()` and injects a delimited block in `agent-context-builder` between Instructions and Output Schema. Durable sequence: `agent.lastGuidanceAppliedId`.
 
 ### Agent Configuration (Minimal)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,13 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 Provider task ownership: task watchers persist an owned termination boundary with each active task.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
+Provider continuation is agent- and generation-owned and becomes durable only after logical output
+validation and the `onComplete` hook succeed. Persist the exact ledger high-water cursor, applied
+guidance cursor, and selected prompt identity with the observed provider session; restored
+continuations fail closed unless the final durable `TASK_COMPLETED` boundary and all provenance
+match. Continuation sources query strictly after that cursor and de-duplicate the exact triggering
+message by ledger ID. If the installed CLI cannot resume, rebuild full context or fail before
+launch—never send a continuation delta to a fresh provider session.
 
 Provider session reuse is explicit-ID and agent-owned. Watcher-observed IDs are distinct from
 requested resume IDs. Commit continuation only after logical/structured success and bind it to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,9 +335,12 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 Provider continuation is agent- and generation-owned and becomes durable only after logical output
 validation and the `onComplete` hook succeed. A requested resume is successful only when the
 watcher captures that exact same nonempty provider session ID; absent or forked identity fails the
-attempt before hooks and forces the retry to rebuild full context. Persist the exact SQLite rowid
-high-water sequence, applied guidance sequence, and bounded SHA-256 selected-prompt identity with
-the observed provider session; never persist the selected prompt text. Restored
+attempt before hooks and forces the retry to rebuild full context. Watchers track every unique
+session ID observed in a task; once two IDs differ, the persisted capture is permanently ambiguous
+even if a later event repeats the requested ID. Persist SQLite rowid high-water and applied-guidance
+cursors as canonical decimal strings, bind them to SQLite as `BigInt`, and never coerce them through
+JavaScript `Number`. Persist those cursors and a bounded SHA-256 selected-prompt identity with the
+observed provider session; never persist the selected prompt text. Restored
 continuations fail closed unless the final durable `TASK_COMPLETED` boundary and all provenance
 match. Full and continuation source/guidance reads are bounded through the captured high-water;
 continuations query strictly after their prior sequence and de-duplicate the exact triggering

--- a/cli/commands/inspect.js
+++ b/cli/commands/inspect.js
@@ -140,6 +140,7 @@ function buildTaskSummary(task, details) {
     error: task.error || null,
     cwd: task.cwd || null,
     sessionId: task.sessionId || null,
+    requestedResumeSessionId: task.requestedResumeSessionId || null,
     attachable: Boolean(task.attachable),
     socketPath: details.socketPath.path,
     socketPathExists: details.socketPath.exists,

--- a/cli/index.js
+++ b/cli/index.js
@@ -2837,7 +2837,7 @@ taskCmd
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
   .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
-  .option('-r, --resume <sessionId>', 'Resume a specific Claude session (claude only)')
+  .option('-r, --resume <sessionId>', 'Resume a specific provider session (Claude or Codex)')
   .option('-c, --continue', 'Continue the most recent Claude session (claude only)')
   .option(
     '-o, --output-format <format>',

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -1,4 +1,4 @@
-import { stringifyJson } from '../json';
+import { getString, isRecord, stringifyJson, tryParseJson } from '../json';
 import {
   type BuildProviderCommandOptions,
   type ClaudeCliFeatures,
@@ -65,6 +65,7 @@ function detectCliFeatures(helpText?: string | null): ClaudeCliFeatures {
     supportsVerbose: unknown ? true : /--verbose/.test(help),
     supportsModel: unknown ? true : /--model/.test(help),
     supportsEffort: unknown ? true : /--effort/.test(help),
+    supportsResume: unknown ? true : /--resume/.test(help),
     unknown,
   };
 }
@@ -114,13 +115,21 @@ function addAutoApproveArgs(args: string[], options: BuildProviderCommandOptions
 }
 
 function addSessionArgs(args: string[], options: BuildProviderCommandOptions): void {
-  if (options.resumeSessionId) {
+  const features = optionFeatures(options);
+  if (options.resumeSessionId && features.supportsResume !== false) {
     args.push('--resume', options.resumeSessionId);
     return;
   }
-  if (options.continueSession) {
+  if (options.continueSession && features.supportsResume !== false) {
     args.push('--continue');
   }
+}
+
+function extractSessionId(line: string): string | null {
+  const event = tryParseJson(line.trim());
+  if (!isRecord(event)) return null;
+  const sessionId = getString(event, 'session_id');
+  return sessionId?.trim() || null;
 }
 
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
@@ -163,6 +172,18 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
         'claude',
         'claude-reasoning',
         'Claude CLI does not support --effort; skipping reasoningEffort.'
+      )
+    );
+  }
+  if (
+    (options.resumeSessionId || options.continueSession) &&
+    features.supportsResume === false
+  ) {
+    warnings.push(
+      warning(
+        'claude',
+        'claude-session-resume-unsupported',
+        'Claude CLI does not support session resume; starting a fresh session.'
       )
     );
   }
@@ -227,6 +248,7 @@ export const claudeAdapter: ProviderAdapter = {
   defaultMinLevel: 'level1',
   detectCliFeatures,
   buildCommand,
+  extractSessionId,
   parseEvent: parseClaudeEvent,
   createParserState: () => createParserState('claude'),
   resolveModelSpec,

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -116,6 +116,11 @@ function addAutoApproveArgs(args: string[], options: BuildProviderCommandOptions
 
 function addSessionArgs(args: string[], options: BuildProviderCommandOptions): void {
   const features = optionFeatures(options);
+  if ((options.resumeSessionId || options.continueSession) && features.supportsResume === false) {
+    throw new Error(
+      'Claude CLI cannot safely run continuation context because this installation lacks --resume.'
+    );
+  }
   if (options.resumeSessionId && features.supportsResume !== false) {
     args.push('--resume', options.resumeSessionId);
     return;
@@ -172,18 +177,6 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
         'claude',
         'claude-reasoning',
         'Claude CLI does not support --effort; skipping reasoningEffort.'
-      )
-    );
-  }
-  if (
-    (options.resumeSessionId || options.continueSession) &&
-    features.supportsResume === false
-  ) {
-    warnings.push(
-      warning(
-        'claude',
-        'claude-session-resume-unsupported',
-        'Claude CLI does not support session resume; starting a fresh session.'
       )
     );
   }

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -1,3 +1,4 @@
+import { getString, isRecord, tryParseJson } from '../json';
 import { appendJsonSchemaPrompt, writeStrictOutputSchemaFile } from '../schema';
 import {
   type BuildProviderCommandOptions,
@@ -18,7 +19,6 @@ import {
   createParserState,
   optionFeatures,
   resolveModelSpecWithConfig,
-  unsupportedSessionControlWarnings,
   validateModelIdFromCatalog,
   warning,
 } from './common';
@@ -55,8 +55,16 @@ function detectCliFeatures(helpText?: string | null): CodexCliFeatures {
     supportsConfigOverride: supports(help, /--config\b/),
     supportsModel: supports(help, /\s-m\b/) || supports(help, /--model\b/),
     supportsSkipGitRepoCheck: supports(help, /--skip-git-repo-check\b/),
+    supportsResume: supports(help, /\bresume\b/),
     unknown,
   };
+}
+
+function extractSessionId(line: string): string | null {
+  const event = tryParseJson(line.trim());
+  if (!isRecord(event) || getString(event, 'type') !== 'thread.started') return null;
+  const sessionId = getString(event, 'thread_id');
+  return sessionId?.trim() || null;
 }
 
 function addOutputArgs(args: string[], options: BuildProviderCommandOptions): void {
@@ -118,7 +126,25 @@ function applySchemaArgs(
 
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
-  const warnings: WarningMetadata[] = unsupportedSessionControlWarnings('codex', options);
+  const warnings: WarningMetadata[] = [];
+  if (options.continueSession) {
+    warnings.push(
+      warning(
+        'codex',
+        'unsupported-session-control',
+        'Codex requires an explicit session ID; ignoring continueSession.'
+      )
+    );
+  }
+  if (options.resumeSessionId && features.supportsResume === false) {
+    warnings.push(
+      warning(
+        'codex',
+        'codex-session-resume-unsupported',
+        'Codex CLI does not support exec resume; starting a fresh session.'
+      )
+    );
+  }
   if (options.autoApprove && features.supportsAutoApprove === false) {
     warnings.push(
       warning(
@@ -152,14 +178,26 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
   const args: string[] = ['exec'];
   const cleanup: string[] = [];
+  const resumeSessionId =
+    options.resumeSessionId && optionFeatures(options).supportsResume !== false
+      ? options.resumeSessionId
+      : null;
+  if (resumeSessionId) {
+    args.push('resume');
+  }
 
   addOutputArgs(args, options);
   addModelArgs(args, options);
-  addCwdArgs(args, options);
+  if (!resumeSessionId) {
+    addCwdArgs(args, options);
+  }
   addAutoApproveArgs(args, options);
   addSkipGitArgs(args, options);
   const finalContext = applySchemaArgs(args, cleanup, context, options);
 
+  if (resumeSessionId) {
+    args.push(resumeSessionId);
+  }
   args.push(finalContext);
 
   return commandSpec({
@@ -213,6 +251,7 @@ export const codexAdapter: ProviderAdapter = {
   defaultMinLevel: 'level1',
   detectCliFeatures,
   buildCommand,
+  extractSessionId,
   parseEvent: parseCodexEvent,
   createParserState: () => createParserState('codex'),
   resolveModelSpec,

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -176,6 +176,11 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
 }
 
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
+  if (options.resumeSessionId && optionFeatures(options).supportsResume === false) {
+    throw new Error(
+      'Codex CLI cannot safely run continuation context because this installation lacks exec resume.'
+    );
+  }
   const args: string[] = ['exec'];
   const cleanup: string[] = [];
   const resumeSessionId =

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -64,7 +64,7 @@ export function unsupportedSessionControlWarnings(
     warning(
       provider,
       'unsupported-session-control',
-      'resume/continue is only supported for Claude CLI; ignoring.'
+      `Provider ${provider} does not support resume/continue session control; ignoring.`
     ),
   ];
 }

--- a/src/agent-cli-provider/adapters/index.ts
+++ b/src/agent-cli-provider/adapters/index.ts
@@ -79,6 +79,16 @@ export function parseProviderChunk(
   return events;
 }
 
+export function extractProviderSessionId(
+  providerName: KnownProviderName | string,
+  line: string
+): string | null {
+  const adapter = getProviderAdapter(providerName || 'claude');
+  const content = stripTimestampPrefix(line);
+  if (!content || !adapter.extractSessionId) return null;
+  return adapter.extractSessionId(content);
+}
+
 export function resolveModelSpec(
   providerName: KnownProviderName | string,
   level: ModelLevel,

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -42,6 +42,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsNoAskUser',
   'supportsAddDir',
   'supportsMcpConfig',
+  'supportsResume',
   'supportsBundledRunner',
   'supportsAcpStdio',
   'supportsPromptImages',

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -3,6 +3,7 @@ export {
   classifyProviderError,
   detectProviderFatalError,
   detectProviderStreamingModeError,
+  extractProviderSessionId,
   getProviderAdapter,
   listProviderAdapters,
   parseProviderChunk,

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -19,6 +19,7 @@ export interface ProviderCapabilities {
   readonly streamJson: ProviderCapabilityState;
   readonly thinkingMode: ProviderCapabilityState;
   readonly reasoningEffort: ProviderCapabilityState;
+  readonly sessionResume: ProviderCapabilityState;
 }
 
 interface FixedProviderCommandSpec {
@@ -93,13 +94,22 @@ export interface ProviderRegistryEntry {
 }
 
 const STANDARD_CAPABILITIES: Readonly<
-  Pick<ProviderCapabilities, 'dockerIsolation' | 'worktreeIsolation' | 'mcpServers' | 'streamJson' | 'thinkingMode'>
+  Pick<
+    ProviderCapabilities,
+    | 'dockerIsolation'
+    | 'worktreeIsolation'
+    | 'mcpServers'
+    | 'streamJson'
+    | 'thinkingMode'
+    | 'sessionResume'
+  >
 > = {
   dockerIsolation: true,
   worktreeIsolation: true,
   mcpServers: true,
   streamJson: true,
   thinkingMode: true,
+  sessionResume: false,
 };
 
 const CLAUDE_DOCKER_ENV_PASSTHROUGH = [
@@ -161,6 +171,7 @@ export const providerRegistry = [
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
       reasoningEffort: true,
+      sessionResume: true,
     },
     docs: {
       label: 'Claude',
@@ -197,6 +208,7 @@ export const providerRegistry = [
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
       reasoningEffort: true,
+      sessionResume: true,
     },
     docs: {
       label: 'Codex',

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -96,6 +96,7 @@ export interface ClaudeCliFeatures extends BaseCliFeatures {
   readonly supportsVerbose: boolean;
   readonly supportsModel: boolean;
   readonly supportsEffort: boolean;
+  readonly supportsResume: boolean;
 }
 
 export interface CodexCliFeatures extends BaseCliFeatures {
@@ -107,6 +108,7 @@ export interface CodexCliFeatures extends BaseCliFeatures {
   readonly supportsConfigOverride: boolean;
   readonly supportsModel: boolean;
   readonly supportsSkipGitRepoCheck: boolean;
+  readonly supportsResume: boolean;
 }
 
 export interface GeminiCliFeatures extends BaseCliFeatures {
@@ -207,6 +209,7 @@ export interface CliFeatureOverrides {
   readonly supportsNoAskUser?: boolean;
   readonly supportsAddDir?: boolean;
   readonly supportsMcpConfig?: boolean;
+  readonly supportsResume?: boolean;
   readonly supportsBundledRunner?: boolean;
   readonly supportsAcpStdio?: boolean;
   readonly supportsPromptImages?: boolean;
@@ -363,6 +366,7 @@ export interface ProviderAdapter {
   readonly defaultMinLevel: ModelLevel;
   detectCliFeatures(helpText?: string | null): ProviderCliFeatures;
   buildCommand(context: string, options?: BuildProviderCommandOptions): CommandSpec;
+  extractSessionId?(line: string): string | null;
   parseEvent(line: string, state: ProviderParserState): ProviderParseResult;
   createParserState(): ProviderParserState;
   resolveModelSpec(level: ModelLevel, overrides?: LevelOverrides): ResolvedModelSpec;

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -66,6 +66,8 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
+    /** @type {{provider: string, sessionId: string} | null} */
+    this.providerSession = null; // Provider continuation state, owned by this logical agent only
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
     this.running = false;

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -17,6 +17,7 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { buildContext } = require('./agent/agent-context-builder');
 const { collectQueuedGuidance } = require('./agent/guidance-queue');
+const { resolveAgentResumeSessionId } = require('./agent/provider-session');
 const { findMatchingTrigger, evaluateTrigger } = require('./agent/agent-trigger-evaluator');
 const { executeHook } = require('./agent/agent-hook-executor');
 const { injectInput: injectAgentInput } = require('./agent/agent-input-injector');
@@ -66,7 +67,7 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
-    /** @type {{provider: string, sessionId: string} | null} */
+    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null} | null} */
     this.providerSession = null; // Provider continuation state, owned by this logical agent only
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
@@ -437,6 +438,8 @@ class AgentWrapper {
    */
   _buildContext(triggeringMessage) {
     const previousAgentStart = this.lastAgentStartTime;
+    const providerName = this._resolveProvider();
+    const contextMode = resolveAgentResumeSessionId(this, providerName) ? 'continuation' : 'full';
     const queuedGuidance = collectQueuedGuidance({
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
@@ -455,6 +458,7 @@ class AgentWrapper {
       triggeringMessage,
       selectedPrompt: this._selectPrompt(),
       queuedGuidance: queuedGuidance.guidanceBlock,
+      mode: contextMode,
       // Pass isolation state for conditional git restriction
       worktree: this.worktree,
       isolation: this.isolation,

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -463,7 +463,7 @@ class AgentWrapper {
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
       agentId: this.id,
-      afterId: providerSession ? this.lastGuidanceAppliedId : undefined,
+      afterId: this.lastGuidanceAppliedId,
       throughId: this.currentContextSequence,
     });
     this.currentGuidanceSequence =

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -17,7 +17,10 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { buildContext } = require('./agent/agent-context-builder');
 const { collectQueuedGuidance } = require('./agent/guidance-queue');
-const { resolveAgentResumeSessionId } = require('./agent/provider-session');
+const {
+  resolveAgentProviderSession,
+  updateAgentProviderSession,
+} = require('./agent/provider-session');
 const { findMatchingTrigger, evaluateTrigger } = require('./agent/agent-trigger-evaluator');
 const { executeHook } = require('./agent/agent-hook-executor');
 const { injectInput: injectAgentInput } = require('./agent/agent-input-injector');
@@ -67,8 +70,11 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
-    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null} | null} */
+    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null, contextCursor: number, guidanceCursor: number|null, promptText: string|null} | null} */
     this.providerSession = null; // Provider continuation state, owned by this logical agent only
+    this.currentContextCursor = 0;
+    this.currentGuidanceCursor = null;
+    this.currentPromptText = null;
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
     this.running = false;
@@ -122,6 +128,7 @@ class AgentWrapper {
 
     this.testMode = options.testMode || false;
     this.quiet = options.quiet || false;
+    this.providerCliFeatures = options.providerCliFeatures || null;
 
     // ISOLATION SUPPORT - Run tasks inside Docker container
     this.isolation = options.isolation || null;
@@ -439,13 +446,24 @@ class AgentWrapper {
   _buildContext(triggeringMessage) {
     const previousAgentStart = this.lastAgentStartTime;
     const providerName = this._resolveProvider();
-    const contextMode = resolveAgentResumeSessionId(this, providerName) ? 'continuation' : 'full';
+    let providerSession = resolveAgentProviderSession(this, providerName);
+    if (providerSession && !this._providerSupportsSessionResume(providerName)) {
+      updateAgentProviderSession(this, null);
+      providerSession = null;
+    }
+    const contextMode = providerSession ? 'continuation' : 'full';
+    const selectedPrompt = this._selectPrompt();
+    const latestMessage = this.messageBus.findLast({ cluster_id: this.cluster.id });
+    this.currentContextCursor = latestMessage?.timestamp || 0;
     const queuedGuidance = collectQueuedGuidance({
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
       agentId: this.id,
       lastDeliveredAt: this.lastGuidanceAppliedAt,
     });
+    this.currentGuidanceCursor =
+      queuedGuidance.latestTimestamp ?? this.lastGuidanceAppliedAt ?? null;
+    this.currentPromptText = selectedPrompt ?? null;
     const context = buildContext({
       id: this.id,
       role: this.role,
@@ -456,26 +474,31 @@ class AgentWrapper {
       lastTaskEndTime: this.lastTaskEndTime,
       lastAgentStartTime: previousAgentStart,
       triggeringMessage,
-      selectedPrompt: this._selectPrompt(),
+      selectedPrompt,
       queuedGuidance: queuedGuidance.guidanceBlock,
       mode: contextMode,
+      continuationCursor: providerSession?.contextCursor,
+      previousPromptText: providerSession?.promptText,
       // Pass isolation state for conditional git restriction
       worktree: this.worktree,
       isolation: this.isolation,
     });
 
     // Record when this iteration started so future "since: last_agent_start" filters work.
-    const latestMessage = this.messageBus.findLast({ cluster_id: this.cluster.id });
     const latestTimestamp = latestMessage?.timestamp;
     const now = Date.now();
     this.lastAgentStartTime =
       typeof latestTimestamp === 'number' ? Math.max(now, latestTimestamp + 1) : now;
 
-    if (queuedGuidance.latestTimestamp !== null) {
-      this.lastGuidanceAppliedAt = queuedGuidance.latestTimestamp;
-    }
-
     return context;
+  }
+
+  _providerSupportsSessionResume(providerName) {
+    const override = this.providerCliFeatures?.[providerName];
+    if (override && Object.hasOwn(override, 'supportsResume')) {
+      return override.supportsResume === true;
+    }
+    return getProvider(providerName).getCliFeatures().supportsResume === true;
   }
 
   /**

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -18,6 +18,7 @@ const { getProvider } = require('./providers');
 const { buildContext } = require('./agent/agent-context-builder');
 const { collectQueuedGuidance } = require('./agent/guidance-queue');
 const {
+  promptIdentity,
   resolveAgentProviderSession,
   updateAgentProviderSession,
 } = require('./agent/provider-session');
@@ -70,11 +71,11 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
-    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null, contextCursor: number, guidanceCursor: number|null, promptText: string|null} | null} */
+    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null, contextSequence: number, guidanceSequence: number|null, promptIdentity: string|null} | null} */
     this.providerSession = null; // Provider continuation state, owned by this logical agent only
-    this.currentContextCursor = 0;
-    this.currentGuidanceCursor = null;
-    this.currentPromptText = null;
+    this.currentContextSequence = 0;
+    this.currentGuidanceSequence = null;
+    this.currentPromptIdentity = null;
     /** @type {number | null} */
     this.processPid = null; // Track process PID for resource monitoring
     this.running = false;
@@ -85,7 +86,7 @@ class AgentWrapper {
     /** @type {number | null} */
     this.lastAgentStartTime = null; // Track when agent last began executing (for context filtering)
     /** @type {number | null} */
-    this.lastGuidanceAppliedAt = null; // Track last queued guidance applied to prompt
+    this.lastGuidanceAppliedId = null; // Track last queued guidance sequence applied to prompt
 
     // LIVENESS DETECTION - Track output freshness to detect stuck agents
     /** @type {number | null} */
@@ -453,17 +454,21 @@ class AgentWrapper {
     }
     const contextMode = providerSession ? 'continuation' : 'full';
     const selectedPrompt = this._selectPrompt();
-    const latestMessage = this.messageBus.findLast({ cluster_id: this.cluster.id });
-    this.currentContextCursor = latestMessage?.timestamp || 0;
+    const latestMessage = this.messageBus.findLast({
+      cluster_id: this.cluster.id,
+      orderBySequence: true,
+    });
+    this.currentContextSequence = latestMessage?.sequence || 0;
     const queuedGuidance = collectQueuedGuidance({
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
       agentId: this.id,
-      lastDeliveredAt: this.lastGuidanceAppliedAt,
+      afterId: this.lastGuidanceAppliedId,
+      throughId: this.currentContextSequence,
     });
-    this.currentGuidanceCursor =
-      queuedGuidance.latestTimestamp ?? this.lastGuidanceAppliedAt ?? null;
-    this.currentPromptText = selectedPrompt ?? null;
+    this.currentGuidanceSequence =
+      queuedGuidance.latestSequence ?? this.lastGuidanceAppliedId ?? null;
+    this.currentPromptIdentity = promptIdentity(selectedPrompt);
     const context = buildContext({
       id: this.id,
       role: this.role,
@@ -477,8 +482,10 @@ class AgentWrapper {
       selectedPrompt,
       queuedGuidance: queuedGuidance.guidanceBlock,
       mode: contextMode,
-      continuationCursor: providerSession?.contextCursor,
-      previousPromptText: providerSession?.promptText,
+      continuationSequence: providerSession?.contextSequence,
+      contextThroughId: this.currentContextSequence,
+      previousPromptIdentity: providerSession?.promptIdentity,
+      currentPromptIdentity: this.currentPromptIdentity,
       // Pass isolation state for conditional git restriction
       worktree: this.worktree,
       isolation: this.isolation,

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -463,7 +463,7 @@ class AgentWrapper {
       messageBus: this.messageBus,
       clusterId: this.cluster.id,
       agentId: this.id,
-      afterId: this.lastGuidanceAppliedId,
+      afterId: providerSession ? this.lastGuidanceAppliedId : undefined,
       throughId: this.currentContextSequence,
     });
     this.currentGuidanceSequence =

--- a/src/agent-wrapper.js
+++ b/src/agent-wrapper.js
@@ -71,9 +71,9 @@ class AgentWrapper {
     this.currentTask = null;
     /** @type {string | null} */
     this.currentTaskId = null; // Track spawned task ID for resume capability
-    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null, contextSequence: number, guidanceSequence: number|null, promptIdentity: string|null} | null} */
+    /** @type {{provider: string, sessionId: string, agentId: string, taskId: string, generation: number, cwd: string, worktreePath: string|null, contextSequence: string, guidanceSequence: string|null, promptIdentity: string|null} | null} */
     this.providerSession = null; // Provider continuation state, owned by this logical agent only
-    this.currentContextSequence = 0;
+    this.currentContextSequence = '0';
     this.currentGuidanceSequence = null;
     this.currentPromptIdentity = null;
     /** @type {number | null} */
@@ -458,7 +458,7 @@ class AgentWrapper {
       cluster_id: this.cluster.id,
       orderBySequence: true,
     });
-    this.currentContextSequence = latestMessage?.sequence || 0;
+    this.currentContextSequence = latestMessage?.sequence || '0';
     const queuedGuidance = collectQueuedGuidance({
       messageBus: this.messageBus,
       clusterId: this.cluster.id,

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -138,6 +138,74 @@ function buildPacks(params) {
   return packs;
 }
 
+function buildContinuationPacks(params) {
+  const {
+    id,
+    iteration,
+    config,
+    selectedPrompt,
+    queuedGuidance,
+    triggeringMessage,
+    strategy,
+    messageBus,
+    cluster,
+    lastTaskEndTime,
+    lastAgentStartTime,
+  } = params;
+  const packs = [];
+  let order = 0;
+
+  order = pushStaticPack({
+    packs,
+    packId: 'continuationHeader',
+    section: 'continuationHeader',
+    text: `## Continuation Turn\n\nAgent: ${id}\nIteration: ${iteration}\n\nApply only the new material below while retaining the existing session instructions.\n\n`,
+    order,
+  });
+
+  // Iteration-rule prompts may intentionally change between turns. Static prompts,
+  // repository tooling, ISSUE_OPENED/PLAN_READY sources, and output contracts are
+  // already present in the provider session and must not be replayed.
+  if (config.promptConfig?.type === 'rules') {
+    order = pushStaticPack({
+      packs,
+      packId: 'iterationInstructions',
+      section: 'iterationInstructions',
+      text: buildInstructionsSection({ config, selectedPrompt, id }),
+      order,
+    });
+  }
+
+  order = pushStaticPack({
+    packs,
+    packId: 'queuedGuidance',
+    section: 'queuedGuidance',
+    text: queuedGuidance || '',
+    order,
+  });
+  order = appendSourcePacks(
+    packs,
+    {
+      sources: (strategy.sources || []).map((source) => ({
+        ...source,
+        since: 'last_agent_start',
+      })),
+    },
+    { messageBus, cluster, lastTaskEndTime, lastAgentStartTime },
+    order
+  );
+  pushStaticPack({
+    packs,
+    packId: 'triggeringMessage',
+    section: 'triggeringMessage',
+    text: buildTriggeringMessageSection(triggeringMessage),
+    order,
+    options: { preserve: true },
+  });
+
+  return packs;
+}
+
 /**
  * Build execution context for an agent
  * @param {object} params - Context building parameters
@@ -157,7 +225,10 @@ function buildPacks(params) {
  */
 function buildContext(params) {
   const strategy = params.config.contextStrategy || { sources: [] };
-  const packs = buildPacks({ ...params, strategy });
+  const continuation = params.mode === 'continuation';
+  const packs = continuation
+    ? buildContinuationPacks({ ...params, strategy })
+    : buildPacks({ ...params, strategy });
   const maxTokens = resolveLegacyMaxTokens(strategy);
   const packResult = buildContextPacks({
     packs,
@@ -171,7 +242,7 @@ function buildContext(params) {
     role: params.role,
     iteration: params.iteration,
     triggeringMessage: params.triggeringMessage,
-    strategy,
+    strategy: { ...strategy, contextMode: continuation ? 'continuation' : 'full' },
     packs: packResult.packDecisions,
     budget: packResult.budget,
     truncation: packResult.truncation,

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -122,6 +122,7 @@ function buildPacks(params) {
       cluster,
       lastTaskEndTime,
       lastAgentStartTime,
+      throughId: params.contextThroughId,
       triggeringMessageId: triggeringMessage?.id,
     },
     order
@@ -158,8 +159,10 @@ function buildContinuationPacks(params) {
     cluster,
     lastTaskEndTime,
     lastAgentStartTime,
-    continuationCursor,
-    previousPromptText,
+    continuationSequence,
+    contextThroughId,
+    previousPromptIdentity,
+    currentPromptIdentity,
   } = params;
   const packs = [];
   let order = 0;
@@ -175,7 +178,7 @@ function buildContinuationPacks(params) {
   // Iteration-rule prompts may intentionally change between turns. Static prompts,
   // repository tooling, ISSUE_OPENED/PLAN_READY sources, and output contracts are
   // already present in the provider session and must not be replayed.
-  if (config.promptConfig?.type === 'rules' && selectedPrompt !== previousPromptText) {
+  if (config.promptConfig?.type === 'rules' && currentPromptIdentity !== previousPromptIdentity) {
     order = pushStaticPack({
       packs,
       packId: 'iterationInstructions',
@@ -200,7 +203,8 @@ function buildContinuationPacks(params) {
       cluster,
       lastTaskEndTime,
       lastAgentStartTime,
-      afterCursor: continuationCursor,
+      afterId: continuationSequence,
+      throughId: contextThroughId,
       triggeringMessageId: triggeringMessage?.id,
     },
     order

--- a/src/agent/agent-context-builder.js
+++ b/src/agent/agent-context-builder.js
@@ -94,7 +94,8 @@ function buildStaticSections(params) {
 }
 
 function buildPacks(params) {
-  const { strategy, messageBus, cluster, lastTaskEndTime, lastAgentStartTime } = params;
+  const { strategy, messageBus, cluster, lastTaskEndTime, lastAgentStartTime, triggeringMessage } =
+    params;
   const sections = buildStaticSections(params);
   const packs = [];
   let order = 0;
@@ -116,7 +117,13 @@ function buildPacks(params) {
   order = appendSourcePacks(
     packs,
     strategy,
-    { messageBus, cluster, lastTaskEndTime, lastAgentStartTime },
+    {
+      messageBus,
+      cluster,
+      lastTaskEndTime,
+      lastAgentStartTime,
+      triggeringMessageId: triggeringMessage?.id,
+    },
     order
   );
   order = pushStaticPack({
@@ -151,6 +158,8 @@ function buildContinuationPacks(params) {
     cluster,
     lastTaskEndTime,
     lastAgentStartTime,
+    continuationCursor,
+    previousPromptText,
   } = params;
   const packs = [];
   let order = 0;
@@ -166,7 +175,7 @@ function buildContinuationPacks(params) {
   // Iteration-rule prompts may intentionally change between turns. Static prompts,
   // repository tooling, ISSUE_OPENED/PLAN_READY sources, and output contracts are
   // already present in the provider session and must not be replayed.
-  if (config.promptConfig?.type === 'rules') {
+  if (config.promptConfig?.type === 'rules' && selectedPrompt !== previousPromptText) {
     order = pushStaticPack({
       packs,
       packId: 'iterationInstructions',
@@ -185,13 +194,15 @@ function buildContinuationPacks(params) {
   });
   order = appendSourcePacks(
     packs,
+    strategy,
     {
-      sources: (strategy.sources || []).map((source) => ({
-        ...source,
-        since: 'last_agent_start',
-      })),
+      messageBus,
+      cluster,
+      lastTaskEndTime,
+      lastAgentStartTime,
+      afterCursor: continuationCursor,
+      triggeringMessageId: triggeringMessage?.id,
     },
-    { messageBus, cluster, lastTaskEndTime, lastAgentStartTime },
     order
   );
   pushStaticPack({

--- a/src/agent/agent-context-sources.js
+++ b/src/agent/agent-context-sources.js
@@ -66,12 +66,13 @@ function resolveSourceMessages({
   cluster,
   lastTaskEndTime,
   lastAgentStartTime,
-  afterCursor,
+  afterId,
+  throughId,
   triggeringMessageId,
   compact = false,
 }) {
   const sinceTimestamp =
-    afterCursor === undefined
+    afterId === undefined
       ? resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime)
       : undefined;
   const { amount, strategy } = resolveSourceSelection(source, { compact });
@@ -79,7 +80,8 @@ function resolveSourceMessages({
     cluster_id: cluster.id,
     topic: source.topic,
     sender: source.sender,
-    ...(afterCursor === undefined ? { since: sinceTimestamp } : { after: afterCursor }),
+    ...(afterId === undefined ? { since: sinceTimestamp } : { afterId }),
+    throughId,
   });
   const replayableMessages = messages.filter(
     (message) => isReplayableMessage(message) && message.id !== triggeringMessageId
@@ -122,7 +124,8 @@ function buildSourcePack({
   cluster,
   lastTaskEndTime,
   lastAgentStartTime,
-  afterCursor,
+  afterId,
+  throughId,
   triggeringMessageId,
 }) {
   const render = (compact) => {
@@ -132,7 +135,8 @@ function buildSourcePack({
       cluster,
       lastTaskEndTime,
       lastAgentStartTime,
-      afterCursor,
+      afterId,
+      throughId,
       triggeringMessageId,
       compact,
     });

--- a/src/agent/agent-context-sources.js
+++ b/src/agent/agent-context-sources.js
@@ -66,17 +66,24 @@ function resolveSourceMessages({
   cluster,
   lastTaskEndTime,
   lastAgentStartTime,
+  afterCursor,
+  triggeringMessageId,
   compact = false,
 }) {
-  const sinceTimestamp = resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime);
+  const sinceTimestamp =
+    afterCursor === undefined
+      ? resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime)
+      : undefined;
   const { amount, strategy } = resolveSourceSelection(source, { compact });
   const messages = messageBus.query({
     cluster_id: cluster.id,
     topic: source.topic,
     sender: source.sender,
-    since: sinceTimestamp,
+    ...(afterCursor === undefined ? { since: sinceTimestamp } : { after: afterCursor }),
   });
-  const replayableMessages = messages.filter(isReplayableMessage);
+  const replayableMessages = messages.filter(
+    (message) => isReplayableMessage(message) && message.id !== triggeringMessageId
+  );
 
   if (amount === undefined) {
     return replayableMessages;
@@ -115,6 +122,8 @@ function buildSourcePack({
   cluster,
   lastTaskEndTime,
   lastAgentStartTime,
+  afterCursor,
+  triggeringMessageId,
 }) {
   const render = (compact) => {
     const messages = resolveSourceMessages({
@@ -123,6 +132,8 @@ function buildSourcePack({
       cluster,
       lastTaskEndTime,
       lastAgentStartTime,
+      afterCursor,
+      triggeringMessageId,
       compact,
     });
 

--- a/src/agent/agent-context-sources.js
+++ b/src/agent/agent-context-sources.js
@@ -71,16 +71,19 @@ function resolveSourceMessages({
   triggeringMessageId,
   compact = false,
 }) {
-  const sinceTimestamp =
-    afterId === undefined
-      ? resolveSourceSince(source, cluster, lastTaskEndTime, lastAgentStartTime)
-      : undefined;
+  const sinceTimestamp = resolveSourceSince(
+    source,
+    cluster,
+    lastTaskEndTime,
+    lastAgentStartTime
+  );
   const { amount, strategy } = resolveSourceSelection(source, { compact });
   const messages = messageBus.query({
     cluster_id: cluster.id,
     topic: source.topic,
     sender: source.sender,
-    ...(afterId === undefined ? { since: sinceTimestamp } : { afterId }),
+    since: sinceTimestamp,
+    afterId,
     throughId,
   });
   const replayableMessages = messages.filter(

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -438,12 +438,16 @@ function attachResultMetadata(agent, result) {
 }
 
 function publishTaskCompleted(agent, result) {
+  const session = result.providerSession;
   agent._publishLifecycle('TASK_COMPLETED', {
     iteration: agent.iteration,
     success: true,
     taskId: agent.currentTaskId,
     provider: agent._resolveProvider ? agent._resolveProvider() : 'claude',
     tokenUsage: result.tokenUsage || null,
+    contextCursor: session?.contextCursor ?? agent.currentContextCursor,
+    guidanceCursor: session?.guidanceCursor ?? agent.currentGuidanceCursor ?? null,
+    promptText: session?.promptText ?? agent.currentPromptText ?? null,
   });
 }
 
@@ -594,9 +598,17 @@ async function runTaskAttempt(agent, triggeringMessage) {
     );
   }
 
-  // Commit continuation state only after provider completion, structured-output
-  // classification, and platform fallback checks all agree this logical turn succeeded.
+  // The hook publishes the logical output of the turn. Until it succeeds, neither
+  // TASK_COMPLETED nor its provider continuation boundary is durable.
+  try {
+    await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
+  } catch (error) {
+    updateAgentProviderSession(agent, null);
+    throw error;
+  }
+
   updateAgentProviderSession(agent, result.providerSession);
+  agent.lastGuidanceAppliedAt = agent.currentGuidanceCursor;
 
   // Set state to idle BEFORE publishing lifecycle event
   // (so lifecycle message includes correct state)
@@ -608,7 +620,6 @@ async function runTaskAttempt(agent, triggeringMessage) {
   publishTaskCompleted(agent, result);
   publishTokenUsage(agent, result);
   clearTransientTaskState(agent);
-  await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
 }
 
 function logTaskAttemptFailure(agent, attempt, maxRetries, error) {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -442,6 +442,7 @@ function publishTaskCompleted(agent, result) {
     iteration: agent.iteration,
     success: true,
     taskId: agent.currentTaskId,
+    provider: agent._resolveProvider ? agent._resolveProvider() : 'claude',
     tokenUsage: result.tokenUsage || null,
   });
 }
@@ -574,11 +575,11 @@ async function runTaskAttempt(agent, triggeringMessage) {
     updateAgentProviderSession(agent, null);
     throw error;
   }
-  updateAgentProviderSession(agent, result.providerSession);
   attachResultMetadata(agent, result);
 
   // Check if task execution failed
   if (!result.success) {
+    updateAgentProviderSession(agent, null);
     const error = new Error(result.error || 'Task execution failed');
     error.code = result.code || result.errorType || null;
     error.taskId = result.taskId || null;
@@ -592,6 +593,10 @@ async function runTaskAttempt(agent, triggeringMessage) {
       `Validator platform mismatch detected (${fallbackReason}). Retrying in Docker isolation.`
     );
   }
+
+  // Commit continuation state only after provider completion, structured-output
+  // classification, and platform fallback checks all agree this logical turn succeeded.
+  updateAgentProviderSession(agent, result.providerSession);
 
   // Set state to idle BEFORE publishing lifecycle event
   // (so lifecycle message includes correct state)
@@ -981,6 +986,9 @@ async function executeTask(agent, triggeringMessage) {
       await runTaskAttempt(agent, triggeringMessage);
       return;
     } catch (error) {
+      // Any failed logical attempt invalidates continuation before TASK_FAILED is
+      // published and persisted. Retries must reconstruct a fresh full context.
+      updateAgentProviderSession(agent, null);
       if (!agent.running || agent.state === 'stopped') {
         agent._log(`[${agent.id}] Task interrupted during shutdown; skipping retry`);
         return;

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -445,9 +445,9 @@ function publishTaskCompleted(agent, result) {
     taskId: agent.currentTaskId,
     provider: agent._resolveProvider ? agent._resolveProvider() : 'claude',
     tokenUsage: result.tokenUsage || null,
-    contextCursor: session?.contextCursor ?? agent.currentContextCursor,
-    guidanceCursor: session?.guidanceCursor ?? agent.currentGuidanceCursor ?? null,
-    promptText: session?.promptText ?? agent.currentPromptText ?? null,
+    contextSequence: session?.contextSequence ?? agent.currentContextSequence,
+    guidanceSequence: session?.guidanceSequence ?? agent.currentGuidanceSequence ?? null,
+    promptIdentity: session?.promptIdentity ?? agent.currentPromptIdentity ?? null,
   });
 }
 
@@ -608,7 +608,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
   }
 
   updateAgentProviderSession(agent, result.providerSession);
-  agent.lastGuidanceAppliedAt = agent.currentGuidanceCursor;
+  agent.lastGuidanceAppliedId = agent.currentGuidanceSequence;
 
   // Set state to idle BEFORE publishing lifecycle event
   // (so lifecycle message includes correct state)

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -22,6 +22,7 @@ const { normalizeProviderName } = require('../../lib/provider-names');
 const { loadSettings } = require('../../lib/settings');
 const { findPlatformMismatchReason } = require('./validation-platform');
 const { calculateRateLimitDelay, isRateLimitError } = require('./rate-limit-backoff');
+const { updateAgentProviderSession } = require('./provider-session');
 
 const DEFAULT_VALIDATOR_IMAGE = 'zeroshot-cluster-base';
 
@@ -566,7 +567,14 @@ async function runTaskAttempt(agent, triggeringMessage) {
   await applyValidatorJitter(agent);
   publishTaskStarted(agent, triggeringMessage);
 
-  const result = await agent._spawnClaudeTask(context);
+  let result;
+  try {
+    result = await agent._spawnClaudeTask(context);
+  } catch (error) {
+    updateAgentProviderSession(agent, null);
+    throw error;
+  }
+  updateAgentProviderSession(agent, result.providerSession);
   attachResultMetadata(agent, result);
 
   // Check if task execution failed
@@ -579,6 +587,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
 
   const fallbackReason = await maybeRetryValidatorInDocker(agent, result);
   if (fallbackReason) {
+    updateAgentProviderSession(agent, null);
     throw new Error(
       `Validator platform mismatch detected (${fallbackReason}). Retrying in Docker isolation.`
     );

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -31,6 +31,7 @@ const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 const {
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
+  validateCompletedResumeIdentity,
 } = require('./provider-session');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
@@ -1227,6 +1228,11 @@ async function buildCompletionResult({
   taskInfo = getTask(taskId),
 }) {
   const classified = await evaluateStructuredSuccess({ agent, taskId, state, success });
+  const resumeIdentityError = classified.success ? validateCompletedResumeIdentity(taskInfo) : null;
+  if (resumeIdentityError) {
+    classified.success = false;
+    classified.error = resumeIdentityError;
+  }
   let errorContext = classified.error;
   if (!errorContext && !classified.success) {
     errorContext = buildFailureContext({ agent, taskId, providerName, state, stdout });

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1217,7 +1217,15 @@ function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
   });
 }
 
-async function buildCompletionResult({ agent, taskId, providerName, state, stdout, success }) {
+async function buildCompletionResult({
+  agent,
+  taskId,
+  providerName,
+  state,
+  stdout,
+  success,
+  taskInfo = getTask(taskId),
+}) {
   const classified = await evaluateStructuredSuccess({ agent, taskId, state, success });
   let errorContext = classified.error;
   if (!errorContext && !classified.success) {
@@ -1232,7 +1240,8 @@ async function buildCompletionResult({ agent, taskId, providerName, state, stdou
     providerSession: providerSessionFromCompletedTask({
       agent,
       providerName,
-      taskInfo: getTask(taskId),
+      taskInfo,
+      logicalSuccess: classified.success,
     }),
   };
 }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -28,6 +28,10 @@ const {
   wrapTaskRunWithIsolatedSettings,
 } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
+const {
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+} = require('./provider-session');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -750,6 +754,11 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
     args.push(mcpArg);
   }
 
+  const resumeSessionId = resolveAgentResumeSessionId(agent, providerName);
+  if (resumeSessionId) {
+    args.push('--resume', resumeSessionId);
+  }
+
   return args;
 }
 
@@ -1220,6 +1229,11 @@ async function buildCompletionResult({ agent, taskId, providerName, state, stdou
     output: state.output,
     error: errorContext,
     tokenUsage: extractTokenUsage(state.output, providerName),
+    providerSession: providerSessionFromCompletedTask({
+      agent,
+      providerName,
+      taskInfo: getTask(taskId),
+    }),
   };
 }
 
@@ -2375,5 +2389,6 @@ module.exports = {
   broadcastIsolatedLine,
   parseResultOutput,
   buildCompletionResult,
+  buildTaskRunArgs,
   killTask,
 };

--- a/src/agent/guidance-queue.js
+++ b/src/agent/guidance-queue.js
@@ -1,5 +1,6 @@
 const GUIDANCE_BLOCK_START = '<<GUIDANCE_QUEUE_START>>';
 const GUIDANCE_BLOCK_END = '<<GUIDANCE_QUEUE_END>>';
+const { compareMessageSequences } = require('../ledger-sequence');
 
 function formatGuidanceMessage(message) {
   const timestamp = Number.isFinite(message.timestamp)
@@ -24,7 +25,7 @@ function formatGuidanceMessage(message) {
 function orderGuidanceMessages(messages, orderBySequence) {
   return messages.slice().sort((a, b) => {
     if (orderBySequence) {
-      return (a.sequence || 0) - (b.sequence || 0);
+      return compareMessageSequences(a.sequence || '0', b.sequence || '0');
     }
     return (a.timestamp || 0) - (b.timestamp || 0);
   });

--- a/src/agent/guidance-queue.js
+++ b/src/agent/guidance-queue.js
@@ -21,10 +21,19 @@ function formatGuidanceMessage(message) {
   return formatted.trimEnd();
 }
 
-function formatGuidanceBlock(messages) {
+function orderGuidanceMessages(messages, orderBySequence) {
+  return messages.slice().sort((a, b) => {
+    if (orderBySequence) {
+      return (a.sequence || 0) - (b.sequence || 0);
+    }
+    return (a.timestamp || 0) - (b.timestamp || 0);
+  });
+}
+
+function formatGuidanceBlock(messages, { orderBySequence = false } = {}) {
   if (!Array.isArray(messages) || messages.length === 0) return '';
 
-  const ordered = messages.slice().sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+  const ordered = orderGuidanceMessages(messages, orderBySequence);
 
   let block = '## Guidance (Queued)\n\n';
   block += `${GUIDANCE_BLOCK_START}\n`;
@@ -40,7 +49,15 @@ function formatGuidanceBlock(messages) {
   return block;
 }
 
-function collectQueuedGuidance({ messageBus, clusterId, agentId, lastDeliveredAt, limit }) {
+function collectQueuedGuidance({
+  messageBus,
+  clusterId,
+  agentId,
+  afterId,
+  throughId,
+  lastDeliveredAt,
+  limit,
+}) {
   if (!messageBus) {
     throw new Error('collectQueuedGuidance: messageBus is required');
   }
@@ -54,19 +71,23 @@ function collectQueuedGuidance({ messageBus, clusterId, agentId, lastDeliveredAt
   const messages = messageBus.queryGuidanceMailbox({
     cluster_id: clusterId,
     target_agent_id: agentId,
+    afterId,
+    throughId,
     lastDeliveredAt,
     limit,
   });
 
   if (!messages.length) {
-    return { messages: [], latestTimestamp: null, guidanceBlock: '' };
+    return { messages: [], latestSequence: null, latestTimestamp: null, guidanceBlock: '' };
   }
 
-  const ordered = messages.slice().sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+  const sequenceBounded = afterId !== undefined || throughId !== undefined;
+  const ordered = orderGuidanceMessages(messages, sequenceBounded);
+  const latestSequence = ordered[ordered.length - 1].sequence;
   const latestTimestamp = ordered[ordered.length - 1].timestamp;
-  const guidanceBlock = formatGuidanceBlock(ordered);
+  const guidanceBlock = formatGuidanceBlock(ordered, { orderBySequence: sequenceBounded });
 
-  return { messages: ordered, latestTimestamp, guidanceBlock };
+  return { messages: ordered, latestSequence, latestTimestamp, guidanceBlock };
 }
 
 module.exports = {

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -1,7 +1,23 @@
+const path = require('path');
+
 const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
 
-function normalizeSessionId(value) {
+const DURABLE_SESSION_BOUNDARY_EVENTS = new Set([
+  'TASK_STARTED',
+  'TASK_COMPLETED',
+  'TASK_FAILED',
+  'RETRY_SCHEDULED',
+  'AGENT_RESTART_ATTEMPT',
+]);
+const RESTORABLE_AGENT_STATES = new Set(['idle', 'stopped', 'completed']);
+
+function normalizeNonEmptyString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeAbsolutePath(value) {
+  const normalized = normalizeNonEmptyString(value);
+  return normalized ? path.resolve(normalized) : null;
 }
 
 function supportsSessionResume(providerName) {
@@ -16,33 +32,87 @@ function normalizeProviderSession(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return null;
   }
+
   const provider = normalizeProviderName(value.provider);
-  const sessionId = normalizeSessionId(value.sessionId);
-  if (!provider || !sessionId || !supportsSessionResume(provider)) {
+  const sessionId = normalizeNonEmptyString(value.sessionId);
+  const agentId = normalizeNonEmptyString(value.agentId);
+  const taskId = normalizeNonEmptyString(value.taskId);
+  const generation = value.generation;
+  const cwd = normalizeAbsolutePath(value.cwd);
+  const worktreePath =
+    value.worktreePath === null ? null : normalizeAbsolutePath(value.worktreePath);
+
+  if (
+    !provider ||
+    !sessionId ||
+    !agentId ||
+    !taskId ||
+    !Number.isInteger(generation) ||
+    generation < 1 ||
+    !cwd ||
+    !Object.hasOwn(value, 'worktreePath') ||
+    (value.worktreePath !== null && !worktreePath) ||
+    !supportsSessionResume(provider)
+  ) {
     return null;
   }
-  return { provider, sessionId };
+
+  return {
+    provider,
+    sessionId,
+    agentId,
+    taskId,
+    generation,
+    cwd,
+    worktreePath,
+  };
+}
+
+function agentWorkspaceProvenance(agent) {
+  const worktreePath = agent?.worktree?.enabled ? normalizeAbsolutePath(agent.worktree.path) : null;
+  const cwd = normalizeAbsolutePath(agent?.config?.cwd || worktreePath || process.cwd());
+  return { cwd, worktreePath };
 }
 
 function agentCanReuseSession(agent, providerName) {
   return !agent?.isolation?.enabled && supportsSessionResume(providerName);
 }
 
-function resolveAgentResumeSessionId(agent, providerName) {
+function sessionMatchesAgent(session, agent, providerName, expectedGeneration) {
   const provider = normalizeProviderName(providerName);
+  const workspace = agentWorkspaceProvenance(agent);
+  return (
+    agentCanReuseSession(agent, provider) &&
+    session.provider === provider &&
+    session.agentId === agent?.id &&
+    session.generation === expectedGeneration &&
+    session.cwd === workspace.cwd &&
+    session.worktreePath === workspace.worktreePath
+  );
+}
+
+function resolveAgentResumeSessionId(agent, providerName) {
   const stored = normalizeProviderSession(agent?.providerSession);
-  if (!agentCanReuseSession(agent, provider) || !stored || stored.provider !== provider) {
-    if (agent && stored) {
+  const expectedGeneration = Number.isInteger(agent?.iteration) ? agent.iteration - 1 : -1;
+
+  if (!stored || !sessionMatchesAgent(stored, agent, providerName, expectedGeneration)) {
+    if (agent) {
       agent.providerSession = null;
     }
     return null;
   }
+
   return stored.sessionId;
 }
 
-function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
+function providerSessionFromCompletedTask({
+  agent,
+  providerName,
+  taskInfo,
+  logicalSuccess = true,
+}) {
   const provider = normalizeProviderName(providerName);
-  if (!agentCanReuseSession(agent, provider)) {
+  if (!logicalSuccess || !agentCanReuseSession(agent, provider)) {
     return null;
   }
   if (!taskInfo || taskInfo.status !== 'completed') {
@@ -51,8 +121,20 @@ function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
   if (normalizeProviderName(taskInfo.provider) !== provider) {
     return null;
   }
-  const sessionId = normalizeSessionId(taskInfo.sessionId);
-  return sessionId ? { provider, sessionId } : null;
+
+  const sessionId = normalizeNonEmptyString(taskInfo.sessionId);
+  const taskId = normalizeNonEmptyString(taskInfo.id);
+  const generation = agent?.iteration;
+  const agentId = normalizeNonEmptyString(agent?.id);
+  const workspace = agentWorkspaceProvenance(agent);
+  return normalizeProviderSession({
+    provider,
+    sessionId,
+    agentId,
+    taskId,
+    generation,
+    ...workspace,
+  });
 }
 
 function updateAgentProviderSession(agent, value) {
@@ -61,10 +143,46 @@ function updateAgentProviderSession(agent, value) {
   return session;
 }
 
+function readLastDurableSessionBoundary(messageBus, clusterId, agentId) {
+  const lifecycle = messageBus.query({
+    cluster_id: clusterId,
+    topic: 'AGENT_LIFECYCLE',
+    sender: agentId,
+  });
+  return lifecycle
+    .filter((message) => DURABLE_SESSION_BOUNDARY_EVENTS.has(message.content?.data?.event))
+    .at(-1);
+}
+
+function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId }) {
+  const session = normalizeProviderSession(savedState?.providerSession);
+  if (!session || !RESTORABLE_AGENT_STATES.has(savedState?.state || 'idle')) {
+    return null;
+  }
+  if (!sessionMatchesAgent(session, agent, session.provider, savedState.iteration)) {
+    return null;
+  }
+
+  const boundary = readLastDurableSessionBoundary(messageBus, clusterId, agent.id);
+  const data = boundary?.content?.data;
+  if (
+    data?.event !== 'TASK_COMPLETED' ||
+    data.taskId !== session.taskId ||
+    data.iteration !== session.generation ||
+    normalizeProviderName(data.provider) !== session.provider
+  ) {
+    return null;
+  }
+
+  return session;
+}
+
 module.exports = {
+  agentWorkspaceProvenance,
   normalizeProviderSession,
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
+  restoreAgentProviderSession,
   supportsSessionResume,
   updateAgentProviderSession,
 };

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -20,6 +20,18 @@ function normalizeAbsolutePath(value) {
   return normalized ? path.resolve(normalized) : null;
 }
 
+function normalizeCursor(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function normalizeNullableCursor(value) {
+  return value === null ? null : normalizeCursor(value);
+}
+
+function normalizePromptText(value) {
+  return value === null || typeof value === 'string' ? value : undefined;
+}
+
 function supportsSessionResume(providerName) {
   try {
     return providerSupportsCapability(providerName, 'sessionResume');
@@ -41,6 +53,9 @@ function normalizeProviderSession(value) {
   const cwd = normalizeAbsolutePath(value.cwd);
   const worktreePath =
     value.worktreePath === null ? null : normalizeAbsolutePath(value.worktreePath);
+  const contextCursor = normalizeCursor(value.contextCursor);
+  const guidanceCursor = normalizeNullableCursor(value.guidanceCursor);
+  const promptText = normalizePromptText(value.promptText);
 
   if (
     !provider ||
@@ -52,6 +67,11 @@ function normalizeProviderSession(value) {
     !cwd ||
     !Object.hasOwn(value, 'worktreePath') ||
     (value.worktreePath !== null && !worktreePath) ||
+    contextCursor === null ||
+    !Object.hasOwn(value, 'guidanceCursor') ||
+    (value.guidanceCursor !== null && guidanceCursor === null) ||
+    !Object.hasOwn(value, 'promptText') ||
+    promptText === undefined ||
     !supportsSessionResume(provider)
   ) {
     return null;
@@ -65,6 +85,9 @@ function normalizeProviderSession(value) {
     generation,
     cwd,
     worktreePath,
+    contextCursor,
+    guidanceCursor,
+    promptText,
   };
 }
 
@@ -91,7 +114,7 @@ function sessionMatchesAgent(session, agent, providerName, expectedGeneration) {
   );
 }
 
-function resolveAgentResumeSessionId(agent, providerName) {
+function resolveAgentProviderSession(agent, providerName) {
   const stored = normalizeProviderSession(agent?.providerSession);
   const expectedGeneration = Number.isInteger(agent?.iteration) ? agent.iteration - 1 : -1;
 
@@ -102,7 +125,11 @@ function resolveAgentResumeSessionId(agent, providerName) {
     return null;
   }
 
-  return stored.sessionId;
+  return stored;
+}
+
+function resolveAgentResumeSessionId(agent, providerName) {
+  return resolveAgentProviderSession(agent, providerName)?.sessionId || null;
 }
 
 function providerSessionFromCompletedTask({
@@ -134,6 +161,9 @@ function providerSessionFromCompletedTask({
     taskId,
     generation,
     ...workspace,
+    contextCursor: agent?.currentContextCursor,
+    guidanceCursor: agent?.currentGuidanceCursor ?? null,
+    promptText: agent?.currentPromptText ?? null,
   });
 }
 
@@ -156,7 +186,13 @@ function readLastDurableSessionBoundary(messageBus, clusterId, agentId) {
 
 function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId }) {
   const session = normalizeProviderSession(savedState?.providerSession);
-  if (!session || !RESTORABLE_AGENT_STATES.has(savedState?.state || 'idle')) {
+  if (!session || !RESTORABLE_AGENT_STATES.has(savedState?.state)) {
+    return null;
+  }
+  if (
+    !Object.hasOwn(savedState, 'lastGuidanceAppliedAt') ||
+    savedState.lastGuidanceAppliedAt !== session.guidanceCursor
+  ) {
     return null;
   }
   if (!sessionMatchesAgent(session, agent, session.provider, savedState.iteration)) {
@@ -169,7 +205,10 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
     data?.event !== 'TASK_COMPLETED' ||
     data.taskId !== session.taskId ||
     data.iteration !== session.generation ||
-    normalizeProviderName(data.provider) !== session.provider
+    normalizeProviderName(data.provider) !== session.provider ||
+    data.contextCursor !== session.contextCursor ||
+    data.guidanceCursor !== session.guidanceCursor ||
+    data.promptText !== session.promptText
   ) {
     return null;
   }
@@ -181,6 +220,7 @@ module.exports = {
   agentWorkspaceProvenance,
   normalizeProviderSession,
   providerSessionFromCompletedTask,
+  resolveAgentProviderSession,
   resolveAgentResumeSessionId,
   restoreAgentProviderSession,
   supportsSessionResume,

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -132,6 +132,9 @@ function resolveAgentProviderSession(agent, providerName) {
 
   if (!stored || !sessionMatchesAgent(stored, agent, providerName, expectedGeneration)) {
     if (agent) {
+      if (agent.providerSession) {
+        agent.lastGuidanceAppliedId = null;
+      }
       agent.providerSession = null;
     }
     return null;
@@ -208,6 +211,9 @@ function providerSessionFromCompletedTask({
 }
 
 function updateAgentProviderSession(agent, value) {
+  if (agent.providerSession && value === null) {
+    agent.lastGuidanceAppliedId = null;
+  }
   const session = normalizeProviderSession(value);
   agent.providerSession = session;
   return session;

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -1,0 +1,70 @@
+const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
+
+function normalizeSessionId(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function supportsSessionResume(providerName) {
+  try {
+    return providerSupportsCapability(providerName, 'sessionResume');
+  } catch {
+    return false;
+  }
+}
+
+function normalizeProviderSession(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const provider = normalizeProviderName(value.provider);
+  const sessionId = normalizeSessionId(value.sessionId);
+  if (!provider || !sessionId || !supportsSessionResume(provider)) {
+    return null;
+  }
+  return { provider, sessionId };
+}
+
+function agentCanReuseSession(agent, providerName) {
+  return !agent?.isolation?.enabled && supportsSessionResume(providerName);
+}
+
+function resolveAgentResumeSessionId(agent, providerName) {
+  const provider = normalizeProviderName(providerName);
+  const stored = normalizeProviderSession(agent?.providerSession);
+  if (!agentCanReuseSession(agent, provider) || !stored || stored.provider !== provider) {
+    if (agent && stored) {
+      agent.providerSession = null;
+    }
+    return null;
+  }
+  return stored.sessionId;
+}
+
+function providerSessionFromCompletedTask({ agent, providerName, taskInfo }) {
+  const provider = normalizeProviderName(providerName);
+  if (!agentCanReuseSession(agent, provider)) {
+    return null;
+  }
+  if (!taskInfo || taskInfo.status !== 'completed') {
+    return null;
+  }
+  if (normalizeProviderName(taskInfo.provider) !== provider) {
+    return null;
+  }
+  const sessionId = normalizeSessionId(taskInfo.sessionId);
+  return sessionId ? { provider, sessionId } : null;
+}
+
+function updateAgentProviderSession(agent, value) {
+  const session = normalizeProviderSession(value);
+  agent.providerSession = session;
+  return session;
+}
+
+module.exports = {
+  normalizeProviderSession,
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+  supportsSessionResume,
+  updateAgentProviderSession,
+};

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const path = require('path');
 
 const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
+const { tryCanonicalMessageSequence } = require('../ledger-sequence');
 
 const DURABLE_SESSION_BOUNDARY_EVENTS = new Set([
   'TASK_STARTED',
@@ -22,7 +23,7 @@ function normalizeAbsolutePath(value) {
 }
 
 function normalizeCursor(value) {
-  return Number.isInteger(value) && value >= 0 ? value : null;
+  return tryCanonicalMessageSequence(value);
 }
 
 function normalizeNullableCursor(value) {
@@ -148,6 +149,9 @@ function validateCompletedResumeIdentity(taskInfo) {
   if (!requestedSessionId) {
     return null;
   }
+  if (taskInfo?.sessionIdConflict === true) {
+    return 'Provider continuation emitted conflicting session identities';
+  }
 
   const capturedSessionId = normalizeNonEmptyString(taskInfo?.sessionId);
   if (capturedSessionId === requestedSessionId) {
@@ -173,6 +177,9 @@ function providerSessionFromCompletedTask({
     return null;
   }
   if (normalizeProviderName(taskInfo.provider) !== provider) {
+    return null;
+  }
+  if (taskInfo.sessionIdConflict === true) {
     return null;
   }
   if (validateCompletedResumeIdentity(taskInfo)) {
@@ -208,7 +215,7 @@ function readLastDurableSessionBoundary(messageBus, clusterId, agentId) {
     cluster_id: clusterId,
     topic: 'AGENT_LIFECYCLE',
     sender: agentId,
-    afterId: 0,
+    afterId: '0',
   });
   return lifecycle
     .filter((message) => DURABLE_SESSION_BOUNDARY_EVENTS.has(message.content?.data?.event))
@@ -222,7 +229,7 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
   }
   if (
     !Object.hasOwn(savedState, 'lastGuidanceAppliedId') ||
-    savedState.lastGuidanceAppliedId !== session.guidanceSequence
+    normalizeNullableCursor(savedState.lastGuidanceAppliedId) !== session.guidanceSequence
   ) {
     return null;
   }
@@ -237,8 +244,8 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
     data.taskId !== session.taskId ||
     data.iteration !== session.generation ||
     normalizeProviderName(data.provider) !== session.provider ||
-    data.contextSequence !== session.contextSequence ||
-    data.guidanceSequence !== session.guidanceSequence ||
+    normalizeCursor(data.contextSequence) !== session.contextSequence ||
+    normalizeNullableCursor(data.guidanceSequence) !== session.guidanceSequence ||
     data.promptIdentity !== session.promptIdentity
   ) {
     return null;

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const path = require('path');
 
 const { normalizeProviderName, providerSupportsCapability } = require('../../lib/provider-names');
@@ -28,8 +29,18 @@ function normalizeNullableCursor(value) {
   return value === null ? null : normalizeCursor(value);
 }
 
-function normalizePromptText(value) {
-  return value === null || typeof value === 'string' ? value : undefined;
+function normalizePromptIdentity(value) {
+  if (value === null) {
+    return null;
+  }
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value) ? value : undefined;
+}
+
+function promptIdentity(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return `sha256:${crypto.createHash('sha256').update(String(value)).digest('hex')}`;
 }
 
 function supportsSessionResume(providerName) {
@@ -53,9 +64,9 @@ function normalizeProviderSession(value) {
   const cwd = normalizeAbsolutePath(value.cwd);
   const worktreePath =
     value.worktreePath === null ? null : normalizeAbsolutePath(value.worktreePath);
-  const contextCursor = normalizeCursor(value.contextCursor);
-  const guidanceCursor = normalizeNullableCursor(value.guidanceCursor);
-  const promptText = normalizePromptText(value.promptText);
+  const contextSequence = normalizeCursor(value.contextSequence);
+  const guidanceSequence = normalizeNullableCursor(value.guidanceSequence);
+  const normalizedPromptIdentity = normalizePromptIdentity(value.promptIdentity);
 
   if (
     !provider ||
@@ -67,11 +78,11 @@ function normalizeProviderSession(value) {
     !cwd ||
     !Object.hasOwn(value, 'worktreePath') ||
     (value.worktreePath !== null && !worktreePath) ||
-    contextCursor === null ||
-    !Object.hasOwn(value, 'guidanceCursor') ||
-    (value.guidanceCursor !== null && guidanceCursor === null) ||
-    !Object.hasOwn(value, 'promptText') ||
-    promptText === undefined ||
+    contextSequence === null ||
+    !Object.hasOwn(value, 'guidanceSequence') ||
+    (value.guidanceSequence !== null && guidanceSequence === null) ||
+    !Object.hasOwn(value, 'promptIdentity') ||
+    normalizedPromptIdentity === undefined ||
     !supportsSessionResume(provider)
   ) {
     return null;
@@ -85,9 +96,9 @@ function normalizeProviderSession(value) {
     generation,
     cwd,
     worktreePath,
-    contextCursor,
-    guidanceCursor,
-    promptText,
+    contextSequence,
+    guidanceSequence,
+    promptIdentity: normalizedPromptIdentity,
   };
 }
 
@@ -132,6 +143,22 @@ function resolveAgentResumeSessionId(agent, providerName) {
   return resolveAgentProviderSession(agent, providerName)?.sessionId || null;
 }
 
+function validateCompletedResumeIdentity(taskInfo) {
+  const requestedSessionId = normalizeNonEmptyString(taskInfo?.requestedResumeSessionId);
+  if (!requestedSessionId) {
+    return null;
+  }
+
+  const capturedSessionId = normalizeNonEmptyString(taskInfo?.sessionId);
+  if (capturedSessionId === requestedSessionId) {
+    return null;
+  }
+
+  return capturedSessionId
+    ? 'Provider continuation returned a different session identity'
+    : 'Provider continuation did not confirm the requested session identity';
+}
+
 function providerSessionFromCompletedTask({
   agent,
   providerName,
@@ -148,6 +175,9 @@ function providerSessionFromCompletedTask({
   if (normalizeProviderName(taskInfo.provider) !== provider) {
     return null;
   }
+  if (validateCompletedResumeIdentity(taskInfo)) {
+    return null;
+  }
 
   const sessionId = normalizeNonEmptyString(taskInfo.sessionId);
   const taskId = normalizeNonEmptyString(taskInfo.id);
@@ -161,9 +191,9 @@ function providerSessionFromCompletedTask({
     taskId,
     generation,
     ...workspace,
-    contextCursor: agent?.currentContextCursor,
-    guidanceCursor: agent?.currentGuidanceCursor ?? null,
-    promptText: agent?.currentPromptText ?? null,
+    contextSequence: agent?.currentContextSequence,
+    guidanceSequence: agent?.currentGuidanceSequence ?? null,
+    promptIdentity: agent?.currentPromptIdentity ?? null,
   });
 }
 
@@ -178,6 +208,7 @@ function readLastDurableSessionBoundary(messageBus, clusterId, agentId) {
     cluster_id: clusterId,
     topic: 'AGENT_LIFECYCLE',
     sender: agentId,
+    afterId: 0,
   });
   return lifecycle
     .filter((message) => DURABLE_SESSION_BOUNDARY_EVENTS.has(message.content?.data?.event))
@@ -190,8 +221,8 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
     return null;
   }
   if (
-    !Object.hasOwn(savedState, 'lastGuidanceAppliedAt') ||
-    savedState.lastGuidanceAppliedAt !== session.guidanceCursor
+    !Object.hasOwn(savedState, 'lastGuidanceAppliedId') ||
+    savedState.lastGuidanceAppliedId !== session.guidanceSequence
   ) {
     return null;
   }
@@ -206,9 +237,9 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
     data.taskId !== session.taskId ||
     data.iteration !== session.generation ||
     normalizeProviderName(data.provider) !== session.provider ||
-    data.contextCursor !== session.contextCursor ||
-    data.guidanceCursor !== session.guidanceCursor ||
-    data.promptText !== session.promptText
+    data.contextSequence !== session.contextSequence ||
+    data.guidanceSequence !== session.guidanceSequence ||
+    data.promptIdentity !== session.promptIdentity
   ) {
     return null;
   }
@@ -219,10 +250,12 @@ function restoreAgentProviderSession({ agent, savedState, messageBus, clusterId 
 module.exports = {
   agentWorkspaceProvenance,
   normalizeProviderSession,
+  promptIdentity,
   providerSessionFromCompletedTask,
   resolveAgentProviderSession,
   resolveAgentResumeSessionId,
   restoreAgentProviderSession,
   supportsSessionResume,
   updateAgentProviderSession,
+  validateCompletedResumeIdentity,
 };

--- a/src/agent/provider-session.js
+++ b/src/agent/provider-session.js
@@ -149,6 +149,9 @@ function validateCompletedResumeIdentity(taskInfo) {
   if (!requestedSessionId) {
     return null;
   }
+  if (taskInfo?.resumeIdentityVerified !== true) {
+    return 'Provider continuation identity was not durably verified';
+  }
   if (taskInfo?.sessionIdConflict === true) {
     return 'Provider continuation emitted conflicting session identities';
   }

--- a/src/ledger-sequence.js
+++ b/src/ledger-sequence.js
@@ -1,0 +1,63 @@
+const MAX_SQLITE_ROWID = 9223372036854775807n;
+const CANONICAL_SEQUENCE = /^(0|[1-9][0-9]*)$/;
+
+function canonicalMessageSequence(value, name = 'message sequence') {
+  let sequence;
+  if (typeof value === 'string' && CANONICAL_SEQUENCE.test(value)) {
+    sequence = value;
+  } else if (Number.isSafeInteger(value) && value >= 0) {
+    // Accept legacy JSON state while normalizing every new boundary to a
+    // JSON-safe decimal string.
+    sequence = String(value);
+  } else {
+    throw new TypeError(`${name} must be a canonical non-negative decimal string`);
+  }
+
+  if (BigInt(sequence) > MAX_SQLITE_ROWID) {
+    throw new RangeError(`${name} exceeds the SQLite rowid range`);
+  }
+  return sequence;
+}
+
+function messageSequenceFromSql(value, name = 'message sequence') {
+  if (typeof value === 'bigint') {
+    if (value < 0n || value > MAX_SQLITE_ROWID) {
+      throw new RangeError(`${name} is outside the SQLite rowid range`);
+    }
+    return value.toString();
+  }
+  return canonicalMessageSequence(value, name);
+}
+
+function messageSequenceToSql(value, name = 'message sequence') {
+  return BigInt(canonicalMessageSequence(value, name));
+}
+
+function compareMessageSequences(left, right) {
+  const leftValue = messageSequenceToSql(left, 'left message sequence');
+  const rightValue = messageSequenceToSql(right, 'right message sequence');
+  if (leftValue < rightValue) {
+    return -1;
+  }
+  if (leftValue > rightValue) {
+    return 1;
+  }
+  return 0;
+}
+
+function tryCanonicalMessageSequence(value) {
+  try {
+    return canonicalMessageSequence(value);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  MAX_SQLITE_ROWID,
+  canonicalMessageSequence,
+  compareMessageSequences,
+  messageSequenceFromSql,
+  messageSequenceToSql,
+  tryCanonicalMessageSequence,
+};

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -97,11 +97,14 @@ class Ledger extends EventEmitter {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `),
 
-      queryBase: `SELECT * FROM messages WHERE cluster_id = ?`,
+      queryBase: `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?`,
 
       count: this.db.prepare(`SELECT COUNT(*) as count FROM messages WHERE cluster_id = ?`),
 
-      getAll: this.db.prepare(`SELECT * FROM messages WHERE cluster_id = ? ORDER BY timestamp ASC`),
+      getAll: this.db.prepare(
+        `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?` +
+          ` ORDER BY timestamp ASC, rowid ASC`
+      ),
     };
   }
 
@@ -145,7 +148,7 @@ class Ledger extends EventEmitter {
     };
 
     try {
-      this.stmts.insert.run(
+      const insertResult = this.stmts.insert.run(
         record.id,
         record.timestamp,
         record.topic,
@@ -156,6 +159,7 @@ class Ledger extends EventEmitter {
         record.metadata,
         record.cluster_id
       );
+      record.sequence = Number(insertResult.lastInsertRowid);
 
       // Invalidate cache
       this.cache.clear();
@@ -219,7 +223,7 @@ class Ledger extends EventEmitter {
           cluster_id: message.cluster_id,
         };
 
-        this.stmts.insert.run(
+        const insertResult = this.stmts.insert.run(
           record.id,
           record.timestamp,
           record.topic,
@@ -230,6 +234,7 @@ class Ledger extends EventEmitter {
           record.metadata,
           record.cluster_id
         );
+        record.sequence = Number(insertResult.lastInsertRowid);
 
         results.push(this._deserializeMessage(record));
       }
@@ -265,7 +270,19 @@ class Ledger extends EventEmitter {
    * @returns {Array} Matching messages
    */
   query(criteria) {
-    const { cluster_id, topic, sender, receiver, since, after, until, limit, offset } = criteria;
+    const {
+      cluster_id,
+      topic,
+      sender,
+      receiver,
+      since,
+      after,
+      until,
+      afterId,
+      throughId,
+      limit,
+      offset,
+    } = criteria;
 
     if (!cluster_id) {
       throw new Error('cluster_id is required for queries');
@@ -308,13 +325,35 @@ class Ledger extends EventEmitter {
       params.push(typeof until === 'number' ? until : new Date(until).getTime());
     }
 
+    if (afterId !== undefined && afterId !== null) {
+      if (!Number.isInteger(afterId) || afterId < 0) {
+        throw new Error('afterId must be a non-negative durable message sequence');
+      }
+      conditions.push('rowid > ?');
+      params.push(afterId);
+    }
+
+    if (throughId !== undefined && throughId !== null) {
+      if (!Number.isInteger(throughId) || throughId < 0) {
+        throw new Error('throughId must be a non-negative durable message sequence');
+      }
+      conditions.push('rowid <= ?');
+      params.push(throughId);
+    }
+
     // Defend against prototype pollution affecting default query ordering.
     // Only treat `criteria.order` as set if it's an own property.
     const orderValue = Object.prototype.hasOwnProperty.call(criteria, 'order')
       ? criteria.order
       : undefined;
     const direction = String(orderValue ?? 'asc').toLowerCase() === 'desc' ? 'DESC' : 'ASC';
-    let sql = `SELECT * FROM messages WHERE ${conditions.join(' AND ')} ORDER BY timestamp ${direction}`;
+    const sequenceBounded = afterId !== undefined || throughId !== undefined;
+    const orderClause = sequenceBounded
+      ? `rowid ${direction}`
+      : `timestamp ${direction}, rowid ${direction}`;
+    let sql =
+      `SELECT rowid AS sequence, * FROM messages WHERE ${conditions.join(' AND ')}` +
+      ` ORDER BY ${orderClause}`;
 
     if (limit) {
       sql += ` LIMIT ?`;
@@ -333,11 +372,12 @@ class Ledger extends EventEmitter {
 
   /**
    * Query guidance mailbox for cluster-wide + agent-specific guidance
-   * @param {Object} criteria - { cluster_id, target_agent_id, lastDeliveredAt, limit }
-   * @returns {Array} Guidance messages ordered by timestamp ASC
+   * @param {Object} criteria - Timestamp compatibility filters plus afterId/throughId sequences
+   * @returns {Array} Guidance messages ordered by durable message sequence ASC
    */
   queryGuidanceMailbox(criteria) {
-    const { cluster_id, target_agent_id, lastDeliveredAt, limit } = criteria || {};
+    const { cluster_id, target_agent_id, lastDeliveredAt, afterId, throughId, limit } =
+      criteria || {};
 
     if (!cluster_id) {
       throw new Error('cluster_id is required for guidance mailbox queries');
@@ -359,7 +399,7 @@ class Ledger extends EventEmitter {
     }
 
     const params = [cluster_id, USER_GUIDANCE_CLUSTER];
-    let sql = 'SELECT * FROM messages WHERE cluster_id = ? AND (topic = ?';
+    let sql = 'SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? AND (topic = ?';
 
     if (target_agent_id) {
       params.push(USER_GUIDANCE_AGENT, target_agent_id);
@@ -373,7 +413,26 @@ class Ledger extends EventEmitter {
       sql += ' AND timestamp > ?';
     }
 
-    sql += ' ORDER BY timestamp ASC';
+    if (afterId !== undefined && afterId !== null) {
+      if (!Number.isInteger(afterId) || afterId < 0) {
+        throw new Error('afterId must be a non-negative durable message sequence');
+      }
+      params.push(afterId);
+      sql += ' AND rowid > ?';
+    }
+
+    if (throughId !== undefined && throughId !== null) {
+      if (!Number.isInteger(throughId) || throughId < 0) {
+        throw new Error('throughId must be a non-negative durable message sequence');
+      }
+      params.push(throughId);
+      sql += ' AND rowid <= ?';
+    }
+
+    sql +=
+      afterId !== undefined || throughId !== undefined
+        ? ' ORDER BY rowid ASC'
+        : ' ORDER BY timestamp ASC, rowid ASC';
 
     if (limit) {
       params.push(limit);
@@ -391,7 +450,8 @@ class Ledger extends EventEmitter {
    * @returns {Object|null} Last matching message
    */
   findLast(criteria) {
-    const { cluster_id, topic, sender, receiver, since, until } = criteria;
+    const { cluster_id, topic, sender, receiver, since, until, throughId, orderBySequence } =
+      criteria;
 
     if (!cluster_id) {
       throw new Error('cluster_id is required for queries');
@@ -426,7 +486,19 @@ class Ledger extends EventEmitter {
       params.push(typeof until === 'number' ? until : new Date(until).getTime());
     }
 
-    const sql = `SELECT * FROM messages WHERE ${conditions.join(' AND ')} ORDER BY timestamp DESC LIMIT 1`;
+    if (throughId !== undefined && throughId !== null) {
+      if (!Number.isInteger(throughId) || throughId < 0) {
+        throw new Error('throughId must be a non-negative durable message sequence');
+      }
+      conditions.push('rowid <= ?');
+      params.push(throughId);
+    }
+
+    const orderClause =
+      orderBySequence || throughId !== undefined ? 'rowid DESC' : 'timestamp DESC, rowid DESC';
+    const sql =
+      `SELECT rowid AS sequence, * FROM messages WHERE ${conditions.join(' AND ')}` +
+      ` ORDER BY ${orderClause} LIMIT 1`;
 
     const stmt = this.db.prepare(sql);
     const row = stmt.get(...params);
@@ -503,7 +575,9 @@ class Ledger extends EventEmitter {
    */
   _computeTokensByRole(cluster_id) {
     // Query all TOKEN_USAGE messages for this cluster
-    const sql = `SELECT * FROM messages WHERE cluster_id = ? AND topic = 'TOKEN_USAGE' ORDER BY timestamp ASC`;
+    const sql =
+      `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?` +
+      ` AND topic = 'TOKEN_USAGE' ORDER BY timestamp ASC, rowid ASC`;
     const stmt = this.db.prepare(sql);
     const rows = stmt.all(cluster_id);
 
@@ -597,7 +671,7 @@ class Ledger extends EventEmitter {
    * @returns {Function} Stop polling function
    */
   pollForMessages(clusterId, callback, intervalMs = 500, initialCount = 300) {
-    let lastTimestamp = 0;
+    let lastSequence = 0;
     let lastMessageIds = new Set();
     let isFirstPoll = true;
 
@@ -609,23 +683,23 @@ class Ledger extends EventEmitter {
           // First poll: get last N messages by count
           if (clusterId) {
             sql =
-              'SELECT * FROM (SELECT * FROM messages WHERE cluster_id = ? ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC';
+              'SELECT * FROM (SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? ORDER BY rowid DESC LIMIT ?) ORDER BY sequence ASC';
             params = [clusterId, initialCount];
           } else {
             sql =
-              'SELECT * FROM (SELECT * FROM messages ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC';
+              'SELECT * FROM (SELECT rowid AS sequence, * FROM messages ORDER BY rowid DESC LIMIT ?) ORDER BY sequence ASC';
             params = [initialCount];
           }
           isFirstPoll = false;
         } else {
-          // Subsequent polls: get messages since last timestamp
+          // Subsequent polls: get messages after the exact durable sequence.
           if (clusterId) {
             sql =
-              'SELECT * FROM messages WHERE cluster_id = ? AND timestamp >= ? ORDER BY timestamp ASC';
-            params = [clusterId, lastTimestamp - 1000]; // 1s buffer for race conditions
+              'SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? AND rowid > ? ORDER BY rowid ASC';
+            params = [clusterId, lastSequence];
           } else {
-            sql = 'SELECT * FROM messages WHERE timestamp >= ? ORDER BY timestamp ASC';
-            params = [lastTimestamp - 1000];
+            sql = 'SELECT rowid AS sequence, * FROM messages WHERE rowid > ? ORDER BY rowid ASC';
+            params = [lastSequence];
           }
         }
 
@@ -640,9 +714,9 @@ class Ledger extends EventEmitter {
           const message = this._deserializeMessage(row);
           callback(message);
 
-          // Update timestamp high-water mark
-          if (row.timestamp > lastTimestamp) {
-            lastTimestamp = row.timestamp;
+          // Update the database-serialized high-water mark.
+          if (row.sequence > lastSequence) {
+            lastSequence = row.sequence;
           }
         }
 
@@ -687,6 +761,7 @@ class Ledger extends EventEmitter {
   _deserializeMessage(row) {
     const message = {
       id: row.id,
+      sequence: Number.isInteger(row.sequence) ? row.sequence : undefined,
       timestamp: row.timestamp,
       topic: row.topic,
       sender: row.sender,

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -265,7 +265,7 @@ class Ledger extends EventEmitter {
    * @returns {Array} Matching messages
    */
   query(criteria) {
-    const { cluster_id, topic, sender, receiver, since, until, limit, offset } = criteria;
+    const { cluster_id, topic, sender, receiver, since, after, until, limit, offset } = criteria;
 
     if (!cluster_id) {
       throw new Error('cluster_id is required for queries');
@@ -293,6 +293,14 @@ class Ledger extends EventEmitter {
     if (since) {
       conditions.push('timestamp >= ?');
       params.push(typeof since === 'number' ? since : new Date(since).getTime());
+    }
+
+    if (after !== undefined && after !== null) {
+      if (!Number.isInteger(after) || after < 0) {
+        throw new Error('after must be a non-negative durable ledger cursor');
+      }
+      conditions.push('timestamp > ?');
+      params.push(after);
     }
 
     if (until) {

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -16,6 +16,9 @@ const {
   USER_GUIDANCE_AGENT,
   USER_GUIDANCE_CLUSTER,
 } = require('./guidance-topics');
+const { messageSequenceFromSql, messageSequenceToSql } = require('./ledger-sequence');
+
+const MESSAGE_SEQUENCE_SELECT = 'CAST(rowid AS TEXT) AS sequence';
 
 class Ledger extends EventEmitter {
   constructor(dbPath = ':memory:', options = {}) {
@@ -91,18 +94,21 @@ class Ledger extends EventEmitter {
   }
 
   _prepareStatements() {
-    this.stmts = {
-      insert: this.db.prepare(`
+    const insert = this.db.prepare(`
         INSERT INTO messages (id, timestamp, topic, sender, receiver, content_text, content_data, metadata, cluster_id)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `),
+      `);
+    insert.safeIntegers(true);
 
-      queryBase: `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?`,
+    this.stmts = {
+      insert,
+
+      queryBase: `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE cluster_id = ?`,
 
       count: this.db.prepare(`SELECT COUNT(*) as count FROM messages WHERE cluster_id = ?`),
 
       getAll: this.db.prepare(
-        `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?` +
+        `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE cluster_id = ?` +
           ` ORDER BY timestamp ASC, rowid ASC`
       ),
     };
@@ -159,7 +165,7 @@ class Ledger extends EventEmitter {
         record.metadata,
         record.cluster_id
       );
-      record.sequence = Number(insertResult.lastInsertRowid);
+      record.sequence = messageSequenceFromSql(insertResult.lastInsertRowid);
 
       // Invalidate cache
       this.cache.clear();
@@ -234,7 +240,7 @@ class Ledger extends EventEmitter {
           record.metadata,
           record.cluster_id
         );
-        record.sequence = Number(insertResult.lastInsertRowid);
+        record.sequence = messageSequenceFromSql(insertResult.lastInsertRowid);
 
         results.push(this._deserializeMessage(record));
       }
@@ -326,19 +332,13 @@ class Ledger extends EventEmitter {
     }
 
     if (afterId !== undefined && afterId !== null) {
-      if (!Number.isInteger(afterId) || afterId < 0) {
-        throw new Error('afterId must be a non-negative durable message sequence');
-      }
       conditions.push('rowid > ?');
-      params.push(afterId);
+      params.push(messageSequenceToSql(afterId, 'afterId'));
     }
 
     if (throughId !== undefined && throughId !== null) {
-      if (!Number.isInteger(throughId) || throughId < 0) {
-        throw new Error('throughId must be a non-negative durable message sequence');
-      }
       conditions.push('rowid <= ?');
-      params.push(throughId);
+      params.push(messageSequenceToSql(throughId, 'throughId'));
     }
 
     // Defend against prototype pollution affecting default query ordering.
@@ -347,12 +347,14 @@ class Ledger extends EventEmitter {
       ? criteria.order
       : undefined;
     const direction = String(orderValue ?? 'asc').toLowerCase() === 'desc' ? 'DESC' : 'ASC';
-    const sequenceBounded = afterId !== undefined || throughId !== undefined;
+    const sequenceBounded =
+      (afterId !== undefined && afterId !== null) ||
+      (throughId !== undefined && throughId !== null);
     const orderClause = sequenceBounded
       ? `rowid ${direction}`
       : `timestamp ${direction}, rowid ${direction}`;
     let sql =
-      `SELECT rowid AS sequence, * FROM messages WHERE ${conditions.join(' AND ')}` +
+      `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE ${conditions.join(' AND ')}` +
       ` ORDER BY ${orderClause}`;
 
     if (limit) {
@@ -399,7 +401,8 @@ class Ledger extends EventEmitter {
     }
 
     const params = [cluster_id, USER_GUIDANCE_CLUSTER];
-    let sql = 'SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? AND (topic = ?';
+    let sql =
+      `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages ` + 'WHERE cluster_id = ? AND (topic = ?';
 
     if (target_agent_id) {
       params.push(USER_GUIDANCE_AGENT, target_agent_id);
@@ -414,23 +417,17 @@ class Ledger extends EventEmitter {
     }
 
     if (afterId !== undefined && afterId !== null) {
-      if (!Number.isInteger(afterId) || afterId < 0) {
-        throw new Error('afterId must be a non-negative durable message sequence');
-      }
-      params.push(afterId);
+      params.push(messageSequenceToSql(afterId, 'afterId'));
       sql += ' AND rowid > ?';
     }
 
     if (throughId !== undefined && throughId !== null) {
-      if (!Number.isInteger(throughId) || throughId < 0) {
-        throw new Error('throughId must be a non-negative durable message sequence');
-      }
-      params.push(throughId);
+      params.push(messageSequenceToSql(throughId, 'throughId'));
       sql += ' AND rowid <= ?';
     }
 
     sql +=
-      afterId !== undefined || throughId !== undefined
+      (afterId !== undefined && afterId !== null) || (throughId !== undefined && throughId !== null)
         ? ' ORDER BY rowid ASC'
         : ' ORDER BY timestamp ASC, rowid ASC';
 
@@ -487,17 +484,14 @@ class Ledger extends EventEmitter {
     }
 
     if (throughId !== undefined && throughId !== null) {
-      if (!Number.isInteger(throughId) || throughId < 0) {
-        throw new Error('throughId must be a non-negative durable message sequence');
-      }
       conditions.push('rowid <= ?');
-      params.push(throughId);
+      params.push(messageSequenceToSql(throughId, 'throughId'));
     }
 
     const orderClause =
       orderBySequence || throughId !== undefined ? 'rowid DESC' : 'timestamp DESC, rowid DESC';
     const sql =
-      `SELECT rowid AS sequence, * FROM messages WHERE ${conditions.join(' AND ')}` +
+      `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE ${conditions.join(' AND ')}` +
       ` ORDER BY ${orderClause} LIMIT 1`;
 
     const stmt = this.db.prepare(sql);
@@ -576,7 +570,7 @@ class Ledger extends EventEmitter {
   _computeTokensByRole(cluster_id) {
     // Query all TOKEN_USAGE messages for this cluster
     const sql =
-      `SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ?` +
+      `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE cluster_id = ?` +
       ` AND topic = 'TOKEN_USAGE' ORDER BY timestamp ASC, rowid ASC`;
     const stmt = this.db.prepare(sql);
     const rows = stmt.all(cluster_id);
@@ -671,7 +665,7 @@ class Ledger extends EventEmitter {
    * @returns {Function} Stop polling function
    */
   pollForMessages(clusterId, callback, intervalMs = 500, initialCount = 300) {
-    let lastSequence = 0;
+    let lastSequence = '0';
     let lastMessageIds = new Set();
     let isFirstPoll = true;
 
@@ -683,11 +677,14 @@ class Ledger extends EventEmitter {
           // First poll: get last N messages by count
           if (clusterId) {
             sql =
-              'SELECT * FROM (SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? ORDER BY rowid DESC LIMIT ?) ORDER BY sequence ASC';
+              `SELECT * FROM (SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages ` +
+              'WHERE cluster_id = ? ORDER BY rowid DESC LIMIT ?) ' +
+              'ORDER BY CAST(sequence AS INTEGER) ASC';
             params = [clusterId, initialCount];
           } else {
             sql =
-              'SELECT * FROM (SELECT rowid AS sequence, * FROM messages ORDER BY rowid DESC LIMIT ?) ORDER BY sequence ASC';
+              `SELECT * FROM (SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages ` +
+              'ORDER BY rowid DESC LIMIT ?) ORDER BY CAST(sequence AS INTEGER) ASC';
             params = [initialCount];
           }
           isFirstPoll = false;
@@ -695,11 +692,14 @@ class Ledger extends EventEmitter {
           // Subsequent polls: get messages after the exact durable sequence.
           if (clusterId) {
             sql =
-              'SELECT rowid AS sequence, * FROM messages WHERE cluster_id = ? AND rowid > ? ORDER BY rowid ASC';
-            params = [clusterId, lastSequence];
+              `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages ` +
+              'WHERE cluster_id = ? AND rowid > ? ORDER BY rowid ASC';
+            params = [clusterId, messageSequenceToSql(lastSequence)];
           } else {
-            sql = 'SELECT rowid AS sequence, * FROM messages WHERE rowid > ? ORDER BY rowid ASC';
-            params = [lastSequence];
+            sql =
+              `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages ` +
+              'WHERE rowid > ? ORDER BY rowid ASC';
+            params = [messageSequenceToSql(lastSequence)];
           }
         }
 
@@ -714,10 +714,9 @@ class Ledger extends EventEmitter {
           const message = this._deserializeMessage(row);
           callback(message);
 
-          // Update the database-serialized high-water mark.
-          if (row.sequence > lastSequence) {
-            lastSequence = row.sequence;
-          }
+          // Rows are delivered in SQLite rowid order, so the final row is the
+          // exact database-serialized high-water mark.
+          lastSequence = messageSequenceFromSql(row.sequence);
         }
 
         // Prune old message IDs to prevent memory leak
@@ -761,7 +760,10 @@ class Ledger extends EventEmitter {
   _deserializeMessage(row) {
     const message = {
       id: row.id,
-      sequence: Number.isInteger(row.sequence) ? row.sequence : undefined,
+      sequence:
+        row.sequence === undefined
+          ? undefined
+          : messageSequenceFromSql(row.sequence, 'stored message sequence'),
       timestamp: row.timestamp,
       topic: row.topic,
       sender: row.sender,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -52,6 +52,7 @@ const { isProcessRunning } = require('../lib/process-liveness');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
+const { normalizeProviderSession } = require('./agent/provider-session');
 const {
   commandProofsToQualityGates,
   mergeCommandProofs,
@@ -670,6 +671,7 @@ class Orchestrator {
     agent.currentTask = null;
     agent.currentTaskId = savedState.currentTaskId || null;
     agent.processPid = savedState.processPid || null;
+    agent.providerSession = normalizeProviderSession(savedState.providerSession);
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -888,6 +890,7 @@ class Orchestrator {
                 currentTask: a.currentTask ? true : false,
                 currentTaskId: a.currentTaskId,
                 processPid: a.processPid,
+                providerSession: normalizeProviderSession(a.providerSession),
               }))
             : null,
           setupLogPath: cluster.setupLogPath || null,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -52,7 +52,10 @@ const { isProcessRunning } = require('../lib/process-liveness');
 const { getProvider } = require('./providers');
 const StateSnapshotter = require('./state-snapshotter');
 const { resolveClusterRequiredQualityGates } = require('./quality-gates');
-const { normalizeProviderSession } = require('./agent/provider-session');
+const {
+  normalizeProviderSession,
+  restoreAgentProviderSession,
+} = require('./agent/provider-session');
 const {
   commandProofsToQualityGates,
   mergeCommandProofs,
@@ -229,6 +232,19 @@ function buildPrOptions(options, requiredQualityGates) {
     autoMerge,
     ...(requiredQualityGates.length > 0 ? { requiredQualityGates } : {}),
     cwd: options.cwd || process.cwd(),
+  };
+}
+
+function serializeWorktree(worktree) {
+  if (!worktree) {
+    return null;
+  }
+  return {
+    enabled: true,
+    path: worktree.path,
+    branch: worktree.branch,
+    repoRoot: worktree.repoRoot,
+    workDir: worktree.workDir,
   };
 }
 
@@ -646,6 +662,15 @@ class Orchestrator {
       };
     }
 
+    if (clusterData.worktree?.enabled) {
+      agentOptions.worktree = {
+        enabled: true,
+        path: clusterData.worktree.path,
+        branch: clusterData.worktree.branch,
+        repoRoot: clusterData.worktree.repoRoot,
+      };
+    }
+
     return agentOptions;
   }
 
@@ -657,7 +682,7 @@ class Orchestrator {
     return new AgentWrapper(agentConfig, messageBus, clusterContext, agentOptions);
   }
 
-  _restoreAgentState(agent, agentConfig, clusterData) {
+  _restoreAgentState(agent, agentConfig, clusterData, messageBus) {
     if (!clusterData.agentStates) return;
 
     const savedState = clusterData.agentStates.find((state) => state.id === agentConfig.id);
@@ -671,7 +696,12 @@ class Orchestrator {
     agent.currentTask = null;
     agent.currentTaskId = savedState.currentTaskId || null;
     agent.processPid = savedState.processPid || null;
-    agent.providerSession = normalizeProviderSession(savedState.providerSession);
+    agent.providerSession = restoreAgentProviderSession({
+      agent,
+      savedState,
+      messageBus,
+      clusterId: clusterData.id,
+    });
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -701,7 +731,7 @@ class Orchestrator {
         isolationManager
       );
       const agent = this._instantiateAgent(agentConfig, messageBus, clusterContext, agentOptions);
-      this._restoreAgentState(agent, agentConfig, clusterData);
+      this._restoreAgentState(agent, agentConfig, clusterData, messageBus);
       agents.push(agent);
     }
 
@@ -881,6 +911,7 @@ class Orchestrator {
                 workDir: cluster.isolation.workDir, // Required for resume
               }
             : null,
+          worktree: serializeWorktree(cluster.worktree),
           // Persist agent runtime states for accurate status display from other processes
           agentStates: cluster.agents
             ? cluster.agents.map((a) => ({
@@ -1588,6 +1619,8 @@ class Orchestrator {
         [
           'TASK_STARTED',
           'TASK_COMPLETED',
+          'TASK_FAILED',
+          'RETRY_SCHEDULED',
           'PROCESS_SPAWNED',
           'TASK_ID_ASSIGNED',
           'STARTED',

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -702,7 +702,7 @@ class Orchestrator {
       messageBus,
       clusterId: clusterData.id,
     });
-    agent.lastGuidanceAppliedAt = agent.providerSession?.guidanceCursor ?? null;
+    agent.lastGuidanceAppliedId = agent.providerSession?.guidanceSequence ?? null;
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -923,7 +923,7 @@ class Orchestrator {
                 currentTaskId: a.currentTaskId,
                 processPid: a.processPid,
                 providerSession: normalizeProviderSession(a.providerSession),
-                lastGuidanceAppliedAt: a.lastGuidanceAppliedAt ?? null,
+                lastGuidanceAppliedId: a.lastGuidanceAppliedId ?? null,
               }))
             : null,
           setupLogPath: cluster.setupLogPath || null,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -702,6 +702,7 @@ class Orchestrator {
       messageBus,
       clusterId: clusterData.id,
     });
+    agent.lastGuidanceAppliedAt = agent.providerSession?.guidanceCursor ?? null;
   }
 
   _rebuildClusterAgents(clusterContext, messageBus, isolation, isolationManager) {
@@ -922,6 +923,7 @@ class Orchestrator {
                 currentTaskId: a.currentTaskId,
                 processPid: a.processPid,
                 providerSession: normalizeProviderSession(a.providerSession),
+                lastGuidanceAppliedAt: a.lastGuidanceAppliedAt ?? null,
               }))
             : null,
           setupLogPath: cluster.setupLogPath || null,

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -7,7 +7,7 @@
 
 import { appendFileSync, unlinkSync } from 'fs';
 import { unlink } from 'fs/promises';
-import { updateTask } from './store.js';
+import { getTask, updateTask } from './store.js';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
@@ -96,11 +96,14 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const storedTask = getTask(taskId);
 const maybeCaptureProviderSession = createProviderSessionCapture({
   providerName,
   taskId,
   updateTask,
   log,
+  initialSessionId: storedTask?.sessionId || null,
+  initialSessionIdConflict: storedTask?.sessionIdConflict === true,
 });
 
 const env = { ...process.env, ...(commandSpec.env || {}) };

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -97,14 +97,16 @@ function log(msg) {
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
 const storedTask = getTask(taskId);
-const maybeCaptureProviderSession = createProviderSessionCapture({
+const providerSessionCapture = createProviderSessionCapture({
   providerName,
   taskId,
   updateTask,
   log,
+  requestedSessionId: storedTask?.requestedResumeSessionId || null,
   initialSessionId: storedTask?.sessionId || null,
   initialSessionIdConflict: storedTask?.sessionIdConflict === true,
 });
+const maybeCaptureProviderSession = providerSessionCapture.captureLine;
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -318,19 +320,26 @@ server.on('exit', async ({ exitCode, signal }) => {
     log(finalResultJson + '\n');
   }
 
-  writeCompletionFooter(code, signal);
+  const sessionIdentityError = providerSessionCapture.getCompletionError();
+  const resolvedCode =
+    fatalError || sessionIdentityError ? 1 : recovered?.payload ? 0 : code;
+  const status = resolvedCode === 0 ? 'completed' : 'failed';
+
+  writeCompletionFooter(resolvedCode, signal);
   await cleanupCommandSpec();
 
-  const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
-  const status = resolvedCode === 0 ? 'completed' : 'failed';
   try {
     await updateTask(taskId, {
       status,
       pid: null,
       processGroupId: null,
       exitCode: resolvedCode,
-      error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
+      error:
+        fatalError ||
+        sessionIdentityError ||
+        (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
       socketPath: null,
+      ...(sessionIdentityError ? { sessionId: null, sessionIdConflict: true } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -334,12 +334,12 @@ server.on('exit', async ({ exitCode, signal }) => {
       pid: null,
       processGroupId: null,
       exitCode: resolvedCode,
+      ...providerSessionCapture.getCompletionUpdate(resolvedCode),
       error:
         fatalError ||
         sessionIdentityError ||
         (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
       socketPath: null,
-      ...(sessionIdentityError ? { sessionId: null, sessionIdConflict: true } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -14,6 +14,7 @@ import {
   recoverProviderStructuredOutput,
   supportsProviderStructuredOutputRecovery,
 } from './provider-helper-runtime.js';
+import { createProviderSessionCapture } from './provider-session-capture.js';
 import { createRequire } from 'module';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -95,6 +96,12 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const maybeCaptureProviderSession = createProviderSessionCapture({
+  providerName,
+  taskId,
+  updateTask,
+  log,
+});
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -167,6 +174,7 @@ function maybeCaptureStructuredOutput(line) {
 function handleSilentJsonLines(lines, timestamp) {
   for (const line of lines) {
     if (!line.trim()) continue;
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -177,6 +185,7 @@ function handleSilentJsonLines(lines, timestamp) {
 
 function handleStreamingLines(lines, timestamp) {
   for (const line of lines) {
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -190,6 +199,7 @@ function flushOutputBuffer(timestamp) {
     return;
   }
 
+  maybeCaptureProviderSession(outputBuffer);
   if (!enableRecovery) {
     if (!silentJsonMode) {
       log(`[${timestamp}]${outputBuffer}\n`);

--- a/task-lib/commands/resume.js
+++ b/task-lib/commands/resume.js
@@ -10,6 +10,14 @@ export function buildResumeTaskOptions(task) {
   if (!providerSupportsCapability(task.provider, 'sessionResume')) {
     throw new Error(`Provider ${task.provider} does not support safe session resume.`);
   }
+  if (
+    task.requestedResumeSessionId &&
+    (task.status !== 'completed' || task.resumeIdentityVerified !== true)
+  ) {
+    throw new Error(
+      `Task ${task.id} did not durably verify its requested provider session; refusing resume.`
+    );
+  }
   if (!task.sessionId) {
     throw new Error(
       `Task ${task.id} has no captured provider session ID; refusing cwd-wide continuation.`

--- a/task-lib/commands/resume.js
+++ b/task-lib/commands/resume.js
@@ -1,6 +1,26 @@
 import chalk from 'chalk';
+import { createRequire } from 'module';
 import { getTask } from '../store.js';
 import { spawnTask } from '../runner.js';
+
+const require = createRequire(import.meta.url);
+const { providerSupportsCapability } = require('../../lib/provider-names.js');
+
+export function buildResumeTaskOptions(task) {
+  if (!providerSupportsCapability(task.provider, 'sessionResume')) {
+    throw new Error(`Provider ${task.provider} does not support safe session resume.`);
+  }
+  if (!task.sessionId) {
+    throw new Error(
+      `Task ${task.id} has no captured provider session ID; refusing cwd-wide continuation.`
+    );
+  }
+  return {
+    cwd: task.cwd,
+    resume: task.sessionId,
+    provider: task.provider,
+  };
+}
 
 export async function resumeTask(taskId, newPrompt) {
   const task = getTask(taskId);
@@ -23,12 +43,7 @@ export async function resumeTask(taskId, newPrompt) {
   console.log(chalk.dim(`Original prompt: ${task.prompt}`));
   console.log(chalk.dim(`Resume prompt: ${prompt}`));
 
-  const newTask = await spawnTask(prompt, {
-    cwd: task.cwd,
-    continue: true, // Use --continue to load most recent session in that directory
-    sessionId: task.sessionId,
-    provider: task.provider,
-  });
+  const newTask = await spawnTask(prompt, buildResumeTaskOptions(task));
 
   console.log(chalk.green(`\n✓ Resumed as new task: ${chalk.cyan(newTask.id)}`));
   console.log(chalk.dim(`  PID: ${newTask.pid}`));

--- a/task-lib/commands/status.js
+++ b/task-lib/commands/status.js
@@ -41,6 +41,9 @@ export function showStatus(taskId) {
   console.log(`${chalk.dim('PID:')}        ${task.pid || 'N/A'}`);
   console.log(`${chalk.dim('Exit Code:')}  ${task.exitCode ?? 'N/A'}`);
   console.log(`${chalk.dim('Session:')}    ${task.sessionId || 'N/A'}`);
+  if (task.requestedResumeSessionId) {
+    console.log(`${chalk.dim('Requested:')}  ${task.requestedResumeSessionId}`);
+  }
   console.log(`${chalk.dim('Log File:')}   ${task.logFile}`);
 
   console.log(`\n${chalk.dim('Prompt:')}`);

--- a/task-lib/provider-helper-runtime.js
+++ b/task-lib/provider-helper-runtime.js
@@ -19,6 +19,7 @@ export const {
   classifyProviderError,
   detectProviderFatalError,
   detectProviderStreamingModeError,
+  extractProviderSessionId,
   findProviderRegistryEntry,
   getProviderAdapter,
   getProviderRegistryEntry,

--- a/task-lib/provider-session-capture.js
+++ b/task-lib/provider-session-capture.js
@@ -13,7 +13,7 @@ export function captureProviderSessionLine({
   currentSessionId = null,
   observedSessionIds = new Set(currentSessionId ? [currentSessionId] : []),
   sessionIdConflict = false,
-  onCapture,
+  onCapture = () => {},
   onConflict = () => {},
 }) {
   const sessionId = extractProviderSessionId(providerName, line);
@@ -36,18 +36,57 @@ export function captureProviderSessionLine({
   return { currentSessionId: sessionId, sessionIdConflict: false };
 }
 
+function providerSessionCompletionError({
+  requestedSessionId,
+  currentSessionId,
+  sessionIdConflict,
+  persistenceError,
+}) {
+  if (persistenceError) {
+    return `Provider session identity could not be persisted: ${persistenceError.message}`;
+  }
+
+  const requested = requestedSessionId?.trim() || null;
+  if (!requested) {
+    return null;
+  }
+  if (sessionIdConflict) {
+    return 'Provider continuation emitted conflicting session identities';
+  }
+
+  const captured = currentSessionId?.trim() || null;
+  if (captured === requested) {
+    return null;
+  }
+  return captured
+    ? 'Provider continuation returned a different session identity'
+    : 'Provider continuation did not confirm the requested session identity';
+}
+
 export function createProviderSessionCapture({
   providerName,
   taskId,
   updateTask,
   log,
+  requestedSessionId = null,
   initialSessionId = null,
   initialSessionIdConflict = false,
 }) {
   let currentSessionId = initialSessionId;
   let sessionIdConflict = initialSessionIdConflict;
+  let persistenceError = null;
   const observedSessionIds = new Set(initialSessionId ? [initialSessionId] : []);
-  return (line) => {
+
+  function persist(update) {
+    try {
+      updateTask(taskId, update);
+    } catch (error) {
+      persistenceError ||= error;
+      throw error;
+    }
+  }
+
+  function captureLine(line) {
     try {
       ({ currentSessionId, sessionIdConflict } = captureProviderSessionLine({
         providerName,
@@ -55,11 +94,31 @@ export function createProviderSessionCapture({
         currentSessionId,
         observedSessionIds,
         sessionIdConflict,
-        onCapture: (sessionId) => updateTask(taskId, { sessionId }),
-        onConflict: () => updateTask(taskId, { sessionId: null, sessionIdConflict: true }),
+        onCapture: (sessionId) => {
+          // Advance memory before persistence so a failed write can never leave
+          // this watcher believing the earlier identity is still trustworthy.
+          currentSessionId = sessionId;
+          persist({ sessionId });
+        },
+        onConflict: () => {
+          currentSessionId = null;
+          sessionIdConflict = true;
+          persist({ sessionId: null, sessionIdConflict: true });
+        },
       }));
     } catch (error) {
       log(`[${Date.now()}][SESSION] Failed to persist provider session: ${error.message}\n`);
     }
+  }
+
+  return {
+    captureLine,
+    getCompletionError: () =>
+      providerSessionCompletionError({
+        requestedSessionId,
+        currentSessionId,
+        sessionIdConflict,
+        persistenceError,
+      }),
   };
 }

--- a/task-lib/provider-session-capture.js
+++ b/task-lib/provider-session-capture.js
@@ -103,7 +103,11 @@ export function createProviderSessionCapture({
         onConflict: () => {
           currentSessionId = null;
           sessionIdConflict = true;
-          persist({ sessionId: null, sessionIdConflict: true });
+          persist({
+            sessionId: null,
+            sessionIdConflict: true,
+            resumeIdentityVerified: false,
+          });
         },
       }));
     } catch (error) {
@@ -111,14 +115,24 @@ export function createProviderSessionCapture({
     }
   }
 
+  function getCompletionError() {
+    return providerSessionCompletionError({
+      requestedSessionId,
+      currentSessionId,
+      sessionIdConflict,
+      persistenceError,
+    });
+  }
+
   return {
     captureLine,
-    getCompletionError: () =>
-      providerSessionCompletionError({
-        requestedSessionId,
-        currentSessionId,
-        sessionIdConflict,
-        persistenceError,
-      }),
+    getCompletionError,
+    getCompletionUpdate: (resolvedCode) => {
+      const error = getCompletionError();
+      return {
+        resumeIdentityVerified: resolvedCode === 0 && !error,
+        ...(error ? { sessionId: null, sessionIdConflict: true } : {}),
+      };
+    },
   };
 }

--- a/task-lib/provider-session-capture.js
+++ b/task-lib/provider-session-capture.js
@@ -4,33 +4,60 @@ import { extractProviderSessionId } from './provider-helper-runtime.js';
  * Capture a provider-owned session ID from one complete output line.
  *
  * The caller owns persistence so watcher variants can share parsing without
- * importing each other's process lifecycle. Returning the prior ID for
- * duplicate events avoids redundant task-store writes.
+ * importing each other's process lifecycle. Repeated IDs are idempotent; any
+ * differing ID makes the capture permanently ambiguous.
  */
 export function captureProviderSessionLine({
   providerName,
   line,
   currentSessionId = null,
+  observedSessionIds = new Set(currentSessionId ? [currentSessionId] : []),
+  sessionIdConflict = false,
   onCapture,
+  onConflict = () => {},
 }) {
   const sessionId = extractProviderSessionId(providerName, line);
-  if (!sessionId || sessionId === currentSessionId) {
-    return currentSessionId;
+  if (!sessionId) {
+    return { currentSessionId, sessionIdConflict };
+  }
+
+  observedSessionIds.add(sessionId);
+  if (sessionIdConflict || observedSessionIds.size > 1) {
+    if (!sessionIdConflict) {
+      onConflict([...observedSessionIds]);
+    }
+    return { currentSessionId: null, sessionIdConflict: true };
+  }
+
+  if (sessionId === currentSessionId) {
+    return { currentSessionId, sessionIdConflict: false };
   }
   onCapture(sessionId);
-  return sessionId;
+  return { currentSessionId: sessionId, sessionIdConflict: false };
 }
 
-export function createProviderSessionCapture({ providerName, taskId, updateTask, log }) {
-  let currentSessionId = null;
+export function createProviderSessionCapture({
+  providerName,
+  taskId,
+  updateTask,
+  log,
+  initialSessionId = null,
+  initialSessionIdConflict = false,
+}) {
+  let currentSessionId = initialSessionId;
+  let sessionIdConflict = initialSessionIdConflict;
+  const observedSessionIds = new Set(initialSessionId ? [initialSessionId] : []);
   return (line) => {
     try {
-      currentSessionId = captureProviderSessionLine({
+      ({ currentSessionId, sessionIdConflict } = captureProviderSessionLine({
         providerName,
         line,
         currentSessionId,
+        observedSessionIds,
+        sessionIdConflict,
         onCapture: (sessionId) => updateTask(taskId, { sessionId }),
-      });
+        onConflict: () => updateTask(taskId, { sessionId: null, sessionIdConflict: true }),
+      }));
     } catch (error) {
       log(`[${Date.now()}][SESSION] Failed to persist provider session: ${error.message}\n`);
     }

--- a/task-lib/provider-session-capture.js
+++ b/task-lib/provider-session-capture.js
@@ -1,0 +1,38 @@
+import { extractProviderSessionId } from './provider-helper-runtime.js';
+
+/**
+ * Capture a provider-owned session ID from one complete output line.
+ *
+ * The caller owns persistence so watcher variants can share parsing without
+ * importing each other's process lifecycle. Returning the prior ID for
+ * duplicate events avoids redundant task-store writes.
+ */
+export function captureProviderSessionLine({
+  providerName,
+  line,
+  currentSessionId = null,
+  onCapture,
+}) {
+  const sessionId = extractProviderSessionId(providerName, line);
+  if (!sessionId || sessionId === currentSessionId) {
+    return currentSessionId;
+  }
+  onCapture(sessionId);
+  return sessionId;
+}
+
+export function createProviderSessionCapture({ providerName, taskId, updateTask, log }) {
+  let currentSessionId = null;
+  return (line) => {
+    try {
+      currentSessionId = captureProviderSessionLine({
+        providerName,
+        line,
+        currentSessionId,
+        onCapture: (sessionId) => updateTask(taskId, { sessionId }),
+      });
+    } catch (error) {
+      log(`[${Date.now()}][SESSION] Failed to persist provider session: ${error.message}\n`);
+    }
+  };
+}

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -155,7 +155,7 @@ function providerLevelSelection(options) {
   return { modelSpec };
 }
 
-function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {
+export function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {
   return {
     id,
     prompt: prompt.slice(0, 200) + (prompt.length > 200 ? '...' : ''),
@@ -163,7 +163,11 @@ function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, mode
     cwd,
     status: 'running',
     pid: null,
-    sessionId: options.resume || options.sessionId || null,
+    // Only watcher-observed provider output may populate sessionId. A requested
+    // resume ID is diagnostic input, not proof the resumed provider emitted or
+    // accepted that session identity.
+    sessionId: null,
+    requestedResumeSessionId: options.resume || null,
     logFile,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -167,6 +167,7 @@ export function buildTaskRecord({ id, prompt, cwd, options, logFile, providerNam
     // resume ID is diagnostic input, not proof the resumed provider emitted or
     // accepted that session identity.
     sessionId: null,
+    sessionIdConflict: false,
     requestedResumeSessionId: options.resume || null,
     logFile,
     createdAt: new Date().toISOString(),

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -169,6 +169,9 @@ export function buildTaskRecord({ id, prompt, cwd, options, logFile, providerNam
     sessionId: null,
     sessionIdConflict: false,
     requestedResumeSessionId: options.resume || null,
+    // Resumed tasks start fail-closed. Only the watcher terminal transaction
+    // may prove that the requested identity completed without conflict.
+    resumeIdentityVerified: !options.resume,
     logFile,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -12,7 +12,7 @@ import { TASKS_DIR, LOGS_DIR } from './config.js';
 import { generateName } from './name-generator.js';
 
 const DB_FILE = join(TASKS_DIR, 'store.db');
-export const TASK_STORE_SCHEMA_VERSION = 3;
+export const TASK_STORE_SCHEMA_VERSION = 4;
 
 /** @type {Database.Database | null} */
 let db = null;
@@ -44,6 +44,7 @@ function getDb() {
       session_id TEXT,
       session_id_conflict INTEGER NOT NULL DEFAULT 0,
       requested_resume_session_id TEXT,
+      resume_identity_verified INTEGER NOT NULL DEFAULT 0,
       log_file TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -97,6 +98,7 @@ export function migrateTaskStore(database) {
   ensureTaskColumn(database, 'termination_strategy', 'TEXT');
   ensureTaskColumn(database, 'requested_resume_session_id', 'TEXT');
   ensureTaskColumn(database, 'session_id_conflict', 'INTEGER NOT NULL DEFAULT 0');
+  ensureTaskColumn(database, 'resume_identity_verified', 'INTEGER NOT NULL DEFAULT 0');
 
   const version = database.pragma('user_version', { simple: true });
   if (version >= TASK_STORE_SCHEMA_VERSION) return;
@@ -113,6 +115,9 @@ export function migrateTaskStore(database) {
     }
     if (version < 3) {
       database.prepare('UPDATE tasks SET session_id_conflict = 0').run();
+    }
+    if (version < 4) {
+      database.prepare('UPDATE tasks SET resume_identity_verified = 0').run();
     }
     database.pragma(`user_version = ${TASK_STORE_SCHEMA_VERSION}`);
   })();
@@ -146,6 +151,7 @@ function rowToTask(row) {
     sessionId: row.session_id,
     sessionIdConflict: Boolean(row.session_id_conflict),
     requestedResumeSessionId: row.requested_resume_session_id,
+    resumeIdentityVerified: Boolean(row.resume_identity_verified),
     logFile: row.log_file,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -183,11 +189,11 @@ export function saveTasks(tasks) {
   const database = getDb();
   const insert = database.prepare(`
     INSERT OR REPLACE INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, resume_identity_verified, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @resumeIdentityVerified, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -208,6 +214,7 @@ export function saveTasks(tasks) {
         sessionId: task.sessionId || null,
         sessionIdConflict: task.sessionIdConflict ? 1 : 0,
         requestedResumeSessionId: nullable(task.requestedResumeSessionId),
+        resumeIdentityVerified: task.resumeIdentityVerified ? 1 : 0,
         logFile: task.logFile || null,
         createdAt: task.createdAt || new Date().toISOString(),
         updatedAt: task.updatedAt || new Date().toISOString(),
@@ -278,6 +285,7 @@ export function updateTask(id, updates) {
       session_id = @sessionId,
       session_id_conflict = @sessionIdConflict,
       requested_resume_session_id = @requestedResumeSessionId,
+      resume_identity_verified = @resumeIdentityVerified,
       log_file = @logFile,
       updated_at = @updatedAt,
       exit_code = @exitCode,
@@ -302,6 +310,7 @@ export function updateTask(id, updates) {
       sessionId: updated.sessionId || null,
       sessionIdConflict: updated.sessionIdConflict ? 1 : 0,
       requestedResumeSessionId: nullable(updated.requestedResumeSessionId),
+      resumeIdentityVerified: updated.resumeIdentityVerified ? 1 : 0,
       logFile: updated.logFile || null,
       updatedAt: updated.updatedAt,
       exitCode: updated.exitCode ?? null,
@@ -335,11 +344,11 @@ export function addTask(task) {
     .prepare(
       `
     INSERT INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, resume_identity_verified, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @resumeIdentityVerified, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -355,6 +364,7 @@ export function addTask(task) {
       sessionId: fullTask.sessionId || null,
       sessionIdConflict: fullTask.sessionIdConflict ? 1 : 0,
       requestedResumeSessionId: nullable(fullTask.requestedResumeSessionId),
+      resumeIdentityVerified: fullTask.resumeIdentityVerified ? 1 : 0,
       logFile: fullTask.logFile || null,
       createdAt: fullTask.createdAt,
       updatedAt: fullTask.updatedAt,

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -12,6 +12,7 @@ import { TASKS_DIR, LOGS_DIR } from './config.js';
 import { generateName } from './name-generator.js';
 
 const DB_FILE = join(TASKS_DIR, 'store.db');
+export const TASK_STORE_SCHEMA_VERSION = 2;
 
 /** @type {Database.Database | null} */
 let db = null;
@@ -78,9 +79,7 @@ function getDb() {
     CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled);
   `);
 
-  ensureTaskColumn(db, 'process_group_id', 'INTEGER');
-  ensureTaskColumn(db, 'termination_strategy', 'TEXT');
-  ensureTaskColumn(db, 'requested_resume_session_id', 'TEXT');
+  migrateTaskStore(db);
 
   return db;
 }
@@ -90,6 +89,28 @@ function ensureTaskColumn(database, name, definition) {
   if (!columns.some((column) => column.name === name)) {
     database.exec(`ALTER TABLE tasks ADD COLUMN ${name} ${definition}`);
   }
+}
+
+export function migrateTaskStore(database) {
+  ensureTaskColumn(database, 'process_group_id', 'INTEGER');
+  ensureTaskColumn(database, 'termination_strategy', 'TEXT');
+  ensureTaskColumn(database, 'requested_resume_session_id', 'TEXT');
+
+  const version = database.pragma('user_version', { simple: true });
+  if (version >= TASK_STORE_SCHEMA_VERSION) return;
+
+  database.transaction(() => {
+    if (version < 2) {
+      database
+        .prepare(
+          `UPDATE tasks
+           SET requested_resume_session_id = COALESCE(requested_resume_session_id, session_id),
+               session_id = NULL`
+        )
+        .run();
+    }
+    database.pragma(`user_version = ${TASK_STORE_SCHEMA_VERSION}`);
+  })();
 }
 
 function nullable(value) {

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -41,6 +41,7 @@ function getDb() {
       status TEXT NOT NULL DEFAULT 'pending',
       pid INTEGER,
       session_id TEXT,
+      requested_resume_session_id TEXT,
       log_file TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -79,6 +80,7 @@ function getDb() {
 
   ensureTaskColumn(db, 'process_group_id', 'INTEGER');
   ensureTaskColumn(db, 'termination_strategy', 'TEXT');
+  ensureTaskColumn(db, 'requested_resume_session_id', 'TEXT');
 
   return db;
 }
@@ -88,6 +90,10 @@ function ensureTaskColumn(database, name, definition) {
   if (!columns.some((column) => column.name === name)) {
     database.exec(`ALTER TABLE tasks ADD COLUMN ${name} ${definition}`);
   }
+}
+
+function nullable(value) {
+  return value || null;
 }
 
 export function ensureDirs() {
@@ -112,6 +118,7 @@ function rowToTask(row) {
     status: row.status,
     pid: row.pid,
     sessionId: row.session_id,
+    requestedResumeSessionId: row.requested_resume_session_id,
     logFile: row.log_file,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -149,11 +156,11 @@ export function saveTasks(tasks) {
   const database = getDb();
   const insert = database.prepare(`
     INSERT OR REPLACE INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -172,6 +179,7 @@ export function saveTasks(tasks) {
         status: task.status || 'pending',
         pid: task.pid || null,
         sessionId: task.sessionId || null,
+        requestedResumeSessionId: nullable(task.requestedResumeSessionId),
         logFile: task.logFile || null,
         createdAt: task.createdAt || new Date().toISOString(),
         updatedAt: task.updatedAt || new Date().toISOString(),
@@ -240,6 +248,7 @@ export function updateTask(id, updates) {
       status = @status,
       pid = @pid,
       session_id = @sessionId,
+      requested_resume_session_id = @requestedResumeSessionId,
       log_file = @logFile,
       updated_at = @updatedAt,
       exit_code = @exitCode,
@@ -262,6 +271,7 @@ export function updateTask(id, updates) {
       status: updated.status || 'pending',
       pid: updated.pid || null,
       sessionId: updated.sessionId || null,
+      requestedResumeSessionId: nullable(updated.requestedResumeSessionId),
       logFile: updated.logFile || null,
       updatedAt: updated.updatedAt,
       exitCode: updated.exitCode ?? null,
@@ -295,11 +305,11 @@ export function addTask(task) {
     .prepare(
       `
     INSERT INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -313,6 +323,7 @@ export function addTask(task) {
       status: fullTask.status || 'pending',
       pid: fullTask.pid || null,
       sessionId: fullTask.sessionId || null,
+      requestedResumeSessionId: nullable(fullTask.requestedResumeSessionId),
       logFile: fullTask.logFile || null,
       createdAt: fullTask.createdAt,
       updatedAt: fullTask.updatedAt,

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -12,7 +12,7 @@ import { TASKS_DIR, LOGS_DIR } from './config.js';
 import { generateName } from './name-generator.js';
 
 const DB_FILE = join(TASKS_DIR, 'store.db');
-export const TASK_STORE_SCHEMA_VERSION = 2;
+export const TASK_STORE_SCHEMA_VERSION = 3;
 
 /** @type {Database.Database | null} */
 let db = null;
@@ -42,6 +42,7 @@ function getDb() {
       status TEXT NOT NULL DEFAULT 'pending',
       pid INTEGER,
       session_id TEXT,
+      session_id_conflict INTEGER NOT NULL DEFAULT 0,
       requested_resume_session_id TEXT,
       log_file TEXT,
       created_at TEXT NOT NULL,
@@ -95,6 +96,7 @@ export function migrateTaskStore(database) {
   ensureTaskColumn(database, 'process_group_id', 'INTEGER');
   ensureTaskColumn(database, 'termination_strategy', 'TEXT');
   ensureTaskColumn(database, 'requested_resume_session_id', 'TEXT');
+  ensureTaskColumn(database, 'session_id_conflict', 'INTEGER NOT NULL DEFAULT 0');
 
   const version = database.pragma('user_version', { simple: true });
   if (version >= TASK_STORE_SCHEMA_VERSION) return;
@@ -108,6 +110,9 @@ export function migrateTaskStore(database) {
                session_id = NULL`
         )
         .run();
+    }
+    if (version < 3) {
+      database.prepare('UPDATE tasks SET session_id_conflict = 0').run();
     }
     database.pragma(`user_version = ${TASK_STORE_SCHEMA_VERSION}`);
   })();
@@ -139,6 +144,7 @@ function rowToTask(row) {
     status: row.status,
     pid: row.pid,
     sessionId: row.session_id,
+    sessionIdConflict: Boolean(row.session_id_conflict),
     requestedResumeSessionId: row.requested_resume_session_id,
     logFile: row.log_file,
     createdAt: row.created_at,
@@ -177,11 +183,11 @@ export function saveTasks(tasks) {
   const database = getDb();
   const insert = database.prepare(`
     INSERT OR REPLACE INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -200,6 +206,7 @@ export function saveTasks(tasks) {
         status: task.status || 'pending',
         pid: task.pid || null,
         sessionId: task.sessionId || null,
+        sessionIdConflict: task.sessionIdConflict ? 1 : 0,
         requestedResumeSessionId: nullable(task.requestedResumeSessionId),
         logFile: task.logFile || null,
         createdAt: task.createdAt || new Date().toISOString(),
@@ -269,6 +276,7 @@ export function updateTask(id, updates) {
       status = @status,
       pid = @pid,
       session_id = @sessionId,
+      session_id_conflict = @sessionIdConflict,
       requested_resume_session_id = @requestedResumeSessionId,
       log_file = @logFile,
       updated_at = @updatedAt,
@@ -292,6 +300,7 @@ export function updateTask(id, updates) {
       status: updated.status || 'pending',
       pid: updated.pid || null,
       sessionId: updated.sessionId || null,
+      sessionIdConflict: updated.sessionIdConflict ? 1 : 0,
       requestedResumeSessionId: nullable(updated.requestedResumeSessionId),
       logFile: updated.logFile || null,
       updatedAt: updated.updatedAt,
@@ -326,11 +335,11 @@ export function addTask(task) {
     .prepare(
       `
     INSERT INTO tasks (
-      id, prompt, full_prompt, cwd, status, pid, session_id, requested_resume_session_id, log_file,
+      id, prompt, full_prompt, cwd, status, pid, session_id, session_id_conflict, requested_resume_session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy
     ) VALUES (
-      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @requestedResumeSessionId, @logFile,
+      @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @sessionIdConflict, @requestedResumeSessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
     )
@@ -344,6 +353,7 @@ export function addTask(task) {
       status: fullTask.status || 'pending',
       pid: fullTask.pid || null,
       sessionId: fullTask.sessionId || null,
+      sessionIdConflict: fullTask.sessionIdConflict ? 1 : 0,
       requestedResumeSessionId: nullable(fullTask.requestedResumeSessionId),
       logFile: fullTask.logFile || null,
       createdAt: fullTask.createdAt,

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -311,11 +311,11 @@ child.on('close', async (code, signal) => {
       pid: null,
       processGroupId: null,
       exitCode: resolvedCode,
+      ...providerSessionCapture.getCompletionUpdate(resolvedCode),
       error:
         fatalError ||
         sessionIdentityError ||
         (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
-      ...(sessionIdentityError ? { sessionId: null, sessionIdConflict: true } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -38,14 +38,16 @@ function log(msg) {
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
 const storedTask = getTask(taskId);
-const maybeCaptureProviderSession = createProviderSessionCapture({
+const providerSessionCapture = createProviderSessionCapture({
   providerName,
   taskId,
   updateTask,
   log,
+  requestedSessionId: storedTask?.requestedResumeSessionId || null,
   initialSessionId: storedTask?.sessionId || null,
   initialSessionIdConflict: storedTask?.sessionIdConflict === true,
 });
+const maybeCaptureProviderSession = providerSessionCapture.captureLine;
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -295,18 +297,25 @@ child.on('close', async (code, signal) => {
     log(finalResultJson + '\n');
   }
 
-  writeCompletionFooter(code, signal);
+  const sessionIdentityError = providerSessionCapture.getCompletionError();
+  const resolvedCode =
+    fatalError || sessionIdentityError ? 1 : recovered?.payload ? 0 : code;
+  const status = resolvedCode === 0 ? 'completed' : 'failed';
+
+  writeCompletionFooter(resolvedCode, signal);
   await cleanupCommandSpec();
 
-  const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
-  const status = resolvedCode === 0 ? 'completed' : 'failed';
   try {
     await updateTask(taskId, {
       status,
       pid: null,
       processGroupId: null,
       exitCode: resolvedCode,
-      error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
+      error:
+        fatalError ||
+        sessionIdentityError ||
+        (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
+      ...(sessionIdentityError ? { sessionId: null, sessionIdConflict: true } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -8,7 +8,7 @@
 import { spawn } from 'child_process';
 import { appendFileSync, unlinkSync } from 'fs';
 import { unlink } from 'fs/promises';
-import { updateTask } from './store.js';
+import { getTask, updateTask } from './store.js';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
@@ -37,11 +37,14 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const storedTask = getTask(taskId);
 const maybeCaptureProviderSession = createProviderSessionCapture({
   providerName,
   taskId,
   updateTask,
   log,
+  initialSessionId: storedTask?.sessionId || null,
+  initialSessionIdConflict: storedTask?.sessionIdConflict === true,
 });
 
 const env = { ...process.env, ...(commandSpec.env || {}) };

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -15,6 +15,7 @@ import {
   recoverProviderStructuredOutput,
   supportsProviderStructuredOutputRecovery,
 } from './provider-helper-runtime.js';
+import { createProviderSessionCapture } from './provider-session-capture.js';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -36,6 +37,12 @@ function log(msg) {
 
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+const maybeCaptureProviderSession = createProviderSessionCapture({
+  providerName,
+  taskId,
+  updateTask,
+  log,
+});
 
 const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
@@ -136,6 +143,7 @@ function maybeCaptureStructuredOutput(line) {
 function handleSilentJsonLines(lines, timestamp) {
   for (const line of lines) {
     if (!line.trim()) continue;
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -146,6 +154,7 @@ function handleSilentJsonLines(lines, timestamp) {
 
 function handleStreamingLines(lines, timestamp) {
   for (const line of lines) {
+    maybeCaptureProviderSession(line);
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) {
       continue;
@@ -159,6 +168,7 @@ function flushStdoutBuffer(timestamp) {
     return;
   }
 
+  maybeCaptureProviderSession(stdoutBuffer);
   if (!enableRecovery) {
     if (!silentJsonMode) {
       log(`[${timestamp}]${stdoutBuffer}\n`);

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -80,6 +80,30 @@ test('build-command preserves Claude resume and continue options through JSON co
   assert.deepEqual(continued.envelope.result.commandSpec.args.slice(-2), ['--continue', 'ctx']);
 });
 
+test('build-command preserves Codex explicit session resume through JSON contract', () => {
+  const resumed = runExecutable({
+    schemaVersion: 1,
+    command: 'build-command',
+    provider: 'codex',
+    context: 'ctx',
+    options: {
+      resumeSessionId: 'thread-1',
+      cwd: '/tmp/project',
+      cliFeatures: {
+        supportsResume: true,
+        supportsCwd: true,
+      },
+    },
+  });
+
+  assert.equal(resumed.exitCode, 0);
+  assert.equal(resumed.envelope.ok, true);
+  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(0, 2), ['exec', 'resume']);
+  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(-2), ['thread-1', 'ctx']);
+  assert.equal(resumed.envelope.result.commandSpec.args.includes('-C'), false);
+  assert.equal(resumed.envelope.result.commandSpec.cwd, '/tmp/project');
+});
+
 test('build-command redacts adapter auth env values from command spec output', () => {
   const secret = 'plain-secret';
   const response = runExecutable({

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -647,9 +647,26 @@ test('feature probing is deterministic from injected help text', () => {
     supportsVerbose: true,
     supportsModel: true,
     supportsEffort: true,
+    supportsResume: true,
     unknown: true,
   });
 
+  assert.equal(
+    helper.getProviderAdapter('claude').detectCliFeatures('claude --resume').supportsResume,
+    true
+  );
+  assert.equal(
+    helper.getProviderAdapter('claude').detectCliFeatures('claude --print').supportsResume,
+    false
+  );
+  assert.equal(
+    helper.getProviderAdapter('codex').detectCliFeatures('codex exec resume').supportsResume,
+    true
+  );
+  assert.equal(
+    helper.getProviderAdapter('codex').detectCliFeatures('codex exec --json').supportsResume,
+    false
+  );
   assert.equal(
     helper
       .getProviderAdapter('codex')

--- a/tests/fixtures/ledger-sequence-writer.js
+++ b/tests/fixtures/ledger-sequence-writer.js
@@ -1,0 +1,22 @@
+const Ledger = require('../../src/ledger');
+
+const [dbPath, clusterId, sender] = process.argv.slice(2);
+const ledger = new Ledger(dbPath);
+
+process.send({ type: 'ready' });
+process.once('message', ({ timestamp }) => {
+  try {
+    const message = ledger.append({
+      cluster_id: clusterId,
+      topic: 'VALIDATION_RESULT',
+      sender,
+      timestamp,
+      content: { text: sender },
+    });
+    process.send({ type: 'appended', message });
+  } catch (error) {
+    process.send({ type: 'error', error: error.message });
+  } finally {
+    ledger.close();
+  }
+});

--- a/tests/helpers/provider-session-harness.js
+++ b/tests/helpers/provider-session-harness.js
@@ -3,8 +3,28 @@ const os = require('os');
 const path = require('path');
 
 const AgentWrapper = require('../../src/agent-wrapper');
+const { promptIdentity } = require('../../src/agent/provider-session');
 const Ledger = require('../../src/ledger');
 const MessageBus = require('../../src/message-bus');
+
+const PROVIDER_SESSION_TEST_CWD = path.resolve('/tmp/provider-session-project');
+const FOLLOW_UP_PROMPT_IDENTITY = promptIdentity('FOLLOW-UP-INSTRUCTIONS');
+
+function buildProviderSession(overrides = {}) {
+  return {
+    provider: 'claude',
+    sessionId: 'claude-session-1',
+    agentId: 'worker',
+    taskId: 'task-generation-1',
+    generation: 1,
+    cwd: PROVIDER_SESSION_TEST_CWD,
+    worktreePath: null,
+    contextSequence: 41,
+    guidanceSequence: 17,
+    promptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
+    ...overrides,
+  };
+}
 
 function createProviderSessionHarness(prefix) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -55,6 +75,9 @@ function createProviderSessionAgent({ cluster, messageBus, config = {}, runtime 
 }
 
 module.exports = {
+  FOLLOW_UP_PROMPT_IDENTITY,
+  PROVIDER_SESSION_TEST_CWD,
+  buildProviderSession,
   createProviderSessionAgent,
   createProviderSessionHarness,
 };

--- a/tests/helpers/provider-session-harness.js
+++ b/tests/helpers/provider-session-harness.js
@@ -19,8 +19,8 @@ function buildProviderSession(overrides = {}) {
     generation: 1,
     cwd: PROVIDER_SESSION_TEST_CWD,
     worktreePath: null,
-    contextSequence: 41,
-    guidanceSequence: 17,
+    contextSequence: '41',
+    guidanceSequence: '17',
     promptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
     ...overrides,
   };

--- a/tests/helpers/provider-session-harness.js
+++ b/tests/helpers/provider-session-harness.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const AgentWrapper = require('../../src/agent-wrapper');
+const Ledger = require('../../src/ledger');
+const MessageBus = require('../../src/message-bus');
+
+function createProviderSessionHarness(prefix) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const settingsSnapshot = {
+    existed: Object.hasOwn(process.env, 'ZEROSHOT_SETTINGS_FILE'),
+    value: process.env.ZEROSHOT_SETTINGS_FILE,
+  };
+  process.env.ZEROSHOT_SETTINGS_FILE = path.join(tempDir, 'settings.json');
+  fs.writeFileSync(
+    process.env.ZEROSHOT_SETTINGS_FILE,
+    JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+  );
+  const ledger = new Ledger(path.join(tempDir, 'ledger.db'));
+
+  return {
+    ledger,
+    messageBus: new MessageBus(ledger),
+    cleanup() {
+      ledger.close();
+      if (settingsSnapshot.existed) {
+        process.env.ZEROSHOT_SETTINGS_FILE = settingsSnapshot.value;
+      } else {
+        delete process.env.ZEROSHOT_SETTINGS_FILE;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function createProviderSessionAgent({ cluster, messageBus, config = {}, runtime = {} }) {
+  return new AgentWrapper(
+    {
+      id: 'worker',
+      role: 'implementation',
+      provider: 'claude',
+      timeout: 0,
+      contextStrategy: { sources: [] },
+      ...config,
+    },
+    messageBus,
+    cluster,
+    {
+      testMode: true,
+      mockSpawnFn: () => ({ success: true, output: '{}' }),
+      ...runtime,
+    }
+  );
+}
+
+module.exports = {
+  createProviderSessionAgent,
+  createProviderSessionHarness,
+};

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1900,6 +1900,10 @@ function defineLifecycleResumeTests() {
       agent.currentTask = { kill() {} };
       agent.currentTaskId = 'task-live';
       agent.processPid = 4242;
+      agent.providerSession = {
+        provider: 'claude',
+        sessionId: 'agent-owned-session',
+      };
 
       await lifecycleOrchestrator._saveClusters();
 
@@ -1916,6 +1920,10 @@ function defineLifecycleResumeTests() {
 
         assert.strictEqual(restoredAgent.currentTask, null);
         assert.strictEqual(restoredAgent.currentTaskId, 'task-live');
+        assert.deepStrictEqual(restoredAgent.providerSession, {
+          provider: 'claude',
+          sessionId: 'agent-owned-session',
+        });
         assert.strictEqual(restoredState.currentTask, false);
       } finally {
         reloaded.close();

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1942,11 +1942,11 @@ function defineLifecycleResumeTests() {
         generation: agent.iteration,
         cwd: path.resolve(agent.config.cwd || process.cwd()),
         worktreePath: null,
-        contextSequence: 41,
-        guidanceSequence: 17,
+        contextSequence: '41',
+        guidanceSequence: '17',
         promptIdentity: privatePromptIdentity,
       };
-      agent.lastGuidanceAppliedId = 17;
+      agent.lastGuidanceAppliedId = '17';
       cluster.messageBus.publish({
         cluster_id: result.id,
         topic: 'AGENT_LIFECYCLE',
@@ -1958,8 +1958,8 @@ function defineLifecycleResumeTests() {
             provider: 'claude',
             taskId: 'task-complete',
             iteration: agent.iteration,
-            contextSequence: 41,
-            guidanceSequence: 17,
+            contextSequence: '41',
+            guidanceSequence: '17',
             promptIdentity: privatePromptIdentity,
           },
         },
@@ -1998,11 +1998,11 @@ function defineLifecycleResumeTests() {
           generation: agent.iteration,
           cwd: path.resolve(agent.config.cwd || process.cwd()),
           worktreePath: null,
-          contextSequence: 41,
-          guidanceSequence: 17,
+          contextSequence: '41',
+          guidanceSequence: '17',
           promptIdentity: privatePromptIdentity,
         });
-        assert.strictEqual(restoredAgent.lastGuidanceAppliedId, 17);
+        assert.strictEqual(restoredAgent.lastGuidanceAppliedId, '17');
         assert.strictEqual(restoredState.currentTask, false);
       } finally {
         reloaded.close();

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -268,6 +268,25 @@ async function waitForAgentCalls(runner, expectedCalls, timeoutMs = 3000) {
   );
 }
 
+async function waitForLifecycleEvent({ messageBus, clusterId, agentId, event, timeoutMs = 3000 }) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const observed = messageBus
+      .query({
+        cluster_id: clusterId,
+        topic: 'AGENT_LIFECYCLE',
+        sender: agentId,
+      })
+      .some((message) => message.content?.data?.event === event);
+    if (observed) {
+      return;
+    }
+    await sleep(20);
+  }
+
+  throw new Error(`Agent ${agentId} did not publish lifecycle event ${event}`);
+}
+
 function publishInterruptedTaskHistory(
   cluster,
   clusterId,
@@ -1713,15 +1732,27 @@ function defineLifecycleResumeTests() {
       lifecycleMockRunner.when('worker').returns({ done: true });
 
       const result = await lifecycleOrchestrator.start(config, { text: 'Task' });
+      const runningCluster = lifecycleOrchestrator.getCluster(result.id);
+      await waitForLifecycleEvent({
+        messageBus: runningCluster.messageBus,
+        clusterId: result.id,
+        agentId: 'worker',
+        event: 'TASK_COMPLETED',
+      });
       await lifecycleOrchestrator.stop(result.id);
 
       const cluster = lifecycleOrchestrator.getCluster(result.id);
+      const durableHighWater = cluster.messageBus.query({
+        cluster_id: result.id,
+        order: 'desc',
+        limit: 1,
+      })[0].timestamp;
       cluster.failureInfo = {
         agentId: 'worker',
         taskId: 'persisted-worker-failure',
         iteration: 1,
         error: 'boom',
-        timestamp: Date.now(),
+        timestamp: durableHighWater + 1,
       };
 
       const resumedRunner = new MockTaskRunner();
@@ -1908,7 +1939,11 @@ function defineLifecycleResumeTests() {
         generation: agent.iteration,
         cwd: path.resolve(agent.config.cwd || process.cwd()),
         worktreePath: null,
+        contextCursor: 41,
+        guidanceCursor: 17,
+        promptText: agent._selectPrompt(),
       };
+      agent.lastGuidanceAppliedAt = 17;
       cluster.messageBus.publish({
         cluster_id: result.id,
         topic: 'AGENT_LIFECYCLE',
@@ -1920,6 +1955,9 @@ function defineLifecycleResumeTests() {
             provider: 'claude',
             taskId: 'task-complete',
             iteration: agent.iteration,
+            contextCursor: 41,
+            guidanceCursor: 17,
+            promptText: agent._selectPrompt(),
           },
         },
       });
@@ -1947,7 +1985,11 @@ function defineLifecycleResumeTests() {
           generation: agent.iteration,
           cwd: path.resolve(agent.config.cwd || process.cwd()),
           worktreePath: null,
+          contextCursor: 41,
+          guidanceCursor: 17,
+          promptText: agent._selectPrompt(),
         });
+        assert.strictEqual(restoredAgent.lastGuidanceAppliedAt, 17);
         assert.strictEqual(restoredState.currentTask, false);
       } finally {
         reloaded.close();
@@ -1976,13 +2018,20 @@ function defineLifecycleResumeTests() {
         generation: 1,
         cwd,
         worktreePath: null,
+        contextCursor: 41,
+        guidanceCursor: 17,
+        promptText: agent._selectPrompt(),
       };
+      agent.lastGuidanceAppliedAt = 17;
       for (const data of [
         {
           event: 'TASK_COMPLETED',
           provider: 'claude',
           taskId: 'task-complete-generation-1',
           iteration: 1,
+          contextCursor: 41,
+          guidanceCursor: 17,
+          promptText: agent._selectPrompt(),
         },
         {
           event: 'TASK_STARTED',

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -17,6 +17,7 @@ const IsolationManager = require('../src/isolation-manager.js');
 const MockTaskRunner = require('./helpers/mock-task-runner.js');
 const LedgerAssertions = require('./helpers/ledger-assertions.js');
 const Ledger = require('../src/ledger.js');
+const { promptIdentity } = require('../src/agent/provider-session.js');
 
 // Isolate tests from user settings (prevents minModel/maxModel conflicts)
 const testSettingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-test-settings-'));
@@ -1919,6 +1920,8 @@ function defineLifecycleResumeTests() {
 
     it('restores a proven completed session without reviving currentTask handles', async function () {
       const config = createSimpleConfig();
+      const privatePrompt = `PRIVATE-CONTINUATION-PROMPT-${'x'.repeat(16_384)}`;
+      const privatePromptIdentity = promptIdentity(privatePrompt);
       lifecycleMockRunner.when('worker').delays(1000, { done: true });
 
       const result = await lifecycleOrchestrator.start(config, { text: 'Task' });
@@ -1939,11 +1942,11 @@ function defineLifecycleResumeTests() {
         generation: agent.iteration,
         cwd: path.resolve(agent.config.cwd || process.cwd()),
         worktreePath: null,
-        contextCursor: 41,
-        guidanceCursor: 17,
-        promptText: agent._selectPrompt(),
+        contextSequence: 41,
+        guidanceSequence: 17,
+        promptIdentity: privatePromptIdentity,
       };
-      agent.lastGuidanceAppliedAt = 17;
+      agent.lastGuidanceAppliedId = 17;
       cluster.messageBus.publish({
         cluster_id: result.id,
         topic: 'AGENT_LIFECYCLE',
@@ -1955,14 +1958,24 @@ function defineLifecycleResumeTests() {
             provider: 'claude',
             taskId: 'task-complete',
             iteration: agent.iteration,
-            contextCursor: 41,
-            guidanceCursor: 17,
-            promptText: agent._selectPrompt(),
+            contextSequence: 41,
+            guidanceSequence: 17,
+            promptIdentity: privatePromptIdentity,
           },
         },
       });
 
       await lifecycleOrchestrator._saveClusters();
+      const persistedRegistry = fs.readFileSync(
+        path.join(lifecycleStorageDir, 'clusters.json'),
+        'utf8'
+      );
+      const exportedLedger = lifecycleOrchestrator.export(result.id, 'json');
+      assert.ok(privatePromptIdentity.length <= 71);
+      assert.ok(!persistedRegistry.includes(privatePrompt));
+      assert.ok(!exportedLedger.includes(privatePrompt));
+      assert.ok(!persistedRegistry.includes('"promptText"'));
+      assert.ok(!exportedLedger.includes('"promptText"'));
 
       const reloaded = await Orchestrator.create({
         taskRunner: new MockTaskRunner(),
@@ -1985,11 +1998,11 @@ function defineLifecycleResumeTests() {
           generation: agent.iteration,
           cwd: path.resolve(agent.config.cwd || process.cwd()),
           worktreePath: null,
-          contextCursor: 41,
-          guidanceCursor: 17,
-          promptText: agent._selectPrompt(),
+          contextSequence: 41,
+          guidanceSequence: 17,
+          promptIdentity: privatePromptIdentity,
         });
-        assert.strictEqual(restoredAgent.lastGuidanceAppliedAt, 17);
+        assert.strictEqual(restoredAgent.lastGuidanceAppliedId, 17);
         assert.strictEqual(restoredState.currentTask, false);
       } finally {
         reloaded.close();
@@ -2018,20 +2031,20 @@ function defineLifecycleResumeTests() {
         generation: 1,
         cwd,
         worktreePath: null,
-        contextCursor: 41,
-        guidanceCursor: 17,
-        promptText: agent._selectPrompt(),
+        contextSequence: 41,
+        guidanceSequence: 17,
+        promptIdentity: promptIdentity(agent._selectPrompt()),
       };
-      agent.lastGuidanceAppliedAt = 17;
+      agent.lastGuidanceAppliedId = 17;
       for (const data of [
         {
           event: 'TASK_COMPLETED',
           provider: 'claude',
           taskId: 'task-complete-generation-1',
           iteration: 1,
-          contextCursor: 41,
-          guidanceCursor: 17,
-          promptText: agent._selectPrompt(),
+          contextSequence: 41,
+          guidanceSequence: 17,
+          promptIdentity: promptIdentity(agent._selectPrompt()),
         },
         {
           event: 'TASK_STARTED',

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1886,7 +1886,7 @@ function defineLifecycleResumeTests() {
       assert.strictEqual(failureInfo.error, 'unresolved validator failure');
     });
 
-    it('should not restore serialized currentTask handles from disk', async function () {
+    it('restores a proven completed session without reviving currentTask handles', async function () {
       const config = createSimpleConfig();
       lifecycleMockRunner.when('worker').delays(1000, { done: true });
 
@@ -1903,7 +1903,26 @@ function defineLifecycleResumeTests() {
       agent.providerSession = {
         provider: 'claude',
         sessionId: 'agent-owned-session',
+        agentId: agent.id,
+        taskId: 'task-complete',
+        generation: agent.iteration,
+        cwd: path.resolve(agent.config.cwd || process.cwd()),
+        worktreePath: null,
       };
+      cluster.messageBus.publish({
+        cluster_id: result.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: agent.id,
+        content: {
+          text: `${agent.id}: TASK_COMPLETED`,
+          data: {
+            event: 'TASK_COMPLETED',
+            provider: 'claude',
+            taskId: 'task-complete',
+            iteration: agent.iteration,
+          },
+        },
+      });
 
       await lifecycleOrchestrator._saveClusters();
 
@@ -1923,8 +1942,78 @@ function defineLifecycleResumeTests() {
         assert.deepStrictEqual(restoredAgent.providerSession, {
           provider: 'claude',
           sessionId: 'agent-owned-session',
+          agentId: agent.id,
+          taskId: 'task-complete',
+          generation: agent.iteration,
+          cwd: path.resolve(agent.config.cwd || process.cwd()),
+          worktreePath: null,
         });
         assert.strictEqual(restoredState.currentTask, false);
+      } finally {
+        reloaded.close();
+      }
+    });
+
+    it('drops session state when a crash snapshot ends in a live or failed generation', async function () {
+      const config = createSimpleConfig();
+      lifecycleMockRunner.when('worker').delays(1000, { done: true });
+
+      const result = await lifecycleOrchestrator.start(config, { text: 'Task' });
+      const cluster = lifecycleOrchestrator.getCluster(result.id);
+      const agent = cluster.agents[0];
+      const cwd = path.resolve(agent.config.cwd || process.cwd());
+
+      cluster.state = 'stopped';
+      cluster.pid = null;
+      agent.state = 'executing_task';
+      agent.iteration = 2;
+      agent.currentTaskId = 'task-live-generation-2';
+      agent.providerSession = {
+        provider: 'claude',
+        sessionId: 'completed-generation-1',
+        agentId: agent.id,
+        taskId: 'task-complete-generation-1',
+        generation: 1,
+        cwd,
+        worktreePath: null,
+      };
+      for (const data of [
+        {
+          event: 'TASK_COMPLETED',
+          provider: 'claude',
+          taskId: 'task-complete-generation-1',
+          iteration: 1,
+        },
+        {
+          event: 'TASK_STARTED',
+          provider: 'claude',
+          taskId: 'task-live-generation-2',
+          iteration: 2,
+        },
+        {
+          event: 'TASK_FAILED',
+          provider: 'claude',
+          taskId: 'task-live-generation-2',
+          iteration: 2,
+        },
+      ]) {
+        cluster.messageBus.publish({
+          cluster_id: result.id,
+          topic: 'AGENT_LIFECYCLE',
+          sender: agent.id,
+          content: { text: `${agent.id}: ${data.event}`, data },
+        });
+      }
+
+      await lifecycleOrchestrator._saveClusters();
+      const reloaded = await Orchestrator.create({
+        taskRunner: new MockTaskRunner(),
+        storageDir: lifecycleStorageDir,
+        quiet: true,
+      });
+
+      try {
+        assert.strictEqual(reloaded.getCluster(result.id).agents[0].providerSession, null);
       } finally {
         reloaded.close();
       }

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -26,24 +26,33 @@ function buildCommand(provider, context, options = {}) {
 }
 
 describe('Codex provider helper builder', function () {
-  it('warns when unsupported session control options are ignored', function () {
+  it('resumes an explicit session without cwd-wide continuation', function () {
     const resumed = buildCommand('codex', 'test context', {
       resumeSessionId: 'session-123',
+      cwd: '/tmp/project',
     });
-    assert.ok(!resumed.args.includes('--resume'));
-    assert.ok(
-      resumed.warnings.some(
-        (warning) =>
-          warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
-      )
-    );
+    assert.deepStrictEqual(resumed.args.slice(0, 2), ['exec', 'resume']);
+    assert.deepStrictEqual(resumed.args.slice(-2), ['session-123', 'test context']);
+    assert.ok(!resumed.args.includes('-C'));
 
     const continued = buildCommand('codex', 'test context', {
       continueSession: true,
     });
     assert.ok(!continued.args.includes('--continue'));
     assert.ok(continued.warnings.some((warning) => warning.code === 'unsupported-session-control'));
+  });
+
+  it('starts fresh with a warning when the installed Codex CLI cannot resume', function () {
+    const resumed = buildCommand('codex', 'test context', {
+      resumeSessionId: 'session-123',
+      cliFeatures: { supportsResume: false },
+    });
+
+    assert.deepStrictEqual(resumed.args.slice(0, 1), ['exec']);
+    assert.ok(!resumed.args.includes('resume'));
+    assert.ok(
+      resumed.warnings.some((warning) => warning.code === 'codex-session-resume-unsupported')
+    );
   });
 
   it('passes --output-schema when CLI supports it', function () {
@@ -122,7 +131,8 @@ describe('Gemini provider helper builder', function () {
       resumed.warnings.some(
         (warning) =>
           warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
+          warning.message ===
+            'Provider gemini does not support resume/continue session control; ignoring.'
       )
     );
 
@@ -189,7 +199,8 @@ describe('Opencode provider helper builder', function () {
       resumed.warnings.some(
         (warning) =>
           warning.code === 'unsupported-session-control' &&
-          warning.message === 'resume/continue is only supported for Claude CLI; ignoring.'
+          warning.message ===
+            'Provider opencode does not support resume/continue session control; ignoring.'
       )
     );
 
@@ -361,6 +372,18 @@ describe('Claude provider helper builder', function () {
       continueSession: true,
     });
     assert.deepStrictEqual(continued.args.slice(-2), ['--continue', 'test context']);
+  });
+
+  it('starts fresh with a warning when the installed Claude CLI cannot resume', function () {
+    const resumed = buildCommand('claude', 'test context', {
+      resumeSessionId: 'session-123',
+      cliFeatures: { supportsResume: false },
+    });
+
+    assert.ok(!resumed.args.includes('--resume'));
+    assert.ok(
+      resumed.warnings.some((warning) => warning.code === 'claude-session-resume-unsupported')
+    );
   });
 
   it('honors configured Claude executable selection inside the helper', function () {

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -42,16 +42,14 @@ describe('Codex provider helper builder', function () {
     assert.ok(continued.warnings.some((warning) => warning.code === 'unsupported-session-control'));
   });
 
-  it('starts fresh with a warning when the installed Codex CLI cannot resume', function () {
-    const resumed = buildCommand('codex', 'test context', {
-      resumeSessionId: 'session-123',
-      cliFeatures: { supportsResume: false },
-    });
-
-    assert.deepStrictEqual(resumed.args.slice(0, 1), ['exec']);
-    assert.ok(!resumed.args.includes('resume'));
-    assert.ok(
-      resumed.warnings.some((warning) => warning.code === 'codex-session-resume-unsupported')
+  it('fails closed when the installed Codex CLI cannot resume', function () {
+    assert.throws(
+      () =>
+        buildCommand('codex', 'delta-only context', {
+          resumeSessionId: 'session-123',
+          cliFeatures: { supportsResume: false },
+        }),
+      /cannot safely run continuation context/
     );
   });
 
@@ -374,15 +372,14 @@ describe('Claude provider helper builder', function () {
     assert.deepStrictEqual(continued.args.slice(-2), ['--continue', 'test context']);
   });
 
-  it('starts fresh with a warning when the installed Claude CLI cannot resume', function () {
-    const resumed = buildCommand('claude', 'test context', {
-      resumeSessionId: 'session-123',
-      cliFeatures: { supportsResume: false },
-    });
-
-    assert.ok(!resumed.args.includes('--resume'));
-    assert.ok(
-      resumed.warnings.some((warning) => warning.code === 'claude-session-resume-unsupported')
+  it('fails closed when the installed Claude CLI cannot resume', function () {
+    assert.throws(
+      () =>
+        buildCommand('claude', 'delta-only context', {
+          resumeSessionId: 'session-123',
+          cliFeatures: { supportsResume: false },
+        }),
+      /cannot safely run continuation context/
     );
   });
 

--- a/tests/unit/ledger-sequence-cursor.test.js
+++ b/tests/unit/ledger-sequence-cursor.test.js
@@ -1,0 +1,120 @@
+const assert = require('assert');
+const { fork } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Ledger = require('../../src/ledger');
+
+const WRITER_FIXTURE = path.resolve(__dirname, '../fixtures/ledger-sequence-writer.js');
+
+function waitForMessage(child, type) {
+  return new Promise((resolve, reject) => {
+    let onMessage;
+    let onExit;
+    const cleanup = () => {
+      child.off('message', onMessage);
+      child.off('exit', onExit);
+    };
+    onMessage = (message) => {
+      if (message.type === 'error') {
+        cleanup();
+        reject(new Error(message.error));
+      } else if (message.type === type) {
+        cleanup();
+        resolve(message);
+      }
+    };
+    onExit = (code) => {
+      cleanup();
+      reject(new Error(`ledger sequence writer exited before ${type} with code ${code}`));
+    };
+    child.on('message', onMessage);
+    child.on('exit', onExit);
+  });
+}
+
+describe('durable ledger sequence cursors', function () {
+  it('orders same-millisecond writes from independent processes without loss', async function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-ledger-sequence-'));
+    const dbPath = path.join(tempDir, 'ledger.db');
+    const clusterId = 'same-millisecond-cluster';
+    const initializer = new Ledger(dbPath);
+    initializer.close();
+
+    const children = ['writer-a', 'writer-b'].map((sender) =>
+      fork(WRITER_FIXTURE, [dbPath, clusterId, sender], {
+        stdio: ['ignore', 'ignore', 'inherit', 'ipc'],
+      })
+    );
+
+    try {
+      await Promise.all(children.map((child) => waitForMessage(child, 'ready')));
+      const timestamp = Date.now() + 60_000;
+      const results = children.map((child) => {
+        const appended = waitForMessage(child, 'appended');
+        child.send({ timestamp });
+        return appended;
+      });
+      const writes = (await Promise.all(results))
+        .map(({ message }) => message)
+        .sort((left, right) => left.sequence - right.sequence);
+
+      assert.strictEqual(writes[0].timestamp, timestamp);
+      assert.strictEqual(writes[1].timestamp, timestamp);
+      assert.ok(writes[0].sequence < writes[1].sequence);
+
+      const guidanceLedgers = [new Ledger(dbPath), new Ledger(dbPath)];
+      const guidanceTimestamp = timestamp + 1;
+      const guidanceWrites = guidanceLedgers
+        .map((ledger, index) =>
+          ledger.append({
+            cluster_id: clusterId,
+            topic: 'USER_GUIDANCE_AGENT',
+            sender: `operator-${index}`,
+            receiver: 'worker',
+            timestamp: guidanceTimestamp,
+            content: { text: `guidance-${index}` },
+          })
+        )
+        .sort((left, right) => left.sequence - right.sequence);
+      guidanceLedgers.forEach((ledger) => ledger.close());
+      assert.strictEqual(guidanceWrites[0].timestamp, guidanceTimestamp);
+      assert.strictEqual(guidanceWrites[1].timestamp, guidanceTimestamp);
+
+      const reader = new Ledger(dbPath, { readonly: true });
+      try {
+        const delta = reader.query({
+          cluster_id: clusterId,
+          afterId: writes[0].sequence,
+          throughId: writes[1].sequence,
+        });
+        assert.deepStrictEqual(
+          delta.map((message) => message.id),
+          [writes[1].id],
+          'a sequence-bounded continuation must include the second colliding write exactly once'
+        );
+        const guidanceDelta = reader.queryGuidanceMailbox({
+          cluster_id: clusterId,
+          target_agent_id: 'worker',
+          afterId: guidanceWrites[0].sequence,
+          throughId: guidanceWrites[1].sequence,
+        });
+        assert.deepStrictEqual(
+          guidanceDelta.map((message) => message.id),
+          [guidanceWrites[1].id],
+          'guidance must use the same exact sequence bounds'
+        );
+      } finally {
+        reader.close();
+      }
+    } finally {
+      for (const child of children) {
+        if (child.connected) {
+          child.disconnect();
+        }
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/ledger-sequence-cursor.test.js
+++ b/tests/unit/ledger-sequence-cursor.test.js
@@ -5,6 +5,8 @@ const os = require('os');
 const path = require('path');
 
 const Ledger = require('../../src/ledger');
+const { compareMessageSequences, MAX_SQLITE_ROWID } = require('../../src/ledger-sequence');
+const { normalizeProviderSession } = require('../../src/agent/provider-session');
 
 const WRITER_FIXTURE = path.resolve(__dirname, '../fixtures/ledger-sequence-writer.js');
 
@@ -58,11 +60,11 @@ describe('durable ledger sequence cursors', function () {
       });
       const writes = (await Promise.all(results))
         .map(({ message }) => message)
-        .sort((left, right) => left.sequence - right.sequence);
+        .sort((left, right) => compareMessageSequences(left.sequence, right.sequence));
 
       assert.strictEqual(writes[0].timestamp, timestamp);
       assert.strictEqual(writes[1].timestamp, timestamp);
-      assert.ok(writes[0].sequence < writes[1].sequence);
+      assert.strictEqual(compareMessageSequences(writes[0].sequence, writes[1].sequence), -1);
 
       const guidanceLedgers = [new Ledger(dbPath), new Ledger(dbPath)];
       const guidanceTimestamp = timestamp + 1;
@@ -77,7 +79,7 @@ describe('durable ledger sequence cursors', function () {
             content: { text: `guidance-${index}` },
           })
         )
-        .sort((left, right) => left.sequence - right.sequence);
+        .sort((left, right) => compareMessageSequences(left.sequence, right.sequence));
       guidanceLedgers.forEach((ledger) => ledger.close());
       assert.strictEqual(guidanceWrites[0].timestamp, guidanceTimestamp);
       assert.strictEqual(guidanceWrites[1].timestamp, guidanceTimestamp);
@@ -115,6 +117,131 @@ describe('durable ledger sequence cursors', function () {
         }
       }
       fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves adjacent rowids above Number.MAX_SAFE_INTEGER through queries and JSON state', function () {
+    const ledger = new Ledger(':memory:');
+    const clusterId = 'high-rowid-cluster';
+    const first = 9007199254740992n;
+    const rows = [
+      [first, 'source-a', 'VALIDATION_RESULT', 'validator', 'broadcast'],
+      [first + 1n, 'source-b', 'VALIDATION_RESULT', 'validator', 'broadcast'],
+      [first + 2n, 'guidance-a', 'USER_GUIDANCE_AGENT', 'operator', 'worker'],
+      [first + 3n, 'guidance-b', 'USER_GUIDANCE_AGENT', 'operator', 'worker'],
+    ];
+    const insert = ledger.db.prepare(`
+      INSERT INTO messages (
+        rowid, id, timestamp, topic, sender, receiver, content_text, content_data, metadata, cluster_id
+      ) VALUES (
+        @rowid, @id, @timestamp, @topic, @sender, @receiver, @text, NULL, NULL, @clusterId
+      )
+    `);
+
+    try {
+      for (const [rowid, id, topic, sender, receiver] of rows) {
+        insert.run({
+          rowid,
+          id,
+          timestamp: 1000,
+          topic,
+          sender,
+          receiver,
+          text: id,
+          clusterId,
+        });
+      }
+
+      const all = ledger.query({
+        cluster_id: clusterId,
+        afterId: (first - 1n).toString(),
+        throughId: (first + 3n).toString(),
+      });
+      assert.deepStrictEqual(
+        all.map(({ id, sequence }) => [id, sequence]),
+        rows.map(([rowid, id]) => [id, rowid.toString()])
+      );
+      assert.strictEqual(new Set(all.map((message) => message.id)).size, rows.length);
+
+      const sourceDelta = ledger.query({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        afterId: first.toString(),
+        throughId: (first + 1n).toString(),
+      });
+      assert.deepStrictEqual(
+        sourceDelta.map((message) => message.id),
+        ['source-b']
+      );
+
+      const guidanceDelta = ledger.queryGuidanceMailbox({
+        cluster_id: clusterId,
+        target_agent_id: 'worker',
+        afterId: (first + 2n).toString(),
+        throughId: (first + 3n).toString(),
+      });
+      assert.deepStrictEqual(
+        guidanceDelta.map((message) => message.id),
+        ['guidance-b']
+      );
+      assert.strictEqual(
+        ledger.findLast({ cluster_id: clusterId, orderBySequence: true }).sequence,
+        (first + 3n).toString()
+      );
+
+      const persisted = JSON.parse(
+        JSON.stringify(
+          normalizeProviderSession({
+            provider: 'claude',
+            sessionId: 'high-rowid-session',
+            agentId: 'worker',
+            taskId: 'task-high-rowid',
+            generation: 1,
+            cwd: '/tmp/high-rowid',
+            worktreePath: null,
+            contextSequence: sourceDelta[0].sequence,
+            guidanceSequence: guidanceDelta[0].sequence,
+            promptIdentity: null,
+          })
+        )
+      );
+      assert.strictEqual(persisted.contextSequence, (first + 1n).toString());
+      assert.strictEqual(persisted.guidanceSequence, (first + 3n).toString());
+
+      const appended = ledger.append({
+        cluster_id: clusterId,
+        topic: 'VALIDATION_RESULT',
+        sender: 'validator',
+        content: { text: 'source-c' },
+      });
+      assert.strictEqual(appended.sequence, (first + 4n).toString());
+
+      for (const invalid of [
+        '',
+        '01',
+        '-1',
+        (MAX_SQLITE_ROWID + 1n).toString(),
+        Number.MAX_SAFE_INTEGER + 1,
+        first,
+      ]) {
+        assert.throws(
+          () => ledger.query({ cluster_id: clusterId, afterId: invalid }),
+          /canonical non-negative decimal string|SQLite rowid range/
+        );
+      }
+      assert.throws(
+        () => ledger.query({ cluster_id: clusterId, throughId: '01' }),
+        /canonical non-negative decimal string/
+      );
+      assert.strictEqual(
+        normalizeProviderSession({
+          ...persisted,
+          contextSequence: (MAX_SQLITE_ROWID + 1n).toString(),
+        }),
+        null
+      );
+    } finally {
+      ledger.close();
     }
   });
 });

--- a/tests/unit/provider-session-capture.test.js
+++ b/tests/unit/provider-session-capture.test.js
@@ -79,8 +79,8 @@ describe('provider session capture', function () {
       initialSessionId: 'forked-b',
     });
 
-    capture(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
-    capture(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
+    capture.captureLine(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
+    capture.captureLine(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
 
     assert.deepStrictEqual(updates, [
       {
@@ -88,6 +88,64 @@ describe('provider session capture', function () {
         update: { sessionId: null, sessionIdConflict: true },
       },
     ]);
+  });
+
+  it('fails closed when SQLite persistence throws after a second identity', async function () {
+    const { createProviderSessionCapture } =
+      await import('../../task-lib/provider-session-capture.js');
+    const logs = [];
+    let writes = 0;
+    const capture = createProviderSessionCapture({
+      providerName: 'claude',
+      taskId: 'sqlite-failure-task',
+      requestedSessionId: 'requested-a',
+      updateTask: () => {
+        writes += 1;
+        if (writes === 2) {
+          const error = new Error('database is locked');
+          error.code = 'SQLITE_BUSY';
+          throw error;
+        }
+      },
+      log: (message) => logs.push(message),
+    });
+
+    capture.captureLine(JSON.stringify({ type: 'system', session_id: 'requested-a' }));
+    capture.captureLine(JSON.stringify({ type: 'result', session_id: 'forked-b' }));
+    capture.captureLine(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
+
+    assert.strictEqual(writes, 2, 'an in-memory conflict must remain sticky after the failed write');
+    assert.match(capture.getCompletionError(), /could not be persisted: database is locked/);
+    assert.ok(logs.some((message) => message.includes('Failed to persist provider session')));
+  });
+
+  it('requires an explicit requested identity to be observed exactly', async function () {
+    const { createProviderSessionCapture } =
+      await import('../../task-lib/provider-session-capture.js');
+    const lineFor = (sessionId) =>
+      JSON.stringify({ type: 'thread.started', thread_id: sessionId });
+
+    for (const [name, observed, expected] of [
+      ['confirmed', ['requested-a'], null],
+      ['ignored', [], /did not confirm/],
+      ['forked', ['forked-b'], /different session identity/],
+      ['ambiguous', ['requested-a', 'forked-b'], /conflicting session identities/],
+    ]) {
+      const capture = createProviderSessionCapture({
+        providerName: 'codex',
+        taskId: `${name}-resume`,
+        requestedSessionId: 'requested-a',
+        updateTask: () => {},
+        log: () => {},
+      });
+      observed.forEach((sessionId) => capture.captureLine(lineFor(sessionId)));
+      const error = capture.getCompletionError();
+      if (expected === null) {
+        assert.strictEqual(error, null);
+      } else {
+        assert.match(error, expected);
+      }
+    }
   });
 
   it('ignores malformed output and providers without safe resume semantics', async function () {

--- a/tests/unit/provider-session-capture.test.js
+++ b/tests/unit/provider-session-capture.test.js
@@ -85,7 +85,11 @@ describe('provider session capture', function () {
     assert.deepStrictEqual(updates, [
       {
         taskId: 'resumed-task',
-        update: { sessionId: null, sessionIdConflict: true },
+        update: {
+          sessionId: null,
+          sessionIdConflict: true,
+          resumeIdentityVerified: false,
+        },
       },
     ]);
   });
@@ -117,6 +121,83 @@ describe('provider session capture', function () {
     assert.strictEqual(writes, 2, 'an in-memory conflict must remain sticky after the failed write');
     assert.match(capture.getCompletionError(), /could not be persisted: database is locked/);
     assert.ok(logs.some((message) => message.includes('Failed to persist provider session')));
+  });
+
+  it('keeps both watcher recovery paths fail closed when conflict and terminal writes fail', async function () {
+    const { createProviderSessionCapture } =
+      await import('../../task-lib/provider-session-capture.js');
+    const { buildTaskRecord } = await import('../../task-lib/runner.js');
+    const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
+    const { buildCompletionResult } = require('../../src/agent/agent-task-executor');
+
+    for (const watcherName of ['watcher.js', 'attachable-watcher.js']) {
+      let locked = true;
+      let storedTask = buildTaskRecord({
+        id: `${watcherName}-locked-resume`,
+        prompt: 'continue',
+        cwd: '/tmp/project',
+        options: { resume: 'requested-a' },
+        logFile: `/tmp/${watcherName}.log`,
+        providerName: 'claude',
+        modelSpec: {},
+      });
+      const updateTask = (_taskId, update) => {
+        const unsafeWrite =
+          update.sessionIdConflict === true || Object.hasOwn(update, 'status');
+        if (locked && unsafeWrite) {
+          const error = new Error('database is locked');
+          error.code = 'SQLITE_BUSY';
+          throw error;
+        }
+        storedTask = { ...storedTask, ...update };
+      };
+      const capture = createProviderSessionCapture({
+        providerName: 'claude',
+        taskId: storedTask.id,
+        requestedSessionId: storedTask.requestedResumeSessionId,
+        updateTask,
+        log: () => {},
+      });
+
+      capture.captureLine(JSON.stringify({ type: 'system', session_id: 'requested-a' }));
+      capture.captureLine(JSON.stringify({ type: 'result', session_id: 'forked-b' }));
+      assert.strictEqual(storedTask.sessionId, 'requested-a');
+      assert.strictEqual(storedTask.resumeIdentityVerified, false);
+      assert.throws(
+        () =>
+          updateTask(storedTask.id, {
+            status: 'failed',
+            ...capture.getCompletionUpdate(1),
+          }),
+        /database is locked/
+      );
+
+      locked = false;
+      storedTask = { ...storedTask, status: 'stale' };
+      const agent = {
+        id: 'worker',
+        iteration: 2,
+        config: { cwd: '/tmp/project', outputFormat: 'text' },
+        currentContextSequence: '2',
+        currentGuidanceSequence: null,
+        currentPromptIdentity: null,
+        isolation: null,
+        worktree: null,
+      };
+      const recovered = await buildCompletionResult({
+        agent,
+        taskId: storedTask.id,
+        providerName: 'claude',
+        state: { output: 'valid recovered output', logFilePath: null },
+        stdout: 'Status: stale',
+        success: true,
+        taskInfo: storedTask,
+      });
+
+      assert.strictEqual(recovered.success, false);
+      assert.match(recovered.error, /not durably verified/);
+      assert.throws(() => buildResumeTaskOptions(storedTask), /did not durably verify/);
+    }
   });
 
   it('requires an explicit requested identity to be observed exactly', async function () {

--- a/tests/unit/provider-session-capture.test.js
+++ b/tests/unit/provider-session-capture.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+describe('provider session capture', function () {
+  it('captures Claude and Codex session IDs from provider JSONL', async function () {
+    const { captureProviderSessionLine } =
+      await import('../../task-lib/provider-session-capture.js');
+    const captured = [];
+
+    let currentSessionId = captureProviderSessionLine({
+      providerName: 'claude',
+      line: JSON.stringify({ type: 'system', subtype: 'init', session_id: 'claude-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    const duplicateSessionId = captureProviderSessionLine({
+      providerName: 'claude',
+      line: JSON.stringify({ type: 'result', session_id: 'claude-1' }),
+      currentSessionId,
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    assert.strictEqual(duplicateSessionId, 'claude-1');
+    currentSessionId = captureProviderSessionLine({
+      providerName: 'codex',
+      line: JSON.stringify({ type: 'thread.started', thread_id: 'codex-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+
+    assert.strictEqual(currentSessionId, 'codex-1');
+    assert.deepStrictEqual(captured, ['claude-1', 'codex-1']);
+  });
+
+  it('ignores malformed output and providers without safe resume semantics', async function () {
+    const { captureProviderSessionLine } =
+      await import('../../task-lib/provider-session-capture.js');
+    const captured = [];
+
+    const malformed = captureProviderSessionLine({
+      providerName: 'claude',
+      line: '{not-json',
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+    const unsupported = captureProviderSessionLine({
+      providerName: 'gemini',
+      line: JSON.stringify({ type: 'init', session_id: 'gemini-1' }),
+      onCapture: (sessionId) => captured.push(sessionId),
+    });
+
+    assert.strictEqual(malformed, null);
+    assert.strictEqual(unsupported, null);
+    assert.deepStrictEqual(captured, []);
+  });
+});

--- a/tests/unit/provider-session-capture.test.js
+++ b/tests/unit/provider-session-capture.test.js
@@ -6,26 +6,88 @@ describe('provider session capture', function () {
       await import('../../task-lib/provider-session-capture.js');
     const captured = [];
 
-    let currentSessionId = captureProviderSessionLine({
+    const claudeObserved = new Set();
+    let state = captureProviderSessionLine({
       providerName: 'claude',
       line: JSON.stringify({ type: 'system', subtype: 'init', session_id: 'claude-1' }),
+      observedSessionIds: claudeObserved,
       onCapture: (sessionId) => captured.push(sessionId),
     });
-    const duplicateSessionId = captureProviderSessionLine({
+    const duplicate = captureProviderSessionLine({
       providerName: 'claude',
       line: JSON.stringify({ type: 'result', session_id: 'claude-1' }),
-      currentSessionId,
+      currentSessionId: state.currentSessionId,
+      observedSessionIds: claudeObserved,
       onCapture: (sessionId) => captured.push(sessionId),
     });
-    assert.strictEqual(duplicateSessionId, 'claude-1');
-    currentSessionId = captureProviderSessionLine({
+    assert.deepStrictEqual(duplicate, {
+      currentSessionId: 'claude-1',
+      sessionIdConflict: false,
+    });
+    state = captureProviderSessionLine({
       providerName: 'codex',
       line: JSON.stringify({ type: 'thread.started', thread_id: 'codex-1' }),
       onCapture: (sessionId) => captured.push(sessionId),
     });
 
-    assert.strictEqual(currentSessionId, 'codex-1');
+    assert.strictEqual(state.currentSessionId, 'codex-1');
     assert.deepStrictEqual(captured, ['claude-1', 'codex-1']);
+  });
+
+  for (const [providerName, lineFor] of [
+    [
+      'claude',
+      (sessionId) => JSON.stringify({ type: 'system', subtype: 'init', session_id: sessionId }),
+    ],
+    ['codex', (sessionId) => JSON.stringify({ type: 'thread.started', thread_id: sessionId })],
+  ]) {
+    it(`makes conflicting ${providerName} JSONL session IDs sticky`, async function () {
+      const { captureProviderSessionLine } =
+        await import('../../task-lib/provider-session-capture.js');
+      const observedSessionIds = new Set();
+      const captured = [];
+      const conflicts = [];
+      let state = { currentSessionId: null, sessionIdConflict: false };
+
+      for (const sessionId of ['requested-a', 'forked-b', 'requested-a']) {
+        state = captureProviderSessionLine({
+          providerName,
+          line: lineFor(sessionId),
+          observedSessionIds,
+          ...state,
+          onCapture: (value) => captured.push(value),
+          onConflict: (values) => conflicts.push(values),
+        });
+      }
+
+      assert.deepStrictEqual([...observedSessionIds], ['requested-a', 'forked-b']);
+      assert.deepStrictEqual(state, { currentSessionId: null, sessionIdConflict: true });
+      assert.deepStrictEqual(captured, ['requested-a']);
+      assert.deepStrictEqual(conflicts, [['requested-a', 'forked-b']]);
+    });
+  }
+
+  it('persists a conflicting capture by clearing the last ID exactly once', async function () {
+    const { createProviderSessionCapture } =
+      await import('../../task-lib/provider-session-capture.js');
+    const updates = [];
+    const capture = createProviderSessionCapture({
+      providerName: 'claude',
+      taskId: 'resumed-task',
+      updateTask: (taskId, update) => updates.push({ taskId, update }),
+      log: () => {},
+      initialSessionId: 'forked-b',
+    });
+
+    capture(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
+    capture(JSON.stringify({ type: 'result', session_id: 'requested-a' }));
+
+    assert.deepStrictEqual(updates, [
+      {
+        taskId: 'resumed-task',
+        update: { sessionId: null, sessionIdConflict: true },
+      },
+    ]);
   });
 
   it('ignores malformed output and providers without safe resume semantics', async function () {
@@ -44,8 +106,8 @@ describe('provider session capture', function () {
       onCapture: (sessionId) => captured.push(sessionId),
     });
 
-    assert.strictEqual(malformed, null);
-    assert.strictEqual(unsupported, null);
+    assert.deepStrictEqual(malformed, { currentSessionId: null, sessionIdConflict: false });
+    assert.deepStrictEqual(unsupported, { currentSessionId: null, sessionIdConflict: false });
     assert.deepStrictEqual(captured, []);
   });
 });

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -1,53 +1,35 @@
 const assert = require('assert');
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
-const AgentWrapper = require('../../src/agent-wrapper');
-const Ledger = require('../../src/ledger');
-const MessageBus = require('../../src/message-bus');
+const {
+  createProviderSessionAgent,
+  createProviderSessionHarness,
+} = require('../helpers/provider-session-harness');
 
 describe('provider-session continuation context', function () {
-  let tempDir;
-  let ledger;
+  let harness;
   let messageBus;
-  let priorSettingsFile;
 
   beforeEach(function () {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-session-context-'));
-    priorSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
-    process.env.ZEROSHOT_SETTINGS_FILE = path.join(tempDir, 'settings.json');
-    fs.writeFileSync(
-      process.env.ZEROSHOT_SETTINGS_FILE,
-      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
-    );
-    ledger = new Ledger(path.join(tempDir, 'ledger.db'));
-    messageBus = new MessageBus(ledger);
+    harness = createProviderSessionHarness('zeroshot-session-context-');
+    messageBus = harness.messageBus;
   });
 
   afterEach(function () {
-    ledger.close();
-    if (priorSettingsFile === undefined) {
-      delete process.env.ZEROSHOT_SETTINGS_FILE;
-    } else {
-      process.env.ZEROSHOT_SETTINGS_FILE = priorSettingsFile;
-    }
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    harness.cleanup();
   });
 
-  it('sends static context once and only the new turn delta after resume', function () {
+  it('uses the exact durable cursor after restart and de-duplicates the triggering message', function () {
     const cluster = {
       id: 'session-context-cluster',
       createdAt: Date.now(),
       agents: [],
     };
-    const agent = new AgentWrapper(
-      {
-        id: 'worker',
-        role: 'implementation',
-        provider: 'claude',
+    const agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
         prompt: 'STATIC-WORKER-INSTRUCTIONS',
-        timeout: 0,
         contextStrategy: {
           sources: [
             { topic: 'ISSUE_OPENED', limit: 1 },
@@ -56,13 +38,7 @@ describe('provider-session continuation context', function () {
           ],
         },
       },
-      messageBus,
-      cluster,
-      {
-        testMode: true,
-        mockSpawnFn: () => ({ success: true, output: '{}' }),
-      }
-    );
+    });
     const cwd = path.resolve(agent.config.cwd || process.cwd());
 
     messageBus.publish({
@@ -83,6 +59,13 @@ describe('provider-session continuation context', function () {
       sender: 'validator-old',
       content: { text: 'OLD-VALIDATION-RESULT' },
     });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'USER_GUIDANCE_AGENT',
+      sender: 'operator',
+      receiver: 'worker',
+      content: { text: 'FIRST-TURN-GUIDANCE' },
+    });
 
     agent.iteration = 1;
     const firstContext = agent._buildContext({
@@ -93,6 +76,7 @@ describe('provider-session continuation context', function () {
     assert.match(firstContext, /STATIC-WORKER-INSTRUCTIONS/);
     assert.match(firstContext, /STATIC-ISSUE-OPENED/);
     assert.match(firstContext, /STATIC-PLAN-READY/);
+    assert.match(firstContext, /FIRST-TURN-GUIDANCE/);
 
     agent.providerSession = {
       provider: 'claude',
@@ -102,29 +86,49 @@ describe('provider-session continuation context', function () {
       generation: 1,
       cwd,
       worktreePath: null,
+      contextCursor: agent.currentContextCursor,
+      guidanceCursor: agent.currentGuidanceCursor,
+      promptText: agent.currentPromptText,
     };
-    const deltaTimestamp = agent.lastAgentStartTime + 10;
-    messageBus.publish({
+    const firstPostTurn = messageBus.publish({
       cluster_id: cluster.id,
       topic: 'VALIDATION_RESULT',
       sender: 'validator-a',
-      timestamp: deltaTimestamp,
       content: { text: 'NEW-VALIDATION-A' },
     });
     messageBus.publish({
       cluster_id: cluster.id,
       topic: 'VALIDATION_RESULT',
       sender: 'validator-b',
-      timestamp: deltaTimestamp + 1,
       content: { text: 'NEW-VALIDATION-B' },
     });
-    agent.iteration = 2;
-    const secondContext = agent._buildContext({
+    const trigger = messageBus.publish({
+      cluster_id: cluster.id,
       topic: 'VALIDATION_RESULT',
       sender: 'validator',
-      timestamp: deltaTimestamp + 2,
       content: { text: 'NEW-REJECTION-DELTA' },
     });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'USER_GUIDANCE_AGENT',
+      sender: 'operator',
+      receiver: 'worker',
+      content: { text: 'SECOND-TURN-GUIDANCE' },
+    });
+
+    const restoredAgent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: agent.config,
+      runtime: { providerCliFeatures: { claude: { supportsResume: true } } },
+    });
+    restoredAgent.providerSession = agent.providerSession;
+    restoredAgent.lastGuidanceAppliedAt = agent.providerSession.guidanceCursor;
+    restoredAgent.iteration = 2;
+
+    assert.ok(firstPostTurn.timestamp > restoredAgent.providerSession.contextCursor);
+    agent.iteration = 2;
+    const secondContext = restoredAgent._buildContext(trigger);
 
     assert.match(secondContext, /Continuation Turn/);
     assert.match(secondContext, /NEW-REJECTION-DELTA/);
@@ -135,71 +139,49 @@ describe('provider-session continuation context', function () {
     assert.doesNotMatch(secondContext, /STATIC-PLAN-READY/);
     assert.doesNotMatch(secondContext, /FIRST-TURN-TRIGGER/);
     assert.doesNotMatch(secondContext, /OLD-VALIDATION-RESULT/);
+    assert.doesNotMatch(secondContext, /FIRST-TURN-GUIDANCE/);
+    assert.match(secondContext, /SECOND-TURN-GUIDANCE/);
+    assert.strictEqual(
+      secondContext.match(/NEW-REJECTION-DELTA/g)?.length,
+      1,
+      'the trigger must not be duplicated as a source message'
+    );
   });
 
-  it('clears a failed logical result before the retry is constructed', async function () {
-    const cluster = { id: 'retry-cluster', createdAt: Date.now(), agents: [] };
-    let attempts = 0;
-    let agent;
-
-    agent = new AgentWrapper(
-      {
-        id: 'worker',
-        role: 'implementation',
-        provider: 'claude',
-        prompt: 'STATIC-RETRY-INSTRUCTIONS',
-        outputFormat: 'text',
-        maxRetries: 2,
-        timeout: 0,
-        contextStrategy: { sources: [] },
-      },
-      messageBus,
+  it('reconstructs full static context when the installed CLI cannot resume', function () {
+    const cluster = { id: 'old-cli-cluster', createdAt: Date.now(), agents: [] };
+    const agent = createProviderSessionAgent({
       cluster,
-      {
-        testMode: true,
-        quiet: true,
-        mockSpawnFn: (args, { context }) => {
-          attempts += 1;
-          if (attempts === 1) {
-            return {
-              success: false,
-              error: 'logical schema failure',
-              providerSession: {
-                provider: 'claude',
-                sessionId: 'must-not-resume',
-                agentId: 'worker',
-                taskId: 'failed-task',
-                generation: 1,
-                cwd: path.resolve(agent.config.cwd || process.cwd()),
-                worktreePath: null,
-              },
-            };
-          }
+      messageBus,
+      config: {
+        prompt: 'STATIC-OLD-CLI-INSTRUCTIONS',
+      },
+      runtime: {
+        providerCliFeatures: { claude: { supportsResume: false } },
+      },
+    });
+    agent.iteration = 2;
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'unsupported-resume-session',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd: path.resolve(agent.config.cwd || process.cwd()),
+      worktreePath: null,
+      contextCursor: 1,
+      guidanceCursor: null,
+      promptText: 'STATIC-OLD-CLI-INSTRUCTIONS',
+    };
 
-          assert.strictEqual(agent.providerSession, null);
-          assert.ok(!args.includes('--resume'));
-          assert.match(context, /STATIC-RETRY-INSTRUCTIONS/);
-          return { success: true, output: 'done', providerSession: null };
-        },
-      }
-    );
-    agent.running = true;
-
-    await agent._executeTask({
-      topic: 'ISSUE_OPENED',
-      sender: 'system',
-      content: { text: 'retry me' },
+    const context = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'retry with full context' },
     });
 
-    assert.strictEqual(attempts, 2);
+    assert.match(context, /STATIC-OLD-CLI-INSTRUCTIONS/);
+    assert.doesNotMatch(context, /Continuation Turn/);
     assert.strictEqual(agent.providerSession, null);
-    const failed = messageBus
-      .query({
-        cluster_id: cluster.id,
-        topic: 'AGENT_LIFECYCLE',
-        sender: 'worker',
-      })
-      .find((message) => message.content?.data?.event === 'TASK_FAILED');
-    assert.ok(failed, 'failed attempt must be durable before retry');
   });
 });

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -232,6 +232,14 @@ describe('provider-session continuation context', function () {
         providerCliFeatures: { claude: { supportsResume: false } },
       },
     });
+    const appliedGuidance = messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'USER_GUIDANCE_AGENT',
+      sender: 'operator',
+      receiver: 'worker',
+      content: { text: 'GUIDANCE-FROM-INVALIDATED-SESSION' },
+    });
+    agent.lastGuidanceAppliedId = appliedGuidance.sequence;
     agent.iteration = 2;
     agent.providerSession = {
       provider: 'claude',
@@ -242,7 +250,7 @@ describe('provider-session continuation context', function () {
       cwd: path.resolve(agent.config.cwd || process.cwd()),
       worktreePath: null,
       contextSequence: '1',
-      guidanceSequence: null,
+      guidanceSequence: appliedGuidance.sequence,
       promptIdentity: promptIdentity('STATIC-OLD-CLI-INSTRUCTIONS'),
     };
 
@@ -253,8 +261,39 @@ describe('provider-session continuation context', function () {
     });
 
     assert.match(context, /STATIC-OLD-CLI-INSTRUCTIONS/);
+    assert.match(context, /GUIDANCE-FROM-INVALIDATED-SESSION/);
     assert.doesNotMatch(context, /Continuation Turn/);
     assert.strictEqual(agent.providerSession, null);
+
+    agent.providerCliFeatures.claude.supportsResume = true;
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'replacement-session',
+      agentId: 'worker',
+      taskId: 'task-generation-2',
+      generation: 2,
+      cwd: path.resolve(agent.config.cwd || process.cwd()),
+      worktreePath: null,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
+    };
+    agent.lastGuidanceAppliedId = agent.currentGuidanceSequence;
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'USER_GUIDANCE_AGENT',
+      sender: 'operator',
+      receiver: 'worker',
+      content: { text: 'NEW-INCREMENTAL-GUIDANCE' },
+    });
+    agent.iteration = 3;
+    const continuation = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'continue incrementally' },
+    });
+    assert.match(continuation, /NEW-INCREMENTAL-GUIDANCE/);
+    assert.doesNotMatch(continuation, /GUIDANCE-FROM-INVALIDATED-SESSION/);
   });
 
   it('freezes lazy source rendering at the captured durable high-water sequence', function () {

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const path = require('path');
 const { promptIdentity } = require('../../src/agent/provider-session');
+const { compareMessageSequences } = require('../../src/ledger-sequence');
 
 const {
   createProviderSessionAgent,
@@ -127,7 +128,13 @@ describe('provider-session continuation context', function () {
     restoredAgent.lastGuidanceAppliedId = agent.providerSession.guidanceSequence;
     restoredAgent.iteration = 2;
 
-    assert.ok(firstPostTurn.sequence > restoredAgent.providerSession.contextSequence);
+    assert.strictEqual(
+      compareMessageSequences(
+        firstPostTurn.sequence,
+        restoredAgent.providerSession.contextSequence
+      ),
+      1
+    );
     agent.iteration = 2;
     const secondContext = restoredAgent._buildContext(trigger);
 
@@ -170,7 +177,7 @@ describe('provider-session continuation context', function () {
       generation: 1,
       cwd: path.resolve(agent.config.cwd || process.cwd()),
       worktreePath: null,
-      contextSequence: 1,
+      contextSequence: '1',
       guidanceSequence: null,
       promptIdentity: promptIdentity('STATIC-OLD-CLI-INSTRUCTIONS'),
     };

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -1,0 +1,205 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const AgentWrapper = require('../../src/agent-wrapper');
+const Ledger = require('../../src/ledger');
+const MessageBus = require('../../src/message-bus');
+
+describe('provider-session continuation context', function () {
+  let tempDir;
+  let ledger;
+  let messageBus;
+  let priorSettingsFile;
+
+  beforeEach(function () {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-session-context-'));
+    priorSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(tempDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+    );
+    ledger = new Ledger(path.join(tempDir, 'ledger.db'));
+    messageBus = new MessageBus(ledger);
+  });
+
+  afterEach(function () {
+    ledger.close();
+    if (priorSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = priorSettingsFile;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('sends static context once and only the new turn delta after resume', function () {
+    const cluster = {
+      id: 'session-context-cluster',
+      createdAt: Date.now(),
+      agents: [],
+    };
+    const agent = new AgentWrapper(
+      {
+        id: 'worker',
+        role: 'implementation',
+        provider: 'claude',
+        prompt: 'STATIC-WORKER-INSTRUCTIONS',
+        timeout: 0,
+        contextStrategy: {
+          sources: [
+            { topic: 'ISSUE_OPENED', limit: 1 },
+            { topic: 'PLAN_READY', limit: 1 },
+            { topic: 'VALIDATION_RESULT', limit: 5 },
+          ],
+        },
+      },
+      messageBus,
+      cluster,
+      {
+        testMode: true,
+        mockSpawnFn: () => ({ success: true, output: '{}' }),
+      }
+    );
+    const cwd = path.resolve(agent.config.cwd || process.cwd());
+
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'STATIC-ISSUE-OPENED' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'PLAN_READY',
+      sender: 'planner',
+      content: { text: 'STATIC-PLAN-READY' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-old',
+      content: { text: 'OLD-VALIDATION-RESULT' },
+    });
+
+    agent.iteration = 1;
+    const firstContext = agent._buildContext({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'FIRST-TURN-TRIGGER' },
+    });
+    assert.match(firstContext, /STATIC-WORKER-INSTRUCTIONS/);
+    assert.match(firstContext, /STATIC-ISSUE-OPENED/);
+    assert.match(firstContext, /STATIC-PLAN-READY/);
+
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'session-generation-1',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd,
+      worktreePath: null,
+    };
+    const deltaTimestamp = agent.lastAgentStartTime + 10;
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-a',
+      timestamp: deltaTimestamp,
+      content: { text: 'NEW-VALIDATION-A' },
+    });
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator-b',
+      timestamp: deltaTimestamp + 1,
+      content: { text: 'NEW-VALIDATION-B' },
+    });
+    agent.iteration = 2;
+    const secondContext = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      timestamp: deltaTimestamp + 2,
+      content: { text: 'NEW-REJECTION-DELTA' },
+    });
+
+    assert.match(secondContext, /Continuation Turn/);
+    assert.match(secondContext, /NEW-REJECTION-DELTA/);
+    assert.match(secondContext, /NEW-VALIDATION-A/);
+    assert.match(secondContext, /NEW-VALIDATION-B/);
+    assert.doesNotMatch(secondContext, /STATIC-WORKER-INSTRUCTIONS/);
+    assert.doesNotMatch(secondContext, /STATIC-ISSUE-OPENED/);
+    assert.doesNotMatch(secondContext, /STATIC-PLAN-READY/);
+    assert.doesNotMatch(secondContext, /FIRST-TURN-TRIGGER/);
+    assert.doesNotMatch(secondContext, /OLD-VALIDATION-RESULT/);
+  });
+
+  it('clears a failed logical result before the retry is constructed', async function () {
+    const cluster = { id: 'retry-cluster', createdAt: Date.now(), agents: [] };
+    let attempts = 0;
+    let agent;
+
+    agent = new AgentWrapper(
+      {
+        id: 'worker',
+        role: 'implementation',
+        provider: 'claude',
+        prompt: 'STATIC-RETRY-INSTRUCTIONS',
+        outputFormat: 'text',
+        maxRetries: 2,
+        timeout: 0,
+        contextStrategy: { sources: [] },
+      },
+      messageBus,
+      cluster,
+      {
+        testMode: true,
+        quiet: true,
+        mockSpawnFn: (args, { context }) => {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              success: false,
+              error: 'logical schema failure',
+              providerSession: {
+                provider: 'claude',
+                sessionId: 'must-not-resume',
+                agentId: 'worker',
+                taskId: 'failed-task',
+                generation: 1,
+                cwd: path.resolve(agent.config.cwd || process.cwd()),
+                worktreePath: null,
+              },
+            };
+          }
+
+          assert.strictEqual(agent.providerSession, null);
+          assert.ok(!args.includes('--resume'));
+          assert.match(context, /STATIC-RETRY-INSTRUCTIONS/);
+          return { success: true, output: 'done', providerSession: null };
+        },
+      }
+    );
+    agent.running = true;
+
+    await agent._executeTask({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'retry me' },
+    });
+
+    assert.strictEqual(attempts, 2);
+    assert.strictEqual(agent.providerSession, null);
+    const failed = messageBus
+      .query({
+        cluster_id: cluster.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+      })
+      .find((message) => message.content?.data?.event === 'TASK_FAILED');
+    assert.ok(failed, 'failed attempt must be durable before retry');
+  });
+});

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const path = require('path');
+const { promptIdentity } = require('../../src/agent/provider-session');
 
 const {
   createProviderSessionAgent,
@@ -86,9 +87,9 @@ describe('provider-session continuation context', function () {
       generation: 1,
       cwd,
       worktreePath: null,
-      contextCursor: agent.currentContextCursor,
-      guidanceCursor: agent.currentGuidanceCursor,
-      promptText: agent.currentPromptText,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
     };
     const firstPostTurn = messageBus.publish({
       cluster_id: cluster.id,
@@ -123,10 +124,10 @@ describe('provider-session continuation context', function () {
       runtime: { providerCliFeatures: { claude: { supportsResume: true } } },
     });
     restoredAgent.providerSession = agent.providerSession;
-    restoredAgent.lastGuidanceAppliedAt = agent.providerSession.guidanceCursor;
+    restoredAgent.lastGuidanceAppliedId = agent.providerSession.guidanceSequence;
     restoredAgent.iteration = 2;
 
-    assert.ok(firstPostTurn.timestamp > restoredAgent.providerSession.contextCursor);
+    assert.ok(firstPostTurn.sequence > restoredAgent.providerSession.contextSequence);
     agent.iteration = 2;
     const secondContext = restoredAgent._buildContext(trigger);
 
@@ -169,9 +170,9 @@ describe('provider-session continuation context', function () {
       generation: 1,
       cwd: path.resolve(agent.config.cwd || process.cwd()),
       worktreePath: null,
-      contextCursor: 1,
-      guidanceCursor: null,
-      promptText: 'STATIC-OLD-CLI-INSTRUCTIONS',
+      contextSequence: 1,
+      guidanceSequence: null,
+      promptIdentity: promptIdentity('STATIC-OLD-CLI-INSTRUCTIONS'),
     };
 
     const context = agent._buildContext({
@@ -183,5 +184,72 @@ describe('provider-session continuation context', function () {
     assert.match(context, /STATIC-OLD-CLI-INSTRUCTIONS/);
     assert.doesNotMatch(context, /Continuation Turn/);
     assert.strictEqual(agent.providerSession, null);
+  });
+
+  it('freezes lazy source rendering at the captured durable high-water sequence', function () {
+    const cluster = { id: 'bounded-context-cluster', createdAt: Date.now(), agents: [] };
+    const agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: 'BOUNDED-CONTEXT-INSTRUCTIONS',
+        contextStrategy: {
+          sources: [{ topic: 'VALIDATION_RESULT' }],
+        },
+      },
+    });
+
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'BEFORE-SNAPSHOT' },
+    });
+
+    const originalQuery = messageBus.query.bind(messageBus);
+    let injected = false;
+    messageBus.query = (criteria) => {
+      if (!injected && criteria.topic === 'VALIDATION_RESULT') {
+        injected = true;
+        messageBus.publish({
+          cluster_id: cluster.id,
+          topic: 'VALIDATION_RESULT',
+          sender: 'validator',
+          content: { text: 'AFTER-SNAPSHOT' },
+        });
+      }
+      return originalQuery(criteria);
+    };
+
+    agent.iteration = 1;
+    const first = agent._buildContext({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'start' },
+    });
+    assert.match(first, /BEFORE-SNAPSHOT/);
+    assert.doesNotMatch(first, /AFTER-SNAPSHOT/);
+
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'bounded-session',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd: path.resolve(agent.config.cwd || process.cwd()),
+      worktreePath: null,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
+    };
+    agent.iteration = 2;
+
+    const second = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'next' },
+    });
+    assert.strictEqual(second.match(/AFTER-SNAPSHOT/g)?.length, 1);
+    assert.doesNotMatch(second, /BEFORE-SNAPSHOT/);
   });
 });

--- a/tests/unit/provider-session-context.test.js
+++ b/tests/unit/provider-session-context.test.js
@@ -156,6 +156,70 @@ describe('provider-session continuation context', function () {
     );
   });
 
+  it('combines continuation cursors with last-task timestamp boundaries', function () {
+    const cluster = { id: 'bounded-since-cluster', createdAt: Date.now(), agents: [] };
+    const agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: 'BOUNDED-SINCE-INSTRUCTIONS',
+        contextStrategy: {
+          sources: [{ topic: 'VALIDATION_RESULT', since: 'last_task_end' }],
+        },
+      },
+      runtime: { providerCliFeatures: { claude: { supportsResume: true } } },
+    });
+
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'initial trigger' },
+    });
+    agent.iteration = 1;
+    agent._buildContext({ topic: 'ISSUE_OPENED', content: { text: 'initial trigger' } });
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'bounded-since-session',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd: path.resolve(agent.config.cwd || process.cwd()),
+      worktreePath: null,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
+    };
+
+    const previousTaskMessage = messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'CREATED-DURING-PREVIOUS-TASK' },
+    });
+    agent.lastTaskEndTime = previousTaskMessage.timestamp + 100;
+    messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      timestamp: agent.lastTaskEndTime + 1,
+      content: { text: 'AFTER-LAST-TASK-END' },
+    });
+    const trigger = messageBus.publish({
+      cluster_id: cluster.id,
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      timestamp: agent.lastTaskEndTime + 2,
+      content: { text: 'CURRENT-TRIGGER' },
+    });
+    agent.iteration = 2;
+    const continuation = agent._buildContext(trigger);
+
+    assert.match(continuation, /AFTER-LAST-TASK-END/);
+    assert.match(continuation, /CURRENT-TRIGGER/);
+    assert.doesNotMatch(continuation, /CREATED-DURING-PREVIOUS-TASK/);
+  });
+
   it('reconstructs full static context when the installed CLI cannot resume', function () {
     const cluster = { id: 'old-cli-cluster', createdAt: Date.now(), agents: [] };
     const agent = createProviderSessionAgent({

--- a/tests/unit/provider-session-lifecycle.test.js
+++ b/tests/unit/provider-session-lifecycle.test.js
@@ -122,6 +122,7 @@ describe('provider-session lifecycle boundaries', function () {
                 provider: 'claude',
                 status: 'completed',
                 requestedResumeSessionId: 'claude-session-1',
+                resumeIdentityVerified: true,
                 sessionId: 'claude-session-1',
                 sessionIdConflict: true,
               },

--- a/tests/unit/provider-session-lifecycle.test.js
+++ b/tests/unit/provider-session-lifecycle.test.js
@@ -1,8 +1,10 @@
 const assert = require('assert');
 const path = require('path');
 const sinon = require('sinon');
+const { buildCompletionResult } = require('../../src/agent/agent-task-executor');
 
 const {
+  buildProviderSession,
   createProviderSessionAgent,
   createProviderSessionHarness,
 } = require('../helpers/provider-session-harness');
@@ -79,6 +81,88 @@ describe('provider-session lifecycle boundaries', function () {
       })
       .find((message) => message.content?.data?.event === 'TASK_FAILED');
     assert.ok(failed, 'failed attempt must be durable before retry');
+  });
+
+  it('fails a requested A resume captured as B then A before hooks and retries fresh', async function () {
+    const cluster = { id: 'ambiguous-resume-cluster', createdAt: Date.now(), agents: [] };
+    let attempts = 0;
+    let agent;
+    agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: 'FULL-FRESH-RETRY-INSTRUCTIONS',
+        outputFormat: 'text',
+        maxRetries: 2,
+        hooks: {
+          onComplete: {
+            action: 'publish_message',
+            config: { topic: 'IMPLEMENTATION_READY' },
+          },
+        },
+      },
+      runtime: {
+        quiet: true,
+        providerCliFeatures: { claude: { supportsResume: true } },
+        mockSpawnFn: (args, { context }) => {
+          attempts += 1;
+          if (attempts === 1) {
+            const resumeIndex = args.indexOf('--resume');
+            assert.ok(resumeIndex >= 0);
+            assert.strictEqual(args[resumeIndex + 1], 'claude-session-1');
+            return buildCompletionResult({
+              agent,
+              taskId: 'ambiguous-resume-task',
+              providerName: 'claude',
+              state: { output: 'done', logFilePath: null },
+              stdout: 'Status: completed',
+              success: true,
+              taskInfo: {
+                id: 'ambiguous-resume-task',
+                provider: 'claude',
+                status: 'completed',
+                requestedResumeSessionId: 'claude-session-1',
+                sessionId: 'claude-session-1',
+                sessionIdConflict: true,
+              },
+            });
+          }
+
+          assert.strictEqual(agent.providerSession, null);
+          assert.ok(!args.includes('--resume'));
+          assert.match(context, /FULL-FRESH-RETRY-INSTRUCTIONS/);
+          return { success: true, output: 'fresh retry done', providerSession: null };
+        },
+      },
+    });
+    agent.iteration = 1;
+    agent.providerSession = buildProviderSession({
+      cwd: path.resolve(agent.config.cwd || process.cwd()),
+    });
+    agent.lastGuidanceAppliedId = agent.providerSession.guidanceSequence;
+    agent.running = true;
+
+    await agent._executeTask({
+      topic: 'VALIDATION_RESULT',
+      sender: 'validator',
+      content: { text: 'retry the continuation' },
+    });
+
+    assert.strictEqual(attempts, 2);
+    assert.strictEqual(
+      messageBus.count({ cluster_id: cluster.id, topic: 'IMPLEMENTATION_READY' }),
+      1,
+      'the ambiguous resumed output must fail before its completion hook'
+    );
+    const lifecycleEvents = messageBus
+      .query({
+        cluster_id: cluster.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+      })
+      .map((message) => message.content?.data?.event);
+    assert.strictEqual(lifecycleEvents.filter((event) => event === 'TASK_COMPLETED').length, 1);
+    assert.ok(lifecycleEvents.includes('TASK_FAILED'));
   });
 
   it('does not recognize a completed turn or session when the onComplete hook crashes', async function () {

--- a/tests/unit/provider-session-lifecycle.test.js
+++ b/tests/unit/provider-session-lifecycle.test.js
@@ -1,0 +1,202 @@
+const assert = require('assert');
+const path = require('path');
+const sinon = require('sinon');
+
+const {
+  createProviderSessionAgent,
+  createProviderSessionHarness,
+} = require('../helpers/provider-session-harness');
+
+describe('provider-session lifecycle boundaries', function () {
+  let harness;
+  let messageBus;
+
+  beforeEach(function () {
+    harness = createProviderSessionHarness('zeroshot-session-lifecycle-');
+    messageBus = harness.messageBus;
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    harness.cleanup();
+  });
+
+  it('clears a failed logical result before the retry is constructed', async function () {
+    const cluster = { id: 'retry-cluster', createdAt: Date.now(), agents: [] };
+    let attempts = 0;
+    let agent;
+
+    agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: 'STATIC-RETRY-INSTRUCTIONS',
+        outputFormat: 'text',
+        maxRetries: 2,
+      },
+      runtime: {
+        quiet: true,
+        mockSpawnFn: (args, { context }) => {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              success: false,
+              error: 'logical schema failure',
+              providerSession: {
+                provider: 'claude',
+                sessionId: 'must-not-resume',
+                agentId: 'worker',
+                taskId: 'failed-task',
+                generation: 1,
+                cwd: path.resolve(agent.config.cwd || process.cwd()),
+                worktreePath: null,
+              },
+            };
+          }
+
+          assert.strictEqual(agent.providerSession, null);
+          assert.ok(!args.includes('--resume'));
+          assert.match(context, /STATIC-RETRY-INSTRUCTIONS/);
+          return { success: true, output: 'done', providerSession: null };
+        },
+      },
+    });
+    agent.running = true;
+
+    await agent._executeTask({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'retry me' },
+    });
+
+    assert.strictEqual(attempts, 2);
+    assert.strictEqual(agent.providerSession, null);
+    const failed = messageBus
+      .query({
+        cluster_id: cluster.id,
+        topic: 'AGENT_LIFECYCLE',
+        sender: 'worker',
+      })
+      .find((message) => message.content?.data?.event === 'TASK_FAILED');
+    assert.ok(failed, 'failed attempt must be durable before retry');
+  });
+
+  it('does not recognize a completed turn or session when the onComplete hook crashes', async function () {
+    const clock = sinon.useFakeTimers();
+    const cluster = { id: 'hook-crash-cluster', createdAt: Date.now(), agents: [] };
+    let agent;
+    agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: 'STATIC-HOOK-INSTRUCTIONS',
+        outputFormat: 'text',
+        maxRetries: 1,
+        hooks: { onComplete: { action: 'unknown_test_hook' } },
+      },
+      runtime: {
+        quiet: true,
+        providerCliFeatures: { claude: { supportsResume: true } },
+        mockSpawnFn: () => ({
+          success: true,
+          output: 'done',
+          providerSession: {
+            provider: 'claude',
+            sessionId: 'must-not-survive-hook-crash',
+            agentId: 'worker',
+            taskId: 'task-generation-1',
+            generation: 1,
+            cwd: path.resolve(agent.config.cwd || process.cwd()),
+            worktreePath: null,
+            contextCursor: agent.currentContextCursor,
+            guidanceCursor: agent.currentGuidanceCursor,
+            promptText: agent.currentPromptText,
+          },
+        }),
+      },
+    });
+    agent.running = true;
+
+    const execution = agent._executeTask({
+      topic: 'ISSUE_OPENED',
+      sender: 'system',
+      content: { text: 'run hook crash' },
+    });
+    await clock.runAllAsync();
+    await execution;
+
+    const lifecycle = messageBus.query({
+      cluster_id: cluster.id,
+      topic: 'AGENT_LIFECYCLE',
+      sender: 'worker',
+    });
+    assert.ok(
+      !lifecycle.some((message) => message.content?.data?.event === 'TASK_COMPLETED'),
+      'TASK_COMPLETED must follow successful hook publication'
+    );
+    assert.strictEqual(agent.providerSession, null);
+    assert.ok(
+      messageBus
+        .query({ cluster_id: cluster.id, topic: 'CLUSTER_FAILED' })
+        .some((message) => message.content?.data?.reason === 'on_complete_hook_failed')
+    );
+  });
+
+  it('replays a changed rules prompt once but omits an unchanged subsequent prompt', function () {
+    const cluster = { id: 'prompt-rules-cluster', createdAt: Date.now(), agents: [] };
+    const agent = createProviderSessionAgent({
+      cluster,
+      messageBus,
+      config: {
+        prompt: {
+          initial: 'FIRST-ITERATION-INSTRUCTIONS',
+          subsequent: 'FOLLOW-UP-INSTRUCTIONS',
+        },
+      },
+      runtime: {
+        providerCliFeatures: { claude: { supportsResume: true } },
+      },
+    });
+    const cwd = path.resolve(agent.config.cwd || process.cwd());
+
+    agent.iteration = 1;
+    const first = agent._buildContext({ topic: 'ISSUE_OPENED', content: { text: 'start' } });
+    assert.match(first, /FIRST-ITERATION-INSTRUCTIONS/);
+
+    agent.providerSession = {
+      provider: 'claude',
+      sessionId: 'generation-1',
+      agentId: 'worker',
+      taskId: 'task-1',
+      generation: 1,
+      cwd,
+      worktreePath: null,
+      contextCursor: agent.currentContextCursor,
+      guidanceCursor: agent.currentGuidanceCursor,
+      promptText: agent.currentPromptText,
+    };
+    agent.iteration = 2;
+    const second = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      content: { text: 'retry two' },
+    });
+    assert.match(second, /FOLLOW-UP-INSTRUCTIONS/);
+
+    agent.providerSession = {
+      ...agent.providerSession,
+      sessionId: 'generation-2',
+      taskId: 'task-2',
+      generation: 2,
+      contextCursor: agent.currentContextCursor,
+      guidanceCursor: agent.currentGuidanceCursor,
+      promptText: agent.currentPromptText,
+    };
+    agent.iteration = 3;
+    const third = agent._buildContext({
+      topic: 'VALIDATION_RESULT',
+      content: { text: 'retry three' },
+    });
+    assert.match(third, /Continuation Turn/);
+    assert.doesNotMatch(third, /FOLLOW-UP-INSTRUCTIONS/);
+  });
+});

--- a/tests/unit/provider-session-lifecycle.test.js
+++ b/tests/unit/provider-session-lifecycle.test.js
@@ -108,9 +108,9 @@ describe('provider-session lifecycle boundaries', function () {
             generation: 1,
             cwd: path.resolve(agent.config.cwd || process.cwd()),
             worktreePath: null,
-            contextCursor: agent.currentContextCursor,
-            guidanceCursor: agent.currentGuidanceCursor,
-            promptText: agent.currentPromptText,
+            contextSequence: agent.currentContextSequence,
+            guidanceSequence: agent.currentGuidanceSequence,
+            promptIdentity: agent.currentPromptIdentity,
           },
         }),
       },
@@ -171,9 +171,9 @@ describe('provider-session lifecycle boundaries', function () {
       generation: 1,
       cwd,
       worktreePath: null,
-      contextCursor: agent.currentContextCursor,
-      guidanceCursor: agent.currentGuidanceCursor,
-      promptText: agent.currentPromptText,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
     };
     agent.iteration = 2;
     const second = agent._buildContext({
@@ -187,9 +187,9 @@ describe('provider-session lifecycle boundaries', function () {
       sessionId: 'generation-2',
       taskId: 'task-2',
       generation: 2,
-      contextCursor: agent.currentContextCursor,
-      guidanceCursor: agent.currentGuidanceCursor,
-      promptText: agent.currentPromptText,
+      contextSequence: agent.currentContextSequence,
+      guidanceSequence: agent.currentGuidanceSequence,
+      promptIdentity: agent.currentPromptIdentity,
     };
     agent.iteration = 3;
     const third = agent._buildContext({

--- a/tests/unit/provider-session-restore.test.js
+++ b/tests/unit/provider-session-restore.test.js
@@ -1,0 +1,172 @@
+const assert = require('assert');
+const path = require('path');
+
+const {
+  restoreAgentProviderSession,
+  updateAgentProviderSession,
+} = require('../../src/agent/provider-session');
+
+const TEST_CWD = path.resolve('/tmp/provider-session-project');
+
+function buildSession(overrides = {}) {
+  return {
+    provider: 'claude',
+    sessionId: 'claude-session-1',
+    agentId: 'worker',
+    taskId: 'task-generation-1',
+    generation: 1,
+    cwd: TEST_CWD,
+    worktreePath: null,
+    contextCursor: 41,
+    guidanceCursor: 17,
+    promptText: 'FOLLOW-UP-INSTRUCTIONS',
+    ...overrides,
+  };
+}
+
+function buildAgent() {
+  return {
+    id: 'worker',
+    iteration: 1,
+    config: { cwd: TEST_CWD },
+    cluster: { id: 'cluster-1' },
+    providerSession: null,
+    currentContextCursor: 41,
+    currentGuidanceCursor: 17,
+    lastGuidanceAppliedAt: 17,
+    currentPromptText: 'FOLLOW-UP-INSTRUCTIONS',
+    isolation: null,
+    worktree: null,
+  };
+}
+
+function lifecycleBus(messages) {
+  return {
+    query: () =>
+      messages.map((data, index) => ({
+        timestamp: index + 1,
+        content: { data },
+      })),
+  };
+}
+
+function restore(agent, savedState, messages) {
+  return restoreAgentProviderSession({
+    agent,
+    savedState,
+    messageBus: lifecycleBus(messages),
+    clusterId: 'cluster-1',
+  });
+}
+
+const completedBoundary = {
+  event: 'TASK_COMPLETED',
+  provider: 'claude',
+  taskId: 'task-generation-1',
+  iteration: 1,
+  contextCursor: 41,
+  guidanceCursor: 17,
+  promptText: 'FOLLOW-UP-INSTRUCTIONS',
+};
+
+describe('provider-session restart proof', function () {
+  it('restores only the exact last completed task boundary', function () {
+    const agent = buildAgent();
+    const savedState = {
+      state: 'idle',
+      iteration: 1,
+      providerSession: buildSession(),
+      lastGuidanceAppliedAt: 17,
+    };
+
+    assert.deepStrictEqual(restore(agent, savedState, [completedBoundary]), buildSession());
+
+    for (const boundary of [
+      { event: 'TASK_STARTED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'TASK_FAILED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'RETRY_SCHEDULED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+    ]) {
+      assert.strictEqual(restore(agent, savedState, [completedBoundary, boundary]), null);
+    }
+  });
+
+  it('drops legacy session-only state because its task provenance is ambiguous', function () {
+    const agent = buildAgent();
+    updateAgentProviderSession(agent, {
+      provider: 'claude',
+      sessionId: 'legacy-session',
+    });
+    assert.strictEqual(agent.providerSession, null);
+  });
+
+  it('drops continuation state without an exact durable context cursor', function () {
+    const agent = buildAgent();
+    const missingCursor = buildSession();
+    delete missingCursor.contextCursor;
+
+    updateAgentProviderSession(agent, missingCursor);
+    assert.strictEqual(agent.providerSession, null);
+
+    assert.strictEqual(
+      restore(
+        agent,
+        {
+          state: 'idle',
+          iteration: 1,
+          providerSession: missingCursor,
+        },
+        [
+          {
+            event: 'TASK_COMPLETED',
+            provider: 'claude',
+            taskId: 'task-generation-1',
+            iteration: 1,
+          },
+        ]
+      ),
+      null
+    );
+  });
+
+  it('fails closed when restored state is absent or guidance provenance is not bound', function () {
+    const agent = buildAgent();
+
+    for (const savedState of [
+      {
+        iteration: 1,
+        providerSession: buildSession(),
+        lastGuidanceAppliedAt: 17,
+      },
+      {
+        state: 'idle',
+        iteration: 1,
+        providerSession: buildSession(),
+      },
+      {
+        state: 'idle',
+        iteration: 1,
+        providerSession: buildSession(),
+        lastGuidanceAppliedAt: 16,
+      },
+    ]) {
+      assert.strictEqual(restore(agent, savedState, [completedBoundary]), null);
+    }
+  });
+
+  it('rejects a restored completion whose durable cursor differs from the saved session', function () {
+    const agent = buildAgent();
+    assert.strictEqual(
+      restore(
+        agent,
+        {
+          state: 'idle',
+          iteration: 1,
+          providerSession: buildSession(),
+          lastGuidanceAppliedAt: 17,
+        },
+        [{ ...completedBoundary, contextCursor: 42 }]
+      ),
+      null
+    );
+  });
+});

--- a/tests/unit/provider-session-restore.test.js
+++ b/tests/unit/provider-session-restore.test.js
@@ -1,28 +1,13 @@
 const assert = require('assert');
-const path = require('path');
-
 const {
   restoreAgentProviderSession,
   updateAgentProviderSession,
 } = require('../../src/agent/provider-session');
-
-const TEST_CWD = path.resolve('/tmp/provider-session-project');
-
-function buildSession(overrides = {}) {
-  return {
-    provider: 'claude',
-    sessionId: 'claude-session-1',
-    agentId: 'worker',
-    taskId: 'task-generation-1',
-    generation: 1,
-    cwd: TEST_CWD,
-    worktreePath: null,
-    contextCursor: 41,
-    guidanceCursor: 17,
-    promptText: 'FOLLOW-UP-INSTRUCTIONS',
-    ...overrides,
-  };
-}
+const {
+  FOLLOW_UP_PROMPT_IDENTITY,
+  PROVIDER_SESSION_TEST_CWD: TEST_CWD,
+  buildProviderSession: buildSession,
+} = require('../helpers/provider-session-harness');
 
 function buildAgent() {
   return {
@@ -31,10 +16,10 @@ function buildAgent() {
     config: { cwd: TEST_CWD },
     cluster: { id: 'cluster-1' },
     providerSession: null,
-    currentContextCursor: 41,
-    currentGuidanceCursor: 17,
-    lastGuidanceAppliedAt: 17,
-    currentPromptText: 'FOLLOW-UP-INSTRUCTIONS',
+    currentContextSequence: 41,
+    currentGuidanceSequence: 17,
+    lastGuidanceAppliedId: 17,
+    currentPromptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
     isolation: null,
     worktree: null,
   };
@@ -64,9 +49,9 @@ const completedBoundary = {
   provider: 'claude',
   taskId: 'task-generation-1',
   iteration: 1,
-  contextCursor: 41,
-  guidanceCursor: 17,
-  promptText: 'FOLLOW-UP-INSTRUCTIONS',
+  contextSequence: 41,
+  guidanceSequence: 17,
+  promptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
 };
 
 describe('provider-session restart proof', function () {
@@ -76,7 +61,7 @@ describe('provider-session restart proof', function () {
       state: 'idle',
       iteration: 1,
       providerSession: buildSession(),
-      lastGuidanceAppliedAt: 17,
+      lastGuidanceAppliedId: 17,
     };
 
     assert.deepStrictEqual(restore(agent, savedState, [completedBoundary]), buildSession());
@@ -102,7 +87,7 @@ describe('provider-session restart proof', function () {
   it('drops continuation state without an exact durable context cursor', function () {
     const agent = buildAgent();
     const missingCursor = buildSession();
-    delete missingCursor.contextCursor;
+    delete missingCursor.contextSequence;
 
     updateAgentProviderSession(agent, missingCursor);
     assert.strictEqual(agent.providerSession, null);
@@ -135,7 +120,7 @@ describe('provider-session restart proof', function () {
       {
         iteration: 1,
         providerSession: buildSession(),
-        lastGuidanceAppliedAt: 17,
+        lastGuidanceAppliedId: 17,
       },
       {
         state: 'idle',
@@ -146,7 +131,7 @@ describe('provider-session restart proof', function () {
         state: 'idle',
         iteration: 1,
         providerSession: buildSession(),
-        lastGuidanceAppliedAt: 16,
+        lastGuidanceAppliedId: 16,
       },
     ]) {
       assert.strictEqual(restore(agent, savedState, [completedBoundary]), null);
@@ -162,9 +147,9 @@ describe('provider-session restart proof', function () {
           state: 'idle',
           iteration: 1,
           providerSession: buildSession(),
-          lastGuidanceAppliedAt: 17,
+          lastGuidanceAppliedId: 17,
         },
-        [{ ...completedBoundary, contextCursor: 42 }]
+        [{ ...completedBoundary, contextSequence: 42 }]
       ),
       null
     );

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -1,29 +1,14 @@
 const assert = require('assert');
-const path = require('path');
-
 const {
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
 } = require('../../src/agent/provider-session');
 const { buildCompletionResult, buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
-
-const TEST_CWD = path.resolve('/tmp/provider-session-project');
-
-function buildSession(overrides = {}) {
-  return {
-    provider: 'claude',
-    sessionId: 'claude-session-1',
-    agentId: 'worker',
-    taskId: 'task-generation-1',
-    generation: 1,
-    cwd: TEST_CWD,
-    worktreePath: null,
-    contextCursor: 41,
-    guidanceCursor: 17,
-    promptText: 'FOLLOW-UP-INSTRUCTIONS',
-    ...overrides,
-  };
-}
+const {
+  FOLLOW_UP_PROMPT_IDENTITY,
+  PROVIDER_SESSION_TEST_CWD: TEST_CWD,
+  buildProviderSession: buildSession,
+} = require('../helpers/provider-session-harness');
 
 function buildAgent(overrides = {}) {
   return {
@@ -32,10 +17,10 @@ function buildAgent(overrides = {}) {
     config: { cwd: TEST_CWD, ...overrides.config },
     cluster: { id: 'cluster-1' },
     providerSession: overrides.providerSession ?? null,
-    currentContextCursor: overrides.currentContextCursor ?? 41,
-    currentGuidanceCursor: overrides.currentGuidanceCursor ?? 17,
-    lastGuidanceAppliedAt: overrides.lastGuidanceAppliedAt ?? 17,
-    currentPromptText: overrides.currentPromptText ?? 'FOLLOW-UP-INSTRUCTIONS',
+    currentContextSequence: overrides.currentContextSequence ?? 41,
+    currentGuidanceSequence: overrides.currentGuidanceSequence ?? 17,
+    lastGuidanceAppliedId: overrides.lastGuidanceAppliedId ?? 17,
+    currentPromptIdentity: overrides.currentPromptIdentity ?? FOLLOW_UP_PROMPT_IDENTITY,
     isolation: overrides.isolation || null,
     worktree: overrides.worktree || null,
   };
@@ -111,9 +96,9 @@ describe('agent-owned provider session reuse', function () {
       generation: 1,
       cwd: TEST_CWD,
       worktreePath: null,
-      contextCursor: 41,
-      guidanceCursor: 17,
-      promptText: 'FOLLOW-UP-INSTRUCTIONS',
+      contextSequence: 41,
+      guidanceSequence: 17,
+      promptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
     });
 
     assert.strictEqual(
@@ -166,6 +151,51 @@ describe('agent-owned provider session reuse', function () {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.providerSession, null);
     assert.match(result.error, /schema mismatch/);
+  });
+
+  it('accepts only the exact provider identity requested for a resumed turn', async function () {
+    const agent = buildAgent({
+      iteration: 2,
+      config: { outputFormat: 'text' },
+    });
+    const baseTaskInfo = {
+      id: 'task-generation-2',
+      provider: 'claude',
+      status: 'completed',
+      requestedResumeSessionId: 'claude-session-1',
+    };
+
+    const confirmed = await buildCompletionResult({
+      agent,
+      taskId: baseTaskInfo.id,
+      providerName: 'claude',
+      state: { output: 'done', logFilePath: null },
+      stdout: 'Status: completed',
+      success: true,
+      taskInfo: { ...baseTaskInfo, sessionId: 'claude-session-1' },
+    });
+    assert.strictEqual(confirmed.success, true);
+    assert.strictEqual(confirmed.providerSession.sessionId, 'claude-session-1');
+
+    for (const [name, sessionId, expectedError] of [
+      ['ignored', null, /did not confirm/],
+      ['forked', 'forked-session', /different session identity/],
+      ['absent', undefined, /did not confirm/],
+    ]) {
+      const result = await buildCompletionResult({
+        agent,
+        taskId: baseTaskInfo.id,
+        providerName: 'claude',
+        state: { output: `${name} resume probe`, logFilePath: null },
+        stdout: 'Status: completed',
+        success: true,
+        taskInfo: { ...baseTaskInfo, sessionId },
+      });
+
+      assert.strictEqual(result.success, false, `${name} resume must fail the logical attempt`);
+      assert.strictEqual(result.providerSession, null);
+      assert.match(result.error, expectedError);
+    }
   });
 
   it('never leaks one agent session into another agent', function () {

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert');
+
+const {
+  providerSessionFromCompletedTask,
+  resolveAgentResumeSessionId,
+  updateAgentProviderSession,
+} = require('../../src/agent/provider-session');
+const { buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+
+function buildAgent(overrides = {}) {
+  return {
+    config: { cwd: process.cwd(), ...overrides.config },
+    cluster: { id: 'cluster-1' },
+    providerSession: overrides.providerSession || null,
+    isolation: overrides.isolation || null,
+    worktree: overrides.worktree || null,
+  };
+}
+
+function taskArgs(agent, providerName) {
+  return buildTaskRunArgs({
+    agent,
+    providerName,
+    modelSpec: {},
+    runOutputFormat: 'stream-json',
+  });
+}
+
+describe('agent-owned provider session reuse', function () {
+  it('reuses explicit Claude and Codex IDs for the same logical agent', function () {
+    const claude = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
+    });
+    const codex = buildAgent({
+      providerSession: { provider: 'codex', sessionId: 'codex-thread-1' },
+    });
+
+    assert.deepStrictEqual(taskArgs(claude, 'claude').slice(-2), ['--resume', 'claude-session-1']);
+    assert.deepStrictEqual(taskArgs(codex, 'codex').slice(-2), ['--resume', 'codex-thread-1']);
+  });
+
+  it('starts fresh for unsupported providers, Docker isolation, and provider switches', function () {
+    const unsupported = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
+    });
+    assert.ok(!taskArgs(unsupported, 'gemini').includes('--resume'));
+    assert.strictEqual(unsupported.providerSession, null);
+
+    const isolated = buildAgent({
+      providerSession: { provider: 'claude', sessionId: 'claude-session-2' },
+      isolation: { enabled: true },
+    });
+    assert.ok(!taskArgs(isolated, 'claude').includes('--resume'));
+    assert.strictEqual(isolated.providerSession, null);
+  });
+
+  it('captures completed tasks and invalidates failed retry boundaries', function () {
+    const agent = buildAgent();
+    const completed = providerSessionFromCompletedTask({
+      agent,
+      providerName: 'codex',
+      taskInfo: {
+        provider: 'codex',
+        status: 'completed',
+        sessionId: 'thread-complete',
+      },
+    });
+    updateAgentProviderSession(agent, completed);
+    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), 'thread-complete');
+
+    const failed = providerSessionFromCompletedTask({
+      agent,
+      providerName: 'codex',
+      taskInfo: {
+        provider: 'codex',
+        status: 'failed',
+        sessionId: 'thread-failed',
+      },
+    });
+    updateAgentProviderSession(agent, failed);
+    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), null);
+  });
+
+  it('never leaks one agent session into another agent', function () {
+    const worker = buildAgent();
+    const validator = buildAgent();
+    updateAgentProviderSession(worker, {
+      provider: 'claude',
+      sessionId: 'worker-session',
+    });
+
+    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'worker-session');
+    assert.strictEqual(resolveAgentResumeSessionId(validator, 'claude'), null);
+    assert.strictEqual(validator.providerSession, null);
+  });
+});

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -96,8 +96,8 @@ describe('agent-owned provider session reuse', function () {
       generation: 1,
       cwd: TEST_CWD,
       worktreePath: null,
-      contextSequence: 41,
-      guidanceSequence: 17,
+      contextSequence: '41',
+      guidanceSequence: '17',
       promptIdentity: FOLLOW_UP_PROMPT_IDENTITY,
     });
 
@@ -196,6 +196,23 @@ describe('agent-owned provider session reuse', function () {
       assert.strictEqual(result.providerSession, null);
       assert.match(result.error, expectedError);
     }
+
+    const ambiguous = await buildCompletionResult({
+      agent,
+      taskId: baseTaskInfo.id,
+      providerName: 'claude',
+      state: { output: 'provider emitted forked then requested IDs', logFilePath: null },
+      stdout: 'Status: completed',
+      success: true,
+      taskInfo: {
+        ...baseTaskInfo,
+        sessionId: 'claude-session-1',
+        sessionIdConflict: true,
+      },
+    });
+    assert.strictEqual(ambiguous.success, false);
+    assert.strictEqual(ambiguous.providerSession, null);
+    assert.match(ambiguous.error, /conflicting session identities/);
   });
 
   it('never leaks one agent session into another agent', function () {

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -163,6 +163,7 @@ describe('agent-owned provider session reuse', function () {
       provider: 'claude',
       status: 'completed',
       requestedResumeSessionId: 'claude-session-1',
+      resumeIdentityVerified: true,
     };
 
     const confirmed = await buildCompletionResult({

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -1,17 +1,36 @@
 const assert = require('assert');
+const path = require('path');
 
 const {
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
+  restoreAgentProviderSession,
   updateAgentProviderSession,
 } = require('../../src/agent/provider-session');
-const { buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+const { buildCompletionResult, buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
+
+const TEST_CWD = path.resolve('/tmp/provider-session-project');
+
+function buildSession(overrides = {}) {
+  return {
+    provider: 'claude',
+    sessionId: 'claude-session-1',
+    agentId: 'worker',
+    taskId: 'task-generation-1',
+    generation: 1,
+    cwd: TEST_CWD,
+    worktreePath: null,
+    ...overrides,
+  };
+}
 
 function buildAgent(overrides = {}) {
   return {
-    config: { cwd: process.cwd(), ...overrides.config },
+    id: overrides.id || 'worker',
+    iteration: overrides.iteration ?? 2,
+    config: { cwd: TEST_CWD, ...overrides.config },
     cluster: { id: 'cluster-1' },
-    providerSession: overrides.providerSession || null,
+    providerSession: overrides.providerSession ?? null,
     isolation: overrides.isolation || null,
     worktree: overrides.worktree || null,
   };
@@ -26,71 +45,188 @@ function taskArgs(agent, providerName) {
   });
 }
 
+function lifecycleBus(messages) {
+  return {
+    query: () =>
+      messages.map((data, index) => ({
+        timestamp: index + 1,
+        content: { data },
+      })),
+  };
+}
+
 describe('agent-owned provider session reuse', function () {
-  it('reuses explicit Claude and Codex IDs for the same logical agent', function () {
-    const claude = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
-    });
+  it('reuses an explicit ID only for the next generation of the same logical agent', function () {
+    const claude = buildAgent({ providerSession: buildSession() });
     const codex = buildAgent({
-      providerSession: { provider: 'codex', sessionId: 'codex-thread-1' },
+      providerSession: buildSession({
+        provider: 'codex',
+        sessionId: 'codex-thread-1',
+      }),
     });
 
     assert.deepStrictEqual(taskArgs(claude, 'claude').slice(-2), ['--resume', 'claude-session-1']);
     assert.deepStrictEqual(taskArgs(codex, 'codex').slice(-2), ['--resume', 'codex-thread-1']);
+
+    const staleGeneration = buildAgent({
+      iteration: 3,
+      providerSession: buildSession(),
+    });
+    assert.ok(!taskArgs(staleGeneration, 'claude').includes('--resume'));
+    assert.strictEqual(staleGeneration.providerSession, null);
   });
 
-  it('starts fresh for unsupported providers, Docker isolation, and provider switches', function () {
-    const unsupported = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-1' },
-    });
+  it('starts fresh for unsupported providers, Docker, provider switches, and worktree drift', function () {
+    const unsupported = buildAgent({ providerSession: buildSession() });
     assert.ok(!taskArgs(unsupported, 'gemini').includes('--resume'));
-    assert.strictEqual(unsupported.providerSession, null);
 
     const isolated = buildAgent({
-      providerSession: { provider: 'claude', sessionId: 'claude-session-2' },
+      providerSession: buildSession(),
       isolation: { enabled: true },
     });
     assert.ok(!taskArgs(isolated, 'claude').includes('--resume'));
-    assert.strictEqual(isolated.providerSession, null);
+
+    const moved = buildAgent({
+      providerSession: buildSession({ worktreePath: '/tmp/old-worktree' }),
+      worktree: { enabled: true, path: '/tmp/new-worktree' },
+    });
+    assert.ok(!taskArgs(moved, 'claude').includes('--resume'));
   });
 
-  it('captures completed tasks and invalidates failed retry boundaries', function () {
-    const agent = buildAgent();
+  it('captures only logically successful completed tasks with full provenance', function () {
+    const agent = buildAgent({ iteration: 1 });
+    const taskInfo = {
+      id: 'task-generation-1',
+      provider: 'codex',
+      status: 'completed',
+      sessionId: 'thread-complete',
+    };
     const completed = providerSessionFromCompletedTask({
       agent,
       providerName: 'codex',
-      taskInfo: {
-        provider: 'codex',
-        status: 'completed',
-        sessionId: 'thread-complete',
-      },
+      taskInfo,
+      logicalSuccess: true,
     });
-    updateAgentProviderSession(agent, completed);
-    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), 'thread-complete');
 
-    const failed = providerSessionFromCompletedTask({
+    assert.deepStrictEqual(completed, {
+      provider: 'codex',
+      sessionId: 'thread-complete',
+      agentId: 'worker',
+      taskId: 'task-generation-1',
+      generation: 1,
+      cwd: TEST_CWD,
+      worktreePath: null,
+    });
+
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo,
+        logicalSuccess: false,
+      }),
+      null
+    );
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo: { ...taskInfo, status: 'failed' },
+      }),
+      null
+    );
+    assert.strictEqual(
+      providerSessionFromCompletedTask({
+        agent,
+        providerName: 'codex',
+        taskInfo: { ...taskInfo, sessionId: null },
+      }),
+      null
+    );
+  });
+
+  it('discards a provider-completed session when structured output is invalid', async function () {
+    const agent = {
+      ...buildAgent({ iteration: 1 }),
+      _parseResultOutput: () => Promise.reject(new Error('schema mismatch')),
+    };
+    const result = await buildCompletionResult({
       agent,
-      providerName: 'codex',
+      taskId: 'task-generation-1',
+      providerName: 'claude',
+      state: { output: '{"wrong":true}', logFilePath: null },
+      stdout: 'Status: completed',
+      success: true,
       taskInfo: {
-        provider: 'codex',
-        status: 'failed',
-        sessionId: 'thread-failed',
+        id: 'task-generation-1',
+        provider: 'claude',
+        status: 'completed',
+        sessionId: 'must-be-discarded',
       },
     });
-    updateAgentProviderSession(agent, failed);
-    assert.strictEqual(resolveAgentResumeSessionId(agent, 'codex'), null);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.providerSession, null);
+    assert.match(result.error, /schema mismatch/);
   });
 
   it('never leaks one agent session into another agent', function () {
-    const worker = buildAgent();
-    const validator = buildAgent();
-    updateAgentProviderSession(worker, {
-      provider: 'claude',
-      sessionId: 'worker-session',
+    const worker = buildAgent({ providerSession: buildSession() });
+    const validator = buildAgent({
+      id: 'validator',
+      providerSession: buildSession(),
     });
 
-    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'worker-session');
+    assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'claude-session-1');
     assert.strictEqual(resolveAgentResumeSessionId(validator, 'claude'), null);
     assert.strictEqual(validator.providerSession, null);
+  });
+
+  it('restores only the exact last completed task boundary', function () {
+    const agent = buildAgent({ iteration: 1 });
+    const savedState = {
+      state: 'idle',
+      iteration: 1,
+      providerSession: buildSession(),
+    };
+    const completed = {
+      event: 'TASK_COMPLETED',
+      provider: 'claude',
+      taskId: 'task-generation-1',
+      iteration: 1,
+    };
+
+    const restored = restoreAgentProviderSession({
+      agent,
+      savedState,
+      messageBus: lifecycleBus([completed]),
+      clusterId: 'cluster-1',
+    });
+    assert.deepStrictEqual(restored, buildSession());
+
+    for (const boundary of [
+      { event: 'TASK_STARTED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'TASK_FAILED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+      { event: 'RETRY_SCHEDULED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
+    ]) {
+      assert.strictEqual(
+        restoreAgentProviderSession({
+          agent,
+          savedState,
+          messageBus: lifecycleBus([completed, boundary]),
+          clusterId: 'cluster-1',
+        }),
+        null
+      );
+    }
+  });
+
+  it('drops legacy session-only state because its task provenance is ambiguous', function () {
+    const agent = buildAgent({ iteration: 1 });
+    updateAgentProviderSession(agent, {
+      provider: 'claude',
+      sessionId: 'legacy-session',
+    });
+    assert.strictEqual(agent.providerSession, null);
   });
 });

--- a/tests/unit/provider-session-reuse.test.js
+++ b/tests/unit/provider-session-reuse.test.js
@@ -4,8 +4,6 @@ const path = require('path');
 const {
   providerSessionFromCompletedTask,
   resolveAgentResumeSessionId,
-  restoreAgentProviderSession,
-  updateAgentProviderSession,
 } = require('../../src/agent/provider-session');
 const { buildCompletionResult, buildTaskRunArgs } = require('../../src/agent/agent-task-executor');
 
@@ -20,6 +18,9 @@ function buildSession(overrides = {}) {
     generation: 1,
     cwd: TEST_CWD,
     worktreePath: null,
+    contextCursor: 41,
+    guidanceCursor: 17,
+    promptText: 'FOLLOW-UP-INSTRUCTIONS',
     ...overrides,
   };
 }
@@ -31,6 +32,10 @@ function buildAgent(overrides = {}) {
     config: { cwd: TEST_CWD, ...overrides.config },
     cluster: { id: 'cluster-1' },
     providerSession: overrides.providerSession ?? null,
+    currentContextCursor: overrides.currentContextCursor ?? 41,
+    currentGuidanceCursor: overrides.currentGuidanceCursor ?? 17,
+    lastGuidanceAppliedAt: overrides.lastGuidanceAppliedAt ?? 17,
+    currentPromptText: overrides.currentPromptText ?? 'FOLLOW-UP-INSTRUCTIONS',
     isolation: overrides.isolation || null,
     worktree: overrides.worktree || null,
   };
@@ -43,16 +48,6 @@ function taskArgs(agent, providerName) {
     modelSpec: {},
     runOutputFormat: 'stream-json',
   });
-}
-
-function lifecycleBus(messages) {
-  return {
-    query: () =>
-      messages.map((data, index) => ({
-        timestamp: index + 1,
-        content: { data },
-      })),
-  };
 }
 
 describe('agent-owned provider session reuse', function () {
@@ -116,6 +111,9 @@ describe('agent-owned provider session reuse', function () {
       generation: 1,
       cwd: TEST_CWD,
       worktreePath: null,
+      contextCursor: 41,
+      guidanceCursor: 17,
+      promptText: 'FOLLOW-UP-INSTRUCTIONS',
     });
 
     assert.strictEqual(
@@ -180,53 +178,5 @@ describe('agent-owned provider session reuse', function () {
     assert.strictEqual(resolveAgentResumeSessionId(worker, 'claude'), 'claude-session-1');
     assert.strictEqual(resolveAgentResumeSessionId(validator, 'claude'), null);
     assert.strictEqual(validator.providerSession, null);
-  });
-
-  it('restores only the exact last completed task boundary', function () {
-    const agent = buildAgent({ iteration: 1 });
-    const savedState = {
-      state: 'idle',
-      iteration: 1,
-      providerSession: buildSession(),
-    };
-    const completed = {
-      event: 'TASK_COMPLETED',
-      provider: 'claude',
-      taskId: 'task-generation-1',
-      iteration: 1,
-    };
-
-    const restored = restoreAgentProviderSession({
-      agent,
-      savedState,
-      messageBus: lifecycleBus([completed]),
-      clusterId: 'cluster-1',
-    });
-    assert.deepStrictEqual(restored, buildSession());
-
-    for (const boundary of [
-      { event: 'TASK_STARTED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
-      { event: 'TASK_FAILED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
-      { event: 'RETRY_SCHEDULED', provider: 'claude', taskId: 'task-generation-2', iteration: 2 },
-    ]) {
-      assert.strictEqual(
-        restoreAgentProviderSession({
-          agent,
-          savedState,
-          messageBus: lifecycleBus([completed, boundary]),
-          clusterId: 'cluster-1',
-        }),
-        null
-      );
-    }
-  });
-
-  it('drops legacy session-only state because its task provenance is ambiguous', function () {
-    const agent = buildAgent({ iteration: 1 });
-    updateAgentProviderSession(agent, {
-      provider: 'claude',
-      sessionId: 'legacy-session',
-    });
-    assert.strictEqual(agent.providerSession, null);
   });
 });

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+
+describe('single-task session resume', function () {
+  it('uses the captured explicit provider session ID', async function () {
+    const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
+    assert.deepStrictEqual(
+      buildResumeTaskOptions({
+        id: 'task-1',
+        provider: 'codex',
+        sessionId: 'thread-1',
+        cwd: '/tmp/project',
+      }),
+      {
+        provider: 'codex',
+        resume: 'thread-1',
+        cwd: '/tmp/project',
+      }
+    );
+  });
+
+  it('fails deterministically instead of selecting another task or agent session', async function () {
+    const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
+
+    assert.throws(
+      () =>
+        buildResumeTaskOptions({
+          id: 'task-without-session',
+          provider: 'claude',
+          sessionId: null,
+          cwd: '/tmp/project',
+        }),
+      /no captured provider session ID/
+    );
+    assert.throws(
+      () =>
+        buildResumeTaskOptions({
+          id: 'unsupported-task',
+          provider: 'gemini',
+          sessionId: 'gemini-session',
+          cwd: '/tmp/project',
+        }),
+      /does not support safe session resume/
+    );
+  });
+});

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -16,6 +16,7 @@ describe('single-task session resume', function () {
 
     assert.strictEqual(task.requestedResumeSessionId, 'requested-thread');
     assert.strictEqual(task.sessionId, null);
+    assert.strictEqual(task.sessionIdConflict, false);
   });
 
   it('uses the captured explicit provider session ID', async function () {
@@ -75,9 +76,12 @@ describe('single-task session resume', function () {
       migrateTaskStore(database);
 
       const row = database
-        .prepare('SELECT session_id, requested_resume_session_id FROM tasks WHERE id = ?')
+        .prepare(
+          'SELECT session_id, session_id_conflict, requested_resume_session_id FROM tasks WHERE id = ?'
+        )
         .get('legacy-task');
       assert.strictEqual(row.session_id, null);
+      assert.strictEqual(row.session_id_conflict, 0);
       assert.strictEqual(row.requested_resume_session_id, 'historically-requested-id');
       assert.strictEqual(
         database.pragma('user_version', { simple: true }),
@@ -93,9 +97,15 @@ describe('single-task session resume', function () {
       migrateTaskStore(database);
       assert.deepStrictEqual(
         database
-          .prepare('SELECT session_id, requested_resume_session_id FROM tasks WHERE id = ?')
+          .prepare(
+            'SELECT session_id, session_id_conflict, requested_resume_session_id FROM tasks WHERE id = ?'
+          )
           .get('captured-task'),
-        { session_id: 'observed-id', requested_resume_session_id: 'requested-id' }
+        {
+          session_id: 'observed-id',
+          session_id_conflict: 0,
+          requested_resume_session_id: 'requested-id',
+        }
       );
     } finally {
       database.close();

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const Database = require('better-sqlite3');
 
 describe('single-task session resume', function () {
   it('keeps a requested resume ID separate from watcher-captured identity', async function () {
@@ -57,5 +58,47 @@ describe('single-task session resume', function () {
         }),
       /does not support safe session resume/
     );
+  });
+
+  it('migrates legacy requested IDs out of the observed session column with version proof', async function () {
+    const { migrateTaskStore, TASK_STORE_SCHEMA_VERSION } = await import('../../task-lib/store.js');
+    const database = new Database(':memory:');
+    try {
+      database.exec(`
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          session_id TEXT
+        );
+        INSERT INTO tasks (id, session_id) VALUES ('legacy-task', 'historically-requested-id');
+      `);
+
+      migrateTaskStore(database);
+
+      const row = database
+        .prepare('SELECT session_id, requested_resume_session_id FROM tasks WHERE id = ?')
+        .get('legacy-task');
+      assert.strictEqual(row.session_id, null);
+      assert.strictEqual(row.requested_resume_session_id, 'historically-requested-id');
+      assert.strictEqual(
+        database.pragma('user_version', { simple: true }),
+        TASK_STORE_SCHEMA_VERSION
+      );
+
+      database
+        .prepare(
+          `INSERT INTO tasks (id, session_id, requested_resume_session_id)
+           VALUES ('captured-task', 'observed-id', 'requested-id')`
+        )
+        .run();
+      migrateTaskStore(database);
+      assert.deepStrictEqual(
+        database
+          .prepare('SELECT session_id, requested_resume_session_id FROM tasks WHERE id = ?')
+          .get('captured-task'),
+        { session_id: 'observed-id', requested_resume_session_id: 'requested-id' }
+      );
+    } finally {
+      database.close();
+    }
   });
 });

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -1,6 +1,22 @@
 const assert = require('assert');
 
 describe('single-task session resume', function () {
+  it('keeps a requested resume ID separate from watcher-captured identity', async function () {
+    const { buildTaskRecord } = await import('../../task-lib/runner.js');
+    const task = buildTaskRecord({
+      id: 'task-resumed',
+      prompt: 'continue',
+      cwd: '/tmp/project',
+      options: { resume: 'requested-thread' },
+      logFile: '/tmp/task-resumed.log',
+      providerName: 'codex',
+      modelSpec: {},
+    });
+
+    assert.strictEqual(task.requestedResumeSessionId, 'requested-thread');
+    assert.strictEqual(task.sessionId, null);
+  });
+
   it('uses the captured explicit provider session ID', async function () {
     const { buildResumeTaskOptions } = await import('../../task-lib/commands/resume.js');
     assert.deepStrictEqual(

--- a/tests/unit/task-resume-session.test.js
+++ b/tests/unit/task-resume-session.test.js
@@ -17,6 +17,7 @@ describe('single-task session resume', function () {
     assert.strictEqual(task.requestedResumeSessionId, 'requested-thread');
     assert.strictEqual(task.sessionId, null);
     assert.strictEqual(task.sessionIdConflict, false);
+    assert.strictEqual(task.resumeIdentityVerified, false);
   });
 
   it('uses the captured explicit provider session ID', async function () {
@@ -59,6 +60,19 @@ describe('single-task session resume', function () {
         }),
       /does not support safe session resume/
     );
+    assert.throws(
+      () =>
+        buildResumeTaskOptions({
+          id: 'unverified-resumed-task',
+          provider: 'claude',
+          status: 'stale',
+          requestedResumeSessionId: 'requested-session',
+          sessionId: 'requested-session',
+          resumeIdentityVerified: false,
+          cwd: '/tmp/project',
+        }),
+      /did not durably verify/
+    );
   });
 
   it('migrates legacy requested IDs out of the observed session column with version proof', async function () {
@@ -77,12 +91,13 @@ describe('single-task session resume', function () {
 
       const row = database
         .prepare(
-          'SELECT session_id, session_id_conflict, requested_resume_session_id FROM tasks WHERE id = ?'
+          'SELECT session_id, session_id_conflict, requested_resume_session_id, resume_identity_verified FROM tasks WHERE id = ?'
         )
         .get('legacy-task');
       assert.strictEqual(row.session_id, null);
       assert.strictEqual(row.session_id_conflict, 0);
       assert.strictEqual(row.requested_resume_session_id, 'historically-requested-id');
+      assert.strictEqual(row.resume_identity_verified, 0);
       assert.strictEqual(
         database.pragma('user_version', { simple: true }),
         TASK_STORE_SCHEMA_VERSION
@@ -98,13 +113,14 @@ describe('single-task session resume', function () {
       assert.deepStrictEqual(
         database
           .prepare(
-            'SELECT session_id, session_id_conflict, requested_resume_session_id FROM tasks WHERE id = ?'
+            'SELECT session_id, session_id_conflict, requested_resume_session_id, resume_identity_verified FROM tasks WHERE id = ?'
           )
           .get('captured-task'),
         {
           session_id: 'observed-id',
           session_id_conflict: 0,
           requested_resume_session_id: 'requested-id',
+          resume_identity_verified: 0,
         }
       );
     } finally {


### PR DESCRIPTION
## Main-trunk migration

Replaces #808 after the main-trunk cutover. This branch starts at the new `main`, preserves the original isolated diff and commit author, and removes the legacy `dev` history from the PR.

## Original PR body

## Summary

- capture Claude session IDs and Codex thread IDs from provider JSONL output
- persist continuation state on the owning logical agent and restore it with cluster state
- resume only that same agent by explicit session ID; never use cwd-wide latest-session selection
- fail closed to a fresh session on provider changes, failed tasks, unsupported CLI versions, or Docker isolation
- make manual task resume use the captured explicit provider session for Claude and Codex

This follows the revised scope in #482: provider-side session reuse rather than direct API `cache_control` plumbing.

## Validation

- `npm run check`
- `npm run check:agent-cli-provider:ci` (135 passing)
- focused provider/session/persistence tests (24 passing)
- `opcore check --changed --json`
- `npm test`: 1705 passing, 18 pending; 7 local attach/PTTY tests fail with the environment-level `node-pty` error `posix_spawnp failed`

Fixes #482
