### PR TITLE
fix: isolate Claude safety hooks per run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Provider detection           | `lib/provider-detection.js`                                             |
 | Provider capabilities        | `src/providers/capabilities.js`                                         |
 | Claude settings overlay      | `src/worktree-claude-config.js`                                         |
+| Detached task cleanup owner  | `task-lib/command-spec-cleanup.js`                                      |
+| Shared watcher output path   | `task-lib/watcher-output-runtime.js`                                    |
 | Start-cluster helper         | `lib/start-cluster.js`                                                  |
 | Legacy worker facade         | `lib/cluster-worker/`                                                   |
 | Legacy worker executable     | `bin/zeroshot-cluster-worker.js`                                        |
@@ -331,7 +333,10 @@ Restart persistence: orchestrator publishes `AGENT_RESTART_ATTEMPT` to the ledge
 
 Provider task ownership: task watchers persist an owned termination boundary with each active task.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
-`taskkill /T`. Recovery must terminate that recorded boundary before retrying work.
+`taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
+ownership is persisted with the task and may run only after that boundary is confirmed terminal.
+Killed/stale recovery consumes the persisted cleanup, and recursive cleanup is restricted to
+Zeroshot-owned provider overlays.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,9 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.
 Killed/stale recovery consumes the persisted cleanup, and recursive cleanup is restricted to
-Zeroshot-owned provider overlays.
+Zeroshot-owned provider overlays. If watcher termination cannot confirm that boundary, the task
+remains nonterminal with its PID, process group, strategy, and cleanup ownership intact; retry and
+cleanup stay blocked until a later kill confirms termination.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Gateway tools/policy         | `src/agent-cli-provider/gateway-tools.ts`                               |
 | Provider detection           | `lib/provider-detection.js`                                             |
 | Provider capabilities        | `src/providers/capabilities.js`                                         |
+| Claude settings overlay      | `src/worktree-claude-config.js`                                         |
 | Start-cluster helper         | `lib/start-cluster.js`                                                  |
 | Legacy worker facade         | `lib/cluster-worker/`                                                   |
 | Legacy worker executable     | `bin/zeroshot-cluster-worker.js`                                        |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,13 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.
+Once the outer task wrapper process starts, ambiguous rejection, timeout, nonzero exit, or task-ID
+parse failure transfers cleanup ownership to the task lifecycle; only a proven pre-spawn failure may
+eager-clean caller-owned resources. Watcher completion clears a cleanup receipt only after an
+initialized cleanup owner actually succeeds. Cleanup metadata is a closed one-to-one receipt:
+Claude settings overlays must be owned temporary directories, and Codex output-schema files must be
+exact regular, non-symlink UUID JSON files directly inside canonical `zeroshot-schema-*` temp
+directories. Unsafe or uninitialized cleanup remains persisted and warning-visible.
 Killed/stale recovery consumes the persisted cleanup, and recursive cleanup is restricted to
 Zeroshot-owned provider overlays. A terminal task that retains cleanup ownership after a failed
 watcher cleanup retries that persisted cleanup through `kill` without signaling the already-terminal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,10 +335,10 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.
-Once the outer task wrapper process starts, ambiguous rejection, timeout, nonzero exit, or task-ID
-parse failure transfers cleanup ownership to the task lifecycle; only a proven pre-spawn failure may
-eager-clean caller-owned resources. Watcher completion clears a cleanup receipt only after an
-initialized cleanup owner actually succeeds. Cleanup metadata is a closed one-to-one receipt:
+Cleanup ownership transfers only when the detached task row durably records the wrapper's unique
+spawn-ownership token; process spawn and human-readable task-ID output are not receipts. Failures
+before that receipt leave cleanup with the caller. Watcher completion clears a cleanup receipt only
+after an initialized cleanup owner actually succeeds. Cleanup metadata is a closed one-to-one receipt:
 Claude settings overlays must be owned temporary directories, and Codex output-schema files must be
 exact regular, non-symlink UUID JSON files directly inside canonical `zeroshot-schema-*` temp
 directories. Unsafe or uninitialized cleanup remains persisted and warning-visible.
@@ -348,6 +348,9 @@ watcher cleanup retries that persisted cleanup through `kill` without signaling 
 provider boundary; success clears the receipt and failure keeps it retryable. If watcher termination
 cannot confirm that boundary, the task remains nonterminal with its PID, process group, strategy,
 and cleanup ownership intact; retry and cleanup stay blocked until a later kill confirms termination.
+Cancellation before PID publication is a durable task intent. Both watcher paths check it before
+provider spawn and immediately after publishing the owned PID boundary; callers retain their task
+handle until terminal state and command cleanup are both confirmed.
 
 ### Guidance Messaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,9 +336,11 @@ POSIX providers run in a dedicated process group; Windows providers use the exac
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.
 Killed/stale recovery consumes the persisted cleanup, and recursive cleanup is restricted to
-Zeroshot-owned provider overlays. If watcher termination cannot confirm that boundary, the task
-remains nonterminal with its PID, process group, strategy, and cleanup ownership intact; retry and
-cleanup stay blocked until a later kill confirms termination.
+Zeroshot-owned provider overlays. A terminal task that retains cleanup ownership after a failed
+watcher cleanup retries that persisted cleanup through `kill` without signaling the already-terminal
+provider boundary; success clears the receipt and failure keeps it retryable. If watcher termination
+cannot confirm that boundary, the task remains nonterminal with its PID, process group, strategy,
+and cleanup ownership intact; retry and cleanup stay blocked until a later kill confirms termination.
 
 ### Guidance Messaging
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -3806,6 +3806,22 @@ program
     }
   });
 
+// Resolve the durable task ownership receipt for an in-flight detached launch.
+program
+  .command('get-task-id-by-spawn-token <token>')
+  .description('Output task ID for an internal spawn ownership token (machine-readable)')
+  .action(async (token) => {
+    try {
+      const { getTaskIdBySpawnToken } = await import(
+        '../task-lib/commands/get-task-id-by-spawn-token.js'
+      );
+      getTaskIdBySpawnToken(token);
+    } catch (error) {
+      console.error('Error resolving task spawn ownership:', error.message);
+      process.exit(1);
+    }
+  });
+
 function failTuiUnavailable() {
   console.error(
     'The TUI is not included in this Zeroshot release. Use `zeroshot logs -f`, `zeroshot logs -w`, or `zeroshot list` instead.'

--- a/cluster-hooks/block-ask-user-question.py
+++ b/cluster-hooks/block-ask-user-question.py
@@ -2,9 +2,8 @@
 """
 PreToolUse hook to block AskUserQuestion in zeroshot agent mode.
 
-This hook is installed globally but ONLY activates when the environment
-variable ZEROSHOT_BLOCK_ASK_USER=1 is set. This keeps the blocking
-specific to zeroshot invocations without affecting normal Claude usage.
+This hook is loaded from a per-run Zeroshot settings overlay and only activates
+when the environment variable ZEROSHOT_BLOCK_ASK_USER=1 is set.
 
 Exit codes:
 - 0 with JSON: Normal execution (allow/deny decision)

--- a/cluster-hooks/block-dangerous-git.py
+++ b/cluster-hooks/block-dangerous-git.py
@@ -2,9 +2,8 @@
 """
 PreToolUse hook to block dangerous git commands in zeroshot worktree mode.
 
-This hook is installed globally but ONLY activates when the environment
-variable ZEROSHOT_WORKTREE=1 is set. This keeps the blocking specific to
-worktree-isolated zeroshot invocations.
+This hook is loaded from a per-run Zeroshot settings overlay and only activates
+when the environment variable ZEROSHOT_WORKTREE=1 is set.
 
 Blocks:
 - git stash (all forms) - hides work from other agents

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -1,4 +1,5 @@
 import { stringifyJson } from '../json';
+import { contractError } from '../contract-errors';
 import {
   type BuildProviderCommandOptions,
   type ClaudeCliFeatures,
@@ -65,6 +66,10 @@ function detectCliFeatures(helpText?: string | null): ClaudeCliFeatures {
     supportsVerbose: unknown ? true : /--verbose/.test(help),
     supportsModel: unknown ? true : /--model/.test(help),
     supportsEffort: unknown ? true : /--effort/.test(help),
+    // Settings carry mandatory safety hooks, so an unprobed or old CLI must
+    // fail closed before a provider process is spawned.
+    supportsSettings: !unknown && /--settings/.test(help),
+    supportsMcpConfig: !unknown && /--mcp-config/.test(help),
     unknown,
   };
 }
@@ -130,6 +135,33 @@ function addSettingsArgs(args: string[], options: BuildProviderCommandOptions): 
   }
 }
 
+function addMcpConfigArgs(args: string[], options: BuildProviderCommandOptions): void {
+  if (!options.mcpConfig?.length) return;
+  args.push('--mcp-config', ...options.mcpConfig);
+}
+
+function failClosedUnsupportedRunConfig(options: BuildProviderCommandOptions): void {
+  const features = optionFeatures(options);
+  if (options.claudeSettingsFile?.trim() && features.supportsSettings === false) {
+    throw contractError({
+      code: 'invalid-field',
+      field: 'options.cliFeatures.supportsSettings',
+      exitCode: 2,
+      message:
+        'Claude CLI does not advertise --settings support required for Zeroshot safety hooks. Upgrade Claude Code before running this task.',
+    });
+  }
+  if (options.mcpConfig?.length && features.supportsMcpConfig === false) {
+    throw contractError({
+      code: 'invalid-field',
+      field: 'options.cliFeatures.supportsMcpConfig',
+      exitCode: 2,
+      message:
+        'Claude CLI does not advertise --mcp-config support required to preserve repository MCP tools. Upgrade Claude Code before running this task.',
+    });
+  }
+}
+
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
   const warnings: WarningMetadata[] = [];
@@ -177,10 +209,15 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
 }
 
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
+  failClosedUnsupportedRunConfig(options);
   const { command, args: commandPrefix } = resolveClaudeCommand();
-  const args: string[] = [...commandPrefix, '--print', '--input-format', 'text'];
+  const args: string[] = [...commandPrefix, '--print'];
   const authEnv = options.authEnv ?? {};
 
+  // --mcp-config is variadic. A following option terminates its values before
+  // the positional prompt.
+  addMcpConfigArgs(args, options);
+  args.push('--input-format', 'text');
   addOutputArgs(args, options);
   addSchemaArgs(args, options);
   addModelArgs(args, options);

--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -123,6 +123,13 @@ function addSessionArgs(args: string[], options: BuildProviderCommandOptions): v
   }
 }
 
+function addSettingsArgs(args: string[], options: BuildProviderCommandOptions): void {
+  const settingsPath = options.claudeSettingsFile?.trim();
+  if (settingsPath) {
+    args.push('--settings', settingsPath);
+  }
+}
+
 function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
   const warnings: WarningMetadata[] = [];
@@ -179,6 +186,7 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
   addModelArgs(args, options);
   addAutoApproveArgs(args, options);
   addSessionArgs(args, options);
+  addSettingsArgs(args, options);
 
   args.push(context);
 

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -208,6 +208,11 @@ function normalizeBuildOptions(value: Record<string, unknown>): BuildProviderCom
     'continueSession',
     optionalBooleanValue(value.continueSession, 'options.continueSession')
   );
+  addDefined(
+    result,
+    'claudeSettingsFile',
+    optionalStringValue(value.claudeSettingsFile, 'options.claudeSettingsFile')
+  );
   addDefined(result, 'cliFeatures', optionalCliFeatures(value.cliFeatures));
   addDefined(result, 'mcpConfig', optionalMcpConfig(value.mcpConfig));
   addDefined(

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -23,6 +23,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsVerbose',
   'supportsModel',
   'supportsEffort',
+  'supportsSettings',
   'supportsJson',
   'supportsOutputSchema',
   'supportsDir',

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -96,6 +96,8 @@ export interface ClaudeCliFeatures extends BaseCliFeatures {
   readonly supportsVerbose: boolean;
   readonly supportsModel: boolean;
   readonly supportsEffort: boolean;
+  readonly supportsSettings: boolean;
+  readonly supportsMcpConfig: boolean;
 }
 
 export interface CodexCliFeatures extends BaseCliFeatures {
@@ -188,6 +190,7 @@ export interface CliFeatureOverrides {
   readonly supportsVerbose?: boolean;
   readonly supportsModel?: boolean;
   readonly supportsEffort?: boolean;
+  readonly supportsSettings?: boolean;
   readonly supportsJson?: boolean;
   readonly supportsOutputSchema?: boolean;
   readonly supportsDir?: boolean;
@@ -223,10 +226,10 @@ export interface CliFeatureOverrides {
 }
 
 export interface CleanupMetadata {
-  readonly kind: 'temp-file';
+  readonly kind: 'temp-file' | 'temp-directory';
   readonly provider: ProviderId;
   readonly path: string;
-  readonly reason: 'output-schema';
+  readonly reason: 'output-schema' | 'settings-overlay';
 }
 
 export interface WarningMetadata {

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -260,6 +260,7 @@ export interface BuildProviderCommandOptions {
   readonly autoApprove?: boolean;
   readonly resumeSessionId?: string;
   readonly continueSession?: boolean;
+  readonly claudeSettingsFile?: string;
   readonly cliFeatures?: CliFeatureOverrides;
   readonly authEnv?: Readonly<Record<string, string>>;
   readonly strictSchema?: boolean;

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -268,10 +268,9 @@ export interface BuildProviderCommandOptions {
   readonly authEnv?: Readonly<Record<string, string>>;
   readonly strictSchema?: boolean;
   readonly gateway?: GatewayBuildOptions;
-  // MCP server configs forwarded to providers that accept an MCP config CLI flag (currently
-  // Copilot's `--additional-mcp-config`). Each entry is an inline JSON string (the standard
-  // `{"mcpServers": {...}}` envelope) or an `@<path>` file reference; adapters emit one flag per
-  // entry. Providers whose adapter models no MCP flag ignore this field.
+  // MCP server configs forwarded to providers that accept an MCP config CLI flag. Claude accepts
+  // one variadic `--mcp-config` followed by file paths; adapters such as Copilot accept repeated
+  // flags with inline JSON so configs survive container path translation.
   readonly mcpConfig?: readonly string[];
 }
 

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -1283,6 +1283,7 @@ function exhaustLivenessTermination(agent, context, terminationError) {
   error.restartExhausted = true;
   error.terminationExhausted = true;
   error.terminationAttempts = attempts;
+  error.retainTaskHandle = true;
 
   agent.state = 'error';
   agent.cluster.failureInfo = {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -201,7 +201,7 @@ function start(agent) {
 async function stop(agent) {
   stopLivenessCheck(agent);
 
-  if (!agent.running) {
+  if (!agent.running && !agent.currentTask) {
     return;
   }
 

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -215,7 +215,10 @@ async function stop(agent) {
 
   // Kill current task if any
   if (agent.currentTask) {
-    await agent._killTask('Task stopped by cluster shutdown');
+    const termination = await agent._killTask('Task stopped by cluster shutdown');
+    if (termination?.forced === false) {
+      throw new Error(`Task shutdown could not confirm termination: ${termination.reason}`);
+    }
   }
 
   // Wait for in-flight execution to complete (up to 5 seconds)
@@ -477,7 +480,8 @@ function publishTokenUsage(agent, result) {
   });
 }
 
-function clearTransientTaskState(agent) {
+function clearTransientTaskState(agent, error = null) {
+  if (error?.retainTaskHandle) return;
   stopLivenessCheck(agent);
   agent.currentTask = null;
   agent.currentTaskId = null;
@@ -1052,7 +1056,7 @@ async function executeTask(agent, triggeringMessage) {
           code: error.code || null,
           attempt,
         });
-        clearTransientTaskState(agent);
+        clearTransientTaskState(agent, error);
         logTaskAttemptFailure(agent, attempt, maxRetries, error);
         // Model unavailability on Vertex is deterministic — retrying wastes nothing but time.
         await handleFinalFailure(agent, triggeringMessage, error, attempt);
@@ -1065,7 +1069,7 @@ async function executeTask(agent, triggeringMessage) {
         code: error.code || null,
         attempt,
       });
-      clearTransientTaskState(agent);
+      clearTransientTaskState(agent, error);
       const stuckTaskResult = await handleRecoverableStuckTaskFailure({
         agent,
         triggeringMessage,
@@ -1228,7 +1232,9 @@ function attemptLivenessTermination(agent, settings) {
   Promise.resolve()
     .then(() => agent._killTask({ reason: context.reason, code: context.code }))
     .then((termination) => {
-      if (termination?.forced === false) return;
+      if (termination?.forced === false) {
+        throw new Error(termination.reason || 'Task termination was not confirmed');
+      }
       publishLivenessTerminationEvent(agent, context);
     })
     .catch((error) => {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1377,10 +1377,26 @@ function handleStatusExecError({ agent, state, ctPath, taskId, error, stderr, re
   return true;
 }
 
+function hasPendingCommandCleanup(statusOutput) {
+  return /Cleanup:\s+pending/i.test(stripAnsiCodes(statusOutput));
+}
+
+function retryHostTerminalCleanup({ agent, taskId, state, ctPath }) {
+  if (state.commandCleanupRecoveryPending) return;
+  state.commandCleanupRecoveryPending = true;
+  runCommandWithTimeout(ctPath, ['kill', taskId], { timeout: 10000 }, (error) => {
+    state.commandCleanupRecoveryPending = false;
+    if (error) {
+      agent._log(`[${agent.id}] Terminal command cleanup recovery will retry: ${error.message}`);
+    }
+  });
+}
+
 function handleStatusCompletion({
   agent,
   taskId,
   providerName,
+  ctPath,
   state,
   stdout,
   pollLogFile,
@@ -1391,6 +1407,11 @@ function handleStatusCompletion({
 
   if (!isCompleted && !isFailed && !isStale && !isKilled) {
     return false;
+  }
+
+  if (hasPendingCommandCleanup(cleanStdout)) {
+    retryHostTerminalCleanup({ agent, taskId, state, ctPath });
+    return true;
   }
 
   pollLogFile();
@@ -1487,6 +1508,7 @@ function createLogFollower({ agent, taskId, fsModule, ctPath, providerName }) {
           state.consecutiveExecFailures = 0;
           handleStatusCompletion({
             agent,
+            ctPath,
             taskId,
             providerName,
             state,
@@ -1511,7 +1533,7 @@ function createLogFollower({ agent, taskId, fsModule, ctPath, providerName }) {
  */
 function followClaudeTaskLogs(agent, taskId) {
   const fsModule = require('fs');
-  const ctPath = getClaudeTasksPath();
+  const ctPath = agent.taskCliPath || getClaudeTasksPath();
   const providerName = agent._resolveProvider ? agent._resolveProvider() : 'claude';
 
   return createLogFollower({ agent, taskId, fsModule, ctPath, providerName });
@@ -1880,6 +1902,13 @@ function rejectIsolatedFollower({ agent, state, cleanup, reject, error }) {
   reject(error);
 }
 
+function rejectIsolatedFollowerRetainingHandle({ state, cleanup, reject, error }) {
+  if (state.resolved || state.failureSettled) return;
+  state.failureSettled = true;
+  cleanup();
+  reject(error);
+}
+
 async function resolveIsolatedTaskIdBySpawnToken(manager, clusterId, ownershipToken) {
   const result = await manager.execInContainer(clusterId, [
     'zeroshot',
@@ -2096,7 +2125,7 @@ function buildIsolatedLifecycleHandle({
     terminate,
     kill: terminate,
     failClosed(error) {
-      rejectIsolatedFollower({ agent, state, cleanup, reject, error });
+      rejectIsolatedFollowerRetainingHandle({ state, cleanup, reject, error });
     },
   };
 }
@@ -2169,6 +2198,7 @@ function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLi
   });
 }
 
+
 async function checkIsolatedStatus({
   agent,
   manager,
@@ -2195,6 +2225,28 @@ async function checkIsolatedStatus({
   const isNotFound = statusOutput.includes('not_found');
 
   if (!status && !isNotFound) {
+    return;
+  }
+
+  if (status && hasPendingCommandCleanup(statusOutput)) {
+    if (!state.commandCleanupRecoveryPromise) {
+      const recovery = manager.execInContainer(clusterId, ['zeroshot', 'kill', taskId]);
+      state.commandCleanupRecoveryPromise = recovery;
+      try {
+        const result = await recovery;
+        if (result.code !== 0) {
+          agent._log(
+            `[${agent.id}] Isolated terminal command cleanup recovery will retry: ${
+              result.stderr || result.stdout || `exit ${result.code}`
+            }`
+          );
+        }
+      } finally {
+        if (state.commandCleanupRecoveryPromise === recovery) {
+          state.commandCleanupRecoveryPromise = null;
+        }
+      }
+    }
     return;
   }
 

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -20,7 +20,11 @@ const { loadSettings } = require('../../lib/settings.js');
 const { resolveClaudeAuth } = require('../../lib/settings/claude-auth.js');
 const { prependWorktreeToolBinToEnv } = require('../worktree-tooling-env.js');
 const {
-  prepareClaudeConfigDir,
+  CLAUDE_SETTINGS_ENV,
+  cleanupClaudeSettingsOverlay,
+  ensureAskUserQuestionHook,
+  ensureDangerousGitHook,
+  prepareClaudeSettingsOverlay,
   resolveRepoMcpConfigPath,
 } = require('../worktree-claude-config.js');
 const {
@@ -372,10 +376,6 @@ function extractErrorContext({ output, statusOutput, taskId, isNotFound = false,
   return sanitizeErrorMessage(`Task failed. Output: ${trimmedOutput}`);
 }
 
-// Track which config dirs already have zeroshot-installed hooks.
-const askUserQuestionHookInstalledDirs = new Set();
-const dangerousGitHookInstalledDirs = new Set();
-
 /**
  * Extract token usage from NDJSON output.
  * Looks for the 'result' event line which contains usage data.
@@ -427,162 +427,6 @@ function extractTokenUsage(output, providerName = 'claude') {
     durationMs: resultEvent.duration || null,
     modelUsage: resultEvent.modelUsage || null,
   };
-}
-
-/**
- * Ensure the AskUserQuestion blocking hook is installed in user's Claude config.
- * This adds defense-in-depth by blocking the tool at the Claude CLI level.
- * Modifies ~/.claude/settings.json and copies hook script to ~/.claude/hooks/
- *
- * Safe to call multiple times - only modifies config once per process.
- */
-function ensureAskUserQuestionHook(targetClaudeDir = null) {
-  const userClaudeDir =
-    targetClaudeDir || process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-  if (askUserQuestionHookInstalledDirs.has(userClaudeDir)) {
-    return;
-  }
-  const hooksDir = path.join(userClaudeDir, 'hooks');
-  const settingsPath = path.join(userClaudeDir, 'settings.json');
-  const hookScriptName = 'block-ask-user-question.py';
-  const hookScriptDst = path.join(hooksDir, hookScriptName);
-
-  // Ensure hooks directory exists
-  if (!fs.existsSync(hooksDir)) {
-    fs.mkdirSync(hooksDir, { recursive: true });
-  }
-
-  // Copy hook script if not present or outdated
-  const hookScriptSrc = path.join(__dirname, '..', '..', 'cluster-hooks', hookScriptName);
-  if (fs.existsSync(hookScriptSrc)) {
-    // Always copy to ensure latest version
-    fs.copyFileSync(hookScriptSrc, hookScriptDst);
-    fs.chmodSync(hookScriptDst, 0o755);
-  }
-
-  // Read existing settings or create new
-  let settings = {};
-  if (fs.existsSync(settingsPath)) {
-    try {
-      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    } catch (e) {
-      console.warn(`[AgentTaskExecutor] Could not parse settings.json, creating new: ${e.message}`);
-      settings = {};
-    }
-  }
-
-  // Ensure hooks structure exists
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-  if (!settings.hooks.PreToolUse) {
-    settings.hooks.PreToolUse = [];
-  }
-
-  // Check if AskUserQuestion hook already exists
-  const hasHook = settings.hooks.PreToolUse.some(
-    (entry) =>
-      entry.matcher === 'AskUserQuestion' ||
-      (entry.hooks && entry.hooks.some((h) => h.command && h.command.includes(hookScriptName)))
-  );
-
-  if (!hasHook) {
-    // Add the hook
-    settings.hooks.PreToolUse.push({
-      matcher: 'AskUserQuestion',
-      hooks: [
-        {
-          type: 'command',
-          command: hookScriptDst,
-        },
-      ],
-    });
-
-    // Write updated settings
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
-    console.log(`[AgentTaskExecutor] Installed AskUserQuestion blocking hook in ${settingsPath}`);
-  }
-
-  askUserQuestionHookInstalledDirs.add(userClaudeDir);
-}
-
-/**
- * Ensure the dangerous git blocking hook is installed in user's Claude config.
- * This blocks dangerous git commands like stash, checkout --, reset --hard, etc.
- * Modifies ~/.claude/settings.json and copies hook script to ~/.claude/hooks/
- *
- * Only used in worktree mode - Docker isolation mode has its own git-safe.sh wrapper.
- * Safe to call multiple times - only modifies config once per process.
- */
-function ensureDangerousGitHook(targetClaudeDir = null) {
-  const userClaudeDir =
-    targetClaudeDir || process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-  if (dangerousGitHookInstalledDirs.has(userClaudeDir)) {
-    return;
-  }
-  const hooksDir = path.join(userClaudeDir, 'hooks');
-  const settingsPath = path.join(userClaudeDir, 'settings.json');
-  const hookScriptName = 'block-dangerous-git.py';
-  const hookScriptDst = path.join(hooksDir, hookScriptName);
-
-  // Ensure hooks directory exists
-  if (!fs.existsSync(hooksDir)) {
-    fs.mkdirSync(hooksDir, { recursive: true });
-  }
-
-  // Copy hook script if not present or outdated
-  const hookScriptSrc = path.join(__dirname, '..', '..', 'cluster-hooks', hookScriptName);
-  if (fs.existsSync(hookScriptSrc)) {
-    // Always copy to ensure latest version
-    fs.copyFileSync(hookScriptSrc, hookScriptDst);
-    fs.chmodSync(hookScriptDst, 0o755);
-  }
-
-  // Read existing settings or create new
-  let settings = {};
-  if (fs.existsSync(settingsPath)) {
-    try {
-      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    } catch (e) {
-      console.warn(`[AgentTaskExecutor] Could not parse settings.json, creating new: ${e.message}`);
-      settings = {};
-    }
-  }
-
-  // Ensure hooks structure exists
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-  if (!settings.hooks.PreToolUse) {
-    settings.hooks.PreToolUse = [];
-  }
-
-  // Check if dangerous git hook already exists
-  const hasHook = settings.hooks.PreToolUse.some(
-    (entry) =>
-      entry.matcher === 'Bash' &&
-      entry.hooks &&
-      entry.hooks.some((h) => h.command && h.command.includes(hookScriptName))
-  );
-
-  if (!hasHook) {
-    // Add the hook - matches Bash tool to check for dangerous git commands
-    settings.hooks.PreToolUse.push({
-      matcher: 'Bash',
-      hooks: [
-        {
-          type: 'command',
-          command: hookScriptDst,
-        },
-      ],
-    });
-
-    // Write updated settings
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
-    console.log(`[AgentTaskExecutor] Installed dangerous git blocking hook in ${settingsPath}`);
-  }
-
-  dangerousGitHookInstalledDirs.add(userClaudeDir);
 }
 
 /**
@@ -644,66 +488,69 @@ async function spawnClaudeTask(agent, context) {
     return spawnClaudeTaskIsolated(agent, context);
   }
 
-  // NON-ISOLATION MODE: For Claude, use user's existing Claude config
+  // NON-ISOLATION MODE: Load safety hooks through an additional per-run settings file. Claude
+  // still reads the user's normal config and the repository's project/local config.
   // AskUserQuestion blocking handled via:
   // 1. Prompt injection (see agent-context-builder)
   // 2. PreToolUse hook (defense-in-depth) - activated by ZEROSHOT_BLOCK_ASK_USER env var
-  const claudeConfigDir =
+  const claudeSettingsPath =
     providerName === 'claude'
-      ? prepareClaudeConfigDir({
-          cwd,
-          worktreePath: agent.worktree?.path || null,
+      ? prepareClaudeSettingsOverlay({
+          includeDangerousGit: Boolean(agent.worktree?.enabled),
         })
       : null;
 
-  ensureProviderHooks(agent, providerName, claudeConfigDir);
-  const spawnEnv = buildSpawnEnv(agent, providerName, modelSpec, { claudeConfigDir });
-  const taskId = await spawnTaskProcess({
-    agent,
-    ctPath,
-    args,
-    cwd,
-    spawnEnv,
-  });
+  try {
+    const spawnEnv = buildSpawnEnv(agent, providerName, modelSpec, { claudeSettingsPath });
+    const taskId = await spawnTaskProcess({
+      agent,
+      ctPath,
+      args,
+      cwd,
+      spawnEnv,
+    });
 
-  agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId}`);
+    agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId}`);
 
-  // Wait for task to be registered in zeroshot storage (race condition fix)
-  await waitForTaskReady(agent, taskId);
+    // Wait for task to be registered in zeroshot storage (race condition fix)
+    await waitForTaskReady(agent, taskId);
 
-  // CRITICAL: Poll for REAL process PID from task store
-  // The watcher spawns the actual CLI and writes PID to SQLite asynchronously.
-  // We must poll because the watcher runs in a forked process.
-  const MAX_PID_POLLS = 30; // 3 seconds max
-  const PID_POLL_DELAY = 100;
-  let realPid = null;
-  let terminalBeforePidObservation = false;
+    // CRITICAL: Poll for REAL process PID from task store
+    // The watcher spawns the actual CLI and writes PID to SQLite asynchronously.
+    // We must poll because the watcher runs in a forked process.
+    const MAX_PID_POLLS = 30; // 3 seconds max
+    const PID_POLL_DELAY = 100;
+    let realPid = null;
+    let terminalBeforePidObservation = false;
 
-  for (let i = 0; i < MAX_PID_POLLS; i++) {
-    const taskInfo = getTask(taskId);
-    if (taskInfo?.pid) {
-      realPid = taskInfo.pid;
-      break;
+    for (let i = 0; i < MAX_PID_POLLS; i++) {
+      const taskInfo = getTask(taskId);
+      if (taskInfo?.pid) {
+        realPid = taskInfo.pid;
+        break;
+      }
+      if (taskInfo && ['completed', 'failed', 'killed', 'stale'].includes(taskInfo.status)) {
+        terminalBeforePidObservation = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
     }
-    if (taskInfo && ['completed', 'failed', 'killed', 'stale'].includes(taskInfo.status)) {
-      terminalBeforePidObservation = true;
-      break;
+
+    if (realPid) {
+      agent.processPid = realPid;
+      agent._publishLifecycle('PROCESS_SPAWNED', { pid: realPid });
+      agent._log(`📋 Agent ${agent.id}: Process PID: ${realPid}`);
+    } else if (terminalBeforePidObservation) {
+      agent._log(`📋 Agent ${agent.id}: Task finished before PID observation`);
+    } else {
+      agent._log(`⚠️ Agent ${agent.id}: PID not available (task may use non-standard watcher)`);
     }
-    await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
-  }
 
-  if (realPid) {
-    agent.processPid = realPid;
-    agent._publishLifecycle('PROCESS_SPAWNED', { pid: realPid });
-    agent._log(`📋 Agent ${agent.id}: Process PID: ${realPid}`);
-  } else if (terminalBeforePidObservation) {
-    agent._log(`📋 Agent ${agent.id}: Task finished before PID observation`);
-  } else {
-    agent._log(`⚠️ Agent ${agent.id}: PID not available (task may use non-standard watcher)`);
+    // Keep the overlay alive until the provider exits, then remove it.
+    return await followClaudeTaskLogs(agent, taskId);
+  } finally {
+    cleanupClaudeSettingsOverlay(claudeSettingsPath);
   }
-
-  // Now follow the logs and stream output
-  return followClaudeTaskLogs(agent, taskId);
 }
 
 function resolveAgentModelSpec(agent) {
@@ -744,8 +591,8 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
   }
 
   // MCP servers: providers whose CLI accepts an MCP config flag (e.g. Copilot's
-  // --additional-mcp-config) cannot use the Claude config-dir overlay, so forward the repo's
-  // `.mcp.json` (the same MCP source Claude consumes) inline via `--mcp-config`.
+  // --additional-mcp-config) cannot discover Claude's project config, so forward the repo's
+  // `.mcp.json` inline via `--mcp-config`.
   for (const mcpArg of resolveMcpConfigArgs(agent, providerName)) {
     args.push(mcpArg);
   }
@@ -756,10 +603,10 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
 /**
  * Build the `--mcp-config` args for a task-run invocation, or [] when they don't apply.
  *
- * Only providers whose adapter models an MCP config CLI flag receive it — Claude consumes MCP via
- * the config-dir `.mcp.json` overlay (see prepareClaudeConfigDir) and needs no flag. The repo
- * `.mcp.json` content is inlined (not passed as an @<path> reference) so the identical value works
- * under local, worktree, and Docker isolation without host/container path translation.
+ * Only providers whose adapter models an MCP config CLI flag receive it — Claude discovers its
+ * project MCP config directly and needs no flag. The repo `.mcp.json` content is inlined (not
+ * passed as an @<path> reference) so the identical value works under local, worktree, and Docker
+ * isolation without host/container path translation.
  */
 function resolveMcpConfigArgs(agent, providerName) {
   if (!providerModelsMcpConfigFlag(providerName)) return [];
@@ -809,21 +656,8 @@ function buildFinalContext({ agent, context, desiredOutputFormat, runOutputForma
   return context;
 }
 
-function ensureProviderHooks(agent, providerName, claudeConfigDir = null) {
-  if (providerName !== 'claude') {
-    return;
-  }
-
-  ensureAskUserQuestionHook(claudeConfigDir);
-
-  // WORKTREE MODE: Install git safety hook (blocks dangerous git commands)
-  if (agent.worktree?.enabled) {
-    ensureDangerousGitHook(claudeConfigDir);
-  }
-}
-
 function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
-  const { claudeConfigDir = null } = options;
+  const { claudeSettingsPath = null } = options;
   const spawnEnv = { ...process.env };
   const agentCwd = agent.config?.cwd || agent.worktree?.path || process.cwd();
   const clusterId = agent.cluster?.id || agent.cluster_id || process.env.ZEROSHOT_CLUSTER_ID;
@@ -848,8 +682,8 @@ function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
 
   if (providerName === 'claude') {
     Object.assign(spawnEnv, buildClaudeEnv(modelSpec));
-    if (claudeConfigDir) {
-      spawnEnv.CLAUDE_CONFIG_DIR = claudeConfigDir;
+    if (claudeSettingsPath) {
+      spawnEnv[CLAUDE_SETTINGS_ENV] = claudeSettingsPath;
     }
 
     // WORKTREE MODE: Activate git safety hook via environment variable
@@ -2365,6 +2199,7 @@ async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
 
 module.exports = {
   ensureAskUserQuestionHook,
+  ensureDangerousGitHook,
   spawnClaudeTask,
   followClaudeTaskLogs,
   followClaudeTaskLogsIsolated,

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -15,7 +15,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { parseProviderChunk, getProvider } = require('../providers');
-const { getTask } = require('../../task-lib/store.js');
+const { getTask, getTaskBySpawnOwnershipToken } = require('../../task-lib/store.js');
 const { loadSettings } = require('../../lib/settings.js');
 const { resolveClaudeAuth } = require('../../lib/settings/claude-auth.js');
 const { prependWorktreeToolBinToEnv } = require('../worktree-tooling-env.js');
@@ -34,7 +34,9 @@ const {
 } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 const {
+  TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,
 } = require('../task-spawn-cleanup-ownership');
@@ -724,12 +726,14 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
 
   // spawn() throws on null bytes in argv; strip them before they get there.
   const safeArgs = args.map((arg) => (typeof arg === 'string' ? arg.replace(/\0/g, '') : arg));
+  const ownershipToken = createTaskSpawnOwnershipToken();
+  const findPersistedTaskId = () => getTaskBySpawnOwnershipToken(ownershipToken)?.id || null;
 
   return new Promise((resolve, reject) => {
     const proc = spawn(ctPath, safeArgs, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: spawnEnv,
+      env: { ...spawnEnv, [TASK_SPAWN_OWNERSHIP_TOKEN_ENV]: ownershipToken },
       windowsHide: true,
     });
 
@@ -740,7 +744,7 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
     let stdout = '';
     let stderr = '';
     let resolved = false;
-    const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(proc);
+    const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
     const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
 
     // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs
@@ -783,6 +787,7 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
           stdout,
           stderr,
           parseTaskId: parseTaskIdFromOutput,
+          persistedTaskId: findPersistedTaskId(),
         });
       } catch (error) {
         rejectWithOwnership(error);
@@ -2163,22 +2168,21 @@ async function killTask(agent, termination = 'Task killed') {
     return killIsolatedTask(agent, currentTask, taskId, reason, code);
   }
 
-  agent._stopLivenessCheck?.();
-
   // Kill the underlying task before resolving the local follower. This keeps
   // retries from racing a provider process that is still shutting down.
   if (taskId) {
-    const ctPath = getClaudeTasksPath();
+    const ctPath = agent.taskCommandPath || getClaudeTasksPath();
     try {
       // `kill` is a top-level smart command. `task kill` has never existed.
       await runCommandWithTimeout(ctPath, ['kill', taskId], { timeout: 10000 });
       agent._log?.(`Killed task ${taskId}`);
     } catch (error) {
-      // Resolve the local follower even if the task is already terminal or the
-      // management CLI is unavailable; shutdown state must still reconcile.
-      agent._log?.(`Note: Could not kill task ${taskId}: ${error.message}`);
+      agent._log?.(`Note: Could not confirm termination for task ${taskId}: ${error.message}`);
+      return { forced: false, reason: error.message };
     }
   }
+
+  agent._stopLivenessCheck?.();
 
   if (currentTask && typeof currentTask.kill === 'function') {
     currentTask.kill(reason, { code });

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -36,6 +36,7 @@ const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
 const {
   TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  callerOwnsCommandCleanup,
   createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,
@@ -762,7 +763,7 @@ function createPendingTaskLaunchHandle({
     kill(reason = 'Task killed') {
       handle.cancelled = true;
       if (cancellation) return cancellation;
-      cancellation = (async () => {
+      const cancellationAttempt = (async () => {
         let taskId = findPersistedTaskId();
         let commandError = null;
         let commandAttempted = false;
@@ -804,7 +805,18 @@ function createPendingTaskLaunchHandle({
         agent._log?.(`Cancelled pending task launch${taskId ? ` ${taskId}` : ''}: ${reason}`);
         return { forced: true, taskId: taskId || null };
       })();
-      return cancellation;
+      cancellation = cancellationAttempt;
+      cancellationAttempt.then(
+        (termination) => {
+          if (termination?.forced === false && cancellation === cancellationAttempt) {
+            cancellation = null;
+          }
+        },
+        () => {
+          if (cancellation === cancellationAttempt) cancellation = null;
+        }
+      );
+      return cancellationAttempt;
     },
   };
   return handle;
@@ -864,11 +876,37 @@ function spawnTaskProcess({
     let resolved = false;
     let timeoutError = null;
     const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
-    const rejectWithOwnership = (error) => {
-      if (!findPersistedTaskId() && wrapperClosed && agent.currentTask === pendingLaunch) {
+    const rejectWithOwnership = async (error) => {
+      const classifiedError = classifyCleanupOwnership(error);
+      if (
+        !callerOwnsCommandCleanup(classifiedError) &&
+        agent.currentTask === pendingLaunch
+      ) {
+        let termination;
+        try {
+          termination = await pendingLaunch.kill(classifiedError.message);
+        } catch (cleanupError) {
+          termination = { forced: false, reason: cleanupError.message };
+        }
+        if (termination?.forced === false) {
+          classifiedError.message += ` Task cleanup was not confirmed: ${termination.reason}`;
+          classifiedError.retainTaskHandle = true;
+          classifiedError.permanent = true;
+          classifiedError.restartExhausted = true;
+          classifiedError.terminationExhausted = true;
+          classifiedError.terminationAttempts = 1;
+          classifiedError.taskId = agent.currentTaskId || null;
+        } else if (agent.currentTask === pendingLaunch) {
+          agent.currentTask = null;
+          agent.currentTaskId = null;
+          agent.processPid = null;
+          agent.lastOutputTime = null;
+          agent.taskStartedAt = null;
+        }
+      } else if (wrapperClosed && agent.currentTask === pendingLaunch) {
         agent.currentTask = null;
       }
-      reject(classifyCleanupOwnership(error));
+      reject(classifiedError);
     };
 
     // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs
@@ -889,17 +927,17 @@ function spawnTaskProcess({
       stderr += data.toString();
     });
 
-    proc.on('close', (code, signal) => {
+    proc.on('close', async (code, signal) => {
       clearTimeout(spawnTimeout);
       if (resolved) return;
       resolved = true;
       if (timeoutError) {
-        rejectWithOwnership(timeoutError);
+        await rejectWithOwnership(timeoutError);
         return;
       }
       // Handle process killed by signal (e.g., SIGTERM, SIGKILL, SIGSTOP)
       if (signal) {
-        rejectWithOwnership(
+        await rejectWithOwnership(
           new Error(`Process killed by signal ${signal}${stderr ? `: ${stderr}` : ''}`)
         );
         return;
@@ -915,7 +953,7 @@ function spawnTaskProcess({
           persistedTaskId: findPersistedTaskId(),
         });
       } catch (error) {
-        rejectWithOwnership(error);
+        await rejectWithOwnership(error);
         return;
       }
 
@@ -1603,10 +1641,18 @@ async function spawnClaudeTaskIsolated(agent, context) {
       if (resolved) return;
       resolved = true;
       clearTimeout(spawnTimeout);
-      if (!retainHandle && agent.currentTask === isolatedPendingLaunch) {
+      const rejection = error instanceof Error ? error : new Error(String(error));
+      if (retainHandle) {
+        rejection.retainTaskHandle = true;
+        rejection.permanent = true;
+        rejection.restartExhausted = true;
+        rejection.terminationExhausted = true;
+        rejection.terminationAttempts = 1;
+        rejection.taskId = isolatedTaskId || agent.currentTaskId || null;
+      } else if (agent.currentTask === isolatedPendingLaunch) {
         agent.currentTask = null;
       }
-      reject(error);
+      reject(rejection);
     };
 
     proc.once('close', markWrapperClosed);
@@ -1719,7 +1765,10 @@ async function spawnClaudeTaskIsolated(agent, context) {
         resolved = true;
         resolve(spawnedTaskId);
       } catch (error) {
-        rejectLaunch(error, { retainHandle: Boolean(isolatedTaskId) });
+        const termination = await isolatedPendingLaunch.kill(error.message);
+        if (!resolved) {
+          rejectLaunch(error, { retainHandle: termination?.forced === false });
+        }
       }
     });
 
@@ -1877,7 +1926,7 @@ async function terminateIsolatedTask(manager, clusterId, taskId) {
   return {
     alreadyTerminal: Boolean(beforeStatus),
     forced: !beforeStatus && afterStatus === 'killed',
-    status: afterStatus,
+    status: beforeStatus || afterStatus,
   };
 }
 

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1525,10 +1525,14 @@ async function spawnClaudeTaskIsolated(agent, context) {
 
   // STEP 1: Spawn task and extract task ID (same as non-isolated mode)
   // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it
-  const SPAWN_TIMEOUT_MS = 30000; // 30 seconds to spawn task
-  // Note: Auth env vars are injected by IsolationManager, we only need model mapping here
-  const isolatedEnv =
-    providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {};
+  const SPAWN_TIMEOUT_MS = agent.spawnTimeoutMs ?? 30000;
+  const ownershipToken = createTaskSpawnOwnershipToken();
+  // Auth env vars are injected by IsolationManager; the launch token is the
+  // only authoritative bridge back to the detached task row in the container.
+  const isolatedEnv = {
+    ...(providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {}),
+    [TASK_SPAWN_OWNERSHIP_TOKEN_ENV]: ownershipToken,
+  };
 
   let isolatedPendingLaunch = null;
   const taskId = await new Promise((resolve, reject) => {
@@ -1539,6 +1543,12 @@ async function spawnClaudeTaskIsolated(agent, context) {
     let isolatedTaskId = null;
     let wrapperClosed = false;
     let resolveWrapperClose;
+    let stdout = '';
+    let stderr = '';
+    let resolved = false;
+    let timeoutError = null;
+    let spawnTimeout = null;
+    let cancellation = null;
     const waitForWrapperClose = new Promise((resolveClose) => {
       resolveWrapperClose = resolveClose;
     });
@@ -1548,6 +1558,28 @@ async function spawnClaudeTaskIsolated(agent, context) {
         resolveWrapperClose();
       }
     };
+    const findPersistedTaskId = async () => {
+      const persistedTaskId = await resolveIsolatedTaskIdBySpawnToken(
+        manager,
+        clusterId,
+        ownershipToken
+      );
+      if (persistedTaskId) {
+        isolatedTaskId = persistedTaskId;
+        assignDurableTaskId(agent, persistedTaskId);
+      }
+      return persistedTaskId;
+    };
+    const rejectLaunch = (error, { retainHandle = false } = {}) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(spawnTimeout);
+      if (!retainHandle && agent.currentTask === isolatedPendingLaunch) {
+        agent.currentTask = null;
+      }
+      reject(error);
+    };
+
     proc.once('close', markWrapperClosed);
     proc.once('error', markWrapperClosed);
     isolatedPendingLaunch = {
@@ -1555,21 +1587,56 @@ async function spawnClaudeTaskIsolated(agent, context) {
       cancelled: false,
       async kill(reason = 'Task killed') {
         isolatedPendingLaunch.cancelled = true;
-        let termination = null;
-        if (isolatedTaskId) {
-          termination = await terminateIsolatedTask(manager, clusterId, isolatedTaskId);
-          if (termination?.forced === false) return termination;
+        if (cancellation) return cancellation;
+        cancellation = (async () => {
+          let termination = null;
+          let commandError = null;
+          try {
+            const persistedTaskId = isolatedTaskId || (await findPersistedTaskId());
+            if (persistedTaskId) {
+              termination = await terminateIsolatedTask(manager, clusterId, persistedTaskId);
+            }
+          } catch (error) {
+            commandError = error;
+          }
+
+          if (!wrapperClosed) {
+            proc.kill('SIGKILL');
+            await waitForWrapperClose;
+          }
+
+          try {
+            const persistedTaskId = isolatedTaskId || (await findPersistedTaskId());
+            if (persistedTaskId && !termination) {
+              termination = await terminateIsolatedTask(manager, clusterId, persistedTaskId);
+              commandError = null;
+            }
+          } catch (error) {
+            commandError ||= error;
+          }
+
+          if (commandError) {
+            return { forced: false, reason: commandError.message };
+          }
+          agent._log?.(`Cancelled pending isolated task launch: ${reason}`);
+          return termination
+            ? { ...termination, forced: true, taskId: isolatedTaskId }
+            : { forced: true, taskId: null };
+        })();
+
+        const termination = await cancellation;
+        if (termination?.forced === false) cancellation = null;
+        if (!resolved) {
+          const error =
+            timeoutError ||
+            new Error(
+              termination?.forced === false
+                ? `Task launch cancellation was not confirmed: ${termination.reason}`
+                : `Task launch cancelled: ${isolatedTaskId || 'before persistence'}`
+            );
+          rejectLaunch(error, { retainHandle: termination?.forced === false });
         }
-        if (!wrapperClosed) {
-          proc.kill('SIGKILL');
-          await waitForWrapperClose;
-        }
-        if (isolatedTaskId && !termination) {
-          termination = await terminateIsolatedTask(manager, clusterId, isolatedTaskId);
-        }
-        if (termination?.forced === false) return termination;
-        agent._log?.(`Cancelled pending isolated task launch: ${reason}`);
-        return termination || { forced: true };
+        return termination;
       },
     };
     agent.currentTask = isolatedPendingLaunch;
@@ -1578,21 +1645,17 @@ async function spawnClaudeTaskIsolated(agent, context) {
     agent.processPid = proc.pid;
     agent._publishLifecycle('PROCESS_SPAWNED', { pid: proc.pid });
 
-    let stdout = '';
-    let stderr = '';
-    let resolved = false;
-
-    // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs
-    const spawnTimeout = setTimeout(() => {
+    // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs. Timeout
+    // uses the same cancellation path so a durable child cannot outlive it.
+    spawnTimeout = setTimeout(() => {
       if (resolved) return;
-      resolved = true;
-      proc.kill('SIGKILL');
-      reject(
-        new Error(
-          `Spawn timeout after ${SPAWN_TIMEOUT_MS / 1000}s - provider CLI hung. ` +
-            `stdout: ${stdout.slice(-500)}, stderr: ${stderr.slice(-500)}`
-        )
+      timeoutError = new Error(
+        `Spawn timeout after ${SPAWN_TIMEOUT_MS / 1000}s - provider CLI hung. ` +
+          `stdout: ${stdout.slice(-500)}, stderr: ${stderr.slice(-500)}`
       );
+      isolatedPendingLaunch.kill(timeoutError.message).catch((error) => {
+        rejectLaunch(error, { retainHandle: true });
+      });
     }, SPAWN_TIMEOUT_MS);
 
     proc.stdout.on('data', (data) => {
@@ -1603,40 +1666,41 @@ async function spawnClaudeTaskIsolated(agent, context) {
       stderr += data.toString();
     });
 
-    proc.on('close', (code, signal) => {
+    proc.on('close', async (code, signal) => {
       clearTimeout(spawnTimeout);
-      if (resolved) return;
-      resolved = true;
-      // Handle process killed by signal
+      if (resolved || isolatedPendingLaunch.cancelled) return;
       if (signal) {
-        reject(new Error(`Process killed by signal ${signal}${stderr ? `: ${stderr}` : ''}`));
+        await isolatedPendingLaunch.kill(
+          `Process killed by signal ${signal}${stderr ? `: ${stderr}` : ''}`
+        );
         return;
       }
 
-      if (code === 0) {
-        // Parse task ID from output: "✓ Task spawned: xxx-yyy-nn"
-        const spawnedTaskId = parseTaskIdFromOutput(stdout);
-        if (spawnedTaskId) {
-          isolatedTaskId = spawnedTaskId;
-          assignDurableTaskId(agent, spawnedTaskId);
-
-          resolve(spawnedTaskId);
-        } else {
-          reject(new Error(`Could not parse task ID from output: ${stdout}`));
-        }
-      } else {
-        reject(new Error(`zeroshot task run failed with code ${code}: ${stderr}`));
+      try {
+        const persistedTaskId = await findPersistedTaskId();
+        const spawnedTaskId = requireTaskIdFromWrapperResult({
+          code,
+          stdout,
+          stderr,
+          parseTaskId: parseTaskIdFromOutput,
+          persistedTaskId,
+        });
+        isolatedTaskId = spawnedTaskId;
+        assignDurableTaskId(agent, spawnedTaskId);
+        resolved = true;
+        resolve(spawnedTaskId);
+      } catch (error) {
+        rejectLaunch(error, { retainHandle: Boolean(isolatedTaskId) });
       }
     });
 
-    proc.on('error', (error) => {
-      if (!isolatedTaskId && agent.currentTask === isolatedPendingLaunch) {
-        agent.currentTask = null;
-      }
+    proc.on('error', async (error) => {
       clearTimeout(spawnTimeout);
-      if (resolved) return;
-      resolved = true;
-      reject(error);
+      if (resolved || isolatedPendingLaunch.cancelled) return;
+      const termination = await isolatedPendingLaunch.kill(error.message);
+      if (termination?.forced === false && !resolved) {
+        rejectLaunch(error, { retainHandle: true });
+      }
     });
   });
   if (isolatedPendingLaunch?.cancelled) throw new Error(`Task launch cancelled: ${taskId}`);
@@ -1738,6 +1802,25 @@ function rejectIsolatedFollower({ agent, state, cleanup, reject, error }) {
   reject(error);
 }
 
+async function resolveIsolatedTaskIdBySpawnToken(manager, clusterId, ownershipToken) {
+  const result = await manager.execInContainer(clusterId, [
+    'zeroshot',
+    'get-task-id-by-spawn-token',
+    ownershipToken,
+  ]);
+  if (result.code === 2) return null;
+  if (result.code !== 0) {
+    throw new Error(
+      `Failed to resolve isolated task ownership: ${result.stderr || result.stdout || `exit ${result.code}`}`
+    );
+  }
+  const taskId = result.stdout.trim();
+  if (!taskId) {
+    throw new Error('Isolated task ownership lookup returned an empty task ID');
+  }
+  return taskId;
+}
+
 function parseIsolatedStatus(output) {
   return output.match(/Status:\s+(completed|failed|killed|stale|cancelled)/i)?.[1].toLowerCase();
 }
@@ -1745,22 +1828,26 @@ function parseIsolatedStatus(output) {
 async function terminateIsolatedTask(manager, clusterId, taskId) {
   const before = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
   const beforeStatus = before.code === 0 ? parseIsolatedStatus(before.stdout) : null;
-  if (beforeStatus) {
-    return { alreadyTerminal: true, forced: false, status: beforeStatus };
-  }
-
   const result = await manager.execInContainer(clusterId, ['zeroshot', 'kill', taskId]);
-  const status = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
-  const afterStatus = status.code === 0 ? parseIsolatedStatus(status.stdout) : null;
-  if (!afterStatus) {
+  if (result.code !== 0) {
     throw new Error(
       `Failed to terminate isolated task ${taskId}: ${result.stderr || result.stdout || `exit ${result.code}`}`
     );
   }
 
+  const status = await manager.execInContainer(clusterId, ['zeroshot', 'status', taskId]);
+  const afterStatus = status.code === 0 ? parseIsolatedStatus(status.stdout) : null;
+  if (!afterStatus) {
+    throw new Error(
+      `Failed to confirm isolated task ${taskId} after cleanup recovery: ${
+        status.stderr || status.stdout || `exit ${status.code}`
+      }`
+    );
+  }
+
   return {
-    alreadyTerminal: false,
-    forced: afterStatus === 'killed',
+    alreadyTerminal: Boolean(beforeStatus),
+    forced: !beforeStatus && afterStatus === 'killed',
     status: afterStatus,
   };
 }
@@ -2377,24 +2464,28 @@ async function killTask(agent, termination = 'Task killed') {
 
 async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
   let termination;
-  if (currentTask && typeof currentTask.terminate === 'function') {
-    termination = await currentTask.terminate(reason, { code });
-  } else {
-    termination = await terminateIsolatedTask(
-      agent.isolation.manager,
-      agent.isolation.clusterId,
-      taskId
-    );
-    if (currentTask && typeof currentTask.kill === 'function') {
-      currentTask.kill(reason, { code });
+  try {
+    if (currentTask && typeof currentTask.terminate === 'function') {
+      termination = await currentTask.terminate(reason, { code });
+    } else {
+      termination = await terminateIsolatedTask(
+        agent.isolation.manager,
+        agent.isolation.clusterId,
+        taskId
+      );
+      if (currentTask && typeof currentTask.kill === 'function') {
+        currentTask.kill(reason, { code });
+      }
     }
+  } catch (error) {
+    return { forced: false, reason: error.message };
   }
 
-  agent._stopLivenessCheck?.();
-  if (termination?.forced === false) {
+  if (termination?.forced === false && !termination.alreadyTerminal) {
     return termination;
   }
 
+  agent._stopLivenessCheck?.();
   agent.currentTask = null;
   agent.currentTaskId = null;
   agent.processPid = null;

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -509,6 +509,7 @@ async function spawnClaudeTask(agent, context) {
       : null;
 
   let taskId;
+  let pendingLaunch;
   try {
     const spawnEnv = buildSpawnEnv(agent, providerName, modelSpec, { claudeSettingsPath });
     taskId = await spawnTaskProcess({
@@ -518,6 +519,7 @@ async function spawnClaudeTask(agent, context) {
       cwd,
       spawnEnv,
     });
+    pendingLaunch = agent.currentTask;
   } catch (error) {
     cleanupCallerOwnedCommand(error, () => cleanupClaudeSettingsOverlay(claudeSettingsPath));
     throw error;
@@ -528,6 +530,7 @@ async function spawnClaudeTask(agent, context) {
   // files that a live provider still reads.
   agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId}`);
   await waitForTaskReady(agent, taskId);
+  if (pendingLaunch?.cancelled) throw new Error(`Task launch cancelled: ${taskId}`);
 
   const MAX_PID_POLLS = 30;
   const PID_POLL_DELAY = 100;
@@ -546,6 +549,8 @@ async function spawnClaudeTask(agent, context) {
     }
     await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
   }
+
+  if (pendingLaunch?.cancelled) throw new Error(`Task launch cancelled: ${taskId}`);
 
   if (realPid) {
     agent.processPid = realPid;
@@ -720,10 +725,90 @@ function parseTaskIdFromOutput(stdout) {
   return match ? match[1] : null;
 }
 
-function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
-  // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it
-  const SPAWN_TIMEOUT_MS = 30000; // 30 seconds to spawn task
+const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
 
+function assignDurableTaskId(agent, taskId) {
+  if (!taskId || agent.currentTaskId === taskId) return;
+  agent.currentTaskId = taskId;
+  agent._publishLifecycle('TASK_ID_ASSIGNED', {
+    pid: agent.processPid,
+    taskId,
+  });
+}
+
+function createPendingTaskLaunchHandle({
+  agent,
+  proc,
+  ctPath,
+  findPersistedTaskId,
+  waitForWrapperClose,
+  isWrapperClosed,
+}) {
+  let cancellation = null;
+  const handle = {
+    pendingLaunch: true,
+    cancelled: false,
+    kill(reason = 'Task killed') {
+      handle.cancelled = true;
+      if (cancellation) return cancellation;
+      cancellation = (async () => {
+        let taskId = findPersistedTaskId();
+        let commandError = null;
+        let commandAttempted = false;
+        const cancelTask = async (persistedTaskId) => {
+          commandAttempted = true;
+          assignDurableTaskId(agent, persistedTaskId);
+          try {
+            await runCommandWithTimeout(ctPath, ['kill', persistedTaskId], { timeout: 10000 });
+          } catch (error) {
+            commandError = error;
+          }
+        };
+        if (taskId) await cancelTask(taskId);
+
+        if (!isWrapperClosed()) {
+          proc.kill('SIGKILL');
+          await waitForWrapperClose;
+        }
+
+        taskId = taskId || findPersistedTaskId();
+        if (taskId && !commandAttempted) await cancelTask(taskId);
+        if (taskId && commandError === null) {
+          const task = getTask(taskId);
+          if (!task || !TASK_TERMINAL_STATUSES.has(task.status) || task.commandCleanup) {
+            commandError = new Error(
+              `Task ${taskId} termination and command cleanup were not confirmed`
+            );
+          }
+        } else if (taskId) {
+          const task = getTask(taskId);
+          if (task && TASK_TERMINAL_STATUSES.has(task.status) && !task.commandCleanup) {
+            commandError = null;
+          }
+        }
+
+        if (commandError) {
+          return { forced: false, reason: commandError.message };
+        }
+        agent._log?.(`Cancelled pending task launch${taskId ? ` ${taskId}` : ''}: ${reason}`);
+        return { forced: true, taskId: taskId || null };
+      })();
+      return cancellation;
+    },
+  };
+  return handle;
+}
+
+function spawnTaskProcess({
+  agent,
+  ctPath,
+  args,
+  cwd,
+  spawnEnv,
+  spawnTimeoutMs = 30000,
+}) {
+  // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it.
+  const SPAWN_TIMEOUT_MS = spawnTimeoutMs;
   // spawn() throws on null bytes in argv; strip them before they get there.
   const safeArgs = args.map((arg) => (typeof arg === 'string' ? arg.replace(/\0/g, '') : arg));
   const ownershipToken = createTaskSpawnOwnershipToken();
@@ -737,6 +822,28 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
       windowsHide: true,
     });
 
+    let wrapperClosed = false;
+    let resolveWrapperClose;
+    const waitForWrapperClose = new Promise((resolveClose) => {
+      resolveWrapperClose = resolveClose;
+    });
+    const markWrapperClosed = () => {
+      if (wrapperClosed) return;
+      wrapperClosed = true;
+      resolveWrapperClose();
+    };
+    proc.once('close', markWrapperClosed);
+    proc.once('error', markWrapperClosed);
+    const pendingLaunch = createPendingTaskLaunchHandle({
+      agent,
+      proc,
+      ctPath,
+      findPersistedTaskId,
+      waitForWrapperClose,
+      isWrapperClosed: () => wrapperClosed,
+    });
+    agent.currentTask = pendingLaunch;
+
     // NOTE: Don't emit PROCESS_SPAWNED here - proc.pid is a wrapper that exits immediately.
     // Real PID comes from task store after watcher spawns the actual CLI process.
     // PROCESS_SPAWNED is emitted in spawnClaudeTask after waitForTaskReady + PID polling.
@@ -744,20 +851,23 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
     let stdout = '';
     let stderr = '';
     let resolved = false;
+    let timeoutError = null;
     const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
-    const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
+    const rejectWithOwnership = (error) => {
+      if (!findPersistedTaskId() && wrapperClosed && agent.currentTask === pendingLaunch) {
+        agent.currentTask = null;
+      }
+      reject(classifyCleanupOwnership(error));
+    };
 
     // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs
     const spawnTimeout = setTimeout(() => {
       if (resolved) return;
-      resolved = true;
-      proc.kill('SIGKILL');
-      rejectWithOwnership(
-        new Error(
-          `Spawn timeout after ${SPAWN_TIMEOUT_MS / 1000}s - provider CLI hung. ` +
-            `stdout: ${stdout.slice(-500)}, stderr: ${stderr.slice(-500)}`
-        )
+      timeoutError = new Error(
+        `Spawn timeout after ${SPAWN_TIMEOUT_MS / 1000}s - provider CLI hung. ` +
+          `stdout: ${stdout.slice(-500)}, stderr: ${stderr.slice(-500)}`
       );
+      proc.kill('SIGKILL');
     }, SPAWN_TIMEOUT_MS);
 
     proc.stdout.on('data', (data) => {
@@ -772,6 +882,10 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
       clearTimeout(spawnTimeout);
       if (resolved) return;
       resolved = true;
+      if (timeoutError) {
+        rejectWithOwnership(timeoutError);
+        return;
+      }
       // Handle process killed by signal (e.g., SIGTERM, SIGKILL, SIGSTOP)
       if (signal) {
         rejectWithOwnership(
@@ -794,11 +908,7 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
         return;
       }
 
-      agent.currentTaskId = spawnedTaskId; // Track for resume capability
-      agent._publishLifecycle('TASK_ID_ASSIGNED', {
-        pid: agent.processPid,
-        taskId: spawnedTaskId,
-      });
+      assignDurableTaskId(agent, spawnedTaskId);
 
       // Start liveness monitoring
       if (agent.enableLivenessCheck) {
@@ -1409,10 +1519,48 @@ async function spawnClaudeTaskIsolated(agent, context) {
   const isolatedEnv =
     providerName === 'claude' ? buildClaudeEnv(modelSpec, { includeAuth: false }) : {};
 
+  let isolatedPendingLaunch = null;
   const taskId = await new Promise((resolve, reject) => {
     const proc = manager.spawnInContainer(clusterId, command, {
       env: isolatedEnv,
     });
+
+    let isolatedTaskId = null;
+    let wrapperClosed = false;
+    let resolveWrapperClose;
+    const waitForWrapperClose = new Promise((resolveClose) => {
+      resolveWrapperClose = resolveClose;
+    });
+    const markWrapperClosed = () => {
+      if (wrapperClosed) return;
+      wrapperClosed = true;
+      resolveWrapperClose();
+    };
+    proc.once('close', markWrapperClosed);
+    proc.once('error', markWrapperClosed);
+    isolatedPendingLaunch = {
+      pendingLaunch: true,
+      cancelled: false,
+      async kill(reason = 'Task killed') {
+        isolatedPendingLaunch.cancelled = true;
+        let termination = null;
+        if (isolatedTaskId) {
+          termination = await terminateIsolatedTask(manager, clusterId, isolatedTaskId);
+          if (termination?.forced === false) return termination;
+        }
+        if (!wrapperClosed) {
+          proc.kill('SIGKILL');
+          await waitForWrapperClose;
+        }
+        if (isolatedTaskId && !termination) {
+          termination = await terminateIsolatedTask(manager, clusterId, isolatedTaskId);
+        }
+        if (termination?.forced === false) return termination;
+        agent._log?.(`Cancelled pending isolated task launch: ${reason}`);
+        return termination || { forced: true };
+      },
+    };
+    agent.currentTask = isolatedPendingLaunch;
 
     // Track PID for resource monitoring
     agent.processPid = proc.pid;
@@ -1457,11 +1605,8 @@ async function spawnClaudeTaskIsolated(agent, context) {
         // Parse task ID from output: "✓ Task spawned: xxx-yyy-nn"
         const spawnedTaskId = parseTaskIdFromOutput(stdout);
         if (spawnedTaskId) {
-          agent.currentTaskId = spawnedTaskId; // Track for resume capability
-          agent._publishLifecycle('TASK_ID_ASSIGNED', {
-            pid: agent.processPid,
-            taskId: spawnedTaskId,
-          });
+          isolatedTaskId = spawnedTaskId;
+          assignDurableTaskId(agent, spawnedTaskId);
 
           resolve(spawnedTaskId);
         } else {
@@ -1473,12 +1618,16 @@ async function spawnClaudeTaskIsolated(agent, context) {
     });
 
     proc.on('error', (error) => {
+      if (!isolatedTaskId && agent.currentTask === pendingLaunch) {
+        agent.currentTask = null;
+      }
       clearTimeout(spawnTimeout);
       if (resolved) return;
       resolved = true;
       reject(error);
     });
   });
+  if (isolatedPendingLaunch?.cancelled) throw new Error(`Task launch cancelled: ${taskId}`);
 
   agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId} in container...`);
 
@@ -2164,6 +2313,18 @@ async function killTask(agent, termination = 'Task killed') {
   const currentTask = agent.currentTask;
   const taskId = agent.currentTaskId;
 
+  if (currentTask?.pendingLaunch && typeof currentTask.kill === 'function') {
+    const termination = await currentTask.kill(reason, { code });
+    if (termination?.forced === false) return termination;
+    agent._stopLivenessCheck?.();
+    agent.currentTask = null;
+    agent.currentTaskId = null;
+    agent.processPid = null;
+    agent.lastOutputTime = null;
+    agent.taskStartedAt = null;
+    return termination;
+  }
+
   if (agent.isolation?.enabled && taskId) {
     return killIsolatedTask(agent, currentTask, taskId, reason, code);
   }
@@ -2185,7 +2346,7 @@ async function killTask(agent, termination = 'Task killed') {
   agent._stopLivenessCheck?.();
 
   if (currentTask && typeof currentTask.kill === 'function') {
-    currentTask.kill(reason, { code });
+    await currentTask.kill(reason, { code });
   }
 
   agent.currentTask = null;

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -25,6 +25,7 @@ const {
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
   prepareClaudeSettingsOverlay,
+  resolveContainerMcpConfigPath,
   resolveRepoMcpConfigPath,
 } = require('../worktree-claude-config.js');
 const {
@@ -614,7 +615,13 @@ function resolveMcpConfigArgs(agent, providerName) {
   if (!mcpPath) return [];
 
   if (providerName === 'claude') {
-    return ['--mcp-config', mcpPath];
+    const forwardedPath = agent.isolation?.enabled
+      ? resolveContainerMcpConfigPath({
+          cwd: agent.config?.cwd || process.cwd(),
+          worktreePath: agent.worktree?.path || null,
+        })
+      : mcpPath;
+    return forwardedPath ? ['--mcp-config', forwardedPath] : [];
   }
   if (!providerModelsMcpConfigFlag(providerName)) return [];
 

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -500,57 +500,56 @@ async function spawnClaudeTask(agent, context) {
         })
       : null;
 
+  let taskId;
   try {
     const spawnEnv = buildSpawnEnv(agent, providerName, modelSpec, { claudeSettingsPath });
-    const taskId = await spawnTaskProcess({
+    taskId = await spawnTaskProcess({
       agent,
       ctPath,
       args,
       cwd,
       spawnEnv,
     });
-
-    agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId}`);
-
-    // Wait for task to be registered in zeroshot storage (race condition fix)
-    await waitForTaskReady(agent, taskId);
-
-    // CRITICAL: Poll for REAL process PID from task store
-    // The watcher spawns the actual CLI and writes PID to SQLite asynchronously.
-    // We must poll because the watcher runs in a forked process.
-    const MAX_PID_POLLS = 30; // 3 seconds max
-    const PID_POLL_DELAY = 100;
-    let realPid = null;
-    let terminalBeforePidObservation = false;
-
-    for (let i = 0; i < MAX_PID_POLLS; i++) {
-      const taskInfo = getTask(taskId);
-      if (taskInfo?.pid) {
-        realPid = taskInfo.pid;
-        break;
-      }
-      if (taskInfo && ['completed', 'failed', 'killed', 'stale'].includes(taskInfo.status)) {
-        terminalBeforePidObservation = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
-    }
-
-    if (realPid) {
-      agent.processPid = realPid;
-      agent._publishLifecycle('PROCESS_SPAWNED', { pid: realPid });
-      agent._log(`📋 Agent ${agent.id}: Process PID: ${realPid}`);
-    } else if (terminalBeforePidObservation) {
-      agent._log(`📋 Agent ${agent.id}: Task finished before PID observation`);
-    } else {
-      agent._log(`⚠️ Agent ${agent.id}: PID not available (task may use non-standard watcher)`);
-    }
-
-    // Keep the overlay alive until the provider exits, then remove it.
-    return await followClaudeTaskLogs(agent, taskId);
-  } finally {
+  } catch (error) {
     cleanupClaudeSettingsOverlay(claudeSettingsPath);
+    throw error;
   }
+
+  // The task ID transfers provider and cleanup ownership to the detached
+  // watcher. From this point, follower/PID observation failures must not remove
+  // files that a live provider still reads.
+  agent._log(`📋 Agent ${agent.id}: Following zeroshot logs for ${taskId}`);
+  await waitForTaskReady(agent, taskId);
+
+  const MAX_PID_POLLS = 30;
+  const PID_POLL_DELAY = 100;
+  let realPid = null;
+  let terminalBeforePidObservation = false;
+
+  for (let i = 0; i < MAX_PID_POLLS; i++) {
+    const taskInfo = getTask(taskId);
+    if (taskInfo?.pid) {
+      realPid = taskInfo.pid;
+      break;
+    }
+    if (taskInfo && ['completed', 'failed', 'killed', 'stale'].includes(taskInfo.status)) {
+      terminalBeforePidObservation = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, PID_POLL_DELAY));
+  }
+
+  if (realPid) {
+    agent.processPid = realPid;
+    agent._publishLifecycle('PROCESS_SPAWNED', { pid: realPid });
+    agent._log(`📋 Agent ${agent.id}: Process PID: ${realPid}`);
+  } else if (terminalBeforePidObservation) {
+    agent._log(`📋 Agent ${agent.id}: Task finished before PID observation`);
+  } else {
+    agent._log(`⚠️ Agent ${agent.id}: PID not available (task may use non-standard watcher)`);
+  }
+
+  return followClaudeTaskLogs(agent, taskId);
 }
 
 function resolveAgentModelSpec(agent) {
@@ -590,9 +589,9 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
     args.push('--json-schema', schema);
   }
 
-  // MCP servers: providers whose CLI accepts an MCP config flag (e.g. Copilot's
-  // --additional-mcp-config) cannot discover Claude's project config, so forward the repo's
-  // `.mcp.json` inline via `--mcp-config`.
+  // MCP servers: explicitly forward the repo config through the task CLI.
+  // Claude receives the path; providers such as Copilot receive inlined JSON
+  // so it survives container path translation.
   for (const mcpArg of resolveMcpConfigArgs(agent, providerName)) {
     args.push(mcpArg);
   }
@@ -603,19 +602,21 @@ function buildTaskRunArgs({ agent, providerName, modelSpec, runOutputFormat }) {
 /**
  * Build the `--mcp-config` args for a task-run invocation, or [] when they don't apply.
  *
- * Only providers whose adapter models an MCP config CLI flag receive it — Claude discovers its
- * project MCP config directly and needs no flag. The repo `.mcp.json` content is inlined (not
- * passed as an @<path> reference) so the identical value works under local, worktree, and Docker
- * isolation without host/container path translation.
+ * Claude receives the config path because its CLI supports `--mcp-config`.
+ * Other providers whose adapter models an MCP config flag receive inlined
+ * content so the identical value works under Docker isolation.
  */
 function resolveMcpConfigArgs(agent, providerName) {
-  if (!providerModelsMcpConfigFlag(providerName)) return [];
-
   const mcpPath = resolveRepoMcpConfigPath({
     cwd: agent.config?.cwd || process.cwd(),
     worktreePath: agent.worktree?.path || null,
   });
   if (!mcpPath) return [];
+
+  if (providerName === 'claude') {
+    return ['--mcp-config', mcpPath];
+  }
+  if (!providerModelsMcpConfigFlag(providerName)) return [];
 
   const content = fs.readFileSync(mcpPath, 'utf8').trim();
   if (content.length === 0) return [];
@@ -2200,6 +2201,7 @@ async function killIsolatedTask(agent, currentTask, taskId, reason, code) {
 module.exports = {
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
+  resolveMcpConfigArgs,
   spawnClaudeTask,
   followClaudeTaskLogs,
   followClaudeTaskLogsIsolated,

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -33,6 +33,11 @@ const {
   wrapTaskRunWithIsolatedSettings,
 } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
+const {
+  cleanupCallerOwnedCommand,
+  requireTaskIdFromWrapperResult,
+  trackTaskWrapperCleanupOwnership,
+} = require('../task-spawn-cleanup-ownership');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -512,7 +517,7 @@ async function spawnClaudeTask(agent, context) {
       spawnEnv,
     });
   } catch (error) {
-    cleanupClaudeSettingsOverlay(claudeSettingsPath);
+    cleanupCallerOwnedCommand(error, () => cleanupClaudeSettingsOverlay(claudeSettingsPath));
     throw error;
   }
 
@@ -732,13 +737,15 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
     let stdout = '';
     let stderr = '';
     let resolved = false;
+    const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(proc);
+    const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
 
     // CRITICAL: Timeout to prevent infinite hang if provider CLI hangs
     const spawnTimeout = setTimeout(() => {
       if (resolved) return;
       resolved = true;
       proc.kill('SIGKILL');
-      reject(
+      rejectWithOwnership(
         new Error(
           `Spawn timeout after ${SPAWN_TIMEOUT_MS / 1000}s - provider CLI hung. ` +
             `stdout: ${stdout.slice(-500)}, stderr: ${stderr.slice(-500)}`
@@ -760,42 +767,46 @@ function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv }) {
       resolved = true;
       // Handle process killed by signal (e.g., SIGTERM, SIGKILL, SIGSTOP)
       if (signal) {
-        reject(new Error(`Process killed by signal ${signal}${stderr ? `: ${stderr}` : ''}`));
+        rejectWithOwnership(
+          new Error(`Process killed by signal ${signal}${stderr ? `: ${stderr}` : ''}`)
+        );
         return;
       }
 
-      if (code === 0) {
-        // Parse task ID from output: "✓ Task spawned: xxx-yyy-nn"
-        // Format: <adjective>-<noun>-<digits> (may or may not have task- prefix)
-        const spawnedTaskId = parseTaskIdFromOutput(stdout);
-        if (spawnedTaskId) {
-          agent.currentTaskId = spawnedTaskId; // Track for resume capability
-          agent._publishLifecycle('TASK_ID_ASSIGNED', {
-            pid: agent.processPid,
-            taskId: spawnedTaskId,
-          });
-
-          // Start liveness monitoring
-          if (agent.enableLivenessCheck) {
-            agent.taskStartedAt = Date.now();
-            agent.lastOutputTime = agent.taskStartedAt;
-            agent._startLivenessCheck();
-          }
-
-          resolve(spawnedTaskId);
-        } else {
-          reject(new Error(`Could not parse task ID from output: ${stdout}`));
-        }
-      } else {
-        reject(new Error(`zeroshot task run failed with code ${code}: ${stderr}`));
+      let spawnedTaskId;
+      try {
+        spawnedTaskId = requireTaskIdFromWrapperResult({
+          code,
+          stdout,
+          stderr,
+          parseTaskId: parseTaskIdFromOutput,
+        });
+      } catch (error) {
+        rejectWithOwnership(error);
+        return;
       }
+
+      agent.currentTaskId = spawnedTaskId; // Track for resume capability
+      agent._publishLifecycle('TASK_ID_ASSIGNED', {
+        pid: agent.processPid,
+        taskId: spawnedTaskId,
+      });
+
+      // Start liveness monitoring
+      if (agent.enableLivenessCheck) {
+        agent.taskStartedAt = Date.now();
+        agent.lastOutputTime = agent.taskStartedAt;
+        agent._startLivenessCheck();
+      }
+
+      resolve(spawnedTaskId);
     });
 
     proc.on('error', (error) => {
       clearTimeout(spawnTimeout);
       if (resolved) return;
       resolved = true;
-      reject(error);
+      rejectWithOwnership(error);
     });
   });
 }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1543,9 +1543,10 @@ async function spawnClaudeTaskIsolated(agent, context) {
       resolveWrapperClose = resolveClose;
     });
     const markWrapperClosed = () => {
-      if (wrapperClosed) return;
-      wrapperClosed = true;
-      resolveWrapperClose();
+      if (!wrapperClosed) {
+        wrapperClosed = true;
+        resolveWrapperClose();
+      }
     };
     proc.once('close', markWrapperClosed);
     proc.once('error', markWrapperClosed);
@@ -1629,7 +1630,7 @@ async function spawnClaudeTaskIsolated(agent, context) {
     });
 
     proc.on('error', (error) => {
-      if (!isolatedTaskId && agent.currentTask === pendingLaunch) {
+      if (!isolatedTaskId && agent.currentTask === isolatedPendingLaunch) {
         agent.currentTask = null;
       }
       clearTimeout(spawnTimeout);
@@ -2332,15 +2333,15 @@ async function killTask(agent, termination = 'Task killed') {
   const taskId = agent.currentTaskId;
 
   if (currentTask?.pendingLaunch && typeof currentTask.kill === 'function') {
-    const termination = await currentTask.kill(reason, { code });
-    if (termination?.forced === false) return termination;
+    const pendingTermination = await currentTask.kill(reason, { code });
+    if (pendingTermination?.forced === false) return pendingTermination;
     agent._stopLivenessCheck?.();
     agent.currentTask = null;
     agent.currentTaskId = null;
     agent.processPid = null;
     agent.lastOutputTime = null;
     agent.taskStartedAt = null;
-    return termination;
+    return pendingTermination;
   }
 
   if (agent.isolation?.enabled && taskId) {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,8 +12,11 @@ const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
+const { getTaskBySpawnOwnershipToken } = require('../task-lib/store.js');
 const {
+  TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,
 } = require('./task-spawn-cleanup-ownership');
@@ -377,17 +380,19 @@ class ClaudeTaskRunner extends TaskRunner {
    * @returns {Promise<string>}
    */
   _spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, _agentId) {
+    const ownershipToken = createTaskSpawnOwnershipToken();
+    const findPersistedTaskId = () => getTaskBySpawnOwnershipToken(ownershipToken)?.id || null;
     return new Promise((resolve, reject) => {
       const proc = spawn(ctPath, args, {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: spawnEnv,
+        env: { ...spawnEnv, [TASK_SPAWN_OWNERSHIP_TOKEN_ENV]: ownershipToken },
         windowsHide: true,
       });
 
       let stdout = '';
       let stderr = '';
-      const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(proc);
+      const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
       const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
 
       proc.stdout.on('data', (data) => {
@@ -407,6 +412,7 @@ class ClaudeTaskRunner extends TaskRunner {
               stderr,
               parseTaskId: (output) =>
                 output.match(/Task spawned: ((?:task-)?[a-z]+-[a-z]+-[a-z0-9]+)/)?.[1],
+              persistedTaskId: findPersistedTaskId(),
             })
           );
         } catch (error) {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -520,6 +520,7 @@ class ClaudeTaskRunner extends TaskRunner {
       let statusCheckInterval = null;
       let resolved = false;
       let lineBuffer = '';
+      let cleanupRecoveryPending = false;
 
       // Get log file path
       try {
@@ -654,33 +655,43 @@ class ClaudeTaskRunner extends TaskRunner {
 
       statusCheckInterval = setInterval(() => {
         runCommand(ctPath, ['status', taskId], {}, (error, stdout) => {
-          if (resolved) return;
-
-          if (
-            !error &&
-            (stdout.includes('Status:     completed') || stdout.includes('Status:     failed'))
-          ) {
-            const success = stdout.includes('Status:     completed');
-
-            pollLogFile();
-
-            setTimeout(() => {
-              if (resolved) return;
-              resolved = true;
-
-              if (pollInterval) clearInterval(pollInterval);
-              if (statusCheckInterval) clearInterval(statusCheckInterval);
-
-              const errorContext = extractErrorContext(success, stdout);
-
-              resolve({
-                success,
-                output,
-                error: errorContext,
-                taskId,
+          if (resolved || error) return;
+          const terminalMatch = stdout.match(/Status:\s+(completed|failed)/i);
+          if (!terminalMatch) return;
+          if (/Cleanup:\s+pending/i.test(stdout)) {
+            if (!cleanupRecoveryPending) {
+              cleanupRecoveryPending = true;
+              runCommand(ctPath, ['kill', taskId], { timeout: 10000 }, (cleanupError) => {
+                cleanupRecoveryPending = false;
+                if (cleanupError) {
+                  this._log(
+                    `⚠️ [${agentId}]: Terminal cleanup recovery will retry: ${cleanupError.message}`
+                  );
+                }
               });
-            }, 500);
+            }
+            return;
           }
+
+          const success = terminalMatch[1].toLowerCase() === 'completed';
+          pollLogFile();
+
+          setTimeout(() => {
+            if (resolved) return;
+            resolved = true;
+
+            clearInterval(pollInterval);
+            clearInterval(statusCheckInterval);
+
+            const errorContext = extractErrorContext(success, stdout);
+
+            resolve({
+              success,
+              output,
+              error: errorContext,
+              taskId,
+            });
+          }, 500);
         });
       }, 1000);
 

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -17,6 +17,7 @@ const {
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
   prepareClaudeSettingsOverlay,
+  resolveContainerMcpConfigPath,
   resolveRepoMcpConfigPath,
 } = require('./worktree-claude-config');
 const {
@@ -99,6 +100,17 @@ function runCommandSync(command, args, options = {}) {
     throw error;
   }
   return result.stdout?.toString() || '';
+}
+
+function appendIsolatedMcpConfigArgs(command, provider, options) {
+  if (provider !== 'claude') return;
+  const mcpConfigPath = resolveContainerMcpConfigPath({
+    cwd: options.cwd || process.cwd(),
+    worktreePath: options.worktreePath || null,
+  });
+  if (mcpConfigPath) {
+    command.push('--mcp-config', mcpConfigPath);
+  }
 }
 
 class ClaudeTaskRunner extends TaskRunner {
@@ -676,6 +688,8 @@ class ClaudeTaskRunner extends TaskRunner {
     if (jsonSchema && runOutputFormat === 'json') {
       command.push('--json-schema', JSON.stringify(jsonSchema));
     }
+
+    appendIsolatedMcpConfigArgs(command, provider, options);
 
     let finalContext = context;
     if (jsonSchema && desiredOutputFormat === 'json' && runOutputFormat === 'stream-json') {

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -13,6 +13,11 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 const {
+  cleanupCallerOwnedCommand,
+  requireTaskIdFromWrapperResult,
+  trackTaskWrapperCleanupOwnership,
+} = require('./task-spawn-cleanup-ownership');
+const {
   CLAUDE_MCP_CONFIG_ENV,
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
@@ -213,7 +218,9 @@ class ClaudeTaskRunner extends TaskRunner {
     try {
       taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
     } catch (error) {
-      cleanupClaudeSettingsOverlay(spawnEnv[CLAUDE_SETTINGS_ENV]);
+      cleanupCallerOwnedCommand(error, () =>
+        cleanupClaudeSettingsOverlay(spawnEnv[CLAUDE_SETTINGS_ENV])
+      );
       throw error;
     }
 
@@ -380,6 +387,8 @@ class ClaudeTaskRunner extends TaskRunner {
 
       let stdout = '';
       let stderr = '';
+      const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(proc);
+      const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
 
       proc.stdout.on('data', (data) => {
         stdout += data.toString();
@@ -390,20 +399,23 @@ class ClaudeTaskRunner extends TaskRunner {
       });
 
       proc.on('close', (code) => {
-        if (code === 0) {
-          const match = stdout.match(/Task spawned: ((?:task-)?[a-z]+-[a-z]+-[a-z0-9]+)/);
-          if (match) {
-            resolve(match[1]);
-          } else {
-            reject(new Error(`Could not parse task ID from output: ${stdout}`));
-          }
-        } else {
-          reject(new Error(`zeroshot task run failed with code ${code}: ${stderr}`));
+        try {
+          resolve(
+            requireTaskIdFromWrapperResult({
+              code,
+              stdout,
+              stderr,
+              parseTaskId: (output) =>
+                output.match(/Task spawned: ((?:task-)?[a-z]+-[a-z]+-[a-z0-9]+)/)?.[1],
+            })
+          );
+        } catch (error) {
+          rejectWithOwnership(error);
         }
       });
 
       proc.on('error', (error) => {
-        reject(error);
+        rejectWithOwnership(error);
       });
     });
   }

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,7 +12,11 @@ const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
-const { prepareClaudeConfigDir } = require('./worktree-claude-config');
+const {
+  CLAUDE_SETTINGS_ENV,
+  cleanupClaudeSettingsOverlay,
+  prepareClaudeSettingsOverlay,
+} = require('./worktree-claude-config');
 const {
   appendTaskRunModelArgs,
   wrapTaskRunWithIsolatedSettings,
@@ -191,15 +195,22 @@ class ClaudeTaskRunner extends TaskRunner {
       worktreePath,
     });
 
-    const taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
+    const claudeSettingsPath =
+      providerName === 'claude' ? spawnEnv[CLAUDE_SETTINGS_ENV] || null : null;
 
-    this._log(`📋 [${agentId}]: Following zeroshot logs for ${taskId}`);
+    try {
+      const taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
 
-    // Wait for task registration
-    await this._waitForTaskReady(ctPath, taskId);
+      this._log(`📋 [${agentId}]: Following zeroshot logs for ${taskId}`);
 
-    // Follow logs until completion
-    return this._followLogs(ctPath, taskId, agentId);
+      // Wait for task registration
+      await this._waitForTaskReady(ctPath, taskId);
+
+      // Follow logs until completion
+      return await this._followLogs(ctPath, taskId, agentId);
+    } finally {
+      cleanupClaudeSettingsOverlay(claudeSettingsPath);
+    }
   }
 
   _getProviderContext(providerName, settings) {
@@ -325,10 +336,9 @@ class ClaudeTaskRunner extends TaskRunner {
       spawnEnv.ANTHROPIC_MODEL = resolvedModelSpec.model;
     }
     if (providerName === 'claude') {
-      const claudeConfigDir = prepareClaudeConfigDir({ cwd, worktreePath });
-      if (claudeConfigDir) {
-        spawnEnv.CLAUDE_CONFIG_DIR = claudeConfigDir;
-      }
+      spawnEnv[CLAUDE_SETTINGS_ENV] = prepareClaudeSettingsOverlay({
+        includeDangerousGit: Boolean(worktreePath),
+      });
     }
 
     prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -13,9 +13,11 @@ const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
 const {
+  CLAUDE_MCP_CONFIG_ENV,
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
   prepareClaudeSettingsOverlay,
+  resolveRepoMcpConfigPath,
 } = require('./worktree-claude-config');
 const {
   appendTaskRunModelArgs,
@@ -195,22 +197,19 @@ class ClaudeTaskRunner extends TaskRunner {
       worktreePath,
     });
 
-    const claudeSettingsPath =
-      providerName === 'claude' ? spawnEnv[CLAUDE_SETTINGS_ENV] || null : null;
-
+    let taskId;
     try {
-      const taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
-
-      this._log(`📋 [${agentId}]: Following zeroshot logs for ${taskId}`);
-
-      // Wait for task registration
-      await this._waitForTaskReady(ctPath, taskId);
-
-      // Follow logs until completion
-      return await this._followLogs(ctPath, taskId, agentId);
-    } finally {
-      cleanupClaudeSettingsOverlay(claudeSettingsPath);
+      taskId = await this._spawnAndGetTaskId(ctPath, args, cwd, spawnEnv, agentId);
+    } catch (error) {
+      cleanupClaudeSettingsOverlay(spawnEnv[CLAUDE_SETTINGS_ENV]);
+      throw error;
     }
+
+    // Once a task ID is returned, the detached watcher owns provider
+    // termination and command cleanup.
+    this._log(`📋 [${agentId}]: Following zeroshot logs for ${taskId}`);
+    await this._waitForTaskReady(ctPath, taskId);
+    return this._followLogs(ctPath, taskId, agentId);
   }
 
   _getProviderContext(providerName, settings) {
@@ -339,6 +338,10 @@ class ClaudeTaskRunner extends TaskRunner {
       spawnEnv[CLAUDE_SETTINGS_ENV] = prepareClaudeSettingsOverlay({
         includeDangerousGit: Boolean(worktreePath),
       });
+      const mcpConfigPath = resolveRepoMcpConfigPath({ cwd, worktreePath });
+      if (mcpConfigPath) {
+        spawnEnv[CLAUDE_MCP_CONFIG_ENV] = mcpConfigPath;
+      }
     }
 
     prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,10 +12,11 @@ const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
-const { getTaskBySpawnOwnershipToken } = require('../task-lib/store.js');
+const { getTask, getTaskBySpawnOwnershipToken } = require('../task-lib/store.js');
 const {
   TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  callerOwnsCommandCleanup,
   createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,
@@ -93,6 +94,28 @@ function runCommand(command, args, options = {}, callback = null) {
       resolve({ stdout, stderr });
     });
   });
+}
+
+const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale', 'cancelled']);
+
+async function cleanupPersistedTaskAfterLaunchFailure(ctPath, taskId) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    let commandError = null;
+    try {
+      await runCommand(ctPath, ['kill', taskId], { timeout: 10000 });
+    } catch (error) {
+      commandError = error;
+    }
+    const task = getTask(taskId);
+    if (!task || (TASK_TERMINAL_STATUSES.has(task.status) && !task.commandCleanup)) {
+      return;
+    }
+    lastError =
+      commandError ||
+      new Error(`Task ${taskId} termination and command cleanup were not confirmed`);
+  }
+  throw lastError || new Error(`Task ${taskId} cleanup failed`);
 }
 
 function runCommandSync(command, args, options = {}) {
@@ -392,8 +415,37 @@ class ClaudeTaskRunner extends TaskRunner {
 
       let stdout = '';
       let stderr = '';
+      let settled = false;
       const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
-      const rejectWithOwnership = (error) => reject(classifyCleanupOwnership(error));
+      const rejectWithOwnership = async (error) => {
+        if (settled) return;
+        settled = true;
+        const classifiedError = classifyCleanupOwnership(error);
+        if (!callerOwnsCommandCleanup(classifiedError)) {
+          classifiedError.spawnOwnershipToken = ownershipToken;
+          let persistedTaskId = null;
+          let lookupError = null;
+          try {
+            persistedTaskId = findPersistedTaskId();
+          } catch (lookupFailure) {
+            lookupError = lookupFailure;
+          }
+          classifiedError.taskId = persistedTaskId;
+          try {
+            if (lookupError) throw lookupError;
+            if (persistedTaskId) {
+              await cleanupPersistedTaskAfterLaunchFailure(ctPath, persistedTaskId);
+            }
+          } catch (cleanupError) {
+            classifiedError.message += ` Task cleanup was not confirmed: ${cleanupError.message}`;
+            classifiedError.permanent = true;
+            classifiedError.restartExhausted = true;
+            classifiedError.terminationExhausted = true;
+            classifiedError.terminationAttempts = persistedTaskId ? 3 : 1;
+          }
+        }
+        reject(classifiedError);
+      };
 
       proc.stdout.on('data', (data) => {
         stdout += data.toString();
@@ -403,25 +455,26 @@ class ClaudeTaskRunner extends TaskRunner {
         stderr += data.toString();
       });
 
-      proc.on('close', (code) => {
+      proc.on('close', async (code) => {
+        if (settled) return;
         try {
-          resolve(
-            requireTaskIdFromWrapperResult({
-              code,
-              stdout,
-              stderr,
-              parseTaskId: (output) =>
-                output.match(/Task spawned: ((?:task-)?[a-z]+-[a-z]+-[a-z0-9]+)/)?.[1],
-              persistedTaskId: findPersistedTaskId(),
-            })
-          );
+          const taskId = requireTaskIdFromWrapperResult({
+            code,
+            stdout,
+            stderr,
+            parseTaskId: (output) =>
+              output.match(/Task spawned: ((?:task-)?[a-z]+-[a-z]+-[a-z0-9]+)/)?.[1],
+            persistedTaskId: findPersistedTaskId(),
+          });
+          settled = true;
+          resolve(taskId);
         } catch (error) {
-          rejectWithOwnership(error);
+          await rejectWithOwnership(error);
         }
       });
 
-      proc.on('error', (error) => {
-        rejectWithOwnership(error);
+      proc.on('error', async (error) => {
+        await rejectWithOwnership(error);
       });
     });
   }

--- a/src/task-spawn-cleanup-ownership.js
+++ b/src/task-spawn-cleanup-ownership.js
@@ -75,6 +75,7 @@ module.exports = {
   COMMAND_CLEANUP_OWNER,
   TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  callerOwnsCommandCleanup,
   createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,

--- a/src/task-spawn-cleanup-ownership.js
+++ b/src/task-spawn-cleanup-ownership.js
@@ -1,3 +1,7 @@
+const { randomUUID } = require('node:crypto');
+
+const TASK_SPAWN_OWNERSHIP_TOKEN_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
+
 const COMMAND_CLEANUP_OWNER = Object.freeze({
   CALLER: 'caller',
   TASK_LIFECYCLE: 'task-lifecycle',
@@ -8,9 +12,9 @@ function normalizeError(error) {
 }
 
 /**
- * Mark a wrapper failure as occurring after the wrapper process started. At
- * that point task persistence may already have happened, even if human stdout
- * is malformed or the wrapper later exits non-zero.
+ * Mark a wrapper failure after the detached task record durably accepted the
+ * launch ownership token. Human stdout and process spawn events are not
+ * ownership receipts.
  */
 function transferCommandCleanupOwnership(error) {
   const normalized = normalizeError(error);
@@ -26,9 +30,24 @@ function cleanupCallerOwnedCommand(error, cleanup) {
   if (callerOwnsCommandCleanup(error)) cleanup();
 }
 
-function requireTaskIdFromWrapperResult({ code, stdout, stderr, parseTaskId }) {
+function requireTaskIdFromWrapperResult({
+  code,
+  stdout,
+  stderr,
+  parseTaskId,
+  persistedTaskId = null,
+}) {
   if (code !== 0) {
     throw new Error(`zeroshot task run failed with code ${code}: ${stderr}`);
+  }
+  if (persistedTaskId) {
+    const printedTaskId = parseTaskId(stdout);
+    if (printedTaskId && printedTaskId !== persistedTaskId) {
+      throw new Error(
+        `Task ownership receipt ${persistedTaskId} did not match wrapper output ${printedTaskId}.`
+      );
+    }
+    return persistedTaskId;
   }
   const taskId = parseTaskId(stdout);
   if (!taskId) {
@@ -37,17 +56,25 @@ function requireTaskIdFromWrapperResult({ code, stdout, stderr, parseTaskId }) {
   return taskId;
 }
 
-function trackTaskWrapperCleanupOwnership(wrapperProcess) {
-  let wrapperStarted = false;
-  wrapperProcess.once('spawn', () => {
-    wrapperStarted = true;
-  });
-  return (error) => (wrapperStarted ? transferCommandCleanupOwnership(error) : error);
+function createTaskSpawnOwnershipToken() {
+  return randomUUID();
+}
+
+function trackTaskWrapperCleanupOwnership(findPersistedTaskId) {
+  return (error) => {
+    try {
+      return findPersistedTaskId() ? transferCommandCleanupOwnership(error) : error;
+    } catch {
+      return transferCommandCleanupOwnership(error);
+    }
+  };
 }
 
 module.exports = {
   COMMAND_CLEANUP_OWNER,
+  TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
   cleanupCallerOwnedCommand,
+  createTaskSpawnOwnershipToken,
   requireTaskIdFromWrapperResult,
   trackTaskWrapperCleanupOwnership,
 };

--- a/src/task-spawn-cleanup-ownership.js
+++ b/src/task-spawn-cleanup-ownership.js
@@ -40,20 +40,21 @@ function requireTaskIdFromWrapperResult({
   if (code !== 0) {
     throw new Error(`zeroshot task run failed with code ${code}: ${stderr}`);
   }
-  if (persistedTaskId) {
+  if (!persistedTaskId) {
     const printedTaskId = parseTaskId(stdout);
-    if (printedTaskId && printedTaskId !== persistedTaskId) {
-      throw new Error(
-        `Task ownership receipt ${persistedTaskId} did not match wrapper output ${printedTaskId}.`
-      );
-    }
-    return persistedTaskId;
+    throw new Error(
+      `Detached task ownership receipt was not persisted${
+        printedTaskId ? ` for wrapper output ${printedTaskId}` : ''
+      }.`
+    );
   }
-  const taskId = parseTaskId(stdout);
-  if (!taskId) {
-    throw new Error(`Could not parse task ID from output: ${stdout}`);
+  const printedTaskId = parseTaskId(stdout);
+  if (printedTaskId && printedTaskId !== persistedTaskId) {
+    throw new Error(
+      `Task ownership receipt ${persistedTaskId} did not match wrapper output ${printedTaskId}.`
+    );
   }
-  return taskId;
+  return persistedTaskId;
 }
 
 function createTaskSpawnOwnershipToken() {

--- a/src/task-spawn-cleanup-ownership.js
+++ b/src/task-spawn-cleanup-ownership.js
@@ -1,0 +1,53 @@
+const COMMAND_CLEANUP_OWNER = Object.freeze({
+  CALLER: 'caller',
+  TASK_LIFECYCLE: 'task-lifecycle',
+});
+
+function normalizeError(error) {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Mark a wrapper failure as occurring after the wrapper process started. At
+ * that point task persistence may already have happened, even if human stdout
+ * is malformed or the wrapper later exits non-zero.
+ */
+function transferCommandCleanupOwnership(error) {
+  const normalized = normalizeError(error);
+  normalized.commandCleanupOwner = COMMAND_CLEANUP_OWNER.TASK_LIFECYCLE;
+  return normalized;
+}
+
+function callerOwnsCommandCleanup(error) {
+  return error?.commandCleanupOwner !== COMMAND_CLEANUP_OWNER.TASK_LIFECYCLE;
+}
+
+function cleanupCallerOwnedCommand(error, cleanup) {
+  if (callerOwnsCommandCleanup(error)) cleanup();
+}
+
+function requireTaskIdFromWrapperResult({ code, stdout, stderr, parseTaskId }) {
+  if (code !== 0) {
+    throw new Error(`zeroshot task run failed with code ${code}: ${stderr}`);
+  }
+  const taskId = parseTaskId(stdout);
+  if (!taskId) {
+    throw new Error(`Could not parse task ID from output: ${stdout}`);
+  }
+  return taskId;
+}
+
+function trackTaskWrapperCleanupOwnership(wrapperProcess) {
+  let wrapperStarted = false;
+  wrapperProcess.once('spawn', () => {
+    wrapperStarted = true;
+  });
+  return (error) => (wrapperStarted ? transferCommandCleanupOwnership(error) : error);
+}
+
+module.exports = {
+  COMMAND_CLEANUP_OWNER,
+  cleanupCallerOwnedCommand,
+  requireTaskIdFromWrapperResult,
+  trackTaskWrapperCleanupOwnership,
+};

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -37,6 +37,11 @@ function requireTargetClaudeDir(targetClaudeDir) {
   if (typeof targetClaudeDir !== 'string' || !targetClaudeDir) {
     throw new Error('Claude safety hooks require an explicit per-run settings directory.');
   }
+  if (!isClaudeSettingsOverlayDirectory(targetClaudeDir)) {
+    throw new Error(
+      `Claude safety hooks require a Zeroshot-owned Claude settings overlay: ${targetClaudeDir}`
+    );
+  }
   return targetClaudeDir;
 }
 
@@ -187,6 +192,26 @@ function resolveRepoMcpConfigPath(options = {}) {
   return candidates.find((candidate) => fs.existsSync(candidate)) || null;
 }
 
+function resolveContainerMcpConfigPath(options = {}) {
+  const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
+  const hostConfigPath = resolveRepoMcpConfigPath(options);
+  if (!worktreeRoot || !hostConfigPath) {
+    return null;
+  }
+
+  const relativePath = path.relative(worktreeRoot, hostConfigPath);
+  if (
+    !relativePath ||
+    path.isAbsolute(relativePath) ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error(`Repository MCP config is outside the mounted workspace: ${hostConfigPath}`);
+  }
+
+  return path.posix.join('/workspace', relativePath.split(path.sep).join('/'));
+}
+
 module.exports = {
   CLAUDE_MCP_CONFIG_ENV,
   CLAUDE_SETTINGS_ENV,
@@ -196,5 +221,6 @@ module.exports = {
   isClaudeSettingsOverlayDirectory,
   isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,
+  resolveContainerMcpConfigPath,
   resolveRepoMcpConfigPath,
 };

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -136,20 +136,27 @@ function cleanupClaudeSettingsOverlay(settingsPath) {
   return true;
 }
 
-function isClaudeSettingsOverlayPath(settingsPath) {
+function isCanonicalClaudeSettingsOverlayPath(settingsPath) {
   if (typeof settingsPath !== 'string' || !settingsPath) {
+    return false;
+  }
+  const resolvedSettingsPath = path.resolve(settingsPath);
+  const overlayDir = path.dirname(resolvedSettingsPath);
+  return (
+    resolvedSettingsPath === settingsPath &&
+    path.basename(resolvedSettingsPath) === SETTINGS_BASENAME &&
+    path.dirname(overlayDir) === path.resolve(os.tmpdir()) &&
+    path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
+  );
+}
+
+function isClaudeSettingsOverlayPath(settingsPath) {
+  if (!isCanonicalClaudeSettingsOverlayPath(settingsPath)) {
     return false;
   }
 
   const resolvedSettingsPath = path.resolve(settingsPath);
   const overlayDir = path.dirname(resolvedSettingsPath);
-  if (
-    path.basename(resolvedSettingsPath) !== SETTINGS_BASENAME ||
-    path.dirname(overlayDir) !== path.resolve(os.tmpdir()) ||
-    !path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
-  ) {
-    return false;
-  }
 
   try {
     const stat = fs.lstatSync(overlayDir);
@@ -159,6 +166,13 @@ function isClaudeSettingsOverlayPath(settingsPath) {
   } catch {
     return false;
   }
+}
+
+function isCanonicalClaudeSettingsOverlayDirectory(overlayDir) {
+  if (typeof overlayDir !== 'string' || !overlayDir) {
+    return false;
+  }
+  return isCanonicalClaudeSettingsOverlayPath(path.join(overlayDir, SETTINGS_BASENAME));
 }
 
 function isClaudeSettingsOverlayDirectory(overlayDir) {
@@ -213,6 +227,8 @@ module.exports = {
   cleanupClaudeSettingsOverlay,
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
+  isCanonicalClaudeSettingsOverlayDirectory,
+  isCanonicalClaudeSettingsOverlayPath,
   isClaudeSettingsOverlayDirectory,
   isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -10,6 +10,7 @@ const SETTINGS_BASENAME = 'settings.json';
 const OVERLAY_ROOT_BASENAME = 'zeroshot-claude-settings';
 const OVERLAY_PREFIX = 'run-';
 const CLAUDE_SETTINGS_ENV = 'ZEROSHOT_CLAUDE_SETTINGS_FILE';
+const CLAUDE_MCP_CONFIG_ENV = 'ZEROSHOT_CLAUDE_MCP_CONFIG_FILE';
 const ASK_USER_HOOK = 'block-ask-user-question.py';
 const DANGEROUS_GIT_HOOK = 'block-dangerous-git.py';
 
@@ -134,6 +135,18 @@ function prepareClaudeSettingsOverlay(options = {}) {
 }
 
 function cleanupClaudeSettingsOverlay(settingsPath) {
+  if (!isClaudeSettingsOverlayPath(settingsPath)) {
+    return false;
+  }
+
+  const overlayDir = path.dirname(path.resolve(settingsPath));
+  fs.rmSync(overlayDir, { recursive: true, force: true });
+  installedAskUserHookDirs.delete(overlayDir);
+  installedDangerousGitHookDirs.delete(overlayDir);
+  return true;
+}
+
+function isClaudeSettingsOverlayPath(settingsPath) {
   if (typeof settingsPath !== 'string' || !settingsPath) {
     return false;
   }
@@ -141,24 +154,25 @@ function cleanupClaudeSettingsOverlay(settingsPath) {
   const tempRoot = path.resolve(os.tmpdir(), OVERLAY_ROOT_BASENAME);
   const resolvedSettingsPath = path.resolve(settingsPath);
   const overlayDir = path.dirname(resolvedSettingsPath);
-  if (
-    path.basename(resolvedSettingsPath) !== SETTINGS_BASENAME ||
-    path.dirname(overlayDir) !== tempRoot ||
-    !path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
-  ) {
+  return (
+    path.basename(resolvedSettingsPath) === SETTINGS_BASENAME &&
+    path.dirname(overlayDir) === tempRoot &&
+    path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
+  );
+}
+
+function isClaudeSettingsOverlayDirectory(overlayDir) {
+  if (typeof overlayDir !== 'string' || !overlayDir) {
     return false;
   }
-
-  fs.rmSync(overlayDir, { recursive: true, force: true });
-  installedAskUserHookDirs.delete(overlayDir);
-  installedDangerousGitHookDirs.delete(overlayDir);
-  return true;
+  return isClaudeSettingsOverlayPath(path.join(overlayDir, SETTINGS_BASENAME));
 }
 
 /**
- * Resolve the repo's `.mcp.json` path for a given worktree/cwd, or null if none exists. Reused by
- * providers that consume MCP servers through a CLI flag instead of discovering the project config
- * themselves (for example, Copilot's `--additional-mcp-config`).
+ * Resolve the repo's MCP config for a given worktree/cwd. The project-root
+ * `.mcp.json` is Claude's current convention. `.claude/.mcp.json` remains a
+ * deliberate compatibility fallback for repositories created by Zeroshot's
+ * earlier worktree integration.
  */
 function resolveRepoMcpConfigPath(options = {}) {
   const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
@@ -166,15 +180,21 @@ function resolveRepoMcpConfigPath(options = {}) {
     return null;
   }
 
-  const mcpPath = path.join(worktreeRoot, CLAUDE_DIRNAME, MCP_BASENAME);
-  return fs.existsSync(mcpPath) ? mcpPath : null;
+  const candidates = [
+    path.join(worktreeRoot, MCP_BASENAME),
+    path.join(worktreeRoot, CLAUDE_DIRNAME, MCP_BASENAME),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
 }
 
 module.exports = {
+  CLAUDE_MCP_CONFIG_ENV,
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
+  isClaudeSettingsOverlayDirectory,
+  isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,
   resolveRepoMcpConfigPath,
 };

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -7,8 +7,7 @@ const { resolveWorktreeRoot } = require('./worktree-tooling-env');
 const CLAUDE_DIRNAME = '.claude';
 const MCP_BASENAME = '.mcp.json';
 const SETTINGS_BASENAME = 'settings.json';
-const OVERLAY_ROOT_BASENAME = 'zeroshot-claude-settings';
-const OVERLAY_PREFIX = 'run-';
+const OVERLAY_PREFIX = 'zeroshot-claude-settings-';
 const CLAUDE_SETTINGS_ENV = 'ZEROSHOT_CLAUDE_SETTINGS_FILE';
 const CLAUDE_MCP_CONFIG_ENV = 'ZEROSHOT_CLAUDE_MCP_CONFIG_FILE';
 const ASK_USER_HOOK = 'block-ask-user-question.py';
@@ -113,10 +112,8 @@ function ensureDangerousGitHook(targetClaudeDir) {
 }
 
 function prepareClaudeSettingsOverlay(options = {}) {
-  const tempRoot = path.join(os.tmpdir(), OVERLAY_ROOT_BASENAME);
-  fs.mkdirSync(tempRoot, { recursive: true });
-
-  const overlayDir = fs.mkdtempSync(path.join(tempRoot, OVERLAY_PREFIX));
+  const overlayDir = fs.mkdtempSync(path.join(os.tmpdir(), OVERLAY_PREFIX));
+  fs.chmodSync(overlayDir, 0o700);
   try {
     ensureAskUserQuestionHook(overlayDir);
     if (options.includeDangerousGit) {
@@ -144,14 +141,24 @@ function isClaudeSettingsOverlayPath(settingsPath) {
     return false;
   }
 
-  const tempRoot = path.resolve(os.tmpdir(), OVERLAY_ROOT_BASENAME);
   const resolvedSettingsPath = path.resolve(settingsPath);
   const overlayDir = path.dirname(resolvedSettingsPath);
-  return (
-    path.basename(resolvedSettingsPath) === SETTINGS_BASENAME &&
-    path.dirname(overlayDir) === tempRoot &&
-    path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
-  );
+  if (
+    path.basename(resolvedSettingsPath) !== SETTINGS_BASENAME ||
+    path.dirname(overlayDir) !== path.resolve(os.tmpdir()) ||
+    !path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
+  ) {
+    return false;
+  }
+
+  try {
+    const stat = fs.lstatSync(overlayDir);
+    const ownedByProcess =
+      typeof process.getuid !== 'function' || stat.uid === process.getuid();
+    return stat.isDirectory() && !stat.isSymbolicLink() && ownedByProcess && (stat.mode & 0o777) === 0o700;
+  } catch {
+    return false;
+  }
 }
 
 function isClaudeSettingsOverlayDirectory(overlayDir) {

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -127,11 +127,18 @@ function prepareClaudeSettingsOverlay(options = {}) {
 }
 
 function cleanupClaudeSettingsOverlay(settingsPath) {
+  if (!isCanonicalClaudeSettingsOverlayPath(settingsPath)) {
+    return false;
+  }
+
+  const overlayDir = path.dirname(settingsPath);
+  if (!fs.existsSync(overlayDir)) {
+    return true;
+  }
   if (!isClaudeSettingsOverlayPath(settingsPath)) {
     return false;
   }
 
-  const overlayDir = path.dirname(path.resolve(settingsPath));
   fs.rmSync(overlayDir, { recursive: true, force: true });
   return true;
 }
@@ -150,7 +157,7 @@ function isCanonicalClaudeSettingsOverlayPath(settingsPath) {
   );
 }
 
-function isClaudeSettingsOverlayPath(settingsPath) {
+function isClaudeSettingsOverlayPath(settingsPath, platform = process.platform) {
   if (!isCanonicalClaudeSettingsOverlayPath(settingsPath)) {
     return false;
   }
@@ -162,14 +169,19 @@ function isClaudeSettingsOverlayPath(settingsPath) {
     const stat = fs.lstatSync(overlayDir);
     const ownedByProcess =
       typeof process.getuid !== 'function' || stat.uid === process.getuid();
-    return stat.isDirectory() && !stat.isSymbolicLink() && ownedByProcess && (stat.mode & 0o777) === 0o700;
+    const privateMode = platform === 'win32' || (stat.mode & 0o777) === 0o700;
+    return stat.isDirectory() && !stat.isSymbolicLink() && ownedByProcess && privateMode;
   } catch {
     return false;
   }
 }
 
 function isCanonicalClaudeSettingsOverlayDirectory(overlayDir) {
-  if (typeof overlayDir !== 'string' || !overlayDir) {
+  if (
+    typeof overlayDir !== 'string' ||
+    !overlayDir ||
+    path.resolve(overlayDir) !== overlayDir
+  ) {
     return false;
   }
   return isCanonicalClaudeSettingsOverlayPath(path.join(overlayDir, SETTINGS_BASENAME));

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -3,127 +3,162 @@ const os = require('os');
 const path = require('path');
 
 const { resolveWorktreeRoot } = require('./worktree-tooling-env');
-const { provisionClaudeCredentials } = require('./claude-credentials');
 
 const CLAUDE_DIRNAME = '.claude';
-const SETTINGS_BASENAME = 'settings.json';
 const MCP_BASENAME = '.mcp.json';
+const SETTINGS_BASENAME = 'settings.json';
+const OVERLAY_ROOT_BASENAME = 'zeroshot-claude-settings';
+const OVERLAY_PREFIX = 'run-';
+const CLAUDE_SETTINGS_ENV = 'ZEROSHOT_CLAUDE_SETTINGS_FILE';
+const ASK_USER_HOOK = 'block-ask-user-question.py';
+const DANGEROUS_GIT_HOOK = 'block-dangerous-git.py';
 
-function isPlainObject(value) {
-  return value && typeof value === 'object' && !Array.isArray(value);
-}
+const installedAskUserHookDirs = new Set();
+const installedDangerousGitHookDirs = new Set();
 
-function readJsonIfExists(filePath) {
-  if (!fs.existsSync(filePath)) {
-    return null;
+function readSettings(settingsPath) {
+  if (!fs.existsSync(settingsPath)) {
+    return {};
   }
 
   try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
-    return null;
+    return JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Could not parse Claude settings overlay ${settingsPath}: ${error.message}`);
   }
 }
 
-function mergeJson(baseValue, overrideValue) {
-  if (Array.isArray(baseValue) && Array.isArray(overrideValue)) {
-    const seen = new Set();
-    const merged = [];
-
-    for (const entry of [...baseValue, ...overrideValue]) {
-      const key = JSON.stringify(entry);
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      merged.push(entry);
-    }
-
-    return merged;
-  }
-
-  if (isPlainObject(baseValue) && isPlainObject(overrideValue)) {
-    const merged = { ...baseValue };
-    for (const [key, value] of Object.entries(overrideValue)) {
-      if (Object.prototype.hasOwnProperty.call(merged, key)) {
-        merged[key] = mergeJson(merged[key], value);
-      } else {
-        merged[key] = value;
-      }
-    }
-    return merged;
-  }
-
-  return overrideValue === undefined ? baseValue : overrideValue;
+function writeSettings(settingsPath, settings) {
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), { mode: 0o600 });
 }
 
-function ensureDir(dirPath) {
-  fs.mkdirSync(dirPath, { recursive: true });
+function requireTargetClaudeDir(targetClaudeDir) {
+  if (typeof targetClaudeDir !== 'string' || !targetClaudeDir) {
+    throw new Error('Claude safety hooks require an explicit per-run settings directory.');
+  }
+  return targetClaudeDir;
 }
 
-function resolveRepoClaudeConfig(worktreeRoot) {
-  const configDir = path.join(worktreeRoot, CLAUDE_DIRNAME);
-  const settingsPath = path.join(configDir, SETTINGS_BASENAME);
-  const mcpPath = path.join(configDir, MCP_BASENAME);
+function copyHookScript(targetClaudeDir, hookScriptName) {
+  const hooksDir = path.join(targetClaudeDir, 'hooks');
+  fs.mkdirSync(hooksDir, { recursive: true });
 
-  if (!fs.existsSync(settingsPath) && !fs.existsSync(mcpPath)) {
-    return null;
-  }
-
-  return {
-    configDir,
-    settingsPath,
-    mcpPath,
-  };
-}
-
-function prepareClaudeConfigDir(options = {}) {
-  const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
-  if (!worktreeRoot) {
-    return null;
-  }
-
-  const repoConfig = resolveRepoClaudeConfig(worktreeRoot);
-  if (!repoConfig) {
-    return null;
-  }
-
-  const sourceDir =
-    options.sourceDir || process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), CLAUDE_DIRNAME);
-  const tempRoot = path.join(os.tmpdir(), 'zeroshot-claude-configs');
-  ensureDir(tempRoot);
-
-  const overlayDir = fs.mkdtempSync(path.join(tempRoot, 'config-'));
-  ensureDir(path.join(overlayDir, 'hooks'));
-  ensureDir(path.join(overlayDir, 'projects'));
-
-  provisionClaudeCredentials({ sourceDir, destDir: overlayDir });
-
-  const sourceSettings = readJsonIfExists(path.join(sourceDir, SETTINGS_BASENAME)) || {};
-  const repoSettings = readJsonIfExists(repoConfig.settingsPath) || {};
-  const mergedSettings = mergeJson(sourceSettings, repoSettings);
-  if (Object.keys(mergedSettings).length > 0) {
-    fs.writeFileSync(
-      path.join(overlayDir, SETTINGS_BASENAME),
-      JSON.stringify(mergedSettings, null, 2)
+  const sourcePath = path.join(__dirname, '..', 'cluster-hooks', hookScriptName);
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(
+      `Claude safety hook ${hookScriptName} is missing from the Zeroshot installation.`
     );
   }
 
-  const sourceMcp = readJsonIfExists(path.join(sourceDir, MCP_BASENAME)) || {};
-  const repoMcp = readJsonIfExists(repoConfig.mcpPath) || {};
-  const mergedMcp = mergeJson(sourceMcp, repoMcp);
-  if (Object.keys(mergedMcp).length > 0) {
-    fs.writeFileSync(path.join(overlayDir, MCP_BASENAME), JSON.stringify(mergedMcp, null, 2));
+  const destinationPath = path.join(hooksDir, hookScriptName);
+  fs.copyFileSync(sourcePath, destinationPath);
+  fs.chmodSync(destinationPath, 0o755);
+  return destinationPath;
+}
+
+function ensurePreToolUseHooks(settings) {
+  settings.hooks ||= {};
+  settings.hooks.PreToolUse ||= [];
+  return settings.hooks.PreToolUse;
+}
+
+function ensureAskUserQuestionHook(targetClaudeDir) {
+  const overlayDir = requireTargetClaudeDir(targetClaudeDir);
+  if (installedAskUserHookDirs.has(overlayDir)) {
+    return;
   }
 
-  return overlayDir;
+  const hookScriptPath = copyHookScript(overlayDir, ASK_USER_HOOK);
+  const settingsPath = path.join(overlayDir, SETTINGS_BASENAME);
+  const settings = readSettings(settingsPath);
+  const hooks = ensurePreToolUseHooks(settings);
+  const hasHook = hooks.some(
+    (entry) =>
+      entry.matcher === 'AskUserQuestion' ||
+      entry.hooks?.some((hook) => hook.command?.includes(ASK_USER_HOOK))
+  );
+
+  if (!hasHook) {
+    hooks.push({
+      matcher: 'AskUserQuestion',
+      hooks: [{ type: 'command', command: hookScriptPath }],
+    });
+    writeSettings(settingsPath, settings);
+  }
+
+  installedAskUserHookDirs.add(overlayDir);
+}
+
+function ensureDangerousGitHook(targetClaudeDir) {
+  const overlayDir = requireTargetClaudeDir(targetClaudeDir);
+  if (installedDangerousGitHookDirs.has(overlayDir)) {
+    return;
+  }
+
+  const hookScriptPath = copyHookScript(overlayDir, DANGEROUS_GIT_HOOK);
+  const settingsPath = path.join(overlayDir, SETTINGS_BASENAME);
+  const settings = readSettings(settingsPath);
+  const hooks = ensurePreToolUseHooks(settings);
+  const hasHook = hooks.some(
+    (entry) =>
+      entry.matcher === 'Bash' &&
+      entry.hooks?.some((hook) => hook.command?.includes(DANGEROUS_GIT_HOOK))
+  );
+
+  if (!hasHook) {
+    hooks.push({
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: hookScriptPath }],
+    });
+    writeSettings(settingsPath, settings);
+  }
+
+  installedDangerousGitHookDirs.add(overlayDir);
+}
+
+function prepareClaudeSettingsOverlay(options = {}) {
+  const tempRoot = path.join(os.tmpdir(), OVERLAY_ROOT_BASENAME);
+  fs.mkdirSync(tempRoot, { recursive: true });
+
+  const overlayDir = fs.mkdtempSync(path.join(tempRoot, OVERLAY_PREFIX));
+  try {
+    ensureAskUserQuestionHook(overlayDir);
+    if (options.includeDangerousGit) {
+      ensureDangerousGitHook(overlayDir);
+    }
+    return path.join(overlayDir, SETTINGS_BASENAME);
+  } catch (error) {
+    fs.rmSync(overlayDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function cleanupClaudeSettingsOverlay(settingsPath) {
+  if (typeof settingsPath !== 'string' || !settingsPath) {
+    return false;
+  }
+
+  const tempRoot = path.resolve(os.tmpdir(), OVERLAY_ROOT_BASENAME);
+  const resolvedSettingsPath = path.resolve(settingsPath);
+  const overlayDir = path.dirname(resolvedSettingsPath);
+  if (
+    path.basename(resolvedSettingsPath) !== SETTINGS_BASENAME ||
+    path.dirname(overlayDir) !== tempRoot ||
+    !path.basename(overlayDir).startsWith(OVERLAY_PREFIX)
+  ) {
+    return false;
+  }
+
+  fs.rmSync(overlayDir, { recursive: true, force: true });
+  installedAskUserHookDirs.delete(overlayDir);
+  installedDangerousGitHookDirs.delete(overlayDir);
+  return true;
 }
 
 /**
- * Resolve the repo's `.mcp.json` path (the same MCP-server source Claude consumes via
- * prepareClaudeConfigDir) for a given worktree/cwd, or null if none exists. Reused by providers
- * that consume MCP servers through a CLI flag instead of the Claude config-dir overlay (e.g.
- * Copilot's `--additional-mcp-config`), so both providers share one MCP config surface.
+ * Resolve the repo's `.mcp.json` path for a given worktree/cwd, or null if none exists. Reused by
+ * providers that consume MCP servers through a CLI flag instead of discovering the project config
+ * themselves (for example, Copilot's `--additional-mcp-config`).
  */
 function resolveRepoMcpConfigPath(options = {}) {
   const worktreeRoot = resolveWorktreeRoot(options.worktreePath || options.cwd);
@@ -136,6 +171,10 @@ function resolveRepoMcpConfigPath(options = {}) {
 }
 
 module.exports = {
-  prepareClaudeConfigDir,
+  CLAUDE_SETTINGS_ENV,
+  cleanupClaudeSettingsOverlay,
+  ensureAskUserQuestionHook,
+  ensureDangerousGitHook,
+  prepareClaudeSettingsOverlay,
   resolveRepoMcpConfigPath,
 };

--- a/src/worktree-claude-config.js
+++ b/src/worktree-claude-config.js
@@ -14,8 +14,6 @@ const CLAUDE_MCP_CONFIG_ENV = 'ZEROSHOT_CLAUDE_MCP_CONFIG_FILE';
 const ASK_USER_HOOK = 'block-ask-user-question.py';
 const DANGEROUS_GIT_HOOK = 'block-dangerous-git.py';
 
-const installedAskUserHookDirs = new Set();
-const installedDangerousGitHookDirs = new Set();
 
 function readSettings(settingsPath) {
   if (!fs.existsSync(settingsPath)) {
@@ -70,9 +68,6 @@ function ensurePreToolUseHooks(settings) {
 
 function ensureAskUserQuestionHook(targetClaudeDir) {
   const overlayDir = requireTargetClaudeDir(targetClaudeDir);
-  if (installedAskUserHookDirs.has(overlayDir)) {
-    return;
-  }
 
   const hookScriptPath = copyHookScript(overlayDir, ASK_USER_HOOK);
   const settingsPath = path.join(overlayDir, SETTINGS_BASENAME);
@@ -92,14 +87,10 @@ function ensureAskUserQuestionHook(targetClaudeDir) {
     writeSettings(settingsPath, settings);
   }
 
-  installedAskUserHookDirs.add(overlayDir);
 }
 
 function ensureDangerousGitHook(targetClaudeDir) {
   const overlayDir = requireTargetClaudeDir(targetClaudeDir);
-  if (installedDangerousGitHookDirs.has(overlayDir)) {
-    return;
-  }
 
   const hookScriptPath = copyHookScript(overlayDir, DANGEROUS_GIT_HOOK);
   const settingsPath = path.join(overlayDir, SETTINGS_BASENAME);
@@ -119,7 +110,6 @@ function ensureDangerousGitHook(targetClaudeDir) {
     writeSettings(settingsPath, settings);
   }
 
-  installedDangerousGitHookDirs.add(overlayDir);
 }
 
 function prepareClaudeSettingsOverlay(options = {}) {
@@ -146,8 +136,6 @@ function cleanupClaudeSettingsOverlay(settingsPath) {
 
   const overlayDir = path.dirname(path.resolve(settingsPath));
   fs.rmSync(overlayDir, { recursive: true, force: true });
-  installedAskUserHookDirs.delete(overlayDir);
-  installedDangerousGitHookDirs.delete(overlayDir);
   return true;
 }
 

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -6,7 +6,7 @@
  */
 
 import { appendFileSync } from 'fs';
-import { updateTask } from './store.js';
+import { getTask, updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
 import * as watcherOutputRuntime from './watcher-output-runtime.js';
 import { createRequire } from 'module';
@@ -17,7 +17,7 @@ import { createRequire } from 'module';
 // ═══════════════════════════════════════════════════════════════════════════
 
 const [, , taskIdArg, cwdArg, logFileArg, argsJsonArg, configJsonArg] = process.argv;
-let commandCleanup = null;
+let commandCleanup = watcherOutputRuntime.COMMAND_CLEANUP_UNINITIALIZED;
 let crashStarted = false;
 let server = null;
 
@@ -64,6 +64,16 @@ process.on('unhandledRejection', (reason) => {
   void failWatcher(reason, 'unhandledRejection');
 });
 
+const persistedTask = taskIdArg ? getTask(taskIdArg) : null;
+if (persistedTask) {
+  commandCleanup = createCommandSpecCleanup(
+    persistedTask.commandCleanup || { cleanup: [], cleanupMetadata: [] },
+    (cleanupPath, error) => {
+      emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${cleanupPath}: ${error.message}\n`);
+    }
+  );
+}
+
 const require = createRequire(import.meta.url);
 const { AttachServer } = require('../src/attach');
 const { getTaskSocketPath } = require('../src/attach/socket-paths');
@@ -80,10 +90,6 @@ const commandSpec = config.commandSpec || {
   env: config.env || {},
   cleanup: [],
 };
-commandCleanup = createCommandSpecCleanup(commandSpec, (cleanupPath, error) => {
-  emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${cleanupPath}: ${error.message}\n`);
-});
-
 const socketPath = getTaskSocketPath(taskId);
 
 function log(msg) {

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -9,12 +9,7 @@ import { appendFileSync } from 'fs';
 import { updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
 import { terminateProcess } from './process-termination.js';
-import {
-  detectProviderFatalError,
-  detectProviderStreamingModeError,
-  recoverProviderStructuredOutput,
-  supportsProviderStructuredOutputRecovery,
-} from './provider-helper-runtime.js';
+import * as watcherOutputRuntime from './watcher-output-runtime.js';
 import { createRequire } from 'module';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -41,7 +36,7 @@ function emergencyLog(msg) {
 
 async function stopAttachableProvider() {
   const pid = server?.pid;
-  if (!pid || server.state === 'exited') return true;
+  if (!pid) return true;
   const result = await terminateProcess(pid, {
     processGroupId: process.platform === 'win32' ? null : pid,
     terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
@@ -118,156 +113,28 @@ function log(msg) {
   appendFileSync(logFile, msg);
 }
 
-const providerName = normalizeProviderName(config.provider || 'claude');
-const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
-
-const env = { ...process.env, ...(commandSpec.env || {}) };
-const command = commandSpec.binary;
-const finalArgs = [...(commandSpec.args || args)];
-
-const silentJsonMode =
-  config.outputFormat === 'json' &&
-  config.jsonSchema &&
-  config.silentJsonOutput &&
-  supportsProviderStructuredOutputRecovery(providerName);
-
-let finalResultJson = null;
+const { providerName, env, command, finalArgs } = watcherOutputRuntime.resolveWatcherCommand(
+  config,
+  commandSpec,
+  args,
+  normalizeProviderName
+);
 let outputBuffer = '';
-let streamingModeError = null;
-let fatalError = null;
 
-function splitBufferLines(buffer, chunk) {
-  const nextBuffer = buffer + chunk;
-  const lines = nextBuffer.split('\n');
-  const remaining = lines.pop() || '';
-  return { lines, remaining };
-}
-
-function maybeHandleFatalError(line, timestamp) {
-  if (fatalError) {
-    return false;
-  }
-
-  const detected = detectProviderFatalError(providerName, line);
-  if (!detected) {
-    return false;
-  }
-
-  fatalError = detected;
-
-  if (silentJsonMode) {
-    log(`[${timestamp}]${line}\n`);
-  }
-  log(`[${timestamp}][FATAL] ${detected}\n`);
-
+function stopProviderAfterFatalOutput(timestamp) {
   if (server) {
     server.stop('SIGTERM').catch((error) => {
       log(`[${timestamp}][FATAL] Attach server stop failed: ${error.message}\n`);
     });
   }
-  return true;
 }
 
-function captureStreamingError(line, timestamp) {
-  const detectedError = detectProviderStreamingModeError(providerName, line);
-  if (!detectedError) {
-    return false;
-  }
-
-  streamingModeError = { ...detectedError, timestamp };
-  return true;
-}
-
-function maybeCaptureStructuredOutput(line) {
-  try {
-    const json = JSON.parse(line);
-    if (json.structured_output) {
-      finalResultJson = line;
-    }
-  } catch {
-    // Not JSON, skip
-  }
-}
-
-function handleSilentJsonLines(lines, timestamp) {
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    maybeHandleFatalError(line, timestamp);
-    if (captureStreamingError(line, timestamp)) {
-      continue;
-    }
-    maybeCaptureStructuredOutput(line);
-  }
-}
-
-function handleStreamingLines(lines, timestamp) {
-  for (const line of lines) {
-    maybeHandleFatalError(line, timestamp);
-    if (captureStreamingError(line, timestamp)) {
-      continue;
-    }
-    log(`[${timestamp}]${line}\n`);
-  }
-}
-
-function flushOutputBuffer(timestamp) {
-  if (!outputBuffer.trim()) {
-    return;
-  }
-
-  if (!enableRecovery) {
-    if (!silentJsonMode) {
-      log(`[${timestamp}]${outputBuffer}\n`);
-    }
-    return;
-  }
-
-  maybeHandleFatalError(outputBuffer, timestamp);
-  if (captureStreamingError(outputBuffer, timestamp)) {
-    return;
-  }
-
-  if (silentJsonMode) {
-    maybeCaptureStructuredOutput(outputBuffer);
-    return;
-  }
-
-  log(`[${timestamp}]${outputBuffer}\n`);
-}
-
-function attemptRecovery(code, timestamp) {
-  if (!(code !== 0 && streamingModeError?.sessionId)) {
-    return null;
-  }
-
-  const recovered = recoverProviderStructuredOutput(providerName, streamingModeError.sessionId);
-  if (recovered?.payload) {
-    const recoveredLine = JSON.stringify(recovered.payload);
-    if (silentJsonMode) {
-      finalResultJson = recoveredLine;
-    } else {
-      log(`[${timestamp}]${recoveredLine}\n`);
-    }
-  } else if (streamingModeError.line) {
-    if (silentJsonMode) {
-      log(streamingModeError.line + '\n');
-    } else {
-      log(`[${streamingModeError.timestamp}]${streamingModeError.line}\n`);
-    }
-  }
-
-  return recovered;
-}
-
-function writeCompletionFooter(code, signal) {
-  if (config.outputFormat === 'json') {
-    return;
-  }
-
-  log(`\n${'='.repeat(50)}\n`);
-  log(`Finished: ${new Date().toISOString()}\n`);
-  log(`Exit code: ${code}, Signal: ${signal}\n`);
-}
+const outputRuntime = watcherOutputRuntime.createWatcherOutputRuntime({
+  config,
+  providerName,
+  log,
+  stopProvider: stopProviderAfterFatalOutput,
+});
 
 server = new AttachServer({
   id: taskId,
@@ -281,50 +148,21 @@ server = new AttachServer({
 });
 
 server.on('output', (data) => {
-  const chunk = data.toString();
-  const timestamp = Date.now();
-
-  const { lines, remaining } = splitBufferLines(outputBuffer, chunk);
-  outputBuffer = remaining;
-
-  if (silentJsonMode) {
-    handleSilentJsonLines(lines, timestamp);
-  } else {
-    handleStreamingLines(lines, timestamp);
-  }
+  outputBuffer = outputRuntime.consumeOutput(outputBuffer, data);
 });
 
 server.on('exit', async ({ exitCode, signal }) => {
   if (crashStarted) return;
-  const timestamp = Date.now();
-  const code = exitCode;
-
-  flushOutputBuffer(timestamp);
-
-  const recovered = attemptRecovery(code, timestamp);
-
-  if (silentJsonMode && finalResultJson) {
-    log(finalResultJson + '\n');
-  }
-
-  writeCompletionFooter(code, signal);
-  const cleanupSucceeded = await commandCleanup.run();
-
-  const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
-  const status = resolvedCode === 0 ? 'completed' : 'failed';
-  try {
-    await updateTask(taskId, {
-      status,
-      pid: null,
-      processGroupId: null,
-      exitCode: resolvedCode,
-      error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
-      socketPath: null,
-      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
-    });
-  } catch (updateError) {
-    log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
-  }
+  const completion = outputRuntime.complete({ code: exitCode, signal, outputBuffer });
+  await watcherOutputRuntime.completeWatcherTask({
+    taskId,
+    completion,
+    commandCleanup,
+    terminateProvider: stopAttachableProvider,
+    updateTask,
+    emergencyLog,
+    terminalUpdates: { socketPath: null },
+  });
 
   setTimeout(() => {
     process.exit(0);

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -8,7 +8,6 @@
 import { appendFileSync } from 'fs';
 import { updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
-import { terminateProcess } from './process-termination.js';
 import * as watcherOutputRuntime from './watcher-output-runtime.js';
 import { createRequire } from 'module';
 
@@ -34,46 +33,24 @@ function emergencyLog(msg) {
   }
 }
 
-async function stopAttachableProvider() {
-  const pid = server?.pid;
-  if (!pid) return true;
-  const result = await terminateProcess(pid, {
-    processGroupId: process.platform === 'win32' ? null : pid,
-    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
-  });
-  return result.terminated;
+function stopAttachableProvider() {
+  return watcherOutputRuntime.terminateWatcherProvider(server);
 }
 
 async function failWatcher(error, source) {
   if (crashStarted) return;
   crashStarted = true;
-  const timestamp = Date.now();
-  const errorMsg = error instanceof Error ? error.stack || error.message : String(error);
-
-  emergencyLog(`\n[${timestamp}][CRASH] ${source}: ${errorMsg}\n`);
-  const providerTerminal = await stopAttachableProvider();
-  let cleanupSucceeded = false;
-  if (providerTerminal) {
-    cleanupSucceeded = commandCleanup ? await commandCleanup.run() : true;
-  } else {
-    emergencyLog(
-      `[${timestamp}][CRASH] Provider termination could not be confirmed; preserving command cleanup paths.\n`
-    );
-  }
-
   if (taskIdArg) {
-    try {
-      await updateTask(taskIdArg, {
-        status: 'failed',
-        pid: null,
-        processGroupId: null,
-        error: `${source}: ${errorMsg}`,
-        socketPath: null,
-        ...(cleanupSucceeded ? { commandCleanup: null } : {}),
-      });
-    } catch (updateError) {
-      emergencyLog(`[${timestamp}][CRASH] Failed to update task status: ${updateError.message}\n`);
-    }
+    await watcherOutputRuntime.completeWatcherFailure({
+      taskId: taskIdArg,
+      error,
+      source,
+      commandCleanup,
+      terminateProvider: stopAttachableProvider,
+      updateTask,
+      emergencyLog,
+      terminalUpdates: { socketPath: null },
+    });
   }
 
   process.exit(1);

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -119,6 +119,20 @@ const outputRuntime = watcherOutputRuntime.createWatcherOutputRuntime({
   stopProvider: stopProviderAfterFatalOutput,
 });
 
+if (
+  await watcherOutputRuntime.completePendingWatcherCancellation({
+    taskId,
+    getTask,
+    commandCleanup,
+    terminateProvider: async () => true,
+    updateTask,
+    emergencyLog,
+    terminalUpdates: { socketPath: null },
+  })
+) {
+  process.exit(0);
+}
+
 server = new AttachServer({
   id: taskId,
   socketPath,
@@ -174,6 +188,20 @@ try {
     processGroupId: process.platform === 'win32' ? null : server.pid,
     terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
   });
+
+  if (getTask(taskId)?.cancelRequested) {
+    crashStarted = true;
+    await watcherOutputRuntime.completePendingWatcherCancellation({
+      taskId,
+      getTask,
+      commandCleanup,
+      terminateProvider: stopAttachableProvider,
+      updateTask,
+      emergencyLog,
+      terminalUpdates: { socketPath: null },
+    });
+    process.exit(0);
+  }
 
   log(`[${Date.now()}][SYSTEM] Started with PTY (attachable)\n`);
   log(`[${Date.now()}][SYSTEM] Socket: ${socketPath}\n`);

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -34,8 +34,8 @@ function emergencyLog(msg) {
   }
 }
 
-function stopAttachableProvider() {
-  return watcherOutputRuntime.terminateWatcherProvider(server);
+function stopAttachableProvider(exitObserved = false) {
+  return watcherOutputRuntime.terminateWatcherProvider(server, { exitObserved });
 }
 
 async function failWatcher(error, source) {
@@ -166,7 +166,7 @@ server.on('exit', async ({ exitCode, signal }) => {
     taskId,
     completion,
     commandCleanup,
-    terminateProvider: stopAttachableProvider,
+    terminateProvider: () => stopAttachableProvider(true),
     updateTask,
     emergencyLog,
     terminalUpdates: { socketPath: null },

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -5,9 +5,10 @@
  * Runs detached from parent, provides Unix socket for attach clients.
  */
 
-import { appendFileSync, unlinkSync } from 'fs';
-import { unlink } from 'fs/promises';
+import { appendFileSync } from 'fs';
 import { updateTask } from './store.js';
+import { createCommandSpecCleanup } from './command-spec-cleanup.js';
+import { terminateProcess } from './process-termination.js';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
@@ -22,8 +23,9 @@ import { createRequire } from 'module';
 // ═══════════════════════════════════════════════════════════════════════════
 
 const [, , taskIdArg, cwdArg, logFileArg, argsJsonArg, configJsonArg] = process.argv;
-let commandSpecCleanup = [];
-let cleanupStarted = false;
+let commandCleanup = null;
+let crashStarted = false;
+let server = null;
 
 function emergencyLog(msg) {
   if (logFileArg) {
@@ -37,20 +39,42 @@ function emergencyLog(msg) {
   }
 }
 
-function crashWithError(error, source) {
+async function stopAttachableProvider() {
+  const pid = server?.pid;
+  if (!pid || server.state === 'exited') return true;
+  const result = await terminateProcess(pid, {
+    processGroupId: process.platform === 'win32' ? null : pid,
+    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+  });
+  return result.terminated;
+}
+
+async function failWatcher(error, source) {
+  if (crashStarted) return;
+  crashStarted = true;
   const timestamp = Date.now();
   const errorMsg = error instanceof Error ? error.stack || error.message : String(error);
 
   emergencyLog(`\n[${timestamp}][CRASH] ${source}: ${errorMsg}\n`);
-  emergencyLog(`[${timestamp}][CRASH] Process terminating due to unhandled error\n`);
-  cleanupCommandSpecSync();
+  const providerTerminal = await stopAttachableProvider();
+  let cleanupSucceeded = false;
+  if (providerTerminal) {
+    cleanupSucceeded = commandCleanup ? await commandCleanup.run() : true;
+  } else {
+    emergencyLog(
+      `[${timestamp}][CRASH] Provider termination could not be confirmed; preserving command cleanup paths.\n`
+    );
+  }
 
   if (taskIdArg) {
     try {
-      updateTask(taskIdArg, {
+      await updateTask(taskIdArg, {
         status: 'failed',
+        pid: null,
+        processGroupId: null,
         error: `${source}: ${errorMsg}`,
         socketPath: null,
+        ...(cleanupSucceeded ? { commandCleanup: null } : {}),
       });
     } catch (updateError) {
       emergencyLog(`[${timestamp}][CRASH] Failed to update task status: ${updateError.message}\n`);
@@ -61,11 +85,11 @@ function crashWithError(error, source) {
 }
 
 process.on('uncaughtException', (error) => {
-  crashWithError(error, 'uncaughtException');
+  void failWatcher(error, 'uncaughtException');
 });
 
 process.on('unhandledRejection', (reason) => {
-  crashWithError(reason, 'unhandledRejection');
+  void failWatcher(reason, 'unhandledRejection');
 });
 
 const require = createRequire(import.meta.url);
@@ -84,8 +108,9 @@ const commandSpec = config.commandSpec || {
   env: config.env || {},
   cleanup: [],
 };
-commandSpecCleanup = commandSpec.cleanup || [];
-let server = null;
+commandCleanup = createCommandSpecCleanup(commandSpec, (cleanupPath, error) => {
+  emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${cleanupPath}: ${error.message}\n`);
+});
 
 const socketPath = getTaskSocketPath(taskId);
 
@@ -234,30 +259,6 @@ function attemptRecovery(code, timestamp) {
   return recovered;
 }
 
-async function cleanupCommandSpec() {
-  if (cleanupStarted) return;
-  cleanupStarted = true;
-  for (const file of commandSpecCleanup) {
-    try {
-      await unlink(file);
-    } catch (error) {
-      log(`[${Date.now()}][CLEANUP] Failed to delete ${file}: ${error.message}\n`);
-    }
-  }
-}
-
-function cleanupCommandSpecSync() {
-  if (cleanupStarted) return;
-  cleanupStarted = true;
-  for (const file of commandSpecCleanup) {
-    try {
-      unlinkSync(file);
-    } catch (error) {
-      emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${file}: ${error.message}\n`);
-    }
-  }
-}
-
 function writeCompletionFooter(code, signal) {
   if (config.outputFormat === 'json') {
     return;
@@ -294,6 +295,7 @@ server.on('output', (data) => {
 });
 
 server.on('exit', async ({ exitCode, signal }) => {
+  if (crashStarted) return;
   const timestamp = Date.now();
   const code = exitCode;
 
@@ -306,7 +308,7 @@ server.on('exit', async ({ exitCode, signal }) => {
   }
 
   writeCompletionFooter(code, signal);
-  await cleanupCommandSpec();
+  const cleanupSucceeded = await commandCleanup.run();
 
   const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
   const status = resolvedCode === 0 ? 'completed' : 'failed';
@@ -318,6 +320,7 @@ server.on('exit', async ({ exitCode, signal }) => {
       exitCode: resolvedCode,
       error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
       socketPath: null,
+      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
@@ -329,19 +332,7 @@ server.on('exit', async ({ exitCode, signal }) => {
 });
 
 server.on('error', async (err) => {
-  log(`\nError: ${err.message}\n`);
-  await cleanupCommandSpec();
-  try {
-    await updateTask(taskId, {
-      status: 'failed',
-      pid: null,
-      processGroupId: null,
-      error: err.message,
-    });
-  } catch (updateError) {
-    log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
-  }
-  process.exit(1);
+  await failWatcher(err, 'attach server error');
 });
 
 server.on('clientAttach', ({ clientId }) => {
@@ -367,18 +358,15 @@ try {
   log(`[${Date.now()}][SYSTEM] Socket: ${socketPath}\n`);
   log(`[${Date.now()}][SYSTEM] PID: ${server.pid}\n`);
 } catch (err) {
-  log(`\nFailed to start: ${err.message}\n`);
-  await cleanupCommandSpec();
-  updateTask(taskId, { status: 'failed', error: err.message });
-  process.exit(1);
+  await failWatcher(err, 'attach server start');
 }
 
 process.on('SIGTERM', async () => {
   log(`[${Date.now()}][SYSTEM] Received SIGTERM, stopping...\n`);
-  await server.stop('SIGTERM');
+  await stopAttachableProvider();
 });
 
 process.on('SIGINT', async () => {
   log(`[${Date.now()}][SYSTEM] Received SIGINT, stopping...\n`);
-  await server.stop('SIGINT');
+  await stopAttachableProvider();
 });

--- a/task-lib/attachable-watcher.js
+++ b/task-lib/attachable-watcher.js
@@ -124,7 +124,7 @@ if (
     taskId,
     getTask,
     commandCleanup,
-    terminateProvider: async () => true,
+    terminateProvider: () => true,
     updateTask,
     emergencyLog,
     terminalUpdates: { socketPath: null },

--- a/task-lib/command-spec-cleanup.js
+++ b/task-lib/command-spec-cleanup.js
@@ -1,0 +1,84 @@
+import { rm, unlink } from 'fs/promises';
+import { rmSync, unlinkSync } from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { isClaudeSettingsOverlayDirectory } = require('../src/worktree-claude-config');
+
+function cleanupMetadataByPath(commandSpec) {
+  return new Map((commandSpec.cleanupMetadata || []).map((item) => [item.path, item]));
+}
+
+function assertOwnedTempDirectory(cleanupPath, metadata) {
+  if (
+    metadata.provider !== 'claude' ||
+    metadata.reason !== 'settings-overlay' ||
+    !isClaudeSettingsOverlayDirectory(cleanupPath)
+  ) {
+    throw new Error(`Refusing unowned temporary directory cleanup: ${cleanupPath}`);
+  }
+}
+
+async function removeCleanupPath(cleanupPath, metadata) {
+  if (metadata?.kind === 'temp-directory') {
+    assertOwnedTempDirectory(cleanupPath, metadata);
+    await rm(cleanupPath, { recursive: true, force: true });
+    return;
+  }
+  await unlink(cleanupPath);
+}
+
+function removeCleanupPathSync(cleanupPath, metadata) {
+  if (metadata?.kind === 'temp-directory') {
+    assertOwnedTempDirectory(cleanupPath, metadata);
+    rmSync(cleanupPath, { recursive: true, force: true });
+    return;
+  }
+  unlinkSync(cleanupPath);
+}
+
+/**
+ * Build one idempotent cleanup owner for a provider command. Callers may run it
+ * only after the persisted provider termination boundary is terminal.
+ */
+export function createCommandSpecCleanup(commandSpec, logFailure) {
+  const cleanupPaths = commandSpec.cleanup || [];
+  const metadataByPath = cleanupMetadataByPath(commandSpec);
+  let started = false;
+  let result = true;
+
+  return {
+    async run() {
+      if (started) return result;
+      started = true;
+      let succeeded = true;
+      for (const cleanupPath of cleanupPaths) {
+        try {
+          await removeCleanupPath(cleanupPath, metadataByPath.get(cleanupPath));
+        } catch (error) {
+          if (error?.code === 'ENOENT') continue;
+          succeeded = false;
+          logFailure(cleanupPath, error);
+        }
+      }
+      result = succeeded;
+      return result;
+    },
+    runSync() {
+      if (started) return result;
+      started = true;
+      let succeeded = true;
+      for (const cleanupPath of cleanupPaths) {
+        try {
+          removeCleanupPathSync(cleanupPath, metadataByPath.get(cleanupPath));
+        } catch (error) {
+          if (error?.code === 'ENOENT') continue;
+          succeeded = false;
+          logFailure(cleanupPath, error);
+        }
+      }
+      result = succeeded;
+      return result;
+    },
+  };
+}

--- a/task-lib/command-spec-cleanup.js
+++ b/task-lib/command-spec-cleanup.js
@@ -5,7 +5,10 @@ import { basename, dirname, isAbsolute, resolve } from 'path';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { isClaudeSettingsOverlayDirectory } = require('../src/worktree-claude-config');
+const {
+  isCanonicalClaudeSettingsOverlayDirectory,
+  isClaudeSettingsOverlayDirectory,
+} = require('../src/worktree-claude-config');
 
 const CLEANUP_METADATA_KEYS = ['kind', 'path', 'provider', 'reason'];
 const SCHEMA_DIRECTORY_PATTERN = /^zeroshot-schema-[A-Za-z0-9_-]+$/u;
@@ -59,10 +62,20 @@ function assertOwnedTempDirectory(cleanupPath, metadata) {
   if (
     metadata.provider !== 'claude' ||
     metadata.reason !== 'settings-overlay' ||
-    !isClaudeSettingsOverlayDirectory(cleanupPath)
+    !isCanonicalClaudeSettingsOverlayDirectory(cleanupPath)
   ) {
     throw new Error(`Refusing unowned temporary directory cleanup: ${cleanupPath}`);
   }
+  if (isClaudeSettingsOverlayDirectory(cleanupPath)) {
+    return false;
+  }
+  try {
+    lstatSync(cleanupPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
+  throw new Error(`Refusing unowned temporary directory cleanup: ${cleanupPath}`);
 }
 
 function assertCanonicalSchemaPath(cleanupPath, metadata) {
@@ -127,7 +140,7 @@ function assertOwnedSchemaFileSync(cleanupPath, metadata) {
 
 async function removeCleanupPath(cleanupPath, metadata) {
   if (metadata.kind === 'temp-directory') {
-    assertOwnedTempDirectory(cleanupPath, metadata);
+    if (assertOwnedTempDirectory(cleanupPath, metadata)) return;
     await rm(cleanupPath, { recursive: true, force: true });
     return;
   }
@@ -137,7 +150,7 @@ async function removeCleanupPath(cleanupPath, metadata) {
 
 function removeCleanupPathSync(cleanupPath, metadata) {
   if (metadata.kind === 'temp-directory') {
-    assertOwnedTempDirectory(cleanupPath, metadata);
+    if (assertOwnedTempDirectory(cleanupPath, metadata)) return;
     rmSync(cleanupPath, { recursive: true, force: true });
     return;
   }

--- a/task-lib/command-spec-cleanup.js
+++ b/task-lib/command-spec-cleanup.js
@@ -1,12 +1,58 @@
-import { rm, unlink } from 'fs/promises';
-import { rmSync, unlinkSync } from 'fs';
+import { lstat, realpath, rm, unlink } from 'fs/promises';
+import { lstatSync, realpathSync, rmSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { basename, dirname, isAbsolute, resolve } from 'path';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { isClaudeSettingsOverlayDirectory } = require('../src/worktree-claude-config');
 
-function cleanupMetadataByPath(commandSpec) {
-  return new Map((commandSpec.cleanupMetadata || []).map((item) => [item.path, item]));
+const CLEANUP_METADATA_KEYS = ['kind', 'path', 'provider', 'reason'];
+const SCHEMA_DIRECTORY_PATTERN = /^zeroshot-schema-[A-Za-z0-9_-]+$/u;
+const SCHEMA_FILE_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/u;
+
+function assertClosedCleanupMetadata(cleanupPath, metadata) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error(`Refusing cleanup without closed ownership metadata: ${cleanupPath}`);
+  }
+  const keys = Object.keys(metadata).sort();
+  if (
+    keys.length !== CLEANUP_METADATA_KEYS.length ||
+    keys.some((key, index) => key !== CLEANUP_METADATA_KEYS[index])
+  ) {
+    throw new Error(`Refusing cleanup with open ownership metadata: ${cleanupPath}`);
+  }
+  if (metadata.path !== cleanupPath) {
+    throw new Error(`Refusing cleanup with mismatched ownership path: ${cleanupPath}`);
+  }
+}
+
+function createCleanupPlan(commandSpec) {
+  if (!Array.isArray(commandSpec?.cleanup) || !Array.isArray(commandSpec?.cleanupMetadata)) {
+    throw new Error('Refusing cleanup with malformed cleanup collections');
+  }
+  if (commandSpec.cleanup.length !== commandSpec.cleanupMetadata.length) {
+    throw new Error('Refusing cleanup without one closed metadata receipt per path');
+  }
+  const uniquePaths = new Set(commandSpec.cleanup);
+  if (uniquePaths.size !== commandSpec.cleanup.length) {
+    throw new Error('Refusing cleanup with duplicate cleanup paths');
+  }
+
+  return commandSpec.cleanup.map((cleanupPath) => {
+    if (typeof cleanupPath !== 'string' || cleanupPath.length === 0) {
+      throw new Error('Refusing cleanup with a non-string or empty path');
+    }
+    const matches = commandSpec.cleanupMetadata.filter(
+      (metadata) => metadata?.path === cleanupPath
+    );
+    if (matches.length !== 1) {
+      throw new Error(`Refusing cleanup without exact ownership metadata: ${cleanupPath}`);
+    }
+    assertClosedCleanupMetadata(cleanupPath, matches[0]);
+    return { cleanupPath, metadata: matches[0] };
+  });
 }
 
 function assertOwnedTempDirectory(cleanupPath, metadata) {
@@ -19,21 +65,83 @@ function assertOwnedTempDirectory(cleanupPath, metadata) {
   }
 }
 
+function assertCanonicalSchemaPath(cleanupPath, metadata) {
+  if (
+    metadata.kind !== 'temp-file' ||
+    metadata.provider !== 'codex' ||
+    metadata.reason !== 'output-schema' ||
+    !isAbsolute(cleanupPath) ||
+    resolve(cleanupPath) !== cleanupPath
+  ) {
+    throw new Error(`Refusing unowned output-schema cleanup: ${cleanupPath}`);
+  }
+  const schemaDirectory = dirname(cleanupPath);
+  if (
+    dirname(schemaDirectory) !== resolve(tmpdir()) ||
+    !SCHEMA_DIRECTORY_PATTERN.test(basename(schemaDirectory)) ||
+    !SCHEMA_FILE_PATTERN.test(basename(cleanupPath))
+  ) {
+    throw new Error(`Refusing non-canonical output-schema cleanup: ${cleanupPath}`);
+  }
+}
+
+async function assertOwnedSchemaFile(cleanupPath, metadata) {
+  assertCanonicalSchemaPath(cleanupPath, metadata);
+  const schemaDirectory = dirname(cleanupPath);
+  const [tempRoot, realSchemaDirectory, directoryStat, schemaStat] = await Promise.all([
+    realpath(tmpdir()),
+    realpath(schemaDirectory),
+    lstat(schemaDirectory),
+    lstat(cleanupPath),
+  ]);
+  if (
+    directoryStat.isSymbolicLink() ||
+    !directoryStat.isDirectory() ||
+    dirname(realSchemaDirectory) !== tempRoot ||
+    basename(realSchemaDirectory) !== basename(schemaDirectory) ||
+    schemaStat.isSymbolicLink() ||
+    !schemaStat.isFile()
+  ) {
+    throw new Error(`Refusing non-regular or escaped output-schema cleanup: ${cleanupPath}`);
+  }
+}
+
+function assertOwnedSchemaFileSync(cleanupPath, metadata) {
+  assertCanonicalSchemaPath(cleanupPath, metadata);
+  const schemaDirectory = dirname(cleanupPath);
+  const tempRoot = realpathSync(tmpdir());
+  const realSchemaDirectory = realpathSync(schemaDirectory);
+  const directoryStat = lstatSync(schemaDirectory);
+  const schemaStat = lstatSync(cleanupPath);
+  if (
+    directoryStat.isSymbolicLink() ||
+    !directoryStat.isDirectory() ||
+    dirname(realSchemaDirectory) !== tempRoot ||
+    basename(realSchemaDirectory) !== basename(schemaDirectory) ||
+    schemaStat.isSymbolicLink() ||
+    !schemaStat.isFile()
+  ) {
+    throw new Error(`Refusing non-regular or escaped output-schema cleanup: ${cleanupPath}`);
+  }
+}
+
 async function removeCleanupPath(cleanupPath, metadata) {
-  if (metadata?.kind === 'temp-directory') {
+  if (metadata.kind === 'temp-directory') {
     assertOwnedTempDirectory(cleanupPath, metadata);
     await rm(cleanupPath, { recursive: true, force: true });
     return;
   }
+  await assertOwnedSchemaFile(cleanupPath, metadata);
   await unlink(cleanupPath);
 }
 
 function removeCleanupPathSync(cleanupPath, metadata) {
-  if (metadata?.kind === 'temp-directory') {
+  if (metadata.kind === 'temp-directory') {
     assertOwnedTempDirectory(cleanupPath, metadata);
     rmSync(cleanupPath, { recursive: true, force: true });
     return;
   }
+  assertOwnedSchemaFileSync(cleanupPath, metadata);
   unlinkSync(cleanupPath);
 }
 
@@ -42,8 +150,6 @@ function removeCleanupPathSync(cleanupPath, metadata) {
  * only after the persisted provider termination boundary is terminal.
  */
 export function createCommandSpecCleanup(commandSpec, logFailure) {
-  const cleanupPaths = commandSpec.cleanup || [];
-  const metadataByPath = cleanupMetadataByPath(commandSpec);
   let started = false;
   let result = true;
 
@@ -51,10 +157,18 @@ export function createCommandSpecCleanup(commandSpec, logFailure) {
     async run() {
       if (started) return result;
       started = true;
+      let cleanupPlan;
+      try {
+        cleanupPlan = createCleanupPlan(commandSpec);
+      } catch (error) {
+        logFailure('<command-cleanup>', error);
+        result = false;
+        return result;
+      }
       let succeeded = true;
-      for (const cleanupPath of cleanupPaths) {
+      for (const { cleanupPath, metadata } of cleanupPlan) {
         try {
-          await removeCleanupPath(cleanupPath, metadataByPath.get(cleanupPath));
+          await removeCleanupPath(cleanupPath, metadata);
         } catch (error) {
           if (error?.code === 'ENOENT') continue;
           succeeded = false;
@@ -67,10 +181,18 @@ export function createCommandSpecCleanup(commandSpec, logFailure) {
     runSync() {
       if (started) return result;
       started = true;
+      let cleanupPlan;
+      try {
+        cleanupPlan = createCleanupPlan(commandSpec);
+      } catch (error) {
+        logFailure('<command-cleanup>', error);
+        result = false;
+        return result;
+      }
       let succeeded = true;
-      for (const cleanupPath of cleanupPaths) {
+      for (const { cleanupPath, metadata } of cleanupPlan) {
         try {
-          removeCleanupPathSync(cleanupPath, metadataByPath.get(cleanupPath));
+          removeCleanupPathSync(cleanupPath, metadata);
         } catch (error) {
           if (error?.code === 'ENOENT') continue;
           succeeded = false;

--- a/task-lib/commands/clean.js
+++ b/task-lib/commands/clean.js
@@ -37,6 +37,13 @@ export function cleanTasks(options = {}) {
 
   for (const task of toRemove) {
     if (task.commandCleanup) {
+      if (task.status === 'running') {
+        cleanupFailed = true;
+        console.log(
+          chalk.yellow(`  Retained: ${task.id} [running] (live command cleanup ownership)`)
+        );
+        continue;
+      }
       let recovered = false;
       try {
         const cleanup = createCommandSpecCleanup(task.commandCleanup, (cleanupPath, error) => {

--- a/task-lib/commands/clean.js
+++ b/task-lib/commands/clean.js
@@ -1,6 +1,7 @@
 import { unlinkSync, existsSync } from 'fs';
 import chalk from 'chalk';
 import { loadTasks, saveTasks } from '../store.js';
+import { createCommandSpecCleanup } from '../command-spec-cleanup.js';
 
 export function cleanTasks(options = {}) {
   const tasks = loadTasks();
@@ -11,6 +12,8 @@ export function cleanTasks(options = {}) {
     return;
   }
 
+  let cleanupFailed = false;
+  let removedCount = 0;
   const toRemove = [];
 
   for (const task of taskList) {
@@ -33,18 +36,38 @@ export function cleanTasks(options = {}) {
   console.log(chalk.dim(`Removing ${toRemove.length} task(s)...\n`));
 
   for (const task of toRemove) {
-    // Delete log file
+    if (task.commandCleanup) {
+      let recovered = false;
+      try {
+        const cleanup = createCommandSpecCleanup(task.commandCleanup, (cleanupPath, error) => {
+          console.log(chalk.yellow(`Warning: failed to clean up ${cleanupPath}: ${error.message}`));
+        });
+        recovered = cleanup.runSync();
+      } catch (error) {
+        console.log(
+          chalk.yellow(`Warning: failed to validate cleanup for task ${task.id}: ${error.message}`)
+        );
+      }
+      if (!recovered) {
+        cleanupFailed = true;
+        console.log(
+          chalk.yellow(`  Retained: ${task.id} [${task.status}] (command cleanup pending)`)
+        );
+        continue;
+      }
+      task.commandCleanup = null;
+    }
     if (task.logFile && existsSync(task.logFile)) {
       unlinkSync(task.logFile);
     }
 
-    // Remove from tasks
-    delete tasks[task.id];
-
     console.log(chalk.dim(`  Removed: ${task.id} [${task.status}]`));
+    delete tasks[task.id];
+    removedCount++;
   }
 
   saveTasks(tasks);
 
-  console.log(chalk.green(`\n✓ Cleaned ${toRemove.length} task(s)`));
+  console.log(chalk.green(`\n✓ Cleaned ${removedCount} task(s)`));
+  if (cleanupFailed) process.exitCode = 1;
 }

--- a/task-lib/commands/get-task-id-by-spawn-token.js
+++ b/task-lib/commands/get-task-id-by-spawn-token.js
@@ -1,0 +1,10 @@
+import { getTaskBySpawnOwnershipToken } from '../store.js';
+
+export function getTaskIdBySpawnToken(token) {
+  const task = getTaskBySpawnOwnershipToken(token);
+  if (!task) {
+    process.exitCode = 2;
+    return;
+  }
+  process.stdout.write(`${task.id}\n`);
+}

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -1,6 +1,15 @@
 import chalk from 'chalk';
 import { getTask, updateTask } from '../store.js';
-import { terminateProcess } from '../runner.js';
+import { createCommandSpecCleanup } from '../command-spec-cleanup.js';
+import { terminateProcess } from '../process-termination.js';
+
+async function cleanupTerminatedTask(task) {
+  if (!task.commandCleanup) return {};
+  const cleanup = createCommandSpecCleanup(task.commandCleanup, (cleanupPath, error) => {
+    console.log(chalk.yellow(`Warning: failed to clean up ${cleanupPath}: ${error.message}`));
+  });
+  return (await cleanup.run()) ? { commandCleanup: null } : {};
+}
 
 export async function killTaskCommand(taskId, options = {}) {
   const task = getTask(taskId);
@@ -25,16 +34,19 @@ export async function killTaskCommand(taskId, options = {}) {
 
   if (result.terminated && result.alreadyDead) {
     console.log(chalk.yellow('Process already dead, updating status...'));
+    const cleanupUpdate = await cleanupTerminatedTask(task);
     updateTask(taskId, {
       status: 'stale',
       pid: null,
       processGroupId: null,
       error: 'Process died unexpectedly',
+      ...cleanupUpdate,
     });
     return;
   }
 
   if (result.terminated) {
+    const cleanupUpdate = await cleanupTerminatedTask(task);
     const suffix = result.escalated ? ' after SIGKILL escalation' : ' with SIGTERM';
     console.log(chalk.green(`✓ Killed task ${taskId} (PID: ${task.pid})${suffix}`));
     if (result.degraded) {
@@ -46,6 +58,7 @@ export async function killTaskCommand(taskId, options = {}) {
       processGroupId: null,
       exitCode: result.escalated ? 137 : 143,
       error: result.escalated ? 'Killed by user after SIGKILL escalation' : 'Killed by user',
+      ...cleanupUpdate,
     });
   } else {
     console.log(chalk.red(`Failed to kill task ${taskId}`));

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -5,10 +5,28 @@ import { terminateProcess } from '../process-termination.js';
 
 async function cleanupTerminatedTask(task) {
   if (!task.commandCleanup) return {};
-  const cleanup = createCommandSpecCleanup(task.commandCleanup, (cleanupPath, error) => {
-    console.log(chalk.yellow(`Warning: failed to clean up ${cleanupPath}: ${error.message}`));
-  });
-  return (await cleanup.run()) ? { commandCleanup: null } : {};
+  try {
+    const cleanup = createCommandSpecCleanup(task.commandCleanup, (cleanupPath, error) => {
+      console.log(chalk.yellow(`Warning: failed to clean up ${cleanupPath}: ${error.message}`));
+    });
+    return (await cleanup.run()) ? { commandCleanup: null } : {};
+  } catch (error) {
+    console.log(
+      chalk.yellow(`Warning: failed to validate persisted command cleanup: ${error.message}`)
+    );
+    return {};
+  }
+}
+
+async function retryTerminalTaskCleanup(taskId, task) {
+  if (!task.commandCleanup) return;
+  const cleanupUpdate = await cleanupTerminatedTask(task);
+  if (cleanupUpdate.commandCleanup === null) {
+    updateTask(taskId, cleanupUpdate);
+    console.log(chalk.green(`✓ Recovered pending command cleanup for task ${taskId}`));
+    return;
+  }
+  console.log(chalk.yellow(`Warning: command cleanup remains pending for task ${taskId}`));
 }
 
 export async function killTaskCommand(taskId, options = {}) {
@@ -20,6 +38,7 @@ export async function killTaskCommand(taskId, options = {}) {
   }
 
   if (task.status !== 'running') {
+    await retryTerminalTaskCleanup(taskId, task);
     console.log(chalk.yellow(`Task is not running (status: ${task.status})`));
     return;
   }

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -52,6 +52,13 @@ async function waitForStartupCancellation(taskId, options) {
         return true;
       }
     }
+    if (Number.isInteger(current.pid) && current.pid > 0) {
+      await killTaskCommand(taskId, options);
+      const terminal = getTask(taskId);
+      return Boolean(
+        terminal && TERMINAL_STATUSES.has(terminal.status) && !terminal.commandCleanup
+      );
+    }
     await sleep(pollMs);
   }
 
@@ -89,15 +96,33 @@ export async function killTaskCommand(taskId, options = {}) {
     return;
   }
 
+  const platform = options.platform || process.platform;
+  const terminate = options.terminateProcessFn || terminateProcess;
+  const processOptions = { ...options };
+  delete processOptions.platform;
+  delete processOptions.terminateProcessFn;
+
   const terminationOptions = {
-    ...options,
+    ...processOptions,
     processGroupId: task.processGroupId,
     terminationStrategy: task.terminationStrategy || 'process',
   };
 
-  const result = await terminateProcess(task.pid, terminationOptions);
+  const result = await terminate(task.pid, terminationOptions);
 
   if (result.terminated && result.alreadyDead) {
+    if (platform === 'win32' && task.terminationStrategy === 'process-tree') {
+      console.log(
+        chalk.yellow(
+          `Warning: Windows task root ${task.pid} is gone but descendant termination is unverified; preserving cleanup ownership`
+        )
+      );
+      updateTask(taskId, {
+        error: 'Windows process-tree termination could not be confirmed after root exit',
+      });
+      process.exitCode = 1;
+      return;
+    }
     console.log(chalk.yellow('Process already dead, updating status...'));
     const cleanupUpdate = await cleanupTerminatedTask(task);
     updateTask(taskId, {

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { getTask, updateTask } from '../store.js';
+import { getTask, requestTaskCancellation, updateTask } from '../store.js';
 import { createCommandSpecCleanup } from '../command-spec-cleanup.js';
 import { terminateProcess } from '../process-termination.js';
 
@@ -29,6 +29,39 @@ async function retryTerminalTaskCleanup(taskId, task) {
   console.log(chalk.yellow(`Warning: command cleanup remains pending for task ${taskId}`));
 }
 
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForStartupCancellation(taskId, options) {
+  const timeoutMs = options.startupCancelTimeoutMs ?? 8000;
+  const pollMs = options.startupCancelPollMs ?? options.pollMs ?? 25;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() <= deadline) {
+    const current = getTask(taskId);
+    if (!current) break;
+    if (TERMINAL_STATUSES.has(current.status)) {
+      await retryTerminalTaskCleanup(taskId, current);
+      if (!getTask(taskId)?.commandCleanup) {
+        console.log(chalk.green(`✓ Cancelled task ${taskId} before provider startup completed`));
+        return true;
+      }
+    }
+    await sleep(pollMs);
+  }
+
+  console.log(
+    chalk.yellow(
+      `Cancellation for task ${taskId} remains pending; provider termination and cleanup were not confirmed`
+    )
+  );
+  process.exitCode = 1;
+  return false;
+}
+
 export async function killTaskCommand(taskId, options = {}) {
   const task = getTask(taskId);
 
@@ -44,12 +77,13 @@ export async function killTaskCommand(taskId, options = {}) {
   }
 
   if (!Number.isInteger(task.pid) || task.pid <= 0) {
+    requestTaskCancellation(taskId);
     console.log(
       chalk.yellow(
-        `Task ${taskId} has not published a provider PID; preserving its running state and command cleanup ownership`
+        `Task ${taskId} has not published a provider PID; persisted cancellation is pending`
       )
     );
-    process.exitCode = 1;
+    await waitForStartupCancellation(taskId, options);
     return;
   }
 
@@ -69,6 +103,7 @@ export async function killTaskCommand(taskId, options = {}) {
       pid: null,
       processGroupId: null,
       error: 'Process died unexpectedly',
+      cancelRequested: false,
       ...cleanupUpdate,
     });
     return;
@@ -87,6 +122,7 @@ export async function killTaskCommand(taskId, options = {}) {
       processGroupId: null,
       exitCode: result.escalated ? 137 : 143,
       error: result.escalated ? 'Killed by user after SIGKILL escalation' : 'Killed by user',
+      cancelRequested: false,
       ...cleanupUpdate,
     });
   } else {

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -19,14 +19,16 @@ async function cleanupTerminatedTask(task) {
 }
 
 async function retryTerminalTaskCleanup(taskId, task) {
-  if (!task.commandCleanup) return;
+  if (!task.commandCleanup) return true;
   const cleanupUpdate = await cleanupTerminatedTask(task);
   if (cleanupUpdate.commandCleanup === null) {
     updateTask(taskId, cleanupUpdate);
     console.log(chalk.green(`✓ Recovered pending command cleanup for task ${taskId}`));
-    return;
+    return true;
   }
   console.log(chalk.yellow(`Warning: command cleanup remains pending for task ${taskId}`));
+  process.exitCode = 1;
+  return false;
 }
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
@@ -106,6 +108,10 @@ export async function killTaskCommand(taskId, options = {}) {
       cancelRequested: false,
       ...cleanupUpdate,
     });
+    if (getTask(taskId)?.commandCleanup) {
+      console.log(chalk.yellow(`Warning: command cleanup remains pending for task ${taskId}`));
+      process.exitCode = 1;
+    }
     return;
   }
 
@@ -125,6 +131,10 @@ export async function killTaskCommand(taskId, options = {}) {
       cancelRequested: false,
       ...cleanupUpdate,
     });
+    if (getTask(taskId)?.commandCleanup) {
+      console.log(chalk.yellow(`Warning: command cleanup remains pending for task ${taskId}`));
+      process.exitCode = 1;
+    }
   } else {
     console.log(chalk.red(`Failed to kill task ${taskId}`));
     updateTask(taskId, {

--- a/task-lib/commands/kill.js
+++ b/task-lib/commands/kill.js
@@ -43,6 +43,16 @@ export async function killTaskCommand(taskId, options = {}) {
     return;
   }
 
+  if (!Number.isInteger(task.pid) || task.pid <= 0) {
+    console.log(
+      chalk.yellow(
+        `Task ${taskId} has not published a provider PID; preserving its running state and command cleanup ownership`
+      )
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const terminationOptions = {
     ...options,
     processGroupId: task.processGroupId,

--- a/task-lib/commands/status.js
+++ b/task-lib/commands/status.js
@@ -41,6 +41,7 @@ export function showStatus(taskId) {
   console.log(`${chalk.dim('PID:')}        ${task.pid || 'N/A'}`);
   console.log(`${chalk.dim('Exit Code:')}  ${task.exitCode ?? 'N/A'}`);
   console.log(`${chalk.dim('Session:')}    ${task.sessionId || 'N/A'}`);
+  console.log(`${chalk.dim('Cleanup:')}    ${task.commandCleanup ? 'pending' : 'complete'}`);
   if (task.requestedResumeSessionId) {
     console.log(`${chalk.dim('Requested:')}  ${task.requestedResumeSessionId}`);
   }

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -116,9 +116,15 @@ function buildProviderOptions(options, runtime, modelSelection) {
     autoApprove: true,
     ...(modelSelection === undefined ? {} : { modelSpec: modelSelection.modelSpec }),
     ...mcpConfigOption(options),
+    ...claudeSettingsFileOption(),
     ...(options.resume ? { resumeSessionId: options.resume } : {}),
     ...(options.continue ? { continueSession: true } : {}),
   };
+}
+
+function claudeSettingsFileOption() {
+  const settingsPath = process.env.ZEROSHOT_CLAUDE_SETTINGS_FILE?.trim();
+  return settingsPath ? { claudeSettingsFile: settingsPath } : {};
 }
 
 function mcpConfigOption(options) {

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -12,6 +12,11 @@ const {
   ISOLATED_SETTINGS_FILE_MARKER,
   LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV,
 } = require('../src/task-run-model-args.js');
+const {
+  CLAUDE_MCP_CONFIG_ENV,
+  CLAUDE_SETTINGS_ENV,
+  isClaudeSettingsOverlayPath,
+} = require('../src/worktree-claude-config');
 export {
   isOwnedProcessTreeRunning,
   isProcessRunning,
@@ -37,7 +42,7 @@ export function spawnTask(prompt, options = {}) {
   });
   const providerName = prepared.adapter.id;
   const modelSpec = prepared.options.modelSpec;
-  const commandSpec = prepared.commandSpec;
+  const commandSpec = attachClaudeOverlayCleanup(prepared.commandSpec, providerName);
 
   const task = buildTaskRecord({
     id,
@@ -47,6 +52,7 @@ export function spawnTask(prompt, options = {}) {
     logFile,
     providerName,
     modelSpec,
+    commandSpec,
   });
 
   addTask(task);
@@ -123,13 +129,17 @@ function buildProviderOptions(options, runtime, modelSelection) {
 }
 
 function claudeSettingsFileOption() {
-  const settingsPath = process.env.ZEROSHOT_CLAUDE_SETTINGS_FILE?.trim();
+  const settingsPath = process.env[CLAUDE_SETTINGS_ENV]?.trim();
   return settingsPath ? { claudeSettingsFile: settingsPath } : {};
 }
 
 function mcpConfigOption(options) {
-  const entries = options.mcpConfig;
-  if (!Array.isArray(entries) || entries.length === 0) return {};
+  const entries = Array.isArray(options.mcpConfig) ? [...options.mcpConfig] : [];
+  const claudeMcpConfigPath = process.env[CLAUDE_MCP_CONFIG_ENV]?.trim();
+  if (claudeMcpConfigPath && !entries.includes(claudeMcpConfigPath)) {
+    entries.push(claudeMcpConfigPath);
+  }
+  if (entries.length === 0) return {};
   return { mcpConfig: entries };
 }
 
@@ -161,7 +171,28 @@ function providerLevelSelection(options) {
   return { modelSpec };
 }
 
-function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec }) {
+export function attachClaudeOverlayCleanup(commandSpec, providerName) {
+  if (providerName !== 'claude') return commandSpec;
+  const settingsPath = process.env[CLAUDE_SETTINGS_ENV]?.trim();
+  if (!isClaudeSettingsOverlayPath(settingsPath)) return commandSpec;
+
+  const overlayDir = dirname(settingsPath);
+  return {
+    ...commandSpec,
+    cleanup: [...(commandSpec.cleanup || []), overlayDir],
+    cleanupMetadata: [
+      ...(commandSpec.cleanupMetadata || []),
+      {
+        kind: 'temp-directory',
+        provider: 'claude',
+        path: overlayDir,
+        reason: 'settings-overlay',
+      },
+    ],
+  };
+}
+
+function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, modelSpec, commandSpec }) {
   return {
     id,
     prompt: prompt.slice(0, 200) + (prompt.length > 200 ? '...' : ''),
@@ -184,6 +215,13 @@ function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, mode
     attachable: false,
     processGroupId: null,
     terminationStrategy: null,
+    commandCleanup:
+      commandSpec.cleanup?.length > 0
+        ? {
+            cleanup: commandSpec.cleanup,
+            cleanupMetadata: commandSpec.cleanupMetadata || [],
+          }
+        : null,
   };
 }
 

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -17,6 +17,7 @@ const {
   CLAUDE_SETTINGS_ENV,
   isClaudeSettingsOverlayPath,
 } = require('../src/worktree-claude-config');
+const { TASK_SPAWN_OWNERSHIP_TOKEN_ENV } = require('../src/task-spawn-cleanup-ownership');
 export {
   isOwnedProcessTreeRunning,
   isProcessRunning,
@@ -215,6 +216,8 @@ function buildTaskRecord({ id, prompt, cwd, options, logFile, providerName, mode
     attachable: false,
     processGroupId: null,
     terminationStrategy: null,
+    cancelRequested: false,
+    spawnOwnershipToken: process.env[TASK_SPAWN_OWNERSHIP_TOKEN_ENV] || null,
     commandCleanup:
       commandSpec.cleanup?.length > 0
         ? {
@@ -280,6 +283,7 @@ function spawnWatcher({ watcherScript, id, cwd, logFile, finalArgs, watcherConfi
 export function buildWatcherEnv(sourceEnv = process.env) {
   const watcherEnv = { ...sourceEnv };
   delete watcherEnv[LEGACY_ISOLATED_PROVIDER_SETTINGS_ENV];
+  delete watcherEnv[TASK_SPAWN_OWNERSHIP_TOKEN_ENV];
   if (watcherEnv[ISOLATED_SETTINGS_FILE_MARKER] === '1') {
     delete watcherEnv[ISOLATED_SETTINGS_FILE_ENV];
     delete watcherEnv[ISOLATED_SETTINGS_FILE_MARKER];

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -53,7 +53,9 @@ function getDb() {
       attachable INTEGER DEFAULT 0,
       process_group_id INTEGER,
       termination_strategy TEXT,
-      command_cleanup TEXT
+      command_cleanup TEXT,
+      cancel_requested INTEGER DEFAULT 0,
+      spawn_ownership_token TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -81,6 +83,13 @@ function getDb() {
   ensureTaskColumn(db, 'process_group_id', 'INTEGER');
   ensureTaskColumn(db, 'termination_strategy', 'TEXT');
   ensureTaskColumn(db, 'command_cleanup', 'TEXT');
+  ensureTaskColumn(db, 'cancel_requested', 'INTEGER DEFAULT 0');
+  ensureTaskColumn(db, 'spawn_ownership_token', 'TEXT');
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_spawn_ownership_token
+      ON tasks(spawn_ownership_token)
+      WHERE spawn_ownership_token IS NOT NULL
+  `);
 
   return db;
 }
@@ -141,6 +150,8 @@ function rowToTask(row) {
     processGroupId: row.process_group_id,
     terminationStrategy: row.termination_strategy,
     commandCleanup: parseCommandCleanup(row.command_cleanup),
+    cancelRequested: Boolean(row.cancel_requested),
+    spawnOwnershipToken: row.spawn_ownership_token,
   };
 }
 
@@ -169,12 +180,12 @@ export function saveTasks(tasks) {
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy,
-      command_cleanup
+      command_cleanup, cancel_requested, spawn_ownership_token
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy,
-      @commandCleanup
+      @commandCleanup, @cancelRequested, @spawnOwnershipToken
     )
   `);
 
@@ -204,6 +215,8 @@ export function saveTasks(tasks) {
         processGroupId: task.processGroupId || null,
         terminationStrategy: task.terminationStrategy || null,
         commandCleanup: serializeCommandCleanup(task.commandCleanup),
+        cancelRequested: task.cancelRequested ? 1 : 0,
+        spawnOwnershipToken: task.spawnOwnershipToken || null,
       });
     }
   });
@@ -232,6 +245,24 @@ export function withTasksLock(modifier) {
 export function getTask(id) {
   const row = getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(id);
   return rowToTask(row);
+}
+
+export function getTaskBySpawnOwnershipToken(token) {
+  if (typeof token !== 'string' || token.length === 0) return null;
+  const row = getDb().prepare('SELECT * FROM tasks WHERE spawn_ownership_token = ?').get(token);
+  return rowToTask(row);
+}
+
+export function requestTaskCancellation(id) {
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `UPDATE tasks
+       SET cancel_requested = 1, updated_at = ?, error = ?
+       WHERE id = ? AND status = 'running'`
+    )
+    .run(now, 'Cancellation requested before provider startup completed', id);
+  return getTask(id);
 }
 
 /**
@@ -271,7 +302,9 @@ export function updateTask(id, updates) {
       attachable = @attachable,
       process_group_id = @processGroupId,
       termination_strategy = @terminationStrategy,
-      command_cleanup = @commandCleanup
+      command_cleanup = @commandCleanup,
+      cancel_requested =
+        CASE WHEN @hasCancelRequested = 1 THEN @cancelRequested ELSE cancel_requested END
     WHERE id = @id
   `
     )
@@ -295,6 +328,8 @@ export function updateTask(id, updates) {
       processGroupId: updated.processGroupId || null,
       terminationStrategy: updated.terminationStrategy || null,
       commandCleanup: serializeCommandCleanup(updated.commandCleanup),
+      hasCancelRequested: Object.prototype.hasOwnProperty.call(updates, 'cancelRequested') ? 1 : 0,
+      cancelRequested: updated.cancelRequested ? 1 : 0,
     });
 
   return updated;
@@ -320,12 +355,12 @@ export function addTask(task) {
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
       schedule_id, socket_path, attachable, process_group_id, termination_strategy,
-      command_cleanup
+      command_cleanup, cancel_requested, spawn_ownership_token
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
       @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy,
-      @commandCleanup
+      @commandCleanup, @cancelRequested, @spawnOwnershipToken
     )
   `
     )
@@ -350,6 +385,8 @@ export function addTask(task) {
       processGroupId: fullTask.processGroupId || null,
       terminationStrategy: fullTask.terminationStrategy || null,
       commandCleanup: serializeCommandCleanup(fullTask.commandCleanup),
+      cancelRequested: fullTask.cancelRequested ? 1 : 0,
+      spawnOwnershipToken: fullTask.spawnOwnershipToken || null,
     });
 
   return fullTask;

--- a/task-lib/store.js
+++ b/task-lib/store.js
@@ -52,7 +52,8 @@ function getDb() {
       socket_path TEXT,
       attachable INTEGER DEFAULT 0,
       process_group_id INTEGER,
-      termination_strategy TEXT
+      termination_strategy TEXT,
+      command_cleanup TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
@@ -79,6 +80,7 @@ function getDb() {
 
   ensureTaskColumn(db, 'process_group_id', 'INTEGER');
   ensureTaskColumn(db, 'termination_strategy', 'TEXT');
+  ensureTaskColumn(db, 'command_cleanup', 'TEXT');
 
   return db;
 }
@@ -88,6 +90,20 @@ function ensureTaskColumn(database, name, definition) {
   if (!columns.some((column) => column.name === name)) {
     database.exec(`ALTER TABLE tasks ADD COLUMN ${name} ${definition}`);
   }
+}
+
+function parseCommandCleanup(value) {
+  if (typeof value !== 'string' || value === '') return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function serializeCommandCleanup(value) {
+  return value ? JSON.stringify(value) : null;
 }
 
 export function ensureDirs() {
@@ -124,6 +140,7 @@ function rowToTask(row) {
     attachable: Boolean(row.attachable),
     processGroupId: row.process_group_id,
     terminationStrategy: row.termination_strategy,
+    commandCleanup: parseCommandCleanup(row.command_cleanup),
   };
 }
 
@@ -151,11 +168,13 @@ export function saveTasks(tasks) {
     INSERT OR REPLACE INTO tasks (
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
-      schedule_id, socket_path, attachable, process_group_id, termination_strategy
+      schedule_id, socket_path, attachable, process_group_id, termination_strategy,
+      command_cleanup
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
-      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
+      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy,
+      @commandCleanup
     )
   `);
 
@@ -184,6 +203,7 @@ export function saveTasks(tasks) {
         attachable: task.attachable ? 1 : 0,
         processGroupId: task.processGroupId || null,
         terminationStrategy: task.terminationStrategy || null,
+        commandCleanup: serializeCommandCleanup(task.commandCleanup),
       });
     }
   });
@@ -250,7 +270,8 @@ export function updateTask(id, updates) {
       socket_path = @socketPath,
       attachable = @attachable,
       process_group_id = @processGroupId,
-      termination_strategy = @terminationStrategy
+      termination_strategy = @terminationStrategy,
+      command_cleanup = @commandCleanup
     WHERE id = @id
   `
     )
@@ -273,6 +294,7 @@ export function updateTask(id, updates) {
       attachable: updated.attachable ? 1 : 0,
       processGroupId: updated.processGroupId || null,
       terminationStrategy: updated.terminationStrategy || null,
+      commandCleanup: serializeCommandCleanup(updated.commandCleanup),
     });
 
   return updated;
@@ -297,11 +319,13 @@ export function addTask(task) {
     INSERT INTO tasks (
       id, prompt, full_prompt, cwd, status, pid, session_id, log_file,
       created_at, updated_at, exit_code, error, provider, model,
-      schedule_id, socket_path, attachable, process_group_id, termination_strategy
+      schedule_id, socket_path, attachable, process_group_id, termination_strategy,
+      command_cleanup
     ) VALUES (
       @id, @prompt, @fullPrompt, @cwd, @status, @pid, @sessionId, @logFile,
       @createdAt, @updatedAt, @exitCode, @error, @provider, @model,
-      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy
+      @scheduleId, @socketPath, @attachable, @processGroupId, @terminationStrategy,
+      @commandCleanup
     )
   `
     )
@@ -325,6 +349,7 @@ export function addTask(task) {
       attachable: fullTask.attachable ? 1 : 0,
       processGroupId: fullTask.processGroupId || null,
       terminationStrategy: fullTask.terminationStrategy || null,
+      commandCleanup: serializeCommandCleanup(fullTask.commandCleanup),
     });
 
   return fullTask;

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -7,6 +7,8 @@ import {
 } from './provider-helper-runtime.js';
 import { terminateProcess } from './process-termination.js';
 
+export const COMMAND_CLEANUP_UNINITIALIZED = Symbol('command-cleanup-uninitialized');
+
 export function spawnWatcherProvider(command, finalArgs, options) {
   return spawn(command, finalArgs, {
     ...options,
@@ -71,7 +73,18 @@ export async function completeWatcherTask({
     return false;
   }
 
-  const cleanupSucceeded = commandCleanup ? await commandCleanup.run() : true;
+  let cleanupSucceeded = false;
+  if (commandCleanup === COMMAND_CLEANUP_UNINITIALIZED) {
+    emergencyLog(
+      `[${Date.now()}][CLEANUP] Command cleanup ownership was not initialized; preserving the persisted receipt.\n`
+    );
+  } else if (commandCleanup?.run) {
+    try {
+      cleanupSucceeded = await commandCleanup.run();
+    } catch (error) {
+      emergencyLog(`[${Date.now()}][CLEANUP] Command cleanup failed: ${error.message}\n`);
+    }
+  }
   try {
     await updateTask(taskId, {
       status: completion.status,

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -1,0 +1,181 @@
+import {
+  detectProviderFatalError,
+  detectProviderStreamingModeError,
+  recoverProviderStructuredOutput,
+  supportsProviderStructuredOutputRecovery,
+} from './provider-helper-runtime.js';
+
+function splitBufferLines(buffer, chunk) {
+  const nextBuffer = buffer + chunk;
+  const lines = nextBuffer.split('\n');
+  return { lines: lines.slice(0, -1), remaining: lines.at(-1) || '' };
+}
+
+export function resolveWatcherCommand(config, commandSpec, fallbackArgs, normalizeProviderName) {
+  return {
+    providerName: normalizeProviderName(config.provider || 'claude'),
+    env: { ...process.env, ...(commandSpec.env || {}) },
+    command: commandSpec.binary,
+    finalArgs: [...(commandSpec.args || fallbackArgs)],
+  };
+}
+
+export async function completeWatcherTask({
+  taskId,
+  completion,
+  commandCleanup,
+  terminateProvider,
+  updateTask,
+  emergencyLog,
+  terminalUpdates = {},
+}) {
+  const providerTerminal = await terminateProvider();
+  const cleanupSucceeded = providerTerminal ? await commandCleanup.run() : false;
+  if (!providerTerminal) {
+    emergencyLog(
+      `[${Date.now()}][CLEANUP] Provider termination boundary is still live; preserving command cleanup paths.\n`
+    );
+  }
+  try {
+    await updateTask(taskId, {
+      status: completion.status,
+      pid: null,
+      processGroupId: null,
+      exitCode: completion.resolvedCode,
+      error: completion.error,
+      ...terminalUpdates,
+      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
+    });
+  } catch (error) {
+    emergencyLog(`[${Date.now()}][ERROR] Failed to update task status: ${error.message}\n`);
+  }
+}
+
+export function createWatcherOutputRuntime({ config, providerName, log, stopProvider }) {
+  const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
+  const silentJsonMode =
+    config.outputFormat === 'json' &&
+    config.jsonSchema &&
+    config.silentJsonOutput &&
+    enableRecovery;
+  let finalResultJson = null;
+  let streamingModeError = null;
+  let fatalError = null;
+
+  function maybeHandleFatalError(line, timestamp) {
+    if (fatalError) return false;
+    const detected = detectProviderFatalError(providerName, line);
+    if (!detected) return false;
+    fatalError = detected;
+    if (silentJsonMode) log(`[${timestamp}]${line}\n`);
+    log(`[${timestamp}][FATAL] ${detected}\n`);
+    stopProvider(timestamp);
+    return true;
+  }
+
+  function captureStreamingError(line, timestamp) {
+    const detectedError = detectProviderStreamingModeError(providerName, line);
+    if (!detectedError) return false;
+    streamingModeError = { ...detectedError, timestamp };
+    return true;
+  }
+
+  function maybeCaptureStructuredOutput(line) {
+    try {
+      const json = JSON.parse(line);
+      if (json.structured_output) finalResultJson = line;
+    } catch {
+      // Not JSON, skip.
+    }
+  }
+
+  function handleOutputLine(line, timestamp) {
+    if (silentJsonMode && !line.trim()) return;
+    maybeHandleFatalError(line, timestamp);
+    if (captureStreamingError(line, timestamp)) return;
+    if (silentJsonMode) {
+      maybeCaptureStructuredOutput(line);
+    } else {
+      log(`[${timestamp}]${line}\n`);
+    }
+  }
+
+  function consumeOutput(buffer, chunk) {
+    const timestamp = Date.now();
+    const { lines, remaining } = splitBufferLines(buffer, chunk.toString());
+    for (const line of lines) handleOutputLine(line, timestamp);
+    return remaining;
+  }
+
+  function consumeStderr(buffer, chunk) {
+    const timestamp = Date.now();
+    const { lines, remaining } = splitBufferLines(buffer, chunk.toString());
+    for (const line of lines) log(`[${timestamp}]${line}\n`);
+    return remaining;
+  }
+
+  function flushOutput(buffer, timestamp) {
+    if (!buffer.trim()) return;
+    if (!enableRecovery) {
+      if (!silentJsonMode) log(`[${timestamp}]${buffer}\n`);
+      return;
+    }
+    maybeHandleFatalError(buffer, timestamp);
+    if (captureStreamingError(buffer, timestamp)) return;
+    if (silentJsonMode) {
+      maybeCaptureStructuredOutput(buffer);
+    } else {
+      log(`[${timestamp}]${buffer}\n`);
+    }
+  }
+
+  function flushStderr(buffer, timestamp) {
+    if (!buffer.trim()) return;
+    maybeHandleFatalError(buffer, timestamp);
+    log(`[${timestamp}]${buffer}\n`);
+  }
+
+  function attemptRecovery(code, timestamp) {
+    if (!(code !== 0 && streamingModeError?.sessionId)) return null;
+    const recovered = recoverProviderStructuredOutput(providerName, streamingModeError.sessionId);
+    if (recovered?.payload) {
+      const recoveredLine = JSON.stringify(recovered.payload);
+      if (silentJsonMode) {
+        finalResultJson = recoveredLine;
+      } else {
+        log(`[${timestamp}]${recoveredLine}\n`);
+      }
+    } else if (streamingModeError.line) {
+      const prefix = silentJsonMode ? '' : `[${streamingModeError.timestamp}]`;
+      log(`${prefix}${streamingModeError.line}\n`);
+    }
+    return recovered;
+  }
+
+  function complete({ code, signal, outputBuffer, stderrBuffer = null }) {
+    const timestamp = Date.now();
+    flushOutput(outputBuffer, timestamp);
+    if (stderrBuffer !== null) flushStderr(stderrBuffer, timestamp);
+    const recovered = attemptRecovery(code, timestamp);
+    if (silentJsonMode && finalResultJson) log(`${finalResultJson}\n`);
+    if (config.outputFormat !== 'json') {
+      log(`\n${'='.repeat(50)}\n`);
+      log(`Finished: ${new Date().toISOString()}\n`);
+      log(`Exit code: ${code}, Signal: ${signal}\n`);
+    }
+    let resolvedCode = code;
+    if (recovered?.payload) {
+      resolvedCode = 0;
+    }
+    if (fatalError) {
+      resolvedCode = 1;
+    }
+    return {
+      resolvedCode,
+      status: resolvedCode === 0 ? 'completed' : 'failed',
+      error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
+    };
+  }
+
+  return { complete, consumeOutput, consumeStderr };
+}

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -92,12 +92,31 @@ export async function completeWatcherTask({
       processGroupId: null,
       exitCode: completion.resolvedCode,
       error: completion.error,
+      cancelRequested: false,
       ...terminalUpdates,
       ...(cleanupSucceeded ? { commandCleanup: null } : {}),
     });
   } catch (error) {
     emergencyLog(`[${Date.now()}][ERROR] Failed to update task status: ${error.message}\n`);
   }
+  return true;
+}
+
+export async function completePendingWatcherCancellation({
+  taskId,
+  getTask,
+  ...completionOptions
+}) {
+  if (!getTask(taskId)?.cancelRequested) return false;
+  await completeWatcherTask({
+    taskId,
+    ...completionOptions,
+    completion: {
+      status: 'killed',
+      resolvedCode: 143,
+      error: 'Cancellation requested before provider startup completed',
+    },
+  });
   return true;
 }
 

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -1,9 +1,28 @@
+import { spawn } from 'child_process';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
   recoverProviderStructuredOutput,
   supportsProviderStructuredOutputRecovery,
 } from './provider-helper-runtime.js';
+import { terminateProcess } from './process-termination.js';
+
+export function spawnWatcherProvider(command, finalArgs, options) {
+  return spawn(command, finalArgs, {
+    ...options,
+    windowsHide: true,
+  });
+}
+
+export async function terminateWatcherProvider(providerProcess) {
+  const pid = providerProcess?.pid;
+  if (!pid) return true;
+  const result = await terminateProcess(pid, {
+    processGroupId: process.platform === 'win32' ? null : pid,
+    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+  });
+  return result.terminated;
+}
 
 function splitBufferLines(buffer, chunk) {
   const nextBuffer = buffer + chunk;
@@ -29,13 +48,30 @@ export async function completeWatcherTask({
   emergencyLog,
   terminalUpdates = {},
 }) {
-  const providerTerminal = await terminateProvider();
-  const cleanupSucceeded = providerTerminal ? await commandCleanup.run() : false;
+  let providerTerminal = false;
+  try {
+    providerTerminal = await terminateProvider();
+  } catch (error) {
+    emergencyLog(`[${Date.now()}][CLEANUP] Provider termination check failed: ${error.message}\n`);
+  }
   if (!providerTerminal) {
     emergencyLog(
       `[${Date.now()}][CLEANUP] Provider termination boundary is still live; preserving command cleanup paths.\n`
     );
+    try {
+      await updateTask(taskId, {
+        status: 'running',
+        error: completion.error
+          ? `${completion.error}; provider termination could not be confirmed`
+          : 'Provider termination could not be confirmed; retry and cleanup remain blocked',
+      });
+    } catch (error) {
+      emergencyLog(`[${Date.now()}][ERROR] Failed to preserve task ownership: ${error.message}\n`);
+    }
+    return false;
   }
+
+  const cleanupSucceeded = commandCleanup ? await commandCleanup.run() : true;
   try {
     await updateTask(taskId, {
       status: completion.status,
@@ -49,6 +85,20 @@ export async function completeWatcherTask({
   } catch (error) {
     emergencyLog(`[${Date.now()}][ERROR] Failed to update task status: ${error.message}\n`);
   }
+  return true;
+}
+
+export function completeWatcherFailure({ error, source, ...completionOptions }) {
+  const errorMessage = error instanceof Error ? error.stack || error.message : String(error);
+  completionOptions.emergencyLog(`\n[${Date.now()}][CRASH] ${source}: ${errorMessage}\n`);
+  return completeWatcherTask({
+    ...completionOptions,
+    completion: {
+      status: 'failed',
+      resolvedCode: 1,
+      error: `${source}: ${errorMessage}`,
+    },
+  });
 }
 
 export function createWatcherOutputRuntime({ config, providerName, log, stopProvider }) {

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -16,13 +16,19 @@ export function spawnWatcherProvider(command, finalArgs, options) {
   });
 }
 
-export async function terminateWatcherProvider(providerProcess) {
+export async function terminateWatcherProvider(providerProcess, options = {}) {
   const pid = providerProcess?.pid;
   if (!pid) return true;
-  const result = await terminateProcess(pid, {
-    processGroupId: process.platform === 'win32' ? null : pid,
-    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+  const platform = options.platform || process.platform;
+  const terminate = options.terminateProcessFn || terminateProcess;
+  const terminationStrategy = platform === 'win32' ? 'process-tree' : 'process-group';
+  const result = await terminate(pid, {
+    processGroupId: platform === 'win32' ? null : pid,
+    terminationStrategy,
   });
+  if (terminationStrategy === 'process-tree' && result.alreadyDead) {
+    return false;
+  }
   return result.terminated;
 }
 

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -26,7 +26,7 @@ export async function terminateWatcherProvider(providerProcess, options = {}) {
     processGroupId: platform === 'win32' ? null : pid,
     terminationStrategy,
   });
-  if (terminationStrategy === 'process-tree' && result.alreadyDead) {
+  if (terminationStrategy === 'process-tree' && result.alreadyDead && !options.exitObserved) {
     return false;
   }
   return result.terminated;

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -5,15 +5,16 @@
  * Runs detached from parent, updates task status on completion
  */
 
-import { spawn } from 'child_process';
 import { appendFileSync } from 'fs';
 import { updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
-import { terminateProcess } from './process-termination.js';
 import {
+  completeWatcherFailure,
   completeWatcherTask,
   createWatcherOutputRuntime,
   resolveWatcherCommand,
+  spawnWatcherProvider,
+  terminateWatcherProvider,
 } from './watcher-output-runtime.js';
 import { createRequire } from 'module';
 
@@ -53,12 +54,11 @@ const { providerName, env, command, finalArgs } = resolveWatcherCommand(
   normalizeProviderName
 );
 
-let child = spawn(command, finalArgs, {
+let child = spawnWatcherProvider(command, finalArgs, {
   cwd: commandSpec.cwd || cwd,
   env,
   stdio: ['ignore', 'pipe', 'pipe'],
   detached: process.platform !== 'win32',
-  windowsHide: true,
 });
 
 updateTask(taskId, {
@@ -126,56 +126,33 @@ child.on('close', async (code, signal) => {
 child.on('error', async (err) => {
   crashStarted = true;
   log(`\nError: ${err.message}\n`);
-  const providerTerminal = await terminateOwnedProviderBoundary();
-  const cleanupSucceeded = providerTerminal ? await commandCleanup.run() : false;
-  try {
-    await updateTask(taskId, {
-      status: 'failed',
-      pid: null,
-      processGroupId: null,
-      error: err.message,
-      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
-    });
-  } catch (updateError) {
-    log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
-  }
+  await completeWatcherTask({
+    taskId,
+    completion: { status: 'failed', resolvedCode: 1, error: err.message },
+    commandCleanup,
+    terminateProvider: terminateOwnedProviderBoundary,
+    updateTask,
+    emergencyLog,
+  });
   process.exit(1);
 });
 
-async function terminateOwnedProviderBoundary() {
-  if (!child?.pid) return true;
-  const result = await terminateProcess(child.pid, {
-    processGroupId: process.platform === 'win32' ? null : child.pid,
-    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
-  });
-  return result.terminated;
+function terminateOwnedProviderBoundary() {
+  return terminateWatcherProvider(child);
 }
 
 async function crashWithError(error, source) {
   if (crashStarted) return;
   crashStarted = true;
-  const errorMessage = error instanceof Error ? error.stack || error.message : String(error);
-  emergencyLog(`\n[${Date.now()}][CRASH] ${source}: ${errorMessage}\n`);
-  const providerTerminal = await terminateOwnedProviderBoundary();
-  let cleanupSucceeded = false;
-  if (providerTerminal) {
-    cleanupSucceeded = await commandCleanup.run();
-  } else {
-    emergencyLog(
-      `[${Date.now()}][CRASH] Provider termination could not be confirmed; preserving command cleanup paths.\n`
-    );
-  }
-  try {
-    await updateTask(taskId, {
-      status: 'failed',
-      pid: null,
-      processGroupId: null,
-      error: `${source}: ${errorMessage}`,
-      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
-    });
-  } catch (updateError) {
-    emergencyLog(`[${Date.now()}][CRASH] Failed to update task status: ${updateError.message}\n`);
-  }
+  await completeWatcherFailure({
+    taskId,
+    error,
+    source,
+    commandCleanup,
+    terminateProvider: terminateOwnedProviderBoundary,
+    updateTask,
+    emergencyLog,
+  });
   process.exit(1);
 }
 

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -6,10 +6,11 @@
  */
 
 import { appendFileSync } from 'fs';
-import { updateTask } from './store.js';
+import { getTask, updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
 import {
   completeWatcherFailure,
+  completePendingWatcherCancellation,
   completeWatcherTask,
   createWatcherOutputRuntime,
   resolveWatcherCommand,
@@ -54,6 +55,20 @@ const { providerName, env, command, finalArgs } = resolveWatcherCommand(
   normalizeProviderName
 );
 
+if (
+  await completePendingWatcherCancellation({
+    taskId,
+    getTask,
+    commandCleanup,
+    terminateProvider: async () => true,
+    updateTask,
+    emergencyLog,
+  })
+) {
+  process.exit(0);
+}
+
+let crashStarted = false;
 let child = spawnWatcherProvider(command, finalArgs, {
   cwd: commandSpec.cwd || cwd,
   env,
@@ -67,7 +82,21 @@ updateTask(taskId, {
   terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
 });
 
-let crashStarted = false;
+if (
+  await completePendingWatcherCancellation({
+    taskId,
+    getTask,
+    commandCleanup,
+    terminateProvider: terminateOwnedProviderBoundary,
+    updateTask,
+    emergencyLog,
+  })
+) {
+  crashStarted = true;
+  process.exit(0);
+}
+
+
 let stdoutBuffer = '';
 let stderrBuffer = '';
 

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -11,11 +11,10 @@ import { updateTask } from './store.js';
 import { createCommandSpecCleanup } from './command-spec-cleanup.js';
 import { terminateProcess } from './process-termination.js';
 import {
-  detectProviderFatalError,
-  detectProviderStreamingModeError,
-  recoverProviderStructuredOutput,
-  supportsProviderStructuredOutputRecovery,
-} from './provider-helper-runtime.js';
+  completeWatcherTask,
+  createWatcherOutputRuntime,
+  resolveWatcherCommand,
+} from './watcher-output-runtime.js';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -47,12 +46,12 @@ const commandCleanup = createCommandSpecCleanup(commandSpec, (cleanupPath, error
   emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${cleanupPath}: ${error.message}\n`);
 });
 
-const providerName = normalizeProviderName(config.provider || 'claude');
-const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
-
-const env = { ...process.env, ...(commandSpec.env || {}) };
-const command = commandSpec.binary;
-const finalArgs = [...(commandSpec.args || args)];
+const { providerName, env, command, finalArgs } = resolveWatcherCommand(
+  config,
+  commandSpec,
+  args,
+  normalizeProviderName
+);
 
 let child = spawn(command, finalArgs, {
   cwd: commandSpec.cwd || cwd,
@@ -68,44 +67,11 @@ updateTask(taskId, {
   terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
 });
 
-const silentJsonMode =
-  config.outputFormat === 'json' &&
-  config.jsonSchema &&
-  config.silentJsonOutput &&
-  supportsProviderStructuredOutputRecovery(providerName);
-
-let finalResultJson = null;
-let streamingModeError = null;
-let fatalError = null;
 let crashStarted = false;
-
 let stdoutBuffer = '';
 let stderrBuffer = '';
 
-function splitBufferLines(buffer, chunk) {
-  const nextBuffer = buffer + chunk;
-  const lines = nextBuffer.split('\n');
-  const remaining = lines.pop() || '';
-  return { lines, remaining };
-}
-
-function maybeHandleFatalError(line, timestamp) {
-  if (fatalError) {
-    return false;
-  }
-
-  const detected = detectProviderFatalError(providerName, line);
-  if (!detected) {
-    return false;
-  }
-
-  fatalError = detected;
-
-  if (silentJsonMode) {
-    log(`[${timestamp}]${line}\n`);
-  }
-  log(`[${timestamp}][FATAL] ${detected}\n`);
-
+function stopProviderAfterFatalOutput() {
   try {
     child.kill('SIGTERM');
   } catch {
@@ -121,180 +87,47 @@ function maybeHandleFatalError(line, timestamp) {
       }
     }
   }, 5000);
-
-  return true;
 }
 
-function captureStreamingError(line, timestamp) {
-  const detectedError = detectProviderStreamingModeError(providerName, line);
-  if (!detectedError) {
-    return false;
-  }
-
-  streamingModeError = { ...detectedError, timestamp };
-  return true;
-}
-
-function maybeCaptureStructuredOutput(line) {
-  try {
-    const json = JSON.parse(line);
-    if (json.structured_output) {
-      finalResultJson = line;
-    }
-  } catch {
-    // Not JSON, skip
-  }
-}
-
-function handleSilentJsonLines(lines, timestamp) {
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    maybeHandleFatalError(line, timestamp);
-    if (captureStreamingError(line, timestamp)) {
-      continue;
-    }
-    maybeCaptureStructuredOutput(line);
-  }
-}
-
-function handleStreamingLines(lines, timestamp) {
-  for (const line of lines) {
-    maybeHandleFatalError(line, timestamp);
-    if (captureStreamingError(line, timestamp)) {
-      continue;
-    }
-    log(`[${timestamp}]${line}\n`);
-  }
-}
-
-function flushStdoutBuffer(timestamp) {
-  if (!stdoutBuffer.trim()) {
-    return;
-  }
-
-  if (!enableRecovery) {
-    if (!silentJsonMode) {
-      log(`[${timestamp}]${stdoutBuffer}\n`);
-    }
-    return;
-  }
-
-  maybeHandleFatalError(stdoutBuffer, timestamp);
-  if (captureStreamingError(stdoutBuffer, timestamp)) {
-    return;
-  }
-
-  if (silentJsonMode) {
-    maybeCaptureStructuredOutput(stdoutBuffer);
-    return;
-  }
-
-  log(`[${timestamp}]${stdoutBuffer}\n`);
-}
-
-function flushStderrBuffer(timestamp) {
-  if (stderrBuffer.trim()) {
-    maybeHandleFatalError(stderrBuffer, timestamp);
-    log(`[${timestamp}]${stderrBuffer}\n`);
-  }
-}
-
-function attemptRecovery(code, timestamp) {
-  if (!(code !== 0 && streamingModeError?.sessionId)) {
-    return null;
-  }
-
-  const recovered = recoverProviderStructuredOutput(providerName, streamingModeError.sessionId);
-  if (recovered?.payload) {
-    const recoveredLine = JSON.stringify(recovered.payload);
-    if (silentJsonMode) {
-      finalResultJson = recoveredLine;
-    } else {
-      log(`[${timestamp}]${recoveredLine}\n`);
-    }
-  } else if (streamingModeError.line) {
-    if (silentJsonMode) {
-      log(streamingModeError.line + '\n');
-    } else {
-      log(`[${streamingModeError.timestamp}]${streamingModeError.line}\n`);
-    }
-  }
-
-  return recovered;
-}
-
-function writeCompletionFooter(code, signal) {
-  if (config.outputFormat === 'json') {
-    return;
-  }
-
-  log(`\n${'='.repeat(50)}\n`);
-  log(`Finished: ${new Date().toISOString()}\n`);
-  log(`Exit code: ${code}, Signal: ${signal}\n`);
-}
+const outputRuntime = createWatcherOutputRuntime({
+  config,
+  providerName,
+  log,
+  stopProvider: stopProviderAfterFatalOutput,
+});
 
 child.stdout.on('data', (data) => {
-  const chunk = data.toString();
-  const timestamp = Date.now();
-
-  const { lines, remaining } = splitBufferLines(stdoutBuffer, chunk);
-  stdoutBuffer = remaining;
-
-  if (silentJsonMode) {
-    handleSilentJsonLines(lines, timestamp);
-  } else {
-    handleStreamingLines(lines, timestamp);
-  }
+  stdoutBuffer = outputRuntime.consumeOutput(stdoutBuffer, data);
 });
 
 child.stderr.on('data', (data) => {
-  const chunk = data.toString();
-  const timestamp = Date.now();
-
-  const { lines, remaining } = splitBufferLines(stderrBuffer, chunk);
-  stderrBuffer = remaining;
-
-  for (const line of lines) {
-    log(`[${timestamp}]${line}\n`);
-  }
+  stderrBuffer = outputRuntime.consumeStderr(stderrBuffer, data);
 });
 
 child.on('close', async (code, signal) => {
   if (crashStarted) return;
-  const timestamp = Date.now();
-
-  flushStdoutBuffer(timestamp);
-  flushStderrBuffer(timestamp);
-
-  const recovered = attemptRecovery(code, timestamp);
-
-  if (silentJsonMode && finalResultJson) {
-    log(finalResultJson + '\n');
-  }
-
-  writeCompletionFooter(code, signal);
-  const cleanupSucceeded = await commandCleanup.run();
-
-  const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
-  const status = resolvedCode === 0 ? 'completed' : 'failed';
-  try {
-    await updateTask(taskId, {
-      status,
-      pid: null,
-      processGroupId: null,
-      exitCode: resolvedCode,
-      error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
-      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
-    });
-  } catch (updateError) {
-    log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
-  }
+  const completion = outputRuntime.complete({
+    code,
+    signal,
+    outputBuffer: stdoutBuffer,
+    stderrBuffer,
+  });
+  await completeWatcherTask({
+    taskId,
+    completion,
+    commandCleanup,
+    terminateProvider: terminateOwnedProviderBoundary,
+    updateTask,
+    emergencyLog,
+  });
   process.exit(0);
 });
 
 child.on('error', async (err) => {
+  crashStarted = true;
   log(`\nError: ${err.message}\n`);
-  const cleanupSucceeded = commandCleanup.runSync();
+  const providerTerminal = await terminateOwnedProviderBoundary();
+  const cleanupSucceeded = providerTerminal ? await commandCleanup.run() : false;
   try {
     await updateTask(taskId, {
       status: 'failed',
@@ -309,8 +142,8 @@ child.on('error', async (err) => {
   process.exit(1);
 });
 
-async function terminateProviderAfterWatcherCrash() {
-  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return true;
+async function terminateOwnedProviderBoundary() {
+  if (!child?.pid) return true;
   const result = await terminateProcess(child.pid, {
     processGroupId: process.platform === 'win32' ? null : child.pid,
     terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
@@ -323,7 +156,7 @@ async function crashWithError(error, source) {
   crashStarted = true;
   const errorMessage = error instanceof Error ? error.stack || error.message : String(error);
   emergencyLog(`\n[${Date.now()}][CRASH] ${source}: ${errorMessage}\n`);
-  const providerTerminal = await terminateProviderAfterWatcherCrash();
+  const providerTerminal = await terminateOwnedProviderBoundary();
   let cleanupSucceeded = false;
   if (providerTerminal) {
     cleanupSucceeded = await commandCleanup.run();

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -98,8 +98,8 @@ const outputRuntime = createWatcherOutputRuntime({
   providerSessionCapture,
 });
 
-function terminateOwnedProviderBoundary() {
-  return terminateWatcherProvider(child);
+function terminateOwnedProviderBoundary(exitObserved = false) {
+  return terminateWatcherProvider(child, { exitObserved });
 }
 
 async function crashWithError(error, source) {
@@ -165,7 +165,7 @@ child.on('close', async (code, signal) => {
     taskId,
     completion,
     commandCleanup,
-    terminateProvider: terminateOwnedProviderBoundary,
+    terminateProvider: () => terminateOwnedProviderBoundary(true),
     updateTask,
     emergencyLog,
   });

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -60,7 +60,7 @@ if (
     taskId,
     getTask,
     commandCleanup,
-    terminateProvider: async () => true,
+    terminateProvider: () => true,
     updateTask,
     emergencyLog,
   })

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -6,9 +6,10 @@
  */
 
 import { spawn } from 'child_process';
-import { appendFileSync, unlinkSync } from 'fs';
-import { unlink } from 'fs/promises';
+import { appendFileSync } from 'fs';
 import { updateTask } from './store.js';
+import { createCommandSpecCleanup } from './command-spec-cleanup.js';
+import { terminateProcess } from './process-termination.js';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
@@ -34,6 +35,18 @@ function log(msg) {
   appendFileSync(logFile, msg);
 }
 
+function emergencyLog(msg) {
+  try {
+    log(msg);
+  } catch {
+    process.stderr.write(msg);
+  }
+}
+
+const commandCleanup = createCommandSpecCleanup(commandSpec, (cleanupPath, error) => {
+  emergencyLog(`[${Date.now()}][CLEANUP] Failed to delete ${cleanupPath}: ${error.message}\n`);
+});
+
 const providerName = normalizeProviderName(config.provider || 'claude');
 const enableRecovery = supportsProviderStructuredOutputRecovery(providerName);
 
@@ -41,7 +54,7 @@ const env = { ...process.env, ...(commandSpec.env || {}) };
 const command = commandSpec.binary;
 const finalArgs = [...(commandSpec.args || args)];
 
-const child = spawn(command, finalArgs, {
+let child = spawn(command, finalArgs, {
   cwd: commandSpec.cwd || cwd,
   env,
   stdio: ['ignore', 'pipe', 'pipe'],
@@ -64,7 +77,7 @@ const silentJsonMode =
 let finalResultJson = null;
 let streamingModeError = null;
 let fatalError = null;
-let cleanupStarted = false;
+let crashStarted = false;
 
 let stdoutBuffer = '';
 let stderrBuffer = '';
@@ -210,30 +223,6 @@ function attemptRecovery(code, timestamp) {
   return recovered;
 }
 
-async function cleanupCommandSpec() {
-  if (cleanupStarted) return;
-  cleanupStarted = true;
-  for (const file of commandSpec.cleanup || []) {
-    try {
-      await unlink(file);
-    } catch (error) {
-      log(`[${Date.now()}][CLEANUP] Failed to delete ${file}: ${error.message}\n`);
-    }
-  }
-}
-
-function cleanupCommandSpecSync() {
-  if (cleanupStarted) return;
-  cleanupStarted = true;
-  for (const file of commandSpec.cleanup || []) {
-    try {
-      unlinkSync(file);
-    } catch (error) {
-      log(`[${Date.now()}][CLEANUP] Failed to delete ${file}: ${error.message}\n`);
-    }
-  }
-}
-
 function writeCompletionFooter(code, signal) {
   if (config.outputFormat === 'json') {
     return;
@@ -271,6 +260,7 @@ child.stderr.on('data', (data) => {
 });
 
 child.on('close', async (code, signal) => {
+  if (crashStarted) return;
   const timestamp = Date.now();
 
   flushStdoutBuffer(timestamp);
@@ -283,7 +273,7 @@ child.on('close', async (code, signal) => {
   }
 
   writeCompletionFooter(code, signal);
-  await cleanupCommandSpec();
+  const cleanupSucceeded = await commandCleanup.run();
 
   const resolvedCode = fatalError ? 1 : recovered?.payload ? 0 : code;
   const status = resolvedCode === 0 ? 'completed' : 'failed';
@@ -294,6 +284,7 @@ child.on('close', async (code, signal) => {
       processGroupId: null,
       exitCode: resolvedCode,
       error: fatalError || (resolvedCode !== 0 && signal ? `Killed by ${signal}` : null),
+      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
@@ -303,16 +294,62 @@ child.on('close', async (code, signal) => {
 
 child.on('error', async (err) => {
   log(`\nError: ${err.message}\n`);
-  cleanupCommandSpecSync();
+  const cleanupSucceeded = commandCleanup.runSync();
   try {
     await updateTask(taskId, {
       status: 'failed',
       pid: null,
       processGroupId: null,
       error: err.message,
+      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
     });
   } catch (updateError) {
     log(`[${Date.now()}][ERROR] Failed to update task status: ${updateError.message}\n`);
   }
   process.exit(1);
+});
+
+async function terminateProviderAfterWatcherCrash() {
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return true;
+  const result = await terminateProcess(child.pid, {
+    processGroupId: process.platform === 'win32' ? null : child.pid,
+    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+  });
+  return result.terminated;
+}
+
+async function crashWithError(error, source) {
+  if (crashStarted) return;
+  crashStarted = true;
+  const errorMessage = error instanceof Error ? error.stack || error.message : String(error);
+  emergencyLog(`\n[${Date.now()}][CRASH] ${source}: ${errorMessage}\n`);
+  const providerTerminal = await terminateProviderAfterWatcherCrash();
+  let cleanupSucceeded = false;
+  if (providerTerminal) {
+    cleanupSucceeded = await commandCleanup.run();
+  } else {
+    emergencyLog(
+      `[${Date.now()}][CRASH] Provider termination could not be confirmed; preserving command cleanup paths.\n`
+    );
+  }
+  try {
+    await updateTask(taskId, {
+      status: 'failed',
+      pid: null,
+      processGroupId: null,
+      error: `${source}: ${errorMessage}`,
+      ...(cleanupSucceeded ? { commandCleanup: null } : {}),
+    });
+  } catch (updateError) {
+    emergencyLog(`[${Date.now()}][CRASH] Failed to update task status: ${updateError.message}\n`);
+  }
+  process.exit(1);
+}
+
+process.on('uncaughtException', (error) => {
+  void crashWithError(error, 'uncaughtException');
+});
+
+process.on('unhandledRejection', (reason) => {
+  void crashWithError(reason, 'unhandledRejection');
 });

--- a/task-lib/watcher.js
+++ b/task-lib/watcher.js
@@ -55,52 +55,13 @@ const { providerName, env, command, finalArgs } = resolveWatcherCommand(
   normalizeProviderName
 );
 
-if (
-  await completePendingWatcherCancellation({
-    taskId,
-    getTask,
-    commandCleanup,
-    terminateProvider: () => true,
-    updateTask,
-    emergencyLog,
-  })
-) {
-  process.exit(0);
-}
-
 let crashStarted = false;
-let child = spawnWatcherProvider(command, finalArgs, {
-  cwd: commandSpec.cwd || cwd,
-  env,
-  stdio: ['ignore', 'pipe', 'pipe'],
-  detached: process.platform !== 'win32',
-});
-
-updateTask(taskId, {
-  pid: child.pid,
-  processGroupId: process.platform === 'win32' ? null : child.pid,
-  terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
-});
-
-if (
-  await completePendingWatcherCancellation({
-    taskId,
-    getTask,
-    commandCleanup,
-    terminateProvider: terminateOwnedProviderBoundary,
-    updateTask,
-    emergencyLog,
-  })
-) {
-  crashStarted = true;
-  process.exit(0);
-}
-
-
+let child = null;
 let stdoutBuffer = '';
 let stderrBuffer = '';
 
 function stopProviderAfterFatalOutput() {
+  if (!child) return;
   try {
     child.kill('SIGTERM');
   } catch {
@@ -123,6 +84,53 @@ const outputRuntime = createWatcherOutputRuntime({
   providerName,
   log,
   stopProvider: stopProviderAfterFatalOutput,
+});
+
+function terminateOwnedProviderBoundary() {
+  return terminateWatcherProvider(child);
+}
+
+async function crashWithError(error, source) {
+  if (crashStarted) return;
+  crashStarted = true;
+  await completeWatcherFailure({
+    taskId,
+    error,
+    source,
+    commandCleanup,
+    terminateProvider: terminateOwnedProviderBoundary,
+    updateTask,
+    emergencyLog,
+  });
+  process.exit(1);
+}
+
+process.on('uncaughtException', (error) => {
+  void crashWithError(error, 'uncaughtException');
+});
+
+process.on('unhandledRejection', (reason) => {
+  void crashWithError(reason, 'unhandledRejection');
+});
+
+if (
+  await completePendingWatcherCancellation({
+    taskId,
+    getTask,
+    commandCleanup,
+    terminateProvider: () => true,
+    updateTask,
+    emergencyLog,
+  })
+) {
+  process.exit(0);
+}
+
+child = spawnWatcherProvider(command, finalArgs, {
+  cwd: commandSpec.cwd || cwd,
+  env,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  detached: process.platform !== 'win32',
 });
 
 child.stdout.on('data', (data) => {
@@ -153,6 +161,7 @@ child.on('close', async (code, signal) => {
 });
 
 child.on('error', async (err) => {
+  if (crashStarted) return;
   crashStarted = true;
   log(`\nError: ${err.message}\n`);
   await completeWatcherTask({
@@ -166,29 +175,21 @@ child.on('error', async (err) => {
   process.exit(1);
 });
 
-function terminateOwnedProviderBoundary() {
-  return terminateWatcherProvider(child);
-}
+updateTask(taskId, {
+  pid: child.pid,
+  processGroupId: process.platform === 'win32' ? null : child.pid,
+  terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+});
 
-async function crashWithError(error, source) {
-  if (crashStarted) return;
+if (getTask(taskId)?.cancelRequested) {
   crashStarted = true;
-  await completeWatcherFailure({
+  await completePendingWatcherCancellation({
     taskId,
-    error,
-    source,
+    getTask,
     commandCleanup,
     terminateProvider: terminateOwnedProviderBoundary,
     updateTask,
     emergencyLog,
   });
-  process.exit(1);
+  process.exit(0);
 }
-
-process.on('uncaughtException', (error) => {
-  void crashWithError(error, 'uncaughtException');
-});
-
-process.on('unhandledRejection', (reason) => {
-  void crashWithError(reason, 'unhandledRejection');
-});

--- a/tests/agent-cli-provider/executable-contract-option-validation.test.js
+++ b/tests/agent-cli-provider/executable-contract-option-validation.test.js
@@ -35,6 +35,11 @@ const invalidNestedOptionCases = [
     options: { cliFeatures: { supportsDir: 'true' } },
     field: 'options.cliFeatures.supportsDir',
   },
+  {
+    name: 'cliFeatures supportsSettings boolean',
+    options: { cliFeatures: { supportsSettings: 'true' } },
+    field: 'options.cliFeatures.supportsSettings',
+  },
   { name: 'modelSpec object', options: { modelSpec: 'level2' }, field: 'options.modelSpec' },
   {
     name: 'modelSpec level enum',

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -102,6 +102,18 @@ test('runtime Claude command facade delegates to helper', () => {
   });
 });
 
+test('Claude command loads the per-run settings overlay without replacing user config', () => {
+  const command = assertRuntimeCommandParity('claude', 'test context', {
+    outputFormat: 'json',
+    modelSpec: { level: 'level2', model: 'sonnet' },
+    claudeSettingsFile: '/tmp/zeroshot-run-settings.json',
+  });
+  const settingsIndex = command.args.indexOf('--settings');
+  assert.notEqual(settingsIndex, -1);
+  assert.equal(command.args[settingsIndex + 1], '/tmp/zeroshot-run-settings.json');
+  assert.equal(command.env.CLAUDE_CONFIG_DIR, undefined);
+});
+
 test('runtime Codex command facade delegates to helper', () => {
   assertRuntimeCommandParity('codex', 'test context', {
     outputFormat: 'json',

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -107,11 +107,48 @@ test('Claude command loads the per-run settings overlay without replacing user c
     outputFormat: 'json',
     modelSpec: { level: 'level2', model: 'sonnet' },
     claudeSettingsFile: '/tmp/zeroshot-run-settings.json',
+    cliFeatures: { supportsSettings: true },
   });
   const settingsIndex = command.args.indexOf('--settings');
   assert.notEqual(settingsIndex, -1);
   assert.equal(command.args[settingsIndex + 1], '/tmp/zeroshot-run-settings.json');
   assert.equal(command.env.CLAUDE_CONFIG_DIR, undefined);
+});
+
+test('Claude MCP configs remain variadic without consuming the positional prompt', () => {
+  const command = assertRuntimeCommandParity('claude', 'literal task prompt', {
+    mcpConfig: ['/repo/.mcp.json', '/repo/extra.mcp.json'],
+    modelSpec: { model: 'sonnet' },
+    cliFeatures: { supportsMcpConfig: true },
+  });
+  const mcpIndex = command.args.indexOf('--mcp-config');
+  const inputIndex = command.args.indexOf('--input-format');
+  assert.deepEqual(command.args.slice(mcpIndex, inputIndex), [
+    '--mcp-config',
+    '/repo/.mcp.json',
+    '/repo/extra.mcp.json',
+  ]);
+  assert.equal(command.args[inputIndex + 1], 'text');
+  assert.equal(command.args.at(-1), 'literal task prompt');
+});
+
+test('Claude fails closed before spawn when required settings or MCP flags are unavailable', () => {
+  assert.throws(
+    () =>
+      helper.buildProviderCommand('claude', 'context', {
+        claudeSettingsFile: '/tmp/settings.json',
+        cliFeatures: { supportsSettings: false },
+      }),
+    /Upgrade Claude Code/
+  );
+  assert.throws(
+    () =>
+      helper.buildProviderCommand('claude', 'context', {
+        mcpConfig: ['/repo/.mcp.json'],
+        cliFeatures: { supportsMcpConfig: false },
+      }),
+    /Upgrade Claude Code/
+  );
 });
 
 test('runtime Codex command facade delegates to helper', () => {
@@ -659,8 +696,16 @@ test('feature probing is deterministic from injected help text', () => {
     supportsVerbose: true,
     supportsModel: true,
     supportsEffort: true,
+    supportsSettings: false,
+    supportsMcpConfig: false,
     unknown: true,
   });
+  const claudeFeatures = helper
+    .getProviderAdapter('claude')
+    .detectCliFeatures('claude --settings --mcp-config --model');
+  assert.equal(claudeFeatures.supportsSettings, true);
+  assert.equal(claudeFeatures.supportsMcpConfig, true);
+  assert.equal(claudeFeatures.unknown, false);
 
   assert.equal(
     helper

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { URL } = require('node:url');
 
 const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
 const { killTask, spawnTaskProcess } = require('../src/agent/agent-task-executor');

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -157,6 +157,41 @@ describe('Agent stuck-task recovery', function () {
     }
   });
 
+  it('retains the caller task handle until durable termination and cleanup are confirmed', async function () {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-kill-pending-'));
+    const fakeZeroshot = path.join(fakeBin, 'zeroshot');
+    fs.writeFileSync(fakeZeroshot, '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    let followerKilled = false;
+    let livenessStopped = false;
+    const agent = {
+      currentTask: {
+        kill() {
+          followerKilled = true;
+        },
+      },
+      currentTaskId: 'startup-cancel-pending',
+      taskCommandPath: fakeZeroshot,
+      processPid: null,
+      lastOutputTime: 123,
+      taskStartedAt: 456,
+      _stopLivenessCheck() {
+        livenessStopped = true;
+      },
+      _log() {},
+    };
+
+    try {
+      const result = await killTask(agent, 'Provider inactivity timeout');
+      assert.strictEqual(result.forced, false);
+      assert.strictEqual(agent.currentTaskId, 'startup-cancel-pending');
+      assert.notStrictEqual(agent.currentTask, null);
+      assert.strictEqual(followerKilled, false);
+      assert.strictEqual(livenessStopped, false);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
   async function runMockRecovery({ failures, maxRestartAttempts, maxTotalRestarts }) {
     fs.writeFileSync(
       process.env.ZEROSHOT_SETTINGS_FILE,

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 const { URL } = require('node:url');
 
-const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
+const { startLivenessCheck, stopLivenessCheck, stop } = require('../src/agent/agent-lifecycle');
 const { killTask, spawnTaskProcess } = require('../src/agent/agent-task-executor');
 const Orchestrator = require('../src/orchestrator');
 const MockTaskRunner = require('./helpers/mock-task-runner');
@@ -86,6 +86,36 @@ describe('Agent stuck-task recovery', function () {
         jitterFactor: 0,
       })
     );
+  });
+
+  it('retries shutdown termination while an unconfirmed task handle remains', async function () {
+    let terminationAttempts = 0;
+    const agent = {
+      id: 'shutdown-retry',
+      running: true,
+      state: 'running',
+      currentTask: {},
+      livenessCheckInterval: null,
+      unsubscribe: null,
+      _currentExecution: null,
+      _log() {},
+      _killTask() {
+        terminationAttempts += 1;
+        if (terminationAttempts === 1) {
+          return { forced: false, reason: 'provider still running' };
+        }
+        this.currentTask = null;
+        return { forced: true };
+      },
+    };
+
+    await assert.rejects(stop(agent), /could not confirm termination/);
+    assert.strictEqual(agent.running, false);
+    assert.notStrictEqual(agent.currentTask, null);
+
+    await stop(agent);
+    assert.strictEqual(terminationAttempts, 2);
+    assert.strictEqual(agent.currentTask, null);
   });
 
   afterEach(function () {

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -264,7 +264,7 @@ describe('Agent stuck-task recovery', function () {
           spawnEnv: process.env,
         });
         await waitFor(() => agent.currentTask?.pendingLaunch);
-        if (state === 'post-row') await waitFor(() => getTask(taskId));
+        if (state === 'post-row') await waitFor(() => getTask(taskId), 10000);
         if (state === 'post-id') await launch;
 
         const termination = await killTask(agent, `cancel ${state}`);

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -68,6 +68,81 @@ function workerConfig() {
   };
 }
 
+function createPendingLaunchAgent() {
+  return {
+    currentTask: null,
+    currentTaskId: null,
+    processPid: null,
+    lastOutputTime: null,
+    taskStartedAt: null,
+    _publishLifecycle() {},
+    _stopLivenessCheck() {},
+    _log() {},
+  };
+}
+
+async function createPendingLaunchFixture() {
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-launch-windows-'));
+  const fakeZeroshot = path.join(fakeBin, 'zeroshot');
+  const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+  const retryKillMarker = path.join(fakeBin, 'retry-kill-marker');
+  fs.writeFileSync(
+    fakeZeroshot,
+    `#!/usr/bin/env node
+    (async () => {
+      const fs = require('node:fs');
+      const { addTask, updateTask } = await import(${JSON.stringify(storeUrl)});
+      const action = process.argv[2];
+      const taskId = process.argv[3];
+      if (
+        action === 'kill' &&
+        taskId === 'launch-retry-task' &&
+        !fs.existsSync(${JSON.stringify(retryKillMarker)})
+      ) {
+        fs.writeFileSync(${JSON.stringify(retryKillMarker)}, 'failed once\\n');
+        process.exitCode = 1;
+        return;
+      }
+      if (action === 'kill') {
+        updateTask(taskId, {
+          status: 'killed',
+          pid: null,
+          processGroupId: null,
+          cancelRequested: false,
+          commandCleanup: null
+        });
+        return;
+      }
+      if (action === 'pre-row') {
+        setInterval(() => {}, 1000);
+        return;
+      }
+      if (action === 'timeout-row') {
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      }
+      addTask({
+        id: taskId,
+        status: 'running',
+        pid: null,
+        spawnOwnershipToken: process.env.ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN,
+        commandCleanup: null
+      });
+      if (action === 'post-row' || action === 'timeout-row') {
+        setInterval(() => {}, 1000);
+        return;
+      }
+      process.stdout.write('Task spawned: ' + taskId + '\\n');
+    })().catch((error) => {
+      process.stderr.write(error.stack + '\\n');
+      process.exitCode = 1;
+    });
+    `,
+    { mode: 0o755 }
+  );
+  const { getTask, removeTask } = await import(storeUrl);
+  return { fakeBin, fakeZeroshot, getTask, removeTask };
+}
+
 describe('Agent stuck-task recovery', function () {
   this.timeout(10000);
   let settingsDir;
@@ -225,78 +300,15 @@ describe('Agent stuck-task recovery', function () {
 
 
   it('cancels pending launches before persistence, before wrapper close, and before follower install', async function () {
-    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-launch-windows-'));
-    const fakeZeroshot = path.join(fakeBin, 'zeroshot');
-    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
-    const retryKillMarker = path.join(fakeBin, 'retry-kill-marker');
-    fs.writeFileSync(
-      fakeZeroshot,
-      `#!/usr/bin/env node
-      (async () => {
-        const fs = require('node:fs');
-        const { addTask, updateTask } = await import(${JSON.stringify(storeUrl)});
-        const action = process.argv[2];
-        const taskId = process.argv[3];
-        if (
-          action === 'kill' &&
-          taskId === 'launch-retry-task' &&
-          !fs.existsSync(${JSON.stringify(retryKillMarker)})
-        ) {
-          fs.writeFileSync(${JSON.stringify(retryKillMarker)}, 'failed once\\n');
-          process.exitCode = 1;
-          return;
-        }
-        if (action === 'kill') {
-          updateTask(taskId, {
-            status: 'killed',
-            pid: null,
-            processGroupId: null,
-            cancelRequested: false,
-            commandCleanup: null
-          });
-          return;
-        }
-        if (action === 'pre-row') {
-          setInterval(() => {}, 1000);
-          return;
-        }
-        if (action === 'timeout-row') {
-          await new Promise((resolve) => setTimeout(resolve, 40));
-        }
-        addTask({
-          id: taskId,
-          status: 'running',
-          pid: null,
-          spawnOwnershipToken: process.env.ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN,
-          commandCleanup: null
-        });
-        if (action === 'post-row' || action === 'timeout-row') {
-          setInterval(() => {}, 1000);
-          return;
-        }
-        process.stdout.write('Task spawned: ' + taskId + '\\n');
-      })().catch((error) => {
-        process.stderr.write(error.stack + '\\n');
-        process.exitCode = 1;
-      });
-      `,
-      { mode: 0o755 }
-    );
-    const { getTask, removeTask } = await import(storeUrl);
+    const { fakeBin, fakeZeroshot, getTask, removeTask } =
+      await createPendingLaunchFixture();
+    const taskIds = ['launch-prerow-task', 'launch-postrow-task', 'launch-postid-task'];
 
     try {
       for (const state of ['pre-row', 'post-row', 'post-id']) {
         const taskId = `launch-${state.replace('-', '')}-task`;
-        const agent = {
-          currentTask: null,
-          currentTaskId: null,
-          processPid: null,
-          lastOutputTime: null,
-          taskStartedAt: null,
-          _publishLifecycle() {},
-          _stopLivenessCheck() {},
-          _log() {},
-        };
+        removeTask(taskId);
+        const agent = createPendingLaunchAgent();
         const launch = spawnTaskProcess({
           agent,
           ctPath: fakeZeroshot,
@@ -304,6 +316,8 @@ describe('Agent stuck-task recovery', function () {
           cwd: process.cwd(),
           spawnEnv: process.env,
         });
+        const launchRejection =
+          state === 'post-id' ? null : assert.rejects(launch, /killed by signal/i);
         await waitFor(() => agent.currentTask?.pendingLaunch);
         if (state === 'post-row') await waitFor(() => getTask(taskId), 10000);
         if (state === 'post-id') await launch;
@@ -314,62 +328,62 @@ describe('Agent stuck-task recovery', function () {
         assert.strictEqual(agent.currentTaskId, null, state);
         if (state !== 'pre-row') {
           assert.strictEqual(getTask(taskId)?.status, 'killed', state);
-          removeTask(taskId);
-        } else {
-          await assert.rejects(launch, /killed by signal/i);
         }
-        if (state === 'post-row') await assert.rejects(launch, /killed by signal/i);
+        if (launchRejection) await launchRejection;
       }
+    } finally {
+      for (const taskId of taskIds) removeTask(taskId);
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
 
-      const retryTaskId = 'launch-retry-task';
-      removeTask(retryTaskId);
-      const retryAgent = {
-        currentTask: null,
-        currentTaskId: null,
-        processPid: null,
-        lastOutputTime: null,
-        taskStartedAt: null,
-        _publishLifecycle() {},
-        _stopLivenessCheck() {},
-        _log() {},
-      };
-      const retryLaunch = spawnTaskProcess({
-        agent: retryAgent,
+  it('retries an unconfirmed pending-launch cancellation', async function () {
+    const { fakeBin, fakeZeroshot, getTask, removeTask } =
+      await createPendingLaunchFixture();
+    const taskId = 'launch-retry-task';
+    removeTask(taskId);
+    const agent = createPendingLaunchAgent();
+
+    try {
+      const launch = spawnTaskProcess({
+        agent,
         ctPath: fakeZeroshot,
-        args: ['post-row', retryTaskId],
+        args: ['post-row', taskId],
         cwd: process.cwd(),
         spawnEnv: process.env,
       });
-      const retryRejection = assert.rejects(retryLaunch, /killed by signal/i);
-      await waitFor(() => getTask(retryTaskId), 10000);
-      const firstRetryTermination = await killTask(retryAgent, 'first cancellation attempt');
-      assert.strictEqual(firstRetryTermination?.forced, false);
-      assert.notStrictEqual(retryAgent.currentTask, null);
-      const secondRetryTermination = await killTask(retryAgent, 'second cancellation attempt');
-      assert.notStrictEqual(secondRetryTermination?.forced, false);
-      assert.strictEqual(retryAgent.currentTask, null);
-      assert.strictEqual(getTask(retryTaskId)?.status, 'killed');
-      await retryRejection;
-      removeTask(retryTaskId);
+      const rejection = assert.rejects(launch, /killed by signal/i);
+      await waitFor(() => getTask(taskId), 10000);
 
-      const timeoutTaskId = 'launch-timeout-task';
-      removeTask(timeoutTaskId);
-      const timeoutAgent = {
-        currentTask: null,
-        currentTaskId: null,
-        processPid: null,
-        lastOutputTime: null,
-        taskStartedAt: null,
-        _publishLifecycle() {},
-        _stopLivenessCheck() {},
-        _log() {},
-      };
+      const firstTermination = await killTask(agent, 'first cancellation attempt');
+      assert.strictEqual(firstTermination?.forced, false);
+      assert.notStrictEqual(agent.currentTask, null);
+
+      const secondTermination = await killTask(agent, 'second cancellation attempt');
+      assert.notStrictEqual(secondTermination?.forced, false);
+      assert.strictEqual(agent.currentTask, null);
+      assert.strictEqual(getTask(taskId)?.status, 'killed');
+      await rejection;
+    } finally {
+      removeTask(taskId);
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
+
+  it('terminates a durable child after a pending-launch timeout', async function () {
+    const { fakeBin, fakeZeroshot, getTask, removeTask } =
+      await createPendingLaunchFixture();
+    const taskId = 'launch-timeout-task';
+    removeTask(taskId);
+    const agent = createPendingLaunchAgent();
+
+    try {
       let timeoutError;
       try {
         await spawnTaskProcess({
-          agent: timeoutAgent,
+          agent,
           ctPath: fakeZeroshot,
-          args: ['timeout-row', timeoutTaskId],
+          args: ['timeout-row', taskId],
           cwd: process.cwd(),
           spawnEnv: process.env,
           spawnTimeoutMs: 300,
@@ -377,13 +391,14 @@ describe('Agent stuck-task recovery', function () {
       } catch (error) {
         timeoutError = error;
       }
+
       assert.match(timeoutError?.message || '', /Spawn timeout/);
       assert.strictEqual(timeoutError.commandCleanupOwner, 'task-lifecycle');
-      assert.strictEqual(getTask(timeoutTaskId)?.status, 'killed');
-      assert.strictEqual(timeoutAgent.currentTask, null);
-      assert.strictEqual(timeoutAgent.currentTaskId, null);
-      removeTask(timeoutTaskId);
+      assert.strictEqual(getTask(taskId)?.status, 'killed');
+      assert.strictEqual(agent.currentTask, null);
+      assert.strictEqual(agent.currentTaskId, null);
     } finally {
+      removeTask(taskId);
       fs.rmSync(fakeBin, { recursive: true, force: true });
     }
   });

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -198,13 +198,24 @@ describe('Agent stuck-task recovery', function () {
     const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-launch-windows-'));
     const fakeZeroshot = path.join(fakeBin, 'zeroshot');
     const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const retryKillMarker = path.join(fakeBin, 'retry-kill-marker');
     fs.writeFileSync(
       fakeZeroshot,
       `#!/usr/bin/env node
       (async () => {
+        const fs = require('node:fs');
         const { addTask, updateTask } = await import(${JSON.stringify(storeUrl)});
         const action = process.argv[2];
         const taskId = process.argv[3];
+        if (
+          action === 'kill' &&
+          taskId === 'launch-retry-task' &&
+          !fs.existsSync(${JSON.stringify(retryKillMarker)})
+        ) {
+          fs.writeFileSync(${JSON.stringify(retryKillMarker)}, 'failed once\\n');
+          process.exitCode = 1;
+          return;
+        }
         if (action === 'kill') {
           updateTask(taskId, {
             status: 'killed',
@@ -280,7 +291,39 @@ describe('Agent stuck-task recovery', function () {
         if (state === 'post-row') await assert.rejects(launch, /killed by signal/i);
       }
 
+      const retryTaskId = 'launch-retry-task';
+      removeTask(retryTaskId);
+      const retryAgent = {
+        currentTask: null,
+        currentTaskId: null,
+        processPid: null,
+        lastOutputTime: null,
+        taskStartedAt: null,
+        _publishLifecycle() {},
+        _stopLivenessCheck() {},
+        _log() {},
+      };
+      const retryLaunch = spawnTaskProcess({
+        agent: retryAgent,
+        ctPath: fakeZeroshot,
+        args: ['post-row', retryTaskId],
+        cwd: process.cwd(),
+        spawnEnv: process.env,
+      });
+      const retryRejection = assert.rejects(retryLaunch, /killed by signal/i);
+      await waitFor(() => getTask(retryTaskId), 10000);
+      const firstRetryTermination = await killTask(retryAgent, 'first cancellation attempt');
+      assert.strictEqual(firstRetryTermination?.forced, false);
+      assert.notStrictEqual(retryAgent.currentTask, null);
+      const secondRetryTermination = await killTask(retryAgent, 'second cancellation attempt');
+      assert.notStrictEqual(secondRetryTermination?.forced, false);
+      assert.strictEqual(retryAgent.currentTask, null);
+      assert.strictEqual(getTask(retryTaskId)?.status, 'killed');
+      await retryRejection;
+      removeTask(retryTaskId);
+
       const timeoutTaskId = 'launch-timeout-task';
+      removeTask(timeoutTaskId);
       const timeoutAgent = {
         currentTask: null,
         currentTaskId: null,
@@ -306,9 +349,9 @@ describe('Agent stuck-task recovery', function () {
       }
       assert.match(timeoutError?.message || '', /Spawn timeout/);
       assert.strictEqual(timeoutError.commandCleanupOwner, 'task-lifecycle');
-      assert.strictEqual(getTask(timeoutTaskId)?.status, 'running');
-      await killTask(timeoutAgent, 'cancel timeout');
       assert.strictEqual(getTask(timeoutTaskId)?.status, 'killed');
+      assert.strictEqual(timeoutAgent.currentTask, null);
+      assert.strictEqual(timeoutAgent.currentTaskId, null);
       removeTask(timeoutTaskId);
     } finally {
       fs.rmSync(fakeBin, { recursive: true, force: true });

--- a/tests/agent-stuck-recovery.test.js
+++ b/tests/agent-stuck-recovery.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 
 const { startLivenessCheck, stopLivenessCheck } = require('../src/agent/agent-lifecycle');
-const { killTask } = require('../src/agent/agent-task-executor');
+const { killTask, spawnTaskProcess } = require('../src/agent/agent-task-executor');
 const Orchestrator = require('../src/orchestrator');
 const MockTaskRunner = require('./helpers/mock-task-runner');
 
@@ -192,6 +192,127 @@ describe('Agent stuck-task recovery', function () {
     }
   });
 
+
+  it('cancels pending launches before persistence, before wrapper close, and before follower install', async function () {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-launch-windows-'));
+    const fakeZeroshot = path.join(fakeBin, 'zeroshot');
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    fs.writeFileSync(
+      fakeZeroshot,
+      `#!/usr/bin/env node
+      (async () => {
+        const { addTask, updateTask } = await import(${JSON.stringify(storeUrl)});
+        const action = process.argv[2];
+        const taskId = process.argv[3];
+        if (action === 'kill') {
+          updateTask(taskId, {
+            status: 'killed',
+            pid: null,
+            processGroupId: null,
+            cancelRequested: false,
+            commandCleanup: null
+          });
+          return;
+        }
+        if (action === 'pre-row') {
+          setInterval(() => {}, 1000);
+          return;
+        }
+        if (action === 'timeout-row') {
+          await new Promise((resolve) => setTimeout(resolve, 40));
+        }
+        addTask({
+          id: taskId,
+          status: 'running',
+          pid: null,
+          spawnOwnershipToken: process.env.ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN,
+          commandCleanup: null
+        });
+        if (action === 'post-row' || action === 'timeout-row') {
+          setInterval(() => {}, 1000);
+          return;
+        }
+        process.stdout.write('Task spawned: ' + taskId + '\\n');
+      })().catch((error) => {
+        process.stderr.write(error.stack + '\\n');
+        process.exitCode = 1;
+      });
+      `,
+      { mode: 0o755 }
+    );
+    const { getTask, removeTask } = await import(storeUrl);
+
+    try {
+      for (const state of ['pre-row', 'post-row', 'post-id']) {
+        const taskId = `launch-${state.replace('-', '')}-task`;
+        const agent = {
+          currentTask: null,
+          currentTaskId: null,
+          processPid: null,
+          lastOutputTime: null,
+          taskStartedAt: null,
+          _publishLifecycle() {},
+          _stopLivenessCheck() {},
+          _log() {},
+        };
+        const launch = spawnTaskProcess({
+          agent,
+          ctPath: fakeZeroshot,
+          args: [state, taskId],
+          cwd: process.cwd(),
+          spawnEnv: process.env,
+        });
+        await waitFor(() => agent.currentTask?.pendingLaunch);
+        if (state === 'post-row') await waitFor(() => getTask(taskId));
+        if (state === 'post-id') await launch;
+
+        const termination = await killTask(agent, `cancel ${state}`);
+        assert.notStrictEqual(termination?.forced, false, state);
+        assert.strictEqual(agent.currentTask, null, state);
+        assert.strictEqual(agent.currentTaskId, null, state);
+        if (state !== 'pre-row') {
+          assert.strictEqual(getTask(taskId)?.status, 'killed', state);
+          removeTask(taskId);
+        } else {
+          await assert.rejects(launch, /killed by signal/i);
+        }
+        if (state === 'post-row') await assert.rejects(launch, /killed by signal/i);
+      }
+
+      const timeoutTaskId = 'launch-timeout-task';
+      const timeoutAgent = {
+        currentTask: null,
+        currentTaskId: null,
+        processPid: null,
+        lastOutputTime: null,
+        taskStartedAt: null,
+        _publishLifecycle() {},
+        _stopLivenessCheck() {},
+        _log() {},
+      };
+      let timeoutError;
+      try {
+        await spawnTaskProcess({
+          agent: timeoutAgent,
+          ctPath: fakeZeroshot,
+          args: ['timeout-row', timeoutTaskId],
+          cwd: process.cwd(),
+          spawnEnv: process.env,
+          spawnTimeoutMs: 300,
+        });
+      } catch (error) {
+        timeoutError = error;
+      }
+      assert.match(timeoutError?.message || '', /Spawn timeout/);
+      assert.strictEqual(timeoutError.commandCleanupOwner, 'task-lifecycle');
+      assert.strictEqual(getTask(timeoutTaskId)?.status, 'running');
+      await killTask(timeoutAgent, 'cancel timeout');
+      assert.strictEqual(getTask(timeoutTaskId)?.status, 'killed');
+      removeTask(timeoutTaskId);
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
+  });
   async function runMockRecovery({ failures, maxRestartAttempts, maxTotalRestarts }) {
     fs.writeFileSync(
       process.env.ZEROSHOT_SETTINGS_FILE,

--- a/tests/fixtures/ambiguous-task-launch-runtime.js
+++ b/tests/fixtures/ambiguous-task-launch-runtime.js
@@ -8,6 +8,9 @@ const mode = process.argv[2] || process.env.AMBIGUOUS_TASK_MODE;
 const repoRoot = path.resolve(__dirname, '../..');
 const taskId = process.env.AMBIGUOUS_TASK_ID || `ambiguous-${mode}`;
 const settingsEnv = 'ZEROSHOT_CLAUDE_SETTINGS_FILE';
+const ownershipTokenEnv = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
+const scenario = process.env.AMBIGUOUS_TASK_SCENARIO || 'persisted';
+const settingsMarker = process.env.AMBIGUOUS_SETTINGS_MARKER;
 
 function moduleUrl(relativePath) {
   return pathToFileURL(path.join(repoRoot, relativePath)).href;
@@ -25,6 +28,16 @@ function isRunning(pid) {
 async function runAmbiguousWrapper() {
   const { addTask } = await import(moduleUrl('task-lib/store.js'));
   const settingsPath = process.env[settingsEnv];
+  if (settingsMarker) {
+    fs.writeFileSync(settingsMarker, settingsPath, 'utf8');
+  }
+  if (scenario === 'pre-persistence-contract-failure') {
+    const { buildProviderCommand } = await import(moduleUrl('task-lib/provider-helper-runtime.js'));
+    buildProviderCommand('claude', 'unsupported settings test', {
+      claudeSettingsFile: settingsPath,
+      cliFeatures: { supportsSettings: false },
+    });
+  }
   const cleanupPath = path.dirname(settingsPath);
   const provider = childProcess.spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
     detached: process.platform !== 'win32',
@@ -41,6 +54,7 @@ async function runAmbiguousWrapper() {
     processGroupId: process.platform === 'win32' ? null : provider.pid,
     terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
     provider: 'claude',
+    spawnOwnershipToken: process.env[ownershipTokenEnv] || null,
     commandCleanup: {
       cleanup: [cleanupPath],
       cleanupMetadata: [
@@ -54,6 +68,7 @@ async function runAmbiguousWrapper() {
     },
   });
   process.stdout.write('wrapper exited after persisting the task\n');
+  process.exitCode = 1;
 }
 
 function createAgent() {
@@ -83,6 +98,7 @@ function createAgent() {
 async function rejectThroughLauncher() {
   process.env.AMBIGUOUS_TASK_WRAPPER = '1';
   process.env.AMBIGUOUS_TASK_ID = taskId;
+  process.env.AMBIGUOUS_TASK_SCENARIO = scenario;
   process.env.AMBIGUOUS_TASK_MODE = mode;
   if (mode === 'runner') {
     const ClaudeTaskRunner = require('../../src/claude-task-runner');
@@ -123,20 +139,26 @@ async function runScenario() {
   } catch (error) {
     rejection = error;
   }
+  const settingsPath = fs.existsSync(settingsMarker)
+    ? fs.readFileSync(settingsMarker, 'utf8')
+    : null;
   const pending = getTask(taskId);
-  if (!pending) {
+  if (scenario === 'persisted' && !pending) {
     throw new Error(`Ambiguous wrapper did not persist ${taskId}`);
   }
-  const cleanupPath = pending.commandCleanup.cleanup[0];
+  const cleanupPath = pending?.commandCleanup?.cleanup?.[0] || path.dirname(settingsPath);
   const overlayExistsAfterReject = fs.existsSync(cleanupPath);
-  const providerAliveAfterReject = isRunning(pending.pid);
+  const providerAliveAfterReject = pending?.pid ? isRunning(pending.pid) : false;
 
-  await killTaskCommand(taskId, {
-    graceMs: 40,
-    hardKillWaitMs: 500,
-    pollMs: 5,
-  });
-  const terminal = getTask(taskId);
+  let terminal = null;
+  if (pending) {
+    await killTaskCommand(taskId, {
+      graceMs: 40,
+      hardKillWaitMs: 500,
+      pollMs: 5,
+    });
+    terminal = getTask(taskId);
+  }
   process.stdout.write(
     `RESULT:${JSON.stringify({
       rejection: {
@@ -148,7 +170,7 @@ async function runScenario() {
       overlayExistsAfterReject,
       providerAliveAfterReject,
       overlayExistsAfterKill: fs.existsSync(cleanupPath),
-      providerAliveAfterKill: isRunning(pending.pid),
+      providerAliveAfterKill: pending?.pid ? isRunning(pending.pid) : false,
     })}\n`
   );
 }

--- a/tests/fixtures/ambiguous-task-launch-runtime.js
+++ b/tests/fixtures/ambiguous-task-launch-runtime.js
@@ -16,6 +16,35 @@ function moduleUrl(relativePath) {
   return pathToFileURL(path.join(repoRoot, relativePath)).href;
 }
 
+function createFakeZeroshot() {
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-ambiguous-bin-'));
+  const fakeZeroshot = path.join(fakeBin, 'zeroshot');
+  const killCommandUrl = moduleUrl('task-lib/commands/kill.js');
+  fs.writeFileSync(
+    fakeZeroshot,
+    `#!/usr/bin/env node
+    (async () => {
+      if (process.argv[2] === 'kill') {
+        const { killTaskCommand } = await import(${JSON.stringify(killCommandUrl)});
+        await killTaskCommand(process.argv[3], {
+          graceMs: 40,
+          hardKillWaitMs: 500,
+          pollMs: 5,
+        });
+        return;
+      }
+      require(${JSON.stringify(__filename)});
+    })().catch((error) => {
+      process.stderr.write(error.stack + '\\n');
+      process.exitCode = 1;
+    });
+    `,
+    { mode: 0o755 }
+  );
+  return { fakeBin, fakeZeroshot };
+}
+
+
 function isRunning(pid) {
   try {
     process.kill(pid, 0);
@@ -105,30 +134,33 @@ async function rejectThroughLauncher() {
   process.env.AMBIGUOUS_TASK_SCENARIO = scenario;
   process.env.AMBIGUOUS_TASK_MODE = mode;
   if (mode === 'runner') {
-    const ClaudeTaskRunner = require('../../src/claude-task-runner');
-    const runner = new ClaudeTaskRunner({ quiet: true });
-    const spawnAndGetTaskId = runner._spawnAndGetTaskId.bind(runner);
-    runner._spawnAndGetTaskId = (_command, _args, cwd, spawnEnv, agentId) =>
-      spawnAndGetTaskId(process.execPath, [__filename], cwd, spawnEnv, agentId);
-    await runner.run('ambiguous wrapper test', {
-      provider: 'claude',
-      cwd: repoRoot,
-    });
-    return;
+    const { fakeBin, fakeZeroshot } = createFakeZeroshot();
+    try {
+      const ClaudeTaskRunner = require('../../src/claude-task-runner');
+      const runner = new ClaudeTaskRunner({ quiet: true });
+      const spawnAndGetTaskId = runner._spawnAndGetTaskId.bind(runner);
+      runner._spawnAndGetTaskId = (_command, _args, cwd, spawnEnv, agentId) =>
+        spawnAndGetTaskId(fakeZeroshot, [], cwd, spawnEnv, agentId);
+      await runner.run('ambiguous wrapper test', {
+        provider: 'claude',
+        cwd: repoRoot,
+      });
+      return;
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
   }
 
   if (mode === 'agent') {
-    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-ambiguous-bin-'));
-    const fakeZeroshot = path.join(fakeBin, 'zeroshot');
-    fs.writeFileSync(
-      fakeZeroshot,
-      `#!/usr/bin/env node\nrequire(${JSON.stringify(__filename)});\n`,
-      { mode: 0o755 }
-    );
-    process.env.PATH = `${fakeBin}${path.delimiter}${process.env.PATH || ''}`;
-    const { spawnClaudeTask } = require('../../src/agent/agent-task-executor');
-    await spawnClaudeTask(createAgent(), 'ambiguous wrapper test');
-    return;
+    const { fakeBin } = createFakeZeroshot();
+    try {
+      process.env.PATH = `${fakeBin}${path.delimiter}${process.env.PATH || ''}`;
+      const { spawnClaudeTask } = require('../../src/agent/agent-task-executor');
+      await spawnClaudeTask(createAgent(), 'ambiguous wrapper test');
+      return;
+    } finally {
+      fs.rmSync(fakeBin, { recursive: true, force: true });
+    }
   }
 
   throw new Error(`Unknown ambiguous launcher mode: ${mode}`);

--- a/tests/fixtures/ambiguous-task-launch-runtime.js
+++ b/tests/fixtures/ambiguous-task-launch-runtime.js
@@ -1,0 +1,166 @@
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const mode = process.argv[2] || process.env.AMBIGUOUS_TASK_MODE;
+const repoRoot = path.resolve(__dirname, '../..');
+const taskId = process.env.AMBIGUOUS_TASK_ID || `ambiguous-${mode}`;
+const settingsEnv = 'ZEROSHOT_CLAUDE_SETTINGS_FILE';
+
+function moduleUrl(relativePath) {
+  return pathToFileURL(path.join(repoRoot, relativePath)).href;
+}
+
+function isRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runAmbiguousWrapper() {
+  const { addTask } = await import(moduleUrl('task-lib/store.js'));
+  const settingsPath = process.env[settingsEnv];
+  const cleanupPath = path.dirname(settingsPath);
+  const provider = childProcess.spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    detached: process.platform !== 'win32',
+    stdio: 'ignore',
+  });
+  provider.unref();
+  addTask({
+    id: taskId,
+    prompt: mode,
+    fullPrompt: mode,
+    cwd: repoRoot,
+    status: 'running',
+    pid: provider.pid,
+    processGroupId: process.platform === 'win32' ? null : provider.pid,
+    terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+    provider: 'claude',
+    commandCleanup: {
+      cleanup: [cleanupPath],
+      cleanupMetadata: [
+        {
+          kind: 'temp-directory',
+          provider: 'claude',
+          path: cleanupPath,
+          reason: 'settings-overlay',
+        },
+      ],
+    },
+  });
+  process.stdout.write('wrapper exited after persisting the task\n');
+}
+
+function createAgent() {
+  return {
+    id: 'ambiguous-agent',
+    role: 'implementation',
+    config: {
+      cwd: repoRoot,
+      outputFormat: 'stream-json',
+      strictSchema: false,
+    },
+    isolation: { enabled: false },
+    worktree: { enabled: false, path: null },
+    quiet: true,
+    enableLivenessCheck: false,
+    _resolveProvider() {
+      return 'claude';
+    },
+    _resolveModelSpec() {
+      return { model: null, reasoningEffort: null };
+    },
+    _log() {},
+    _publishLifecycle() {},
+  };
+}
+
+async function rejectThroughLauncher() {
+  process.env.AMBIGUOUS_TASK_WRAPPER = '1';
+  process.env.AMBIGUOUS_TASK_ID = taskId;
+  process.env.AMBIGUOUS_TASK_MODE = mode;
+  if (mode === 'runner') {
+    const ClaudeTaskRunner = require('../../src/claude-task-runner');
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    const spawnAndGetTaskId = runner._spawnAndGetTaskId.bind(runner);
+    runner._spawnAndGetTaskId = (_command, _args, cwd, spawnEnv, agentId) =>
+      spawnAndGetTaskId(process.execPath, [__filename], cwd, spawnEnv, agentId);
+    await runner.run('ambiguous wrapper test', {
+      provider: 'claude',
+      cwd: repoRoot,
+    });
+    return;
+  }
+
+  if (mode === 'agent') {
+    const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-ambiguous-bin-'));
+    const fakeZeroshot = path.join(fakeBin, 'zeroshot');
+    fs.writeFileSync(
+      fakeZeroshot,
+      `#!/usr/bin/env node\nrequire(${JSON.stringify(__filename)});\n`,
+      { mode: 0o755 }
+    );
+    process.env.PATH = `${fakeBin}${path.delimiter}${process.env.PATH || ''}`;
+    const { spawnClaudeTask } = require('../../src/agent/agent-task-executor');
+    await spawnClaudeTask(createAgent(), 'ambiguous wrapper test');
+    return;
+  }
+
+  throw new Error(`Unknown ambiguous launcher mode: ${mode}`);
+}
+
+async function runScenario() {
+  const { getTask } = await import(moduleUrl('task-lib/store.js'));
+  const { killTaskCommand } = await import(moduleUrl('task-lib/commands/kill.js'));
+  let rejection;
+  try {
+    await rejectThroughLauncher();
+  } catch (error) {
+    rejection = error;
+  }
+  const pending = getTask(taskId);
+  if (!pending) {
+    throw new Error(`Ambiguous wrapper did not persist ${taskId}`);
+  }
+  const cleanupPath = pending.commandCleanup.cleanup[0];
+  const overlayExistsAfterReject = fs.existsSync(cleanupPath);
+  const providerAliveAfterReject = isRunning(pending.pid);
+
+  await killTaskCommand(taskId, {
+    graceMs: 40,
+    hardKillWaitMs: 500,
+    pollMs: 5,
+  });
+  const terminal = getTask(taskId);
+  process.stdout.write(
+    `RESULT:${JSON.stringify({
+      rejection: {
+        message: rejection?.message,
+        commandCleanupOwner: rejection?.commandCleanupOwner,
+      },
+      pending,
+      terminal,
+      overlayExistsAfterReject,
+      providerAliveAfterReject,
+      overlayExistsAfterKill: fs.existsSync(cleanupPath),
+      providerAliveAfterKill: isRunning(pending.pid),
+    })}\n`
+  );
+}
+
+if (process.env.AMBIGUOUS_TASK_WRAPPER === '1') {
+  runAmbiguousWrapper().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+} else {
+  runScenario().catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/fixtures/ambiguous-task-launch-runtime.js
+++ b/tests/fixtures/ambiguous-task-launch-runtime.js
@@ -38,6 +38,10 @@ async function runAmbiguousWrapper() {
       cliFeatures: { supportsSettings: false },
     });
   }
+  if (scenario === 'legacy-success-no-token') {
+    process.stdout.write(`Task spawned: ${taskId}\n`);
+    return;
+  }
   const cleanupPath = path.dirname(settingsPath);
   const provider = childProcess.spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
     detached: process.platform !== 'win32',

--- a/tests/fixtures/fake-agent/index.js
+++ b/tests/fixtures/fake-agent/index.js
@@ -126,10 +126,32 @@ function isVersionProbe(argv) {
   return argv.includes('--version') && !argv.includes('--print');
 }
 
+function isHelpProbe(argv) {
+  return argv.includes('--help') && !argv.includes('--print');
+}
+
 function main() {
   const argv = process.argv.slice(2);
   if (isVersionProbe(argv)) {
     process.stdout.write('1.0.0 (fake-agent)\n');
+    process.exit(0);
+  }
+  if (isHelpProbe(argv)) {
+    process.stdout.write(
+      [
+        'Usage: claude [options]',
+        '  --output-format <format>',
+        '  --json-schema <schema>',
+        '  --dangerously-skip-permissions',
+        '  --include-partial-messages',
+        '  --verbose',
+        '  --model <model>',
+        '  --effort <effort>',
+        '  --settings <path>',
+        '  --mcp-config <path>',
+        '  stream-json',
+      ].join('\n')
+    );
     process.exit(0);
   }
 

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -161,13 +161,19 @@ async function runUnsafeFileScenario(store, killTaskCommand) {
   }
 }
 
-function runCleanScenario(store, cleanTasks, cleanMode, unsafe = false) {
+function runCleanScenario(store, cleanTasks, cleanMode, unsafe = false, statusOverride = null) {
   const cleanupPath = unsafe
     ? path.join(process.env.ZEROSHOT_HOME, 'user-cleanup')
     : fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-settings-run-clean-'));
   if (unsafe) fs.mkdirSync(cleanupPath);
-  const status = cleanMode === 'completed' ? 'completed' : 'failed';
-  const taskId = `clean-${cleanMode}${unsafe ? '-unsafe' : ''}`;
+  const status = statusOverride || (cleanMode === 'completed' ? 'completed' : 'failed');
+  const taskId = [
+    `clean-${cleanMode}`,
+    unsafe ? 'unsafe' : null,
+    statusOverride,
+  ]
+    .filter(Boolean)
+    .join('-');
   store.addTask(taskRecord(taskId, status, cleanupReceipt(cleanupPath)));
   cleanTasks({ [cleanMode]: true });
   return {
@@ -197,6 +203,8 @@ async function main() {
     result = runCleanScenario(store, cleanTasks, 'all');
   } else if (mode === 'clean-unsafe') {
     result = runCleanScenario(store, cleanTasks, 'all', true);
+  } else if (mode === 'clean-running') {
+    result = runCleanScenario(store, cleanTasks, 'all', false, 'running');
   } else {
     throw new Error(`Unknown terminal cleanup fixture mode: ${mode}`);
   }

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -1,0 +1,131 @@
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const mode = process.argv[2];
+const repoRoot = path.resolve(__dirname, '../..');
+
+function moduleUrl(relativePath) {
+  return pathToFileURL(path.join(repoRoot, relativePath)).href;
+}
+
+function taskRecord(id, status, commandCleanup, ownership = {}) {
+  return {
+    id,
+    prompt: mode,
+    fullPrompt: mode,
+    cwd: repoRoot,
+    status,
+    pid: ownership.pid ?? null,
+    processGroupId: ownership.processGroupId ?? null,
+    terminationStrategy: ownership.terminationStrategy ?? null,
+    commandCleanup,
+  };
+}
+
+function cleanupReceipt(cleanupPath) {
+  return {
+    cleanup: [cleanupPath],
+    cleanupMetadata: [
+      {
+        kind: 'temp-directory',
+        provider: 'claude',
+        path: cleanupPath,
+        reason: 'settings-overlay',
+      },
+    ],
+  };
+}
+
+async function runRetryScenario(store, killTaskCommand, completeWatcherTask) {
+  const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
+  fs.mkdirSync(overlayRoot, { recursive: true });
+  const cleanupPath = fs.mkdtempSync(path.join(overlayRoot, 'run-terminal-retry-'));
+  const taskId = 'terminal-cleanup-retry';
+  store.addTask(taskRecord(taskId, 'running', cleanupReceipt(cleanupPath), { pid: 424242 }));
+  let cleanupRuns = 0;
+
+  await completeWatcherTask({
+    taskId,
+    completion: { status: 'completed', resolvedCode: 0, error: null },
+    commandCleanup: {
+      run() {
+        cleanupRuns += 1;
+        return Promise.resolve(false);
+      },
+    },
+    terminateProvider: () => Promise.resolve(true),
+    updateTask: store.updateTask,
+    emergencyLog() {},
+  });
+
+  const terminal = store.getTask(taskId);
+  const cleanupExistsBeforeRetry = fs.existsSync(cleanupPath);
+  await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
+  return {
+    terminal,
+    recovered: store.getTask(taskId),
+    cleanupRuns,
+    cleanupExistsBeforeRetry,
+    cleanupExistsAfterRetry: fs.existsSync(cleanupPath),
+  };
+}
+
+async function runUnsafeScenario(store, killTaskCommand) {
+  const userDirectory = path.join(process.env.ZEROSHOT_HOME, 'user-owned');
+  fs.mkdirSync(userDirectory);
+  const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  const taskId = 'terminal-cleanup-unsafe';
+  store.addTask(
+    taskRecord(taskId, 'completed', cleanupReceipt(userDirectory), {
+      pid: unrelated.pid,
+      processGroupId: unrelated.pid,
+      terminationStrategy: 'process',
+    })
+  );
+
+  try {
+    await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
+    let unrelatedAlive = true;
+    try {
+      process.kill(unrelated.pid, 0);
+    } catch {
+      unrelatedAlive = false;
+    }
+    return {
+      terminal: store.getTask(taskId),
+      unrelatedAlive,
+      userDirectoryExists: fs.existsSync(userDirectory),
+    };
+  } finally {
+    try {
+      process.kill(unrelated.pid, 'SIGKILL');
+    } catch {
+      // The regression expects this process to remain alive until fixture teardown.
+    }
+  }
+}
+
+async function main() {
+  const store = await import(moduleUrl('task-lib/store.js'));
+  const { killTaskCommand } = await import(moduleUrl('task-lib/commands/kill.js'));
+  const { completeWatcherTask } = await import(moduleUrl('task-lib/watcher-output-runtime.js'));
+  let result;
+  if (mode === 'retry') {
+    result = await runRetryScenario(store, killTaskCommand, completeWatcherTask);
+  } else if (mode === 'unsafe') {
+    result = await runUnsafeScenario(store, killTaskCommand);
+  } else {
+    throw new Error(`Unknown terminal cleanup fixture mode: ${mode}`);
+  }
+  process.stdout.write(`RESULT:${JSON.stringify(result)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -1,4 +1,3 @@
-const { spawn } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -90,75 +89,53 @@ async function runRetryScenario(store, killTaskCommand, completeWatcherTask) {
 async function runUnsafeScenario(store, killTaskCommand) {
   const userDirectory = path.join(process.env.ZEROSHOT_HOME, 'user-owned');
   fs.mkdirSync(userDirectory);
-  const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-    stdio: 'ignore',
-  });
   const taskId = 'terminal-cleanup-unsafe';
   store.addTask(
     taskRecord(taskId, 'completed', cleanupReceipt(userDirectory), {
-      pid: unrelated.pid,
-      processGroupId: unrelated.pid,
+      pid: process.pid,
+      processGroupId: process.pid,
       terminationStrategy: 'process',
     })
   );
 
+  await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
+  let unrelatedAlive = true;
   try {
-    await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
-    let unrelatedAlive = true;
-    try {
-      process.kill(unrelated.pid, 0);
-    } catch {
-      unrelatedAlive = false;
-    }
-    return {
-      terminal: store.getTask(taskId),
-      unrelatedAlive,
-      userDirectoryExists: fs.existsSync(userDirectory),
-    };
-  } finally {
-    try {
-      process.kill(unrelated.pid, 'SIGKILL');
-    } catch {
-      // The regression expects this process to remain alive until fixture teardown.
-    }
+    process.kill(process.pid, 0);
+  } catch {
+    unrelatedAlive = false;
   }
+  return {
+    terminal: store.getTask(taskId),
+    unrelatedAlive,
+    userDirectoryExists: fs.existsSync(userDirectory),
+  };
 }
 
 async function runUnsafeFileScenario(store, killTaskCommand) {
   const userFile = path.join(process.env.ZEROSHOT_HOME, 'user-schema.json');
   fs.writeFileSync(userFile, '{}\n');
-  const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
-    stdio: 'ignore',
-  });
   const taskId = 'terminal-cleanup-unsafe-file';
   store.addTask(
     taskRecord(taskId, 'completed', fileCleanupReceipt(userFile), {
-      pid: unrelated.pid,
-      processGroupId: unrelated.pid,
+      pid: process.pid,
+      processGroupId: process.pid,
       terminationStrategy: 'process',
     })
   );
 
+  await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
+  let unrelatedAlive = true;
   try {
-    await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
-    let unrelatedAlive = true;
-    try {
-      process.kill(unrelated.pid, 0);
-    } catch {
-      unrelatedAlive = false;
-    }
-    return {
-      terminal: store.getTask(taskId),
-      unrelatedAlive,
-      userFileExists: fs.existsSync(userFile),
-    };
-  } finally {
-    try {
-      process.kill(unrelated.pid, 'SIGKILL');
-    } catch {
-      // The regression expects this process to remain alive until fixture teardown.
-    }
+    process.kill(process.pid, 0);
+  } catch {
+    unrelatedAlive = false;
   }
+  return {
+    terminal: store.getTask(taskId),
+    unrelatedAlive,
+    userFileExists: fs.existsSync(userFile),
+  };
 }
 
 function runCleanScenario(store, cleanTasks, cleanMode, unsafe = false, statusOverride = null) {

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -54,9 +54,9 @@ function fileCleanupReceipt(cleanupPath) {
 }
 
 async function runRetryScenario(store, killTaskCommand, completeWatcherTask) {
-  const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
-  fs.mkdirSync(overlayRoot, { recursive: true });
-  const cleanupPath = fs.mkdtempSync(path.join(overlayRoot, 'run-terminal-retry-'));
+  const cleanupPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'zeroshot-claude-settings-run-terminal-retry-')
+  );
   const taskId = 'terminal-cleanup-retry';
   store.addTask(taskRecord(taskId, 'running', cleanupReceipt(cleanupPath), { pid: 424242 }));
   let cleanupRuns = 0;

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -161,10 +161,27 @@ async function runUnsafeFileScenario(store, killTaskCommand) {
   }
 }
 
+function runCleanScenario(store, cleanTasks, cleanMode, unsafe = false) {
+  const cleanupPath = unsafe
+    ? path.join(process.env.ZEROSHOT_HOME, 'user-cleanup')
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-settings-run-clean-'));
+  if (unsafe) fs.mkdirSync(cleanupPath);
+  const status = cleanMode === 'completed' ? 'completed' : 'failed';
+  const taskId = `clean-${cleanMode}${unsafe ? '-unsafe' : ''}`;
+  store.addTask(taskRecord(taskId, status, cleanupReceipt(cleanupPath)));
+  cleanTasks({ [cleanMode]: true });
+  return {
+    retained: store.getTask(taskId) || null,
+    cleanupExists: fs.existsSync(cleanupPath),
+    exitCode: process.exitCode || 0,
+  };
+}
+
 async function main() {
   const store = await import(moduleUrl('task-lib/store.js'));
   const { killTaskCommand } = await import(moduleUrl('task-lib/commands/kill.js'));
   const { completeWatcherTask } = await import(moduleUrl('task-lib/watcher-output-runtime.js'));
+  const { cleanTasks } = await import(moduleUrl('task-lib/commands/clean.js'));
   let result;
   if (mode === 'retry') {
     result = await runRetryScenario(store, killTaskCommand, completeWatcherTask);
@@ -172,6 +189,14 @@ async function main() {
     result = await runUnsafeScenario(store, killTaskCommand);
   } else if (mode === 'unsafe-file') {
     result = await runUnsafeFileScenario(store, killTaskCommand);
+  } else if (mode === 'clean-completed') {
+    result = runCleanScenario(store, cleanTasks, 'completed');
+  } else if (mode === 'clean-failed') {
+    result = runCleanScenario(store, cleanTasks, 'failed');
+  } else if (mode === 'clean-all') {
+    result = runCleanScenario(store, cleanTasks, 'all');
+  } else if (mode === 'clean-unsafe') {
+    result = runCleanScenario(store, cleanTasks, 'all', true);
   } else {
     throw new Error(`Unknown terminal cleanup fixture mode: ${mode}`);
   }

--- a/tests/fixtures/task-terminal-cleanup-runtime.js
+++ b/tests/fixtures/task-terminal-cleanup-runtime.js
@@ -39,6 +39,20 @@ function cleanupReceipt(cleanupPath) {
   };
 }
 
+function fileCleanupReceipt(cleanupPath) {
+  return {
+    cleanup: [cleanupPath],
+    cleanupMetadata: [
+      {
+        kind: 'temp-file',
+        provider: 'codex',
+        path: cleanupPath,
+        reason: 'output-schema',
+      },
+    ],
+  };
+}
+
 async function runRetryScenario(store, killTaskCommand, completeWatcherTask) {
   const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
   fs.mkdirSync(overlayRoot, { recursive: true });
@@ -110,6 +124,43 @@ async function runUnsafeScenario(store, killTaskCommand) {
   }
 }
 
+async function runUnsafeFileScenario(store, killTaskCommand) {
+  const userFile = path.join(process.env.ZEROSHOT_HOME, 'user-schema.json');
+  fs.writeFileSync(userFile, '{}\n');
+  const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  const taskId = 'terminal-cleanup-unsafe-file';
+  store.addTask(
+    taskRecord(taskId, 'completed', fileCleanupReceipt(userFile), {
+      pid: unrelated.pid,
+      processGroupId: unrelated.pid,
+      terminationStrategy: 'process',
+    })
+  );
+
+  try {
+    await killTaskCommand(taskId, { graceMs: 40, pollMs: 5 });
+    let unrelatedAlive = true;
+    try {
+      process.kill(unrelated.pid, 0);
+    } catch {
+      unrelatedAlive = false;
+    }
+    return {
+      terminal: store.getTask(taskId),
+      unrelatedAlive,
+      userFileExists: fs.existsSync(userFile),
+    };
+  } finally {
+    try {
+      process.kill(unrelated.pid, 'SIGKILL');
+    } catch {
+      // The regression expects this process to remain alive until fixture teardown.
+    }
+  }
+}
+
 async function main() {
   const store = await import(moduleUrl('task-lib/store.js'));
   const { killTaskCommand } = await import(moduleUrl('task-lib/commands/kill.js'));
@@ -119,6 +170,8 @@ async function main() {
     result = await runRetryScenario(store, killTaskCommand, completeWatcherTask);
   } else if (mode === 'unsafe') {
     result = await runUnsafeScenario(store, killTaskCommand);
+  } else if (mode === 'unsafe-file') {
+    result = await runUnsafeFileScenario(store, killTaskCommand);
   } else {
     throw new Error(`Unknown terminal cleanup fixture mode: ${mode}`);
   }

--- a/tests/fixtures/watcher-cleanup-runtime.js
+++ b/tests/fixtures/watcher-cleanup-runtime.js
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const {
+  forceKill,
+  forceKillOwnedGroup,
+  isRunning,
+  spawnCapturedWatcher,
+  waitFor,
+} = require('./watcher-runtime-helpers');
+
+const watcherName = process.argv[2];
+const mode = process.argv[3];
+const repoRoot = path.resolve(__dirname, '../..');
+const watcherPath = path.join(repoRoot, 'task-lib', watcherName);
+const taskId = `cleanup-${watcherName}-${mode}`.replaceAll('.', '-');
+const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-watcher-cleanup-'));
+const logFile = path.join(stateDir, 'task.log');
+const providerPidFile = path.join(stateDir, 'provider.pid');
+
+async function main() {
+  const storeUrl = pathToFileURL(path.join(repoRoot, 'task-lib/store.js')).href;
+  const { addTask, getTask } = await import(storeUrl);
+  const {
+    cleanupClaudeSettingsOverlay,
+    prepareClaudeSettingsOverlay,
+  } = require('../../src/worktree-claude-config');
+
+  const settingsPath = prepareClaudeSettingsOverlay();
+  const ownedOverlayDir = path.dirname(settingsPath);
+  let cleanupDir = ownedOverlayDir;
+  let cleanupMetadata = [
+    {
+      kind: 'temp-directory',
+      provider: 'claude',
+      path: cleanupDir,
+      reason: 'settings-overlay',
+    },
+  ];
+
+  if (mode === 'unowned') {
+    cleanupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-unowned-cleanup-'));
+    cleanupMetadata = [
+      {
+        kind: 'temp-directory',
+        provider: 'claude',
+        path: cleanupDir,
+        reason: 'settings-overlay',
+      },
+    ];
+  }
+
+  addTask({
+    id: taskId,
+    prompt: mode,
+    fullPrompt: mode,
+    cwd: repoRoot,
+    status: 'running',
+    pid: null,
+    logFile,
+    provider: 'claude',
+    commandCleanup: { cleanup: [cleanupDir], cleanupMetadata },
+  });
+
+  const providerExitCode = mode === 'exit7' ? 7 : 0;
+  const providerSource =
+    mode === 'crash'
+      ? `
+        const fs = require('fs');
+        fs.writeFileSync(${JSON.stringify(providerPidFile)}, String(process.pid));
+        fs.rmSync(${JSON.stringify(logFile)}, { force: true });
+        fs.mkdirSync(${JSON.stringify(logFile)}, { recursive: true });
+        process.stdout.write('trigger watcher log failure\\n');
+        setInterval(() => {}, 1000);
+      `
+      : `process.stdout.write('provider output\\n'); process.exit(${providerExitCode});`;
+  const commandSpec = {
+    binary: process.execPath,
+    args: ['-e', providerSource],
+    env: {},
+    cleanup: [cleanupDir],
+    cleanupMetadata,
+  };
+  const config = {
+    provider: 'claude',
+    outputFormat: 'stream-json',
+    commandSpec,
+  };
+  const captured = spawnCapturedWatcher(watcherPath, [
+    taskId,
+    repoRoot,
+    logFile,
+    '[]',
+    JSON.stringify(config),
+  ]);
+  const watcher = captured.child;
+
+  let providerPid = null;
+  try {
+    if (mode === 'crash') {
+      providerPid = await waitFor(
+        () =>
+          fs.existsSync(providerPidFile) ? Number(fs.readFileSync(providerPidFile, 'utf8')) : null,
+        `Timed out waiting for ${watcherName} ${mode} provider`
+      );
+    }
+    const watcherExit = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('watcher did not exit')), 20000);
+      watcher.once('close', (code, signal) => {
+        clearTimeout(timeout);
+        resolve({ code, signal });
+      });
+      watcher.once('error', reject);
+    });
+    await waitFor(() => {
+      const task = getTask(taskId);
+      return task && task.status !== 'running' ? task : null;
+    }, `Timed out waiting for ${watcherName} ${mode} terminal task`);
+    const task = getTask(taskId);
+    const logOutput =
+      fs.existsSync(logFile) && fs.statSync(logFile).isFile()
+        ? fs.readFileSync(logFile, 'utf8')
+        : '';
+    process.stdout.write(
+      `RESULT:${JSON.stringify({
+        watcherExit,
+        watcherOutput: captured.output(),
+        providerPid,
+        providerAlive: isRunning(providerPid),
+        cleanupExists: fs.existsSync(cleanupDir),
+        ownedOverlayExists: fs.existsSync(ownedOverlayDir),
+        status: task.status,
+        exitCode: task.exitCode,
+        commandCleanup: task.commandCleanup,
+        logOutput,
+      })}\n`
+    );
+  } finally {
+    forceKillOwnedGroup(providerPid);
+    forceKill(watcher.pid);
+    cleanupClaudeSettingsOverlay(settingsPath);
+    fs.rmSync(cleanupDir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/fixtures/watcher-cleanup-runtime.js
+++ b/tests/fixtures/watcher-cleanup-runtime.js
@@ -79,7 +79,7 @@ async function main() {
         ? `require('fs').writeFileSync(${JSON.stringify(providerPidFile)}, String(process.pid));`
         : `process.stdout.write('provider output\\n'); process.exit(${providerExitCode});`;
   const commandSpec = {
-    binary: process.execPath,
+    binary: mode === 'missing-command' ? path.join(stateDir, 'provider-disappeared') : process.execPath,
     args: ['-e', providerSource],
     env: {},
     cleanup: [cleanupDir],

--- a/tests/fixtures/watcher-cleanup-runtime.js
+++ b/tests/fixtures/watcher-cleanup-runtime.js
@@ -39,7 +39,7 @@ async function main() {
     },
   ];
 
-  if (mode === 'unowned') {
+  if (mode === 'unowned' || mode === 'invalid-args-unowned') {
     cleanupDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-unowned-cleanup-'));
     cleanupMetadata = [
       {
@@ -87,11 +87,12 @@ async function main() {
     outputFormat: 'stream-json',
     commandSpec,
   };
+  const argsJson = mode.startsWith('invalid-args') ? '{invalid-json' : '[]';
   const captured = spawnCapturedWatcher(watcherPath, [
     taskId,
     repoRoot,
     logFile,
-    '[]',
+    argsJson,
     JSON.stringify(config),
   ]);
   const watcher = captured.child;

--- a/tests/fixtures/watcher-cleanup-runtime.js
+++ b/tests/fixtures/watcher-cleanup-runtime.js
@@ -60,6 +60,7 @@ async function main() {
     pid: null,
     logFile,
     provider: 'claude',
+    cancelRequested: mode === 'cancel-before-start',
     commandCleanup: { cleanup: [cleanupDir], cleanupMetadata },
   });
 
@@ -74,7 +75,9 @@ async function main() {
         process.stdout.write('trigger watcher log failure\\n');
         setInterval(() => {}, 1000);
       `
-      : `process.stdout.write('provider output\\n'); process.exit(${providerExitCode});`;
+      : mode === 'cancel-before-start'
+        ? `require('fs').writeFileSync(${JSON.stringify(providerPidFile)}, String(process.pid));`
+        : `process.stdout.write('provider output\\n'); process.exit(${providerExitCode});`;
   const commandSpec = {
     binary: process.execPath,
     args: ['-e', providerSource],
@@ -134,6 +137,7 @@ async function main() {
         status: task.status,
         exitCode: task.exitCode,
         commandCleanup: task.commandCleanup,
+        cancelRequested: task.cancelRequested,
         logOutput,
       })}\n`
     );

--- a/tests/fixtures/watcher-ownership-runtime.js
+++ b/tests/fixtures/watcher-ownership-runtime.js
@@ -2,6 +2,13 @@ const { spawn } = require('child_process');
 const { existsSync, mkdirSync, readFileSync } = require('fs');
 const { dirname, resolve } = require('path');
 const { pathToFileURL } = require('url');
+const {
+  forceKill,
+  forceKillOwnedGroup,
+  isRunning,
+  spawnCapturedWatcher,
+  waitFor: waitForRuntime,
+} = require('./watcher-runtime-helpers');
 
 const watcherName = process.argv[2];
 const repoRoot = resolve(__dirname, '../..');
@@ -10,35 +17,8 @@ const providerPath = resolve(__dirname, 'sigterm-root-with-child.js');
 const logFile = resolve(process.env.HOME, '.zeroshot', `${watcherName}.log`);
 const taskId = watcherName === 'attachable-watcher.js' ? 'runtime-a' : 'runtime-w';
 
-const sleep = (ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
-
-async function waitFor(predicate, timeoutMs = 20000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const result = predicate();
-    if (result) return result;
-    await sleep(20);
-  }
-  throw new Error(`Timed out waiting for ${watcherName} runtime state`);
-}
-
-function isRunning(pid) {
-  if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function forceKill(pid) {
-  if (!pid) return;
-  try {
-    process.kill(pid, 'SIGKILL');
-  } catch {
-    // Already stopped.
-  }
+function waitFor(predicate) {
+  return waitForRuntime(predicate, `Timed out waiting for ${watcherName} runtime state`);
 }
 
 async function main() {
@@ -46,6 +26,20 @@ async function main() {
   const killUrl = pathToFileURL(resolve(repoRoot, 'task-lib/commands/kill.js')).href;
   const { addTask, getTask } = await import(storeUrl);
   const { killTaskCommand } = await import(killUrl);
+  const {
+    cleanupClaudeSettingsOverlay,
+    prepareClaudeSettingsOverlay,
+  } = require('../../src/worktree-claude-config');
+  const settingsPath = prepareClaudeSettingsOverlay();
+  const cleanupDir = dirname(settingsPath);
+  const cleanupMetadata = [
+    {
+      kind: 'temp-directory',
+      provider: 'claude',
+      path: cleanupDir,
+      reason: 'settings-overlay',
+    },
+  ];
 
   mkdirSync(dirname(logFile), { recursive: true });
   addTask({
@@ -58,8 +52,9 @@ async function main() {
     logFile,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    provider: 'codex',
+    provider: 'claude',
     attachable: watcherName === 'attachable-watcher.js',
+    commandCleanup: { cleanup: [cleanupDir], cleanupMetadata },
   });
 
   const unrelated = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
@@ -67,30 +62,22 @@ async function main() {
     stdio: 'ignore',
   });
   const config = {
-    provider: 'codex',
+    provider: 'claude',
     outputFormat: 'stream-json',
     commandSpec: {
       binary: process.execPath,
       args: [providerPath],
       env: {},
-      cleanup: [],
+      cleanup: [cleanupDir],
+      cleanupMetadata,
     },
   };
-  const watcher = spawn(
-    process.execPath,
-    [watcherPath, taskId, repoRoot, logFile, '[]', JSON.stringify(config)],
-    {
-      env: process.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }
+  const captured = spawnCapturedWatcher(
+    watcherPath,
+    [taskId, repoRoot, logFile, '[]', JSON.stringify(config)],
+    { env: process.env }
   );
-  let watcherOutput = '';
-  watcher.stdout.on('data', (chunk) => {
-    watcherOutput += chunk;
-  });
-  watcher.stderr.on('data', (chunk) => {
-    watcherOutput += chunk;
-  });
+  const watcher = captured.child;
 
   let providerPid;
   let descendantPid;
@@ -100,7 +87,7 @@ async function main() {
       if (watcher.exitCode !== null && !task?.pid) {
         const logOutput = existsSync(logFile) ? readFileSync(logFile, 'utf8') : '';
         throw new Error(
-          `${watcherName} exited ${watcher.exitCode} before persisting ownership: ${watcherOutput}${logOutput}`
+          `${watcherName} exited ${watcher.exitCode} before persisting ownership: ${captured.output()}${logOutput}`
         );
       }
       return task?.pid && task.processGroupId && task.terminationStrategy ? task : null;
@@ -127,13 +114,15 @@ async function main() {
       persistedStrategy: persisted.terminationStrategy,
       persistedGroupId: persisted.processGroupId,
       terminalGroupId: terminal.processGroupId,
+      cleanupRemoved: !existsSync(cleanupDir),
     };
     process.stdout.write(`RESULT:${JSON.stringify(result)}\n`);
   } finally {
     forceKill(watcher.pid);
-    forceKill(providerPid);
+    forceKillOwnedGroup(providerPid);
     forceKill(descendantPid);
     forceKill(unrelated.pid);
+    cleanupClaudeSettingsOverlay(settingsPath);
   }
 }
 

--- a/tests/fixtures/watcher-runtime-helpers.js
+++ b/tests/fixtures/watcher-runtime-helpers.js
@@ -1,0 +1,64 @@
+const { spawn } = require('child_process');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor(predicate, timeoutMessage, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = predicate();
+    if (result) return result;
+    await sleep(20);
+  }
+  throw new Error(timeoutMessage);
+}
+
+function isRunning(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function forceKill(pid) {
+  if (!pid) return;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already terminal.
+  }
+}
+
+function forceKillOwnedGroup(pid) {
+  if (!pid) return;
+  try {
+    process.kill(process.platform === 'win32' ? pid : -pid, 'SIGKILL');
+  } catch {
+    // Already terminal.
+  }
+}
+
+function spawnCapturedWatcher(watcherPath, args, options = {}) {
+  const child = spawn(process.execPath, [watcherPath, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+  let output = '';
+  child.stdout.on('data', (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    output += chunk;
+  });
+  return { child, output: () => output };
+}
+
+module.exports = {
+  forceKill,
+  forceKillOwnedGroup,
+  isRunning,
+  spawnCapturedWatcher,
+  waitFor,
+};

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -35,7 +35,7 @@ function createLaunchHarness({ spawnTimeoutMs = 1000 } = {}) {
       capturedEnv = options.env;
       return proc;
     },
-    async execInContainer(_clusterId, command) {
+    execInContainer(_clusterId, command) {
       commands.push(command);
       if (command[1] === 'get-task-id-by-spawn-token') {
         assert.strictEqual(command[2], capturedEnv[OWNERSHIP_ENV]);
@@ -179,7 +179,7 @@ describe('Isolated terminal cleanup recovery', function () {
     const commands = [];
     let shouldFail = failCleanup;
     const manager = {
-      async execInContainer(_clusterId, command) {
+      execInContainer(_clusterId, command) {
         commands.push(command);
         if (command[1] === 'status') {
           return { code: 0, stdout: 'Status: killed\n', stderr: '' };

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -1,0 +1,241 @@
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+
+const {
+  killTask,
+  spawnClaudeTaskIsolated,
+} = require('../src/agent/agent-task-executor');
+
+const OWNERSHIP_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
+
+function createProcess() {
+  const proc = new EventEmitter();
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.pid = 12345;
+  proc.closed = false;
+  proc.kill = (signal) => {
+    if (proc.closed) return;
+    proc.closed = true;
+    setImmediate(() => proc.emit('close', null, signal));
+  };
+  return proc;
+}
+
+function createLaunchHarness({ spawnTimeoutMs = 1000 } = {}) {
+  const proc = createProcess();
+  const taskId = 'task-durable-race1';
+  const commands = [];
+  let rowVisible = false;
+  let status = 'running';
+  let capturedEnv;
+  const manager = {
+    spawnInContainer(_clusterId, _command, options) {
+      capturedEnv = options.env;
+      return proc;
+    },
+    async execInContainer(_clusterId, command) {
+      commands.push(command);
+      if (command[1] === 'get-task-id-by-spawn-token') {
+        assert.strictEqual(command[2], capturedEnv[OWNERSHIP_ENV]);
+        return rowVisible
+          ? { code: 0, stdout: `${taskId}\n`, stderr: '' }
+          : { code: 2, stdout: '', stderr: '' };
+      }
+      if (command[1] === 'status') {
+        return { code: 0, stdout: `Status: ${status}\n`, stderr: '' };
+      }
+      if (command[1] === 'kill') {
+        status = 'killed';
+        return { code: 0, stdout: `Killed ${taskId}\n`, stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command.join(' ')}`);
+    },
+  };
+  const agent = {
+    id: 'isolated-race',
+    config: { outputFormat: 'json', strictSchema: true },
+    isolation: { enabled: true, clusterId: 'cluster-1', manager },
+    enableLivenessCheck: false,
+    spawnTimeoutMs,
+    _resolveProvider: () => 'opencode',
+    _resolveModelSpec: () => ({
+      level: 'level2',
+      model: 'openai/gpt-5.2-codex',
+      reasoningEffort: 'high',
+    }),
+    _resolveModelSpecSource: () => 'direct',
+    _log() {},
+    _publishLifecycle() {},
+    _stopLivenessCheck() {},
+  };
+  return {
+    agent,
+    commands,
+    proc,
+    taskId,
+    setRowVisible() {
+      rowVisible = true;
+    },
+    get capturedEnv() {
+      return capturedEnv;
+    },
+  };
+}
+
+async function waitFor(predicate, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+async function expectCancelledLaunch(harness) {
+  const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+  await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+  const termination = await killTask(harness.agent, 'cancel launch');
+  assert.notStrictEqual(termination?.forced, false);
+  await assert.rejects(launch, /Task launch cancelled/);
+  assert.strictEqual(harness.agent.currentTask, null);
+  return termination;
+}
+
+describe('Isolated detached launch ownership', function () {
+  it('cancels before task-row persistence without inventing task ownership', async function () {
+    const harness = createLaunchHarness();
+    const termination = await expectCancelledLaunch(harness);
+
+    assert.strictEqual(termination.taskId, null);
+    assert.strictEqual(harness.commands.some((command) => command[1] === 'kill'), false);
+    assert.ok(harness.capturedEnv[OWNERSHIP_ENV]);
+  });
+
+  it('resolves the durable token and kills a post-row task before wrapper close', async function () {
+    const harness = createLaunchHarness();
+    const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+    await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+    harness.setRowVisible();
+
+    const termination = await killTask(harness.agent, 'cancel post-row');
+    assert.strictEqual(termination.taskId, harness.taskId);
+    await assert.rejects(launch, /Task launch cancelled/);
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+  });
+
+  it('uses the durable token when stdout has a task ID but the wrapper is still open', async function () {
+    const harness = createLaunchHarness();
+    const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+    await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+    harness.setRowVisible();
+    harness.proc.stdout.write(`Task spawned: ${harness.taskId}\n`);
+
+    const termination = await killTask(harness.agent, 'cancel post-id');
+    assert.strictEqual(termination.taskId, harness.taskId);
+    await assert.rejects(launch, /Task launch cancelled/);
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+  });
+
+  it('cancels after durable ID assignment but before follower installation', async function () {
+    const harness = createLaunchHarness();
+    let terminationPromise = null;
+    harness.agent._publishLifecycle = (event) => {
+      if (event === 'TASK_ID_ASSIGNED' && !terminationPromise) {
+        terminationPromise = killTask(harness.agent, 'cancel post-ID assignment');
+      }
+    };
+    const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+    const launchRejection = assert.rejects(launch, /Task launch cancelled/);
+    await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+    harness.setRowVisible();
+    harness.proc.stdout.write(`Task spawned: ${harness.taskId}\n`);
+    harness.proc.closed = true;
+    harness.proc.emit('close', 0, null);
+
+    await waitFor(() => terminationPromise);
+    const termination = await terminationPromise;
+    assert.strictEqual(termination.taskId, harness.taskId);
+    await launchRejection;
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+  });
+
+  it('routes spawn timeout through durable child termination', async function () {
+    const harness = createLaunchHarness({ spawnTimeoutMs: 30 });
+    harness.setRowVisible();
+
+    await assert.rejects(
+      spawnClaudeTaskIsolated(harness.agent, 'test context'),
+      /Spawn timeout after 0.03s/
+    );
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+    assert.strictEqual(harness.agent.currentTask, null);
+  });
+});
+
+describe('Isolated terminal cleanup recovery', function () {
+  function createTerminalAgent({ failCleanup = false } = {}) {
+    const commands = [];
+    let shouldFail = failCleanup;
+    const manager = {
+      async execInContainer(_clusterId, command) {
+        commands.push(command);
+        if (command[1] === 'status') {
+          return { code: 0, stdout: 'Status: killed\n', stderr: '' };
+        }
+        if (command[1] === 'kill') {
+          if (shouldFail) {
+            return { code: 1, stdout: '', stderr: 'command cleanup remains pending' };
+          }
+          return { code: 0, stdout: 'cleanup recovered\n', stderr: '' };
+        }
+        throw new Error(`Unexpected command: ${command.join(' ')}`);
+      },
+    };
+    const handle = { retained: true };
+    const agent = {
+      currentTask: handle,
+      currentTaskId: 'task-terminal-cleanup',
+      processPid: 123,
+      lastOutputTime: 1,
+      taskStartedAt: 1,
+      isolation: { enabled: true, clusterId: 'cluster-1', manager },
+      _stopLivenessCheck() {},
+    };
+    return {
+      agent,
+      commands,
+      handle,
+      allowCleanup() {
+        shouldFail = false;
+      },
+    };
+  }
+
+  it('invokes kill to recover cleanup for a task already terminal before the call', async function () {
+    const harness = createTerminalAgent();
+    const result = await killTask(harness.agent, 'terminal cleanup');
+
+    assert.strictEqual(result.alreadyTerminal, true);
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+    assert.strictEqual(harness.agent.currentTask, null);
+    assert.strictEqual(harness.agent.currentTaskId, null);
+  });
+
+  it('retains the lifecycle handle on cleanup failure and clears it after retry', async function () {
+    const harness = createTerminalAgent({ failCleanup: true });
+    const failed = await killTask(harness.agent, 'terminal cleanup');
+
+    assert.strictEqual(failed.forced, false);
+    assert.match(failed.reason, /command cleanup remains pending/);
+    assert.strictEqual(harness.agent.currentTask, harness.handle);
+    assert.strictEqual(harness.agent.currentTaskId, 'task-terminal-cleanup');
+
+    harness.allowCleanup();
+    const recovered = await killTask(harness.agent, 'terminal cleanup retry');
+    assert.strictEqual(recovered.alreadyTerminal, true);
+    assert.strictEqual(harness.agent.currentTask, null);
+    assert.strictEqual(harness.agent.currentTaskId, null);
+  });
+});

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -276,29 +276,37 @@ describe('Isolated terminal cleanup recovery', function () {
       spawnInContainer() {
         return createProcess();
       },
-      async execInContainer(_clusterId, command) {
+      execInContainer(_clusterId, command) {
         commands.push(command);
         const commandText = command.join(' ');
         if (commandText.includes('get-log-path')) {
-          return { code: 0, stdout: '/tmp/provider.log\n', stderr: '' };
+          return Promise.resolve({ code: 0, stdout: '/tmp/provider.log\n', stderr: '' });
         }
         if (commandText.includes('status')) {
-          return {
+          return Promise.resolve({
             code: 0,
             stdout: `Status: completed\nCleanup: ${cleanupPending ? 'pending' : 'complete'}\n`,
             stderr: '',
-          };
+          });
         }
         if (command[1] === 'kill') {
           cleanupAttempts += 1;
           if (cleanupAttempts === 1) {
-            return { code: 1, stdout: '', stderr: 'cleanup temporarily unavailable' };
+            return Promise.resolve({
+              code: 1,
+              stdout: '',
+              stderr: 'cleanup temporarily unavailable',
+            });
           }
           cleanupPending = false;
-          return { code: 0, stdout: 'cleanup recovered\n', stderr: '' };
+          return Promise.resolve({ code: 0, stdout: 'cleanup recovered\n', stderr: '' });
         }
         if (commandText.includes('cat')) {
-          return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
+          return Promise.resolve({
+            code: 0,
+            stdout: '{"summary":"done","result":"ok"}\n',
+            stderr: '',
+          });
         }
         throw new Error(`Unexpected command: ${commandText}`);
       },
@@ -316,7 +324,7 @@ describe('Isolated terminal cleanup recovery', function () {
       enableLivenessCheck: false,
       messageBus: { publish() {} },
       _resolveProvider: () => 'codex',
-      _parseResultOutput: async () => ({ summary: 'done', result: 'ok' }),
+      _parseResultOutput: () => ({ summary: 'done', result: 'ok' }),
       _stopLivenessCheck() {},
       _log() {},
     };

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -3,6 +3,7 @@ const { EventEmitter } = require('node:events');
 const { PassThrough } = require('node:stream');
 
 const {
+  followClaudeTaskLogsIsolated,
   killTask,
   spawnClaudeTaskIsolated,
 } = require('../src/agent/agent-task-executor');
@@ -265,5 +266,76 @@ describe('Isolated terminal cleanup recovery', function () {
     assert.strictEqual(recovered.alreadyTerminal, true);
     assert.strictEqual(harness.agent.currentTask, null);
     assert.strictEqual(harness.agent.currentTaskId, null);
+  });
+
+  it('retains a terminal follower until persisted cleanup recovery succeeds', async function () {
+    const commands = [];
+    let cleanupPending = true;
+    let cleanupAttempts = 0;
+    const manager = {
+      spawnInContainer() {
+        return createProcess();
+      },
+      async execInContainer(_clusterId, command) {
+        commands.push(command);
+        const commandText = command.join(' ');
+        if (commandText.includes('get-log-path')) {
+          return { code: 0, stdout: '/tmp/provider.log\n', stderr: '' };
+        }
+        if (commandText.includes('status')) {
+          return {
+            code: 0,
+            stdout: `Status: completed\nCleanup: ${cleanupPending ? 'pending' : 'complete'}\n`,
+            stderr: '',
+          };
+        }
+        if (command[1] === 'kill') {
+          cleanupAttempts += 1;
+          if (cleanupAttempts === 1) {
+            return { code: 1, stdout: '', stderr: 'cleanup temporarily unavailable' };
+          }
+          cleanupPending = false;
+          return { code: 0, stdout: 'cleanup recovered\n', stderr: '' };
+        }
+        if (commandText.includes('cat')) {
+          return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
+        }
+        throw new Error(`Unexpected command: ${commandText}`);
+      },
+    };
+    const agent = {
+      id: 'terminal-cleanup-follower',
+      cluster: { id: 'cluster-1' },
+      config: { cwd: '/tmp/work' },
+      worktree: null,
+      isolation: { enabled: true, clusterId: 'cluster-1', manager },
+      currentTask: null,
+      currentTaskId: 'terminal-cleanup-task',
+      processPid: 123,
+      timeout: 0,
+      enableLivenessCheck: false,
+      messageBus: { publish() {} },
+      _resolveProvider: () => 'codex',
+      _parseResultOutput: async () => ({ summary: 'done', result: 'ok' }),
+      _stopLivenessCheck() {},
+      _log() {},
+    };
+    let settled = false;
+    const execution = followClaudeTaskLogsIsolated(agent, agent.currentTaskId).finally(() => {
+      settled = true;
+    });
+
+    while (cleanupAttempts < 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.strictEqual(settled, false);
+    assert.notStrictEqual(agent.currentTask, null);
+
+    const result = await execution;
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(cleanupAttempts, 2);
+    assert.strictEqual(cleanupPending, false);
+    assert.strictEqual(agent.currentTask, null);
+    assert.ok(commands.some((command) => command[1] === 'kill'));
   });
 });

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -23,12 +23,13 @@ function createProcess() {
   return proc;
 }
 
-function createLaunchHarness({ spawnTimeoutMs = 1000 } = {}) {
+function createLaunchHarness({ spawnTimeoutMs = 1000, lookupFailures = 0 } = {}) {
   const proc = createProcess();
   const taskId = 'task-durable-race1';
   const commands = [];
   let rowVisible = false;
   let status = 'running';
+  let remainingLookupFailures = lookupFailures;
   let capturedEnv;
   const manager = {
     spawnInContainer(_clusterId, _command, options) {
@@ -39,6 +40,10 @@ function createLaunchHarness({ spawnTimeoutMs = 1000 } = {}) {
       commands.push(command);
       if (command[1] === 'get-task-id-by-spawn-token') {
         assert.strictEqual(command[2], capturedEnv[OWNERSHIP_ENV]);
+        if (remainingLookupFailures > 0) {
+          remainingLookupFailures -= 1;
+          return { code: 1, stdout: '', stderr: 'lookup unavailable' };
+        }
         return rowVisible
           ? { code: 0, stdout: `${taskId}\n`, stderr: '' }
           : { code: 2, stdout: '', stderr: '' };
@@ -158,6 +163,29 @@ describe('Isolated detached launch ownership', function () {
     const termination = await terminationPromise;
     assert.strictEqual(termination.taskId, harness.taskId);
     await launchRejection;
+    assert.ok(harness.commands.some((command) => command[1] === 'kill'));
+  });
+
+  it('retains ambiguous token ownership until a later lookup can terminate the task', async function () {
+    const harness = createLaunchHarness({ lookupFailures: 2 });
+    const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+    await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+    const pendingHandle = harness.agent.currentTask;
+    harness.proc.closed = true;
+    harness.proc.emit('close', 0, null);
+
+    const rejection = await launch.then(
+      () => null,
+      (error) => error
+    );
+    assert.strictEqual(rejection?.retainTaskHandle, true);
+    assert.strictEqual(rejection?.permanent, true);
+    assert.strictEqual(harness.agent.currentTask, pendingHandle);
+
+    harness.setRowVisible();
+    const termination = await killTask(harness.agent, 'retry ambiguous ownership cleanup');
+    assert.strictEqual(termination.taskId, harness.taskId);
+    assert.strictEqual(harness.agent.currentTask, null);
     assert.ok(harness.commands.some((command) => command[1] === 'kill'));
   });
 

--- a/tests/isolated-task-recovery.test.js
+++ b/tests/isolated-task-recovery.test.js
@@ -113,7 +113,7 @@ describe('Isolated task lifecycle handles', function () {
     assert.ok(events.some(({ event }) => event === 'AGENT_INACTIVITY_TIMEOUT'));
   });
 
-  it('does not kill or retry a task that completed before recovery reconciliation', async function () {
+  it('preserves completion while terminal cleanup recovery wins reconciliation', async function () {
     const manager = createIsolationManager({ status: 'completed' });
     const { agent } = createIsolatedAgent(manager, {
       lastOutputTime: Date.now() - 100,
@@ -127,7 +127,7 @@ describe('Isolated task lifecycle handles', function () {
     stopLivenessCheck(agent);
 
     assert.strictEqual(result.success, true);
-    assert.strictEqual(manager.killCalls, 0);
+    assert.strictEqual(manager.killCalls, 1);
     assert.strictEqual(agent.currentTask, null);
   });
 

--- a/tests/isolated-task-termination-exhaustion.test.js
+++ b/tests/isolated-task-termination-exhaustion.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { stop } = require('../src/agent/agent-lifecycle');
 
 const {
   runLifecycleRecovery,
@@ -26,7 +27,7 @@ describe('Bounded isolated task recovery', function () {
       assert.strictEqual(recovered.killCalls, 3);
       assert.strictEqual(recovered.manager.maxConcurrentKillCalls, 1);
       assert.strictEqual(recovered.stillMonitored, false);
-      assert.strictEqual(recovered.agent.currentTask, null);
+      assert.notStrictEqual(recovered.agent.currentTask, null);
       assert.strictEqual(recovered.agent.currentTaskId, 'isolated-task');
       assert.strictEqual(recovered.agent.state, 'error');
       assert.strictEqual(recovered.agent.cluster.failureInfo.type, 'task_termination');
@@ -47,6 +48,11 @@ describe('Bounded isolated task recovery', function () {
 
       await sleep(50);
       assert.strictEqual(recovered.manager.killCalls, 3);
+      recovered.manager.allowTermination();
+      recovered.agent.running = true;
+      await stop(recovered.agent);
+      assert.strictEqual(recovered.manager.killCalls, 4);
+      assert.strictEqual(recovered.agent.currentTask, null);
     });
 
     it(`does not retry the provider after permanent ${label}`, async function () {
@@ -68,6 +74,11 @@ describe('Bounded isolated task recovery', function () {
       assert.strictEqual(agentErrors[0].content.data.attempts, 3);
       assert.strictEqual(clusterFailures.length, 1);
       assert.strictEqual(clusterFailures[0].content.data.reason, 'task_termination_unverified');
+      assert.notStrictEqual(recovered.agent.currentTask, null);
+      recovered.manager.allowTermination();
+      await stop(recovered.agent);
+      assert.strictEqual(recovered.manager.killCalls, 4);
+      assert.strictEqual(recovered.agent.currentTask, null);
     });
   }
 });

--- a/tests/mocha-setup.js
+++ b/tests/mocha-setup.js
@@ -15,6 +15,7 @@ const fallbackSettingsFile = path.join(
 const testSettingsFile = inheritedSettingsFile || fallbackSettingsFile;
 const ambientRunVariables = [
   'ZEROSHOT_CLOSE_ISSUE',
+  'ZEROSHOT_CLAUDE_SETTINGS_FILE',
   'ZEROSHOT_CLUSTER_ID',
   'ZEROSHOT_CWD',
   'ZEROSHOT_DAEMON',

--- a/tests/mocha-setup.js
+++ b/tests/mocha-setup.js
@@ -15,6 +15,7 @@ const fallbackSettingsFile = path.join(
 const testSettingsFile = inheritedSettingsFile || fallbackSettingsFile;
 const ambientRunVariables = [
   'ZEROSHOT_CLOSE_ISSUE',
+  'ZEROSHOT_CLAUDE_MCP_CONFIG_FILE',
   'ZEROSHOT_CLAUDE_SETTINGS_FILE',
   'ZEROSHOT_CLUSTER_ID',
   'ZEROSHOT_CWD',

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -10,6 +10,7 @@ const { spawnClaudeTaskIsolated } = require('../src/agent/agent-task-executor');
 const { appendTaskRunModelArgs } = require('../src/task-run-model-args');
 
 const EXTERNAL_MODEL = 'kimi/kimi-k2-5';
+const OWNERSHIP_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
 const CATALOG_MODEL = 'openai/gpt-5.2-codex';
 let settingsDir;
 let settingsFile;
@@ -134,6 +135,9 @@ describe('Nested Docker agent model arguments', function () {
             capturedOptions = options;
             return createClosingProcess();
           },
+          async execInContainer() {
+            return { code: 2, stdout: '', stderr: '' };
+          },
         },
       },
       enableLivenessCheck: false,
@@ -162,7 +166,7 @@ describe('Nested Docker agent model arguments', function () {
         },
       },
     });
-    assert.deepStrictEqual(capturedOptions.env, {});
+    assert.strictEqual(typeof capturedOptions.env[OWNERSHIP_ENV], 'string');
   });
 });
 

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -135,7 +135,7 @@ describe('Nested Docker agent model arguments', function () {
             capturedOptions = options;
             return createClosingProcess();
           },
-          async execInContainer() {
+          execInContainer() {
             return { code: 2, stdout: '', stderr: '' };
           },
         },

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -152,10 +152,7 @@ describe('Nested Docker agent model arguments', function () {
       _publishLifecycle() {},
     };
 
-    await assert.rejects(
-      spawnClaudeTaskIsolated(agent, 'test context'),
-      /zeroshot task run failed with code 1/
-    );
+    await assert.rejects(spawnClaudeTaskIsolated(agent, 'test context'), /Task launch cancelled/);
     assertConfiguredModelArgs(capturedCommand);
     assert.deepStrictEqual(JSON.parse(capturedCommand[3]), {
       providerSettings: {

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -110,6 +110,67 @@ describe('Task cleanup recovery', function () {
       fs.rmSync(taskHome, { recursive: true, force: true });
     }
   });
+
+  it('preserves cleanup ownership while a running task has not published its provider PID', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-starting-store-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const script = `
+      import fs from 'fs';
+      import os from 'os';
+      import path from 'path';
+      const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
+      fs.mkdirSync(overlayRoot, { recursive: true });
+      const startingCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-starting-'));
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      addTask({
+        id: 'starting-task',
+        status: 'running',
+        pid: null,
+        commandCleanup: {
+          cleanup: [startingCleanup],
+          cleanupMetadata: [{
+            kind: 'temp-directory',
+            provider: 'claude',
+            path: startingCleanup,
+            reason: 'settings-overlay'
+          }]
+        }
+      });
+      await killTaskCommand('starting-task');
+      const task = getTask('starting-task');
+      const cleanupExists = fs.existsSync(startingCleanup);
+      const exitCode = process.exitCode || 0;
+      process.exitCode = 0;
+      fs.rmSync(startingCleanup, { recursive: true, force: true });
+      console.log('RESULT:' + JSON.stringify({ task, cleanupExists, exitCode }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.strictEqual(result.task.status, 'running');
+      assert.strictEqual(result.task.pid, null);
+      assert.notStrictEqual(result.task.commandCleanup, null);
+      assert.strictEqual(result.cleanupExists, true);
+      assert.strictEqual(result.exitCode, 1);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Task cleanup after deferred termination', function () {

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -11,10 +11,12 @@ const commandCleanupFixtureSource = `
   import fs from 'fs';
   import os from 'os';
   import path from 'path';
-  const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
-  fs.mkdirSync(overlayRoot, { recursive: true });
-  const liveCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-live-'));
-  const deadCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-dead-'));
+  const liveCleanup = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'zeroshot-claude-settings-run-kill-live-')
+  );
+  const deadCleanup = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'zeroshot-claude-settings-run-kill-dead-')
+  );
   const cleanupMetadata = (cleanupPath) => [{
     kind: 'temp-directory', provider: 'claude',
     path: cleanupPath, reason: 'settings-overlay'
@@ -119,9 +121,9 @@ describe('Task cleanup recovery', function () {
       import fs from 'fs';
       import os from 'os';
       import path from 'path';
-      const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
-      fs.mkdirSync(overlayRoot, { recursive: true });
-      const startingCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-starting-'));
+      const startingCleanup = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'zeroshot-claude-settings-run-kill-starting-')
+      );
       const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
       const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
       addTask({
@@ -282,11 +284,12 @@ describe('Task cleanup recovery', function () {
       import fs from 'fs';
       import os from 'os';
       import path from 'path';
-      const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
-      fs.mkdirSync(overlayRoot, { recursive: true });
-      const cleanupPath = path.join(overlayRoot, 'run-transient-cleanup-retry');
+      const cleanupPath = path.join(
+        os.tmpdir(),
+        'zeroshot-claude-settings-run-transient-cleanup-retry'
+      );
       fs.rmSync(cleanupPath, { recursive: true, force: true });
-      fs.mkdirSync(cleanupPath);
+      fs.mkdirSync(cleanupPath, { mode: 0o700 });
       const { addTask, getTask, updateTask } = await import(${JSON.stringify(storeUrl)});
       const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
       addTask({

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -7,6 +7,7 @@ const { URL } = require('node:url');
 const { promisify } = require('node:util');
 
 const execFileAsync = promisify(execFile);
+const { followClaudeTaskLogs } = require('../src/agent/agent-task-executor');
 const commandCleanupFixtureSource = `
   import fs from 'fs';
   import os from 'os';
@@ -453,6 +454,84 @@ describe('Task cleanup after deferred termination', function () {
       assert.strictEqual(result.cleanupExistsAfterKill, false);
     } finally {
       fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Host follower terminal cleanup recovery', function () {
+  this.timeout(10000);
+
+  it('does not resolve terminal status until persisted cleanup succeeds', async function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-host-follower-cleanup-'));
+    const taskCliPath = path.join(tempDir, 'zeroshot');
+    const logPath = path.join(tempDir, 'task.log');
+    const pendingPath = path.join(tempDir, 'cleanup-pending');
+    const attemptsPath = path.join(tempDir, 'cleanup-attempts');
+    fs.writeFileSync(logPath, '');
+    fs.writeFileSync(pendingPath, 'pending');
+    fs.writeFileSync(
+      taskCliPath,
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const action = process.argv[2];
+if (action === 'get-log-path') {
+  console.log(${JSON.stringify(logPath)});
+} else if (action === 'status') {
+  console.log('Status: completed');
+  console.log('Cleanup: ' + (fs.existsSync(${JSON.stringify(pendingPath)}) ? 'pending' : 'complete'));
+} else if (action === 'kill') {
+  const attempts = fs.existsSync(${JSON.stringify(attemptsPath)})
+    ? Number(fs.readFileSync(${JSON.stringify(attemptsPath)}, 'utf8')) + 1
+    : 1;
+  fs.writeFileSync(${JSON.stringify(attemptsPath)}, String(attempts));
+  if (attempts === 1) {
+    console.error('cleanup temporarily unavailable');
+    process.exitCode = 1;
+  } else {
+    fs.rmSync(${JSON.stringify(pendingPath)}, { force: true });
+    console.log('cleanup recovered');
+  }
+}
+`,
+      { mode: 0o755 }
+    );
+    const agent = {
+      id: 'host-cleanup-follower',
+      config: { cwd: tempDir, outputFormat: 'text' },
+      worktree: null,
+      isolation: null,
+      currentTask: null,
+      currentTaskId: 'host-cleanup-task',
+      processPid: 123,
+      taskCliPath,
+      quiet: true,
+      messageBus: { publish() {} },
+      _resolveProvider: () => 'codex',
+      _stopLivenessCheck() {},
+      _log() {},
+    };
+    let settled = false;
+
+    try {
+      const execution = followClaudeTaskLogs(agent, agent.currentTaskId).finally(() => {
+        settled = true;
+      });
+      const deadline = Date.now() + 3000;
+      while (!fs.existsSync(attemptsPath) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      assert.strictEqual(fs.readFileSync(attemptsPath, 'utf8'), '1');
+      assert.strictEqual(settled, false);
+      assert.notStrictEqual(agent.currentTask, null);
+
+      const result = await execution;
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(fs.readFileSync(attemptsPath, 'utf8'), '2');
+      assert.strictEqual(fs.existsSync(pendingPath), false);
+      assert.strictEqual(agent.currentTask, null);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -273,6 +273,87 @@ describe('Task cleanup recovery', function () {
       fs.rmSync(taskHome, { recursive: true, force: true });
     }
   });
+
+  it('returns failure while terminal cleanup remains and succeeds on retry', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-cleanup-retry-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const script = `
+      import fs from 'fs';
+      import os from 'os';
+      import path from 'path';
+      const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
+      fs.mkdirSync(overlayRoot, { recursive: true });
+      const cleanupPath = path.join(overlayRoot, 'run-transient-cleanup-retry');
+      fs.rmSync(cleanupPath, { recursive: true, force: true });
+      fs.mkdirSync(cleanupPath);
+      const { addTask, getTask, updateTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      addTask({
+        id: 'terminal-cleanup-retry',
+        status: 'failed',
+        pid: null,
+        commandCleanup: {
+          cleanup: [cleanupPath],
+          cleanupMetadata: [{
+            kind: 'temp-directory',
+            provider: 'codex',
+            path: cleanupPath,
+            reason: 'settings-overlay'
+          }]
+        }
+      });
+      await killTaskCommand('terminal-cleanup-retry');
+      const first = {
+        exitCode: process.exitCode || 0,
+        receiptPending: Boolean(getTask('terminal-cleanup-retry').commandCleanup)
+      };
+      updateTask('terminal-cleanup-retry', {
+        commandCleanup: {
+          cleanup: [cleanupPath],
+          cleanupMetadata: [{
+            kind: 'temp-directory',
+            provider: 'claude',
+            path: cleanupPath,
+            reason: 'settings-overlay'
+          }]
+        }
+      });
+      process.exitCode = 0;
+      await killTaskCommand('terminal-cleanup-retry');
+      const second = {
+        exitCode: process.exitCode || 0,
+        receiptPending: Boolean(getTask('terminal-cleanup-retry').commandCleanup),
+        cleanupExists: fs.existsSync(cleanupPath)
+      };
+      console.log('RESULT:' + JSON.stringify({ first, second }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.deepStrictEqual(result.first, { exitCode: 1, receiptPending: true });
+      assert.deepStrictEqual(result.second, {
+        exitCode: 0,
+        receiptPending: false,
+        cleanupExists: false,
+      });
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('Task cleanup after deferred termination', function () {

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -111,7 +111,7 @@ describe('Task cleanup recovery', function () {
     }
   });
 
-  it('preserves cleanup ownership while a running task has not published its provider PID', async function () {
+  it('persists cancellation and cleanup ownership when the watcher fails before publishing a PID', async function () {
     const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-starting-store-'));
     const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
     const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
@@ -138,7 +138,7 @@ describe('Task cleanup recovery', function () {
           }]
         }
       });
-      await killTaskCommand('starting-task');
+      await killTaskCommand('starting-task', { startupCancelTimeoutMs: 40, pollMs: 5 });
       const task = getTask('starting-task');
       const cleanupExists = fs.existsSync(startingCleanup);
       const exitCode = process.exitCode || 0;
@@ -165,8 +165,110 @@ describe('Task cleanup recovery', function () {
       assert.strictEqual(result.task.status, 'running');
       assert.strictEqual(result.task.pid, null);
       assert.notStrictEqual(result.task.commandCleanup, null);
+      assert.strictEqual(result.task.cancelRequested, true);
       assert.strictEqual(result.cleanupExists, true);
       assert.strictEqual(result.exitCode, 1);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+
+  it('honors persisted cancellation after a late provider PID is published', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-late-pid-store-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const runtimeUrl = new URL('../task-lib/watcher-output-runtime.js', `file://${__filename}`)
+      .href;
+    const cleanupUrl = new URL('../task-lib/command-spec-cleanup.js', `file://${__filename}`)
+      .href;
+    const terminationUrl = new URL('../task-lib/process-termination.js', `file://${__filename}`)
+      .href;
+    const script = `
+      import { spawn } from 'child_process';
+      ${commandCleanupFixtureSource}
+      const { addTask, getTask, updateTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      const { completePendingWatcherCancellation } = await import(${JSON.stringify(runtimeUrl)});
+      const { createCommandSpecCleanup } = await import(${JSON.stringify(cleanupUrl)});
+      const { terminateProcess } = await import(${JSON.stringify(terminationUrl)});
+      addTask({
+        id: 'late-pid-task',
+        status: 'running',
+        pid: null,
+        commandCleanup: {
+          cleanup: [liveCleanup],
+          cleanupMetadata: cleanupMetadata(liveCleanup)
+        }
+      });
+      const cancellation = killTaskCommand('late-pid-task', {
+        startupCancelTimeoutMs: 2000,
+        pollMs: 5
+      });
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+        detached: process.platform !== 'win32',
+        stdio: 'ignore'
+      });
+      await new Promise((resolve, reject) => {
+        child.once('spawn', resolve);
+        child.once('error', reject);
+      });
+      updateTask('late-pid-task', {
+        pid: child.pid,
+        processGroupId: process.platform === 'win32' ? null : child.pid,
+        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group'
+      });
+      const commandCleanup = createCommandSpecCleanup(
+        getTask('late-pid-task').commandCleanup,
+        () => {}
+      );
+      await completePendingWatcherCancellation({
+        taskId: 'late-pid-task',
+        getTask,
+        commandCleanup,
+        terminateProvider: () => terminateProcess(child.pid, {
+          processGroupId: process.platform === 'win32' ? null : child.pid,
+          terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+          graceMs: 100,
+          pollMs: 5
+        }).then((result) => result.terminated),
+        updateTask,
+        emergencyLog() {}
+      });
+      await cancellation;
+      const terminal = getTask('late-pid-task');
+      let providerAlive = true;
+      try { process.kill(child.pid, 0); } catch { providerAlive = false; }
+      console.log('RESULT:' + JSON.stringify({
+        terminal,
+        cleanupExists: fs.existsSync(liveCleanup),
+        providerAlive,
+        exitCode: process.exitCode || 0
+      }));
+      try { process.kill(child.pid, 'SIGKILL'); } catch {}
+      fs.rmSync(deadCleanup, { recursive: true, force: true });
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.strictEqual(result.terminal.status, 'killed');
+      assert.strictEqual(result.terminal.cancelRequested, false);
+      assert.strictEqual(result.terminal.commandCleanup, null);
+      assert.strictEqual(result.cleanupExists, false);
+      assert.strictEqual(result.providerAlive, false);
+      assert.strictEqual(result.exitCode, 0);
     } finally {
       fs.rmSync(taskHome, { recursive: true, force: true });
     }

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -1,0 +1,113 @@
+const assert = require('node:assert');
+const { execFile } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { URL } = require('node:url');
+const { promisify } = require('node:util');
+
+const execFileAsync = promisify(execFile);
+const commandCleanupFixtureSource = `
+  import fs from 'fs';
+  import os from 'os';
+  import path from 'path';
+  const overlayRoot = path.join(os.tmpdir(), 'zeroshot-claude-settings');
+  fs.mkdirSync(overlayRoot, { recursive: true });
+  const liveCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-live-'));
+  const deadCleanup = fs.mkdtempSync(path.join(overlayRoot, 'run-kill-dead-'));
+  const cleanupMetadata = (cleanupPath) => [{
+    kind: 'temp-directory', provider: 'claude',
+    path: cleanupPath, reason: 'settings-overlay'
+  }];
+`;
+
+describe('Task cleanup recovery', function () {
+  this.timeout(40000);
+
+  it('cleans persisted resources for killed and already-dead tasks', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-kill-store-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const resistantScript = path.resolve(__dirname, 'fixtures/sigterm-resistant-process.js');
+    const script = `
+      import { spawn } from 'child_process';
+      ${commandCleanupFixtureSource}
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      const base = {
+        prompt: 'hang', fullPrompt: 'hang', cwd: process.cwd(), status: 'running',
+        sessionId: null, logFile: null, createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(), exitCode: null, error: null,
+        provider: 'codex', model: 'fake', scheduleId: null, socketPath: null,
+        attachable: false, processGroupId: null, terminationStrategy: null
+      };
+      const child = spawn(process.execPath, [${JSON.stringify(resistantScript)}], {
+        detached: process.platform !== 'win32',
+        stdio: ['ignore', 'pipe', 'ignore']
+      });
+      await new Promise((resolve) => child.stdout.once('data', resolve));
+      addTask({
+        ...base,
+        id: 'live-task',
+        pid: child.pid,
+        processGroupId: process.platform === 'win32' ? null : child.pid,
+        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+        commandCleanup: {
+          cleanup: [liveCleanup],
+          cleanupMetadata: cleanupMetadata(liveCleanup)
+        }
+      });
+      await killTaskCommand('live-task', { graceMs: 40, pollMs: 5 });
+      addTask({
+        ...base,
+        id: 'dead-task',
+        pid: 99999999,
+        commandCleanup: {
+          cleanup: [deadCleanup],
+          cleanupMetadata: cleanupMetadata(deadCleanup)
+        }
+      });
+      await killTaskCommand('dead-task', { graceMs: 40, pollMs: 5 });
+      console.log('RESULT:' + JSON.stringify({
+        live: getTask('live-task'),
+        dead: getTask('dead-task'),
+        liveCleanupExists: fs.existsSync(liveCleanup),
+        deadCleanupExists: fs.existsSync(deadCleanup)
+      }));
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const terminal = JSON.parse(line.slice('RESULT:'.length));
+      assert.deepStrictEqual(
+        [
+          terminal.live.status,
+          terminal.live.pid,
+          terminal.live.processGroupId,
+          terminal.dead.status,
+          terminal.dead.pid,
+        ],
+        ['killed', null, null, 'stale', null]
+      );
+      assert.match(terminal.live.error, /SIGKILL/);
+      assert.strictEqual(terminal.live.commandCleanup, null);
+      assert.strictEqual(terminal.dead.commandCleanup, null);
+      assert.strictEqual(terminal.liveCleanupExists, false);
+      assert.strictEqual(terminal.deadCleanupExists, false);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -8,6 +8,7 @@ const { promisify } = require('node:util');
 
 const execFileAsync = promisify(execFile);
 const { followClaudeTaskLogs } = require('../src/agent/agent-task-executor');
+const ClaudeTaskRunner = require('../src/claude-task-runner');
 const commandCleanupFixtureSource = `
   import fs from 'fs';
   import os from 'os';
@@ -180,20 +181,11 @@ describe('Task cleanup recovery', function () {
     const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-late-pid-store-'));
     const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
     const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
-    const runtimeUrl = new URL('../task-lib/watcher-output-runtime.js', `file://${__filename}`)
-      .href;
-    const cleanupUrl = new URL('../task-lib/command-spec-cleanup.js', `file://${__filename}`)
-      .href;
-    const terminationUrl = new URL('../task-lib/process-termination.js', `file://${__filename}`)
-      .href;
     const script = `
       import { spawn } from 'child_process';
       ${commandCleanupFixtureSource}
       const { addTask, getTask, updateTask } = await import(${JSON.stringify(storeUrl)});
       const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
-      const { completePendingWatcherCancellation } = await import(${JSON.stringify(runtimeUrl)});
-      const { createCommandSpecCleanup } = await import(${JSON.stringify(cleanupUrl)});
-      const { terminateProcess } = await import(${JSON.stringify(terminationUrl)});
       addTask({
         id: 'late-pid-task',
         status: 'running',
@@ -207,6 +199,9 @@ describe('Task cleanup recovery', function () {
         startupCancelTimeoutMs: 2000,
         pollMs: 5
       });
+      while (!getTask('late-pid-task').cancelRequested) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
       const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
         detached: process.platform !== 'win32',
         stdio: 'ignore'
@@ -219,23 +214,6 @@ describe('Task cleanup recovery', function () {
         pid: child.pid,
         processGroupId: process.platform === 'win32' ? null : child.pid,
         terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group'
-      });
-      const commandCleanup = createCommandSpecCleanup(
-        getTask('late-pid-task').commandCleanup,
-        () => {}
-      );
-      await completePendingWatcherCancellation({
-        taskId: 'late-pid-task',
-        getTask,
-        commandCleanup,
-        terminateProvider: () => terminateProcess(child.pid, {
-          processGroupId: process.platform === 'win32' ? null : child.pid,
-          terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
-          graceMs: 100,
-          pollMs: 5
-        }).then((result) => result.terminated),
-        updateTask,
-        emergencyLog() {}
       });
       await cancellation;
       const terminal = getTask('late-pid-task');
@@ -272,6 +250,67 @@ describe('Task cleanup recovery', function () {
       assert.strictEqual(result.cleanupExists, false);
       assert.strictEqual(result.providerAlive, false);
       assert.strictEqual(result.exitCode, 0);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves Windows process-tree cleanup ownership when the root is already gone', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-win-root-gone-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const script = `
+      ${commandCleanupFixtureSource}
+      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      addTask({
+        id: 'win-root-gone',
+        status: 'running',
+        pid: 424242,
+        terminationStrategy: 'process-tree',
+        commandCleanup: {
+          cleanup: [liveCleanup],
+          cleanupMetadata: cleanupMetadata(liveCleanup)
+        }
+      });
+      await killTaskCommand('win-root-gone', {
+        platform: 'win32',
+        terminateProcessFn: async () => ({
+          terminated: true,
+          alreadyDead: true,
+          scope: 'process-tree'
+        })
+      });
+      const exitCode = process.exitCode || 0;
+      process.exitCode = 0;
+      console.log('RESULT:' + JSON.stringify({
+        task: getTask('win-root-gone'),
+        cleanupExists: fs.existsSync(liveCleanup),
+        exitCode
+      }));
+      fs.rmSync(deadCleanup, { recursive: true, force: true });
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.strictEqual(result.task.status, 'running');
+      assert.strictEqual(result.task.pid, 424242);
+      assert.notStrictEqual(result.task.commandCleanup, null);
+      assert.strictEqual(result.cleanupExists, true);
+      assert.strictEqual(result.exitCode, 1);
     } finally {
       fs.rmSync(taskHome, { recursive: true, force: true });
     }
@@ -530,6 +569,63 @@ if (action === 'get-log-path') {
       assert.strictEqual(fs.readFileSync(attemptsPath, 'utf8'), '2');
       assert.strictEqual(fs.existsSync(pendingPath), false);
       assert.strictEqual(agent.currentTask, null);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Direct runner terminal cleanup recovery', function () {
+  this.timeout(10000);
+
+  it('does not resolve terminal status until persisted cleanup succeeds', async function () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-direct-cleanup-'));
+    const taskCliPath = path.join(tempDir, 'zeroshot');
+    const logPath = path.join(tempDir, 'task.log');
+    const pendingPath = path.join(tempDir, 'cleanup-pending');
+    const attemptsPath = path.join(tempDir, 'cleanup-attempts');
+    fs.writeFileSync(logPath, '');
+    fs.writeFileSync(pendingPath, 'pending');
+    fs.writeFileSync(
+      taskCliPath,
+      `#!/usr/bin/env node
+      const fs = require('node:fs');
+      const action = process.argv[2];
+      if (action === 'get-log-path') {
+        process.stdout.write(${JSON.stringify(logPath)} + '\\n');
+      } else if (action === 'status') {
+        const cleanup = fs.existsSync(${JSON.stringify(pendingPath)}) ? 'pending' : 'complete';
+        process.stdout.write('Status: completed\\nCleanup: ' + cleanup + '\\n');
+      } else if (action === 'kill') {
+        const attempts = fs.existsSync(${JSON.stringify(attemptsPath)})
+          ? Number(fs.readFileSync(${JSON.stringify(attemptsPath)}, 'utf8'))
+          : 0;
+        fs.writeFileSync(${JSON.stringify(attemptsPath)}, String(attempts + 1));
+        if (attempts === 0) process.exit(1);
+        fs.rmSync(${JSON.stringify(pendingPath)}, { force: true });
+      }
+      `,
+      { mode: 0o755 }
+    );
+
+    const runner = new ClaudeTaskRunner({ quiet: true, timeout: 8000 });
+    let settled = false;
+    try {
+      const execution = runner._followLogs(taskCliPath, 'direct-cleanup-task', 'direct-agent');
+      execution.finally(() => {
+        settled = true;
+      });
+      const deadline = Date.now() + 4000;
+      while (!fs.existsSync(attemptsPath) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      assert.strictEqual(fs.readFileSync(attemptsPath, 'utf8'), '1');
+      assert.strictEqual(settled, false);
+      const result = await execution;
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(fs.readFileSync(attemptsPath, 'utf8'), '2');
+      assert.strictEqual(fs.existsSync(pendingPath), false);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/tests/task-cleanup-recovery.test.js
+++ b/tests/task-cleanup-recovery.test.js
@@ -111,3 +111,101 @@ describe('Task cleanup recovery', function () {
     }
   });
 });
+
+describe('Task cleanup after deferred termination', function () {
+  this.timeout(40000);
+
+  it('preserves live ownership after watcher termination fails and allows a later kill', async function () {
+    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-termination-pending-'));
+    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
+    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
+    const runtimeUrl = new URL('../task-lib/watcher-output-runtime.js', `file://${__filename}`)
+      .href;
+    const resistantScript = path.resolve(__dirname, 'fixtures/sigterm-resistant-process.js');
+    const script = `
+      import { spawn } from 'child_process';
+      ${commandCleanupFixtureSource}
+      const { addTask, getTask, updateTask } = await import(${JSON.stringify(storeUrl)});
+      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
+      const { completeWatcherTask } = await import(${JSON.stringify(runtimeUrl)});
+      const child = spawn(process.execPath, [${JSON.stringify(resistantScript)}], {
+        detached: process.platform !== 'win32',
+        stdio: ['ignore', 'pipe', 'ignore']
+      });
+      await new Promise((resolve) => child.stdout.once('data', resolve));
+      addTask({
+        id: 'termination-pending',
+        prompt: 'hang',
+        fullPrompt: 'hang',
+        cwd: process.cwd(),
+        status: 'running',
+        pid: child.pid,
+        processGroupId: process.platform === 'win32' ? null : child.pid,
+        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group',
+        commandCleanup: {
+          cleanup: [liveCleanup],
+          cleanupMetadata: cleanupMetadata(liveCleanup)
+        }
+      });
+      let cleanupRuns = 0;
+      await completeWatcherTask({
+        taskId: 'termination-pending',
+        completion: { status: 'failed', resolvedCode: 1, error: 'watcher crashed' },
+        commandCleanup: { async run() { cleanupRuns += 1; return true; } },
+        terminateProvider: async () => false,
+        updateTask,
+        emergencyLog() {}
+      });
+      const pending = getTask('termination-pending');
+      const cleanupExistsWhilePending = fs.existsSync(liveCleanup);
+      await killTaskCommand('termination-pending', { graceMs: 40, pollMs: 5 });
+      const killed = getTask('termination-pending');
+      console.log('RESULT:' + JSON.stringify({
+        providerPid: child.pid,
+        pending,
+        killed,
+        cleanupRuns,
+        cleanupExistsWhilePending,
+        cleanupExistsAfterKill: fs.existsSync(liveCleanup)
+      }));
+      try { process.kill(child.pid, 'SIGKILL'); } catch {}
+    `;
+
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ['--input-type=module', '-e', script],
+        {
+          env: {
+            ...process.env,
+            HOME: taskHome,
+            USERPROFILE: taskHome,
+            ZEROSHOT_HOME: taskHome,
+          },
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      const result = JSON.parse(line.slice('RESULT:'.length));
+      assert.strictEqual(result.pending.status, 'running');
+      assert.strictEqual(result.pending.pid, result.providerPid);
+      assert.strictEqual(
+        result.pending.processGroupId,
+        process.platform === 'win32' ? null : result.providerPid
+      );
+      assert.strictEqual(
+        result.pending.terminationStrategy,
+        process.platform === 'win32' ? 'process-tree' : 'process-group'
+      );
+      assert.notStrictEqual(result.pending.commandCleanup, null);
+      assert.strictEqual(result.cleanupRuns, 0);
+      assert.strictEqual(result.cleanupExistsWhilePending, true);
+      assert.strictEqual(result.killed.status, 'killed');
+      assert.strictEqual(result.killed.pid, null);
+      assert.strictEqual(result.killed.processGroupId, null);
+      assert.strictEqual(result.killed.commandCleanup, null);
+      assert.strictEqual(result.cleanupExistsAfterKill, false);
+    } finally {
+      fs.rmSync(taskHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -20,7 +20,11 @@ function runFixture(mode) {
         },
       }
     );
-    assert.strictEqual(execution.status, 0, execution.stderr || execution.stdout);
+    assert.strictEqual(
+      execution.status,
+      mode === 'retry' ? 0 : 1,
+      execution.stderr || execution.stdout
+    );
     const { stdout } = execution;
     const resultLine = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
     assert.ok(resultLine, stdout);

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -27,7 +27,7 @@ function runFixture(mode) {
     );
     const { stdout } = execution;
     const resultLine = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
-    assert.ok(resultLine, stdout);
+    assert.ok(resultLine, execution.stderr || stdout);
     return {
       stdout,
       result: JSON.parse(resultLine.slice('RESULT:'.length)),

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -1,0 +1,60 @@
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const filesystem = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+
+function runFixture(mode) {
+  const taskHome = filesystem.mkdtempSync(join(tmpdir(), `zeroshot-terminal-${mode}-`));
+  try {
+    const execution = childProcess.spawnSync(
+      process.execPath,
+      [resolve(__dirname, 'fixtures/task-terminal-cleanup-runtime.js'), mode],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HOME: taskHome,
+          USERPROFILE: taskHome,
+          ZEROSHOT_HOME: taskHome,
+        },
+      }
+    );
+    assert.strictEqual(execution.status, 0, execution.stderr || execution.stdout);
+    const { stdout } = execution;
+    const resultLine = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+    assert.ok(resultLine, stdout);
+    return {
+      stdout,
+      result: JSON.parse(resultLine.slice('RESULT:'.length)),
+    };
+  } finally {
+    filesystem.rmSync(taskHome, { recursive: true, force: true });
+  }
+}
+
+describe('Terminal task cleanup recovery', function () {
+  this.timeout(40000);
+
+  it('retries a watcher cleanup receipt after the task becomes terminal', function () {
+    const { result } = runFixture('retry');
+    assert.strictEqual(result.terminal.status, 'completed');
+    assert.strictEqual(result.terminal.pid, null);
+    assert.notStrictEqual(result.terminal.commandCleanup, null);
+    assert.strictEqual(result.cleanupRuns, 1);
+    assert.strictEqual(result.cleanupExistsBeforeRetry, true);
+    assert.strictEqual(result.recovered.status, 'completed');
+    assert.strictEqual(result.recovered.commandCleanup, null);
+    assert.strictEqual(result.cleanupExistsAfterRetry, false);
+  });
+
+  it('retains unsafe cleanup without terminating the terminal task pid', function () {
+    const { result, stdout } = runFixture('unsafe');
+    assert.strictEqual(result.terminal.status, 'completed');
+    assert.notStrictEqual(result.terminal.commandCleanup, null);
+    assert.strictEqual(result.unrelatedAlive, true);
+    assert.strictEqual(result.userDirectoryExists, true);
+    assert.match(stdout, /cleanup remains pending/i);
+    assert.match(stdout, /Refusing unowned temporary directory cleanup/);
+  });
+});

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -57,4 +57,14 @@ describe('Terminal task cleanup recovery', function () {
     assert.match(stdout, /cleanup remains pending/i);
     assert.match(stdout, /Refusing unowned temporary directory cleanup/);
   });
+
+  it('retains an unsafe output-schema file receipt without touching the terminal task pid', function () {
+    const { result, stdout } = runFixture('unsafe-file');
+    assert.strictEqual(result.terminal.status, 'completed');
+    assert.notStrictEqual(result.terminal.commandCleanup, null);
+    assert.strictEqual(result.unrelatedAlive, true);
+    assert.strictEqual(result.userFileExists, true);
+    assert.match(stdout, /cleanup remains pending/i);
+    assert.match(stdout, /Refusing (?:unowned|non-canonical) output-schema cleanup/);
+  });
 });

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -22,7 +22,7 @@ function runFixture(mode) {
     );
     assert.strictEqual(
       execution.status,
-      ['unsafe', 'unsafe-file', 'clean-unsafe'].includes(mode) ? 1 : 0,
+      ['unsafe', 'unsafe-file', 'clean-unsafe', 'clean-running'].includes(mode) ? 1 : 0,
       execution.stderr || execution.stdout
     );
     const { stdout } = execution;
@@ -88,5 +88,14 @@ describe('Terminal task cleanup recovery', function () {
     assert.strictEqual(result.exitCode, 1);
     assert.match(stdout, /Retained: clean-all-unsafe/);
   });
+  it('retains a running row and live overlay selected by --all', function () {
+    const { result, stdout } = runFixture('clean-running');
+    assert.strictEqual(result.retained.status, 'running');
+    assert.notStrictEqual(result.retained.commandCleanup, null);
+    assert.strictEqual(result.cleanupExists, true);
+    assert.strictEqual(result.exitCode, 1);
+    assert.match(stdout, /Retained: clean-all-running \[running\] \(live command cleanup ownership\)/);
+  });
+
 
 });

--- a/tests/task-terminal-cleanup-recovery.test.js
+++ b/tests/task-terminal-cleanup-recovery.test.js
@@ -22,7 +22,7 @@ function runFixture(mode) {
     );
     assert.strictEqual(
       execution.status,
-      mode === 'retry' ? 0 : 1,
+      ['unsafe', 'unsafe-file', 'clean-unsafe'].includes(mode) ? 1 : 0,
       execution.stderr || execution.stdout
     );
     const { stdout } = execution;
@@ -71,4 +71,22 @@ describe('Terminal task cleanup recovery', function () {
     assert.match(stdout, /cleanup remains pending/i);
     assert.match(stdout, /Refusing (?:unowned|non-canonical) output-schema cleanup/);
   });
+  for (const cleanMode of ['completed', 'failed', 'all']) {
+    it(`recovers cleanup before deleting rows selected by --${cleanMode}`, function () {
+      const { result } = runFixture(`clean-${cleanMode}`);
+      assert.strictEqual(result.retained, null);
+      assert.strictEqual(result.cleanupExists, false);
+      assert.strictEqual(result.exitCode, 0);
+    });
+  }
+
+  it('retains a selected row when clean cannot recover its receipt', function () {
+    const { result, stdout } = runFixture('clean-unsafe');
+    assert.notStrictEqual(result.retained, null);
+    assert.notStrictEqual(result.retained.commandCleanup, null);
+    assert.strictEqual(result.cleanupExists, true);
+    assert.strictEqual(result.exitCode, 1);
+    assert.match(stdout, /Retained: clean-all-unsafe/);
+  });
+
 });

--- a/tests/task-termination-recovery.test.js
+++ b/tests/task-termination-recovery.test.js
@@ -3,7 +3,7 @@ const { execFile, spawn } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { URL, pathToFileURL } = require('url');
+const { pathToFileURL } = require('url');
 const { promisify } = require('util');
 
 const execFileAsync = promisify(execFile);
@@ -71,75 +71,6 @@ describe('Task termination recovery', function () {
       if (child.exitCode === null) child.kill('SIGKILL');
     }
   });
-
-  it('persists killed and already-dead tasks as terminal with no PID', async function () {
-    const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-task-kill-store-'));
-    const storeUrl = new URL('../task-lib/store.js', `file://${__filename}`).href;
-    const killUrl = new URL('../task-lib/commands/kill.js', `file://${__filename}`).href;
-    const resistantScript = path.resolve(__dirname, 'fixtures/sigterm-resistant-process.js');
-    const script = `
-      import { spawn } from 'child_process';
-      const { addTask, getTask } = await import(${JSON.stringify(storeUrl)});
-      const { killTaskCommand } = await import(${JSON.stringify(killUrl)});
-      const base = {
-        prompt: 'hang', fullPrompt: 'hang', cwd: process.cwd(), status: 'running',
-        sessionId: null, logFile: null, createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(), exitCode: null, error: null,
-        provider: 'codex', model: 'fake', scheduleId: null, socketPath: null,
-        attachable: false, processGroupId: null, terminationStrategy: null
-      };
-      const child = spawn(process.execPath, [${JSON.stringify(resistantScript)}],
-        {
-          detached: process.platform !== 'win32',
-          stdio: ['ignore', 'pipe', 'ignore']
-        });
-      await new Promise((resolve) => child.stdout.once('data', resolve));
-      addTask({
-        ...base,
-        id: 'live-task',
-        pid: child.pid,
-        processGroupId: process.platform === 'win32' ? null : child.pid,
-        terminationStrategy: process.platform === 'win32' ? 'process-tree' : 'process-group'
-      });
-      await killTaskCommand('live-task', { graceMs: 40, pollMs: 5 });
-      addTask({ ...base, id: 'dead-task', pid: 99999999 });
-      await killTaskCommand('dead-task', { graceMs: 40, pollMs: 5 });
-      console.log('RESULT:' + JSON.stringify({
-        live: getTask('live-task'),
-        dead: getTask('dead-task')
-      }));
-    `;
-
-    try {
-      const { stdout } = await execFileAsync(
-        process.execPath,
-        ['--input-type=module', '-e', script],
-        {
-          env: {
-            ...process.env,
-            HOME: taskHome,
-            USERPROFILE: taskHome,
-            ZEROSHOT_HOME: taskHome,
-          },
-        }
-      );
-      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
-      const terminal = JSON.parse(line.slice('RESULT:'.length));
-      assert.deepStrictEqual(
-        [
-          terminal.live.status,
-          terminal.live.pid,
-          terminal.live.processGroupId,
-          terminal.dead.status,
-          terminal.dead.pid,
-        ],
-        ['killed', null, null, 'stale', null]
-      );
-      assert.match(terminal.live.error, /SIGKILL/);
-    } finally {
-      fs.rmSync(taskHome, { recursive: true, force: true });
-    }
-  });
 });
 
 describe('Task ownership persistence and runtime wiring', function () {
@@ -155,12 +86,22 @@ describe('Task ownership persistence and runtime wiring', function () {
         status: 'running',
         pid: 4242,
         processGroupId: 4242,
-        terminationStrategy: 'process-group'
+        terminationStrategy: 'process-group',
+        commandCleanup: {
+          cleanup: ['/tmp/owned-cleanup'],
+          cleanupMetadata: [{
+            kind: 'temp-file',
+            provider: 'codex',
+            path: '/tmp/owned-cleanup',
+            reason: 'output-schema'
+          }]
+        }
       });
       const task = getTask('owned-task');
       process.stdout.write(JSON.stringify({
         processGroupId: task.processGroupId,
-        terminationStrategy: task.terminationStrategy
+        terminationStrategy: task.terminationStrategy,
+        commandCleanup: task.commandCleanup
       }));
     `;
 
@@ -175,6 +116,17 @@ describe('Task ownership persistence and runtime wiring', function () {
       assert.deepStrictEqual(JSON.parse(stdout), {
         processGroupId: 4242,
         terminationStrategy: 'process-group',
+        commandCleanup: {
+          cleanup: ['/tmp/owned-cleanup'],
+          cleanupMetadata: [
+            {
+              kind: 'temp-file',
+              provider: 'codex',
+              path: '/tmp/owned-cleanup',
+              reason: 'output-schema',
+            },
+          ],
+        },
       });
     } finally {
       fs.rmSync(tempHome, { recursive: true, force: true });
@@ -197,6 +149,7 @@ describe('Task ownership persistence and runtime wiring', function () {
         assert.strictEqual(result.descendantAlive, false);
         assert.strictEqual(result.unrelatedAlive, true);
         assert.strictEqual(result.terminalGroupId, null);
+        assert.strictEqual(result.cleanupRemoved, true);
         assert.strictEqual(
           result.persistedStrategy,
           process.platform === 'win32' ? 'process-tree' : 'process-group'

--- a/tests/unit/claude-hook-config-isolation.test.js
+++ b/tests/unit/claude-hook-config-isolation.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+const {
+  ensureAskUserQuestionHook,
+  ensureDangerousGitHook,
+} = require('../../src/agent/agent-task-executor');
+
+describe('Claude safety hook config isolation', function () {
+  it('refuses to install safety hooks without an explicit per-run directory', function () {
+    assert.throws(() => ensureAskUserQuestionHook(), /explicit per-run settings directory/);
+    assert.throws(() => ensureDangerousGitHook(), /explicit per-run settings directory/);
+  });
+});

--- a/tests/unit/claude-mcp-forwarding.test.js
+++ b/tests/unit/claude-mcp-forwarding.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveMcpConfigArgs } = require('../../src/agent/agent-task-executor');
+
+describe('Claude repository MCP forwarding', function () {
+  const tempDirs = [];
+
+  afterEach(function () {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeWorktree() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-mcp-forward-'));
+    tempDirs.push(root);
+    fs.writeFileSync(path.join(root, '.git'), 'gitdir: test\n');
+    return root;
+  }
+
+  function claudeArgs(root) {
+    return resolveMcpConfigArgs({ config: { cwd: root }, worktree: { path: root } }, 'claude');
+  }
+
+  it('forwards the root MCP config path to the detached Claude task command', function () {
+    const root = makeWorktree();
+    const mcpPath = path.join(root, '.mcp.json');
+    fs.writeFileSync(mcpPath, '{"mcpServers":{"root":{}}}\n');
+
+    assert.deepStrictEqual(claudeArgs(root), ['--mcp-config', mcpPath]);
+  });
+
+  it('forwards the legacy Claude-directory MCP config when root config is absent', function () {
+    const root = makeWorktree();
+    const claudeDir = path.join(root, '.claude');
+    fs.mkdirSync(claudeDir);
+    const mcpPath = path.join(claudeDir, '.mcp.json');
+    fs.writeFileSync(mcpPath, '{"mcpServers":{"legacy":{}}}\n');
+
+    assert.deepStrictEqual(claudeArgs(root), ['--mcp-config', mcpPath]);
+  });
+});

--- a/tests/unit/claude-mcp-forwarding.test.js
+++ b/tests/unit/claude-mcp-forwarding.test.js
@@ -21,8 +21,15 @@ describe('Claude repository MCP forwarding', function () {
     return root;
   }
 
-  function claudeArgs(root) {
-    return resolveMcpConfigArgs({ config: { cwd: root }, worktree: { path: root } }, 'claude');
+  function claudeArgs(root, isolated = false) {
+    return resolveMcpConfigArgs(
+      {
+        config: { cwd: root },
+        worktree: { path: root },
+        isolation: { enabled: isolated },
+      },
+      'claude'
+    );
   }
 
   it('forwards the root MCP config path to the detached Claude task command', function () {
@@ -31,6 +38,7 @@ describe('Claude repository MCP forwarding', function () {
     fs.writeFileSync(mcpPath, '{"mcpServers":{"root":{}}}\n');
 
     assert.deepStrictEqual(claudeArgs(root), ['--mcp-config', mcpPath]);
+    assert.deepStrictEqual(claudeArgs(root, true), ['--mcp-config', '/workspace/.mcp.json']);
   });
 
   it('forwards the legacy Claude-directory MCP config when root config is absent', function () {
@@ -41,5 +49,9 @@ describe('Claude repository MCP forwarding', function () {
     fs.writeFileSync(mcpPath, '{"mcpServers":{"legacy":{}}}\n');
 
     assert.deepStrictEqual(claudeArgs(root), ['--mcp-config', mcpPath]);
+    assert.deepStrictEqual(claudeArgs(root, true), [
+      '--mcp-config',
+      '/workspace/.claude/.mcp.json',
+    ]);
   });
 });

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { EventEmitter } = require('events');
 
 const ClaudeTaskRunner = require('../../src/claude-task-runner');
 const {
@@ -156,4 +157,58 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
     );
     assert.ok(!fs.existsSync(path.dirname(settingsPath)));
   });
+});
+
+describe('ClaudeTaskRunner isolated MCP forwarding', function () {
+  const tempDirs = [];
+
+  afterEach(function () {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  for (const relativeMcpPath of ['.mcp.json', path.join('.claude', '.mcp.json')]) {
+    it(`uses the container workspace path for ${relativeMcpPath} in isolated runs`, async function () {
+      const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-runner-mcp-'));
+      tempDirs.push(worktreeRoot);
+      fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: isolated-test\n');
+      const mcpPath = path.join(worktreeRoot, relativeMcpPath);
+      fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
+      fs.writeFileSync(mcpPath, '{"mcpServers":{"repo":{}}}\n');
+
+      let spawnedCommand;
+      const proc = new EventEmitter();
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = () => {};
+      const runner = new ClaudeTaskRunner({ quiet: true, timeout: 20 });
+      const resultPromise = runner._runIsolated('context', {
+        provider: 'claude',
+        cwd: worktreeRoot,
+        worktreePath: worktreeRoot,
+        isolation: {
+          enabled: true,
+          clusterId: 'isolated-mcp',
+          manager: {
+            spawnInContainer(_clusterId, command) {
+              spawnedCommand = command;
+              process.nextTick(() => proc.emit('close', 0));
+              return proc;
+            },
+          },
+        },
+      });
+
+      const result = await resultPromise;
+      const mcpIndex = spawnedCommand.indexOf('--mcp-config');
+      assert.strictEqual(result.success, true);
+      assert.ok(mcpIndex > 0, JSON.stringify(spawnedCommand));
+      assert.strictEqual(
+        spawnedCommand[mcpIndex + 1],
+        path.posix.join('/workspace', relativeMcpPath.split(path.sep).join('/'))
+      );
+      assert.ok(!spawnedCommand.includes(mcpPath));
+    });
+  }
 });

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -4,20 +4,44 @@ const os = require('os');
 const path = require('path');
 
 const ClaudeTaskRunner = require('../../src/claude-task-runner');
+const {
+  CLAUDE_SETTINGS_ENV,
+  cleanupClaudeSettingsOverlay,
+} = require('../../src/worktree-claude-config');
 
 describe('ClaudeTaskRunner worktree env forwarding', function () {
   /** @type {string[]} */
   let tempDirs = [];
+  /** @type {string[]} */
+  let settingsOverlays = [];
+  let originalClaudeConfigDir;
+
+  beforeEach(function () {
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  });
 
   afterEach(function () {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+    for (const settingsPath of settingsOverlays.splice(0)) {
+      cleanupClaudeSettingsOverlay(settingsPath);
+    }
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('prepends worktree-local tool bins when cwd is inside a nested submodule', function () {
+  it('preserves user config while forwarding a per-run hook overlay and worktree tools', function () {
     const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-runner-worktree-'));
-    tempDirs.push(worktreeRoot);
+    const userConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-runner-claude-user-'));
+    tempDirs.push(worktreeRoot, userConfigDir);
+    const userSettingsPath = path.join(userConfigDir, 'settings.json');
+    const userSettings = '{"enabledPlugins":{"example@marketplace":true}}\n';
+    fs.writeFileSync(userSettingsPath, userSettings, 'utf8');
+    process.env.CLAUDE_CONFIG_DIR = userConfigDir;
 
     const toolBinDir = path.join(worktreeRoot, '.zeroshot', 'bin');
     const submoduleCwd = path.join(worktreeRoot, 'external', 'zeroshot', 'src');
@@ -46,8 +70,21 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
       cwd: submoduleCwd,
       worktreePath: worktreeRoot,
     });
+    settingsOverlays.push(spawnEnv[CLAUDE_SETTINGS_ENV]);
 
     const pathEntries = spawnEnv.PATH.split(path.delimiter);
+    assert.strictEqual(
+      spawnEnv.CLAUDE_CONFIG_DIR,
+      userConfigDir,
+      'the user config source must remain active'
+    );
+    assert.ok(spawnEnv[CLAUDE_SETTINGS_ENV], 'Claude runs should receive a settings overlay');
+    assert.strictEqual(fs.readFileSync(userSettingsPath, 'utf8'), userSettings);
+    const overlaySettings = JSON.parse(fs.readFileSync(spawnEnv[CLAUDE_SETTINGS_ENV], 'utf8'));
+    assert.deepStrictEqual(
+      overlaySettings.hooks.PreToolUse.map((entry) => entry.matcher),
+      ['AskUserQuestion', 'Bash']
+    );
     assert.strictEqual(pathEntries[0], toolBinDir);
     for (const entry of originalPathEntries) {
       assert.ok(pathEntries.includes(entry));

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const ClaudeTaskRunner = require('../../src/claude-task-runner');
 const {
+  CLAUDE_MCP_CONFIG_ENV,
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
 } = require('../../src/worktree-claude-config');
@@ -62,6 +63,8 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
       'gitdir: nested-submodule\n',
       'utf8'
     );
+    const mcpPath = path.join(worktreeRoot, '.mcp.json');
+    fs.writeFileSync(mcpPath, '{"mcpServers":{"repo":{}}}\n', 'utf8');
 
     const runner = new ClaudeTaskRunner({ quiet: true });
     const originalPathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
@@ -79,6 +82,11 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
       'the user config source must remain active'
     );
     assert.ok(spawnEnv[CLAUDE_SETTINGS_ENV], 'Claude runs should receive a settings overlay');
+    assert.strictEqual(
+      spawnEnv[CLAUDE_MCP_CONFIG_ENV],
+      mcpPath,
+      'Claude runs should explicitly receive the repository MCP config'
+    );
     assert.strictEqual(fs.readFileSync(userSettingsPath, 'utf8'), userSettings);
     const overlaySettings = JSON.parse(fs.readFileSync(spawnEnv[CLAUDE_SETTINGS_ENV], 'utf8'));
     assert.deepStrictEqual(
@@ -112,5 +120,40 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
       args.slice(args.indexOf('--reasoning-effort'), args.indexOf('--reasoning-effort') + 2),
       ['--reasoning-effort', 'max']
     );
+  });
+
+  it('keeps the overlay after task creation transfers ownership to the watcher', async function () {
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    let settingsPath;
+    runner._spawnAndGetTaskId = (_command, _args, _cwd, spawnEnv) => {
+      settingsPath = spawnEnv[CLAUDE_SETTINGS_ENV];
+      return 'task-owned-overlay';
+    };
+    runner._waitForTaskReady = () => {};
+    runner._followLogs = () => {
+      throw new Error('log follower timed out');
+    };
+
+    await assert.rejects(
+      runner.run('context', { provider: 'claude', cwd: process.cwd() }),
+      /log follower timed out/
+    );
+    settingsOverlays.push(settingsPath);
+    assert.ok(fs.existsSync(settingsPath), 'the detached task must retain its live settings file');
+  });
+
+  it('cleans the overlay when task creation fails before ownership transfer', async function () {
+    const runner = new ClaudeTaskRunner({ quiet: true });
+    let settingsPath;
+    runner._spawnAndGetTaskId = (_command, _args, _cwd, spawnEnv) => {
+      settingsPath = spawnEnv[CLAUDE_SETTINGS_ENV];
+      throw new Error('task creation failed');
+    };
+
+    await assert.rejects(
+      runner.run('context', { provider: 'claude', cwd: process.cwd() }),
+      /task creation failed/
+    );
+    assert.ok(!fs.existsSync(path.dirname(settingsPath)));
   });
 });

--- a/tests/unit/command-spec-cleanup-safety.test.js
+++ b/tests/unit/command-spec-cleanup-safety.test.js
@@ -1,0 +1,157 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { randomUUID } = require('node:crypto');
+
+function schemaMetadata(schemaPath, overrides = {}) {
+  return {
+    kind: 'temp-file',
+    provider: 'codex',
+    path: schemaPath,
+    reason: 'output-schema',
+    ...overrides,
+  };
+}
+
+function createSchemaFile() {
+  const schemaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-schema-'));
+  const schemaPath = path.join(schemaRoot, `${randomUUID()}.json`);
+  fs.writeFileSync(schemaPath, '{}\n', { mode: 0o600 });
+  return { schemaRoot, schemaPath };
+}
+
+describe('Command spec cleanup safety', function () {
+  const cleanupRoots = [];
+
+  afterEach(function () {
+    for (const cleanupRoot of cleanupRoots.splice(0)) {
+      fs.rmSync(cleanupRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('removes the exact regular Codex schema file from its canonical temp directory', async function () {
+    const { createCommandSpecCleanup } = await import('../../task-lib/command-spec-cleanup.js');
+    const { schemaRoot, schemaPath } = createSchemaFile();
+    cleanupRoots.push(schemaRoot);
+    const failures = [];
+    const cleanup = createCommandSpecCleanup(
+      {
+        cleanup: [schemaPath],
+        cleanupMetadata: [schemaMetadata(schemaPath)],
+      },
+      (cleanupPath, error) => failures.push({ cleanupPath, error })
+    );
+
+    assert.strictEqual(await cleanup.run(), true);
+    assert.strictEqual(fs.existsSync(schemaPath), false);
+    assert.deepStrictEqual(failures, []);
+  });
+
+  for (const scenario of [
+    {
+      name: 'arbitrary regular file',
+      build() {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-user-file-'));
+        const target = path.join(root, `${randomUUID()}.json`);
+        fs.writeFileSync(target, '{}\n');
+        return { roots: [root], target, metadata: schemaMetadata(target) };
+      },
+    },
+    {
+      name: 'schema symlink',
+      build() {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-user-file-'));
+        const victim = path.join(root, 'victim.json');
+        fs.writeFileSync(victim, '{}\n');
+        const schema = createSchemaFile();
+        fs.rmSync(schema.schemaPath);
+        fs.symlinkSync(victim, schema.schemaPath);
+        return {
+          roots: [root, schema.schemaRoot],
+          target: schema.schemaPath,
+          victim,
+          metadata: schemaMetadata(schema.schemaPath),
+        };
+      },
+    },
+    {
+      name: 'path escape',
+      build() {
+        const schema = createSchemaFile();
+        const victim = path.join(os.tmpdir(), `${randomUUID()}.json`);
+        fs.writeFileSync(victim, '{}\n');
+        const escaped = path.join(schema.schemaRoot, '..', path.basename(victim));
+        return {
+          roots: [schema.schemaRoot, victim],
+          target: escaped,
+          victim,
+          metadata: schemaMetadata(escaped),
+        };
+      },
+    },
+    {
+      name: 'wrong provider',
+      build() {
+        const schema = createSchemaFile();
+        return {
+          roots: [schema.schemaRoot],
+          target: schema.schemaPath,
+          metadata: schemaMetadata(schema.schemaPath, { provider: 'claude' }),
+        };
+      },
+    },
+    {
+      name: 'wrong reason',
+      build() {
+        const schema = createSchemaFile();
+        return {
+          roots: [schema.schemaRoot],
+          target: schema.schemaPath,
+          metadata: schemaMetadata(schema.schemaPath, { reason: 'settings-overlay' }),
+        };
+      },
+    },
+    {
+      name: 'mismatched metadata path',
+      build() {
+        const schema = createSchemaFile();
+        return {
+          roots: [schema.schemaRoot],
+          target: schema.schemaPath,
+          metadata: schemaMetadata(`${schema.schemaPath}.other`),
+        };
+      },
+    },
+    {
+      name: 'open metadata shape',
+      build() {
+        const schema = createSchemaFile();
+        return {
+          roots: [schema.schemaRoot],
+          target: schema.schemaPath,
+          metadata: schemaMetadata(schema.schemaPath, { extra: true }),
+        };
+      },
+    },
+  ]) {
+    it(`refuses ${scenario.name}`, async function () {
+      const { createCommandSpecCleanup } = await import('../../task-lib/command-spec-cleanup.js');
+      const fixture = scenario.build();
+      cleanupRoots.push(...fixture.roots);
+      const failures = [];
+      const cleanup = createCommandSpecCleanup(
+        {
+          cleanup: [fixture.target],
+          cleanupMetadata: [fixture.metadata],
+        },
+        (cleanupPath, error) => failures.push({ cleanupPath, error })
+      );
+
+      assert.strictEqual(await cleanup.run(), false);
+      assert.strictEqual(fs.existsSync(fixture.target), true);
+      if (fixture.victim) assert.strictEqual(fs.existsSync(fixture.victim), true);
+      assert.strictEqual(failures.length, 1);
+    });
+  }
+});

--- a/tests/unit/command-spec-cleanup-safety.test.js
+++ b/tests/unit/command-spec-cleanup-safety.test.js
@@ -14,6 +14,15 @@ function schemaMetadata(schemaPath, overrides = {}) {
   };
 }
 
+function overlayMetadata(overlayPath) {
+  return {
+    kind: 'temp-directory',
+    provider: 'claude',
+    path: overlayPath,
+    reason: 'settings-overlay',
+  };
+}
+
 function createSchemaFile() {
   const schemaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-schema-'));
   const schemaPath = path.join(schemaRoot, `${randomUUID()}.json`);
@@ -154,4 +163,49 @@ describe('Command spec cleanup safety', function () {
       assert.strictEqual(failures.length, 1);
     });
   }
+
+  it('recovers a deleted canonical overlay after receipt persistence fails', async function () {
+    const { createCommandSpecCleanup } = await import('../../task-lib/command-spec-cleanup.js');
+    const { killTaskCommand } = await import('../../task-lib/commands/kill.js');
+    const { addTask, getTask, removeTask } = await import('../../task-lib/store.js');
+    const { prepareClaudeSettingsOverlay } = require('../../src/worktree-claude-config');
+    const settingsPath = prepareClaudeSettingsOverlay();
+    const overlayPath = path.dirname(settingsPath);
+    const taskId = `missing-overlay-${randomUUID()}`;
+    const receipt = {
+      cleanup: [overlayPath],
+      cleanupMetadata: [overlayMetadata(overlayPath)],
+    };
+    addTask({ id: taskId, status: 'failed', pid: null, commandCleanup: receipt });
+
+    try {
+      const firstCleanup = createCommandSpecCleanup(receipt, () => {});
+      assert.strictEqual(await firstCleanup.run(), true);
+      assert.strictEqual(fs.existsSync(overlayPath), false);
+      assert.notStrictEqual(getTask(taskId).commandCleanup, null);
+
+      await killTaskCommand(taskId);
+      assert.strictEqual(getTask(taskId).commandCleanup, null);
+    } finally {
+      removeTask(taskId);
+      fs.rmSync(overlayPath, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a missing noncanonical overlay path', async function () {
+    const { createCommandSpecCleanup } = await import('../../task-lib/command-spec-cleanup.js');
+    const unsafePath = path.join(os.tmpdir(), `unsafe-missing-overlay-${randomUUID()}`);
+    const failures = [];
+    const cleanup = createCommandSpecCleanup(
+      {
+        cleanup: [unsafePath],
+        cleanupMetadata: [overlayMetadata(unsafePath)],
+      },
+      (cleanupPath, error) => failures.push({ cleanupPath, error })
+    );
+
+    assert.strictEqual(await cleanup.run(), false);
+    assert.strictEqual(fs.existsSync(unsafePath), false);
+    assert.strictEqual(failures.length, 1);
+  });
 });

--- a/tests/unit/task-launch-cleanup-ambiguity.test.js
+++ b/tests/unit/task-launch-cleanup-ambiguity.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-function runFixture(mode) {
+function runFixture(mode, scenario = 'persisted') {
   const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), `zeroshot-ambiguous-${mode}-`));
   try {
     const stdout = execFileSync(
@@ -17,6 +17,8 @@ function runFixture(mode) {
           HOME: taskHome,
           USERPROFILE: taskHome,
           ZEROSHOT_HOME: taskHome,
+          AMBIGUOUS_TASK_SCENARIO: scenario,
+          AMBIGUOUS_SETTINGS_MARKER: path.join(taskHome, 'settings-path'),
         },
         timeout: 30000,
       }
@@ -33,9 +35,9 @@ describe('Ambiguous task-wrapper cleanup ownership', function () {
   this.timeout(40000);
 
   for (const mode of ['runner', 'agent']) {
-    it(`${mode} retains the overlay after an exit-0 task-id parse failure until kill`, function () {
+    it(`${mode} transfers cleanup only after a durable task receipt`, function () {
       const result = runFixture(mode);
-      assert.match(result.rejection.message, /Could not parse task ID/);
+      assert.match(result.rejection.message, /failed with code 1/);
       assert.strictEqual(result.rejection.commandCleanupOwner, 'task-lifecycle');
       assert.strictEqual(result.pending.status, 'running');
       assert.notStrictEqual(result.pending.commandCleanup, null);
@@ -46,5 +48,29 @@ describe('Ambiguous task-wrapper cleanup ownership', function () {
       assert.strictEqual(result.overlayExistsAfterKill, false);
       assert.strictEqual(result.providerAliveAfterKill, false);
     });
+
+    it(`${mode} retains caller cleanup for a pre-persistence provider-contract failure`, function () {
+      const result = runFixture(mode, 'pre-persistence-contract-failure');
+      assert.match(result.rejection.message, /Upgrade Claude Code/);
+      assert.strictEqual(result.rejection.commandCleanupOwner, undefined);
+      assert.strictEqual(result.pending, null);
+      assert.strictEqual(result.overlayExistsAfterReject, false);
+    });
   }
+});
+
+describe('Durable task ownership receipt', function () {
+  it('returns the persisted task id without relying on human wrapper stdout', function () {
+    const { requireTaskIdFromWrapperResult } = require('../../src/task-spawn-cleanup-ownership');
+    assert.strictEqual(
+      requireTaskIdFromWrapperResult({
+        code: 0,
+        stdout: 'human output changed',
+        stderr: '',
+        parseTaskId: () => null,
+        persistedTaskId: 'task-durable-receipt',
+      }),
+      'task-durable-receipt'
+    );
+  });
 });

--- a/tests/unit/task-launch-cleanup-ambiguity.test.js
+++ b/tests/unit/task-launch-cleanup-ambiguity.test.js
@@ -35,14 +35,14 @@ describe('Ambiguous task-wrapper cleanup ownership', function () {
   this.timeout(40000);
 
   for (const mode of ['runner', 'agent']) {
-    it(`${mode} transfers cleanup only after a durable task receipt`, function () {
+    it(`${mode} recovers cleanup after a durable task receipt`, function () {
       const result = runFixture(mode);
       assert.match(result.rejection.message, /failed with code 1/);
       assert.strictEqual(result.rejection.commandCleanupOwner, 'task-lifecycle');
-      assert.strictEqual(result.pending.status, 'running');
-      assert.notStrictEqual(result.pending.commandCleanup, null);
-      assert.strictEqual(result.overlayExistsAfterReject, true);
-      assert.strictEqual(result.providerAliveAfterReject, true);
+      assert.strictEqual(result.pending.status, 'killed');
+      assert.strictEqual(result.pending.commandCleanup, null);
+      assert.strictEqual(result.overlayExistsAfterReject, false);
+      assert.strictEqual(result.providerAliveAfterReject, false);
       assert.strictEqual(result.terminal.status, 'killed');
       assert.strictEqual(result.terminal.commandCleanup, null);
       assert.strictEqual(result.overlayExistsAfterKill, false);

--- a/tests/unit/task-launch-cleanup-ambiguity.test.js
+++ b/tests/unit/task-launch-cleanup-ambiguity.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+function runFixture(mode) {
+  const taskHome = fs.mkdtempSync(path.join(os.tmpdir(), `zeroshot-ambiguous-${mode}-`));
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [path.resolve(__dirname, '../fixtures/ambiguous-task-launch-runtime.js'), mode],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          HOME: taskHome,
+          USERPROFILE: taskHome,
+          ZEROSHOT_HOME: taskHome,
+        },
+        timeout: 30000,
+      }
+    );
+    const resultLine = stdout.split('\n').find((line) => line.startsWith('RESULT:'));
+    assert.ok(resultLine, stdout);
+    return JSON.parse(resultLine.slice('RESULT:'.length));
+  } finally {
+    fs.rmSync(taskHome, { recursive: true, force: true });
+  }
+}
+
+describe('Ambiguous task-wrapper cleanup ownership', function () {
+  this.timeout(40000);
+
+  for (const mode of ['runner', 'agent']) {
+    it(`${mode} retains the overlay after an exit-0 task-id parse failure until kill`, function () {
+      const result = runFixture(mode);
+      assert.match(result.rejection.message, /Could not parse task ID/);
+      assert.strictEqual(result.rejection.commandCleanupOwner, 'task-lifecycle');
+      assert.strictEqual(result.pending.status, 'running');
+      assert.notStrictEqual(result.pending.commandCleanup, null);
+      assert.strictEqual(result.overlayExistsAfterReject, true);
+      assert.strictEqual(result.providerAliveAfterReject, true);
+      assert.strictEqual(result.terminal.status, 'killed');
+      assert.strictEqual(result.terminal.commandCleanup, null);
+      assert.strictEqual(result.overlayExistsAfterKill, false);
+      assert.strictEqual(result.providerAliveAfterKill, false);
+    });
+  }
+});

--- a/tests/unit/task-launch-cleanup-ambiguity.test.js
+++ b/tests/unit/task-launch-cleanup-ambiguity.test.js
@@ -56,6 +56,14 @@ describe('Ambiguous task-wrapper cleanup ownership', function () {
       assert.strictEqual(result.pending, null);
       assert.strictEqual(result.overlayExistsAfterReject, false);
     });
+
+    it(`${mode} rejects legacy success output without a durable token receipt`, function () {
+      const result = runFixture(mode, 'legacy-success-no-token');
+      assert.match(result.rejection.message, /ownership receipt was not persisted/);
+      assert.strictEqual(result.rejection.commandCleanupOwner, undefined);
+      assert.strictEqual(result.pending, null);
+      assert.strictEqual(result.overlayExistsAfterReject, false);
+    });
   }
 });
 
@@ -71,6 +79,21 @@ describe('Durable task ownership receipt', function () {
         persistedTaskId: 'task-durable-receipt',
       }),
       'task-durable-receipt'
+    );
+  });
+
+  it('rejects wrapper output that disagrees with the durable receipt', function () {
+    const { requireTaskIdFromWrapperResult } = require('../../src/task-spawn-cleanup-ownership');
+    assert.throws(
+      () =>
+        requireTaskIdFromWrapperResult({
+          code: 0,
+          stdout: 'Task spawned: task-wrong-id',
+          stderr: '',
+          parseTaskId: () => 'task-wrong-id',
+          persistedTaskId: 'task-durable-receipt',
+        }),
+      /did not match wrapper output/
     );
   });
 });

--- a/tests/unit/task-runner-claude-cleanup.test.js
+++ b/tests/unit/task-runner-claude-cleanup.test.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  CLAUDE_SETTINGS_ENV,
+  cleanupClaudeSettingsOverlay,
+  prepareClaudeSettingsOverlay,
+} = require('../../src/worktree-claude-config');
+
+describe('task runner Claude cleanup ownership', function () {
+  let originalSettingsPath;
+  const cleanupPaths = [];
+
+  beforeEach(function () {
+    originalSettingsPath = process.env[CLAUDE_SETTINGS_ENV];
+  });
+
+  afterEach(function () {
+    if (originalSettingsPath === undefined) {
+      delete process.env[CLAUDE_SETTINGS_ENV];
+    } else {
+      process.env[CLAUDE_SETTINGS_ENV] = originalSettingsPath;
+    }
+    for (const cleanupPath of cleanupPaths.splice(0)) {
+      if (path.basename(cleanupPath) === 'settings.json') {
+        cleanupClaudeSettingsOverlay(cleanupPath);
+      } else {
+        fs.rmSync(cleanupPath, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('attaches the owned overlay directory to the Claude command spec', async function () {
+    const { attachClaudeOverlayCleanup } = await import('../../task-lib/runner.js');
+    const settingsPath = prepareClaudeSettingsOverlay();
+    cleanupPaths.push(settingsPath);
+    process.env[CLAUDE_SETTINGS_ENV] = settingsPath;
+
+    const command = attachClaudeOverlayCleanup(
+      { binary: 'claude', args: [], cleanup: [], cleanupMetadata: [] },
+      'claude'
+    );
+    assert.deepStrictEqual(command.cleanup, [path.dirname(settingsPath)]);
+    assert.deepStrictEqual(command.cleanupMetadata, [
+      {
+        kind: 'temp-directory',
+        provider: 'claude',
+        path: path.dirname(settingsPath),
+        reason: 'settings-overlay',
+      },
+    ]);
+  });
+
+  it('does not accept an arbitrary settings path as recursive cleanup', async function () {
+    const { attachClaudeOverlayCleanup } = await import('../../task-lib/runner.js');
+    const unrelatedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-user-settings-'));
+    cleanupPaths.push(unrelatedDir);
+    process.env[CLAUDE_SETTINGS_ENV] = path.join(unrelatedDir, 'settings.json');
+    fs.writeFileSync(process.env[CLAUDE_SETTINGS_ENV], '{}\n');
+
+    const command = { binary: 'claude', args: [], cleanup: [], cleanupMetadata: [] };
+    assert.strictEqual(attachClaudeOverlayCleanup(command, 'claude'), command);
+  });
+});

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+const { execFile } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+
+describe('watcher command cleanup ownership', function () {
+  this.timeout(40000);
+
+  async function runFixture(watcherName, mode) {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-watcher-home-'));
+    try {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [path.resolve(__dirname, '../fixtures/watcher-cleanup-runtime.js'), watcherName, mode],
+        {
+          env: { ...process.env, HOME: tempHome, ZEROSHOT_HOME: tempHome },
+          timeout: 30000,
+        }
+      );
+      const line = stdout.split('\n').find((entry) => entry.startsWith('RESULT:'));
+      assert.ok(line, stdout);
+      return JSON.parse(line.slice('RESULT:'.length));
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  }
+
+  for (const watcherName of ['watcher.js', 'attachable-watcher.js']) {
+    it(`${watcherName} terminates its provider before crash cleanup`, async function () {
+      const result = await runFixture(watcherName, 'crash');
+      assert.strictEqual(result.watcherExit.code, 1, result.watcherOutput);
+      assert.strictEqual(result.providerAlive, false);
+      assert.strictEqual(result.cleanupExists, false);
+      assert.strictEqual(result.status, 'failed');
+      assert.strictEqual(result.commandCleanup, null);
+      assert.match(result.watcherOutput, /\[CRASH\]/);
+    });
+  }
+
+  it('cleans an owned overlay after normal completion', async function () {
+    const result = await runFixture('watcher.js', 'exit0');
+    assert.strictEqual(result.watcherExit.code, 0);
+    assert.strictEqual(result.cleanupExists, false);
+    assert.strictEqual(result.status, 'completed');
+    assert.strictEqual(result.commandCleanup, null);
+  });
+
+  it('cleans an owned overlay after provider failure while preserving provider exit truth', async function () {
+    const result = await runFixture('watcher.js', 'exit7');
+    assert.strictEqual(result.watcherExit.code, 0);
+    assert.strictEqual(result.cleanupExists, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.exitCode, 7);
+    assert.match(result.logOutput, /Exit code: 7/);
+  });
+
+  it('refuses recursive cleanup for an unrelated directory', async function () {
+    const result = await runFixture('watcher.js', 'unowned');
+    assert.strictEqual(result.cleanupExists, true);
+    assert.strictEqual(result.ownedOverlayExists, true);
+    assert.notStrictEqual(result.commandCleanup, null);
+  });
+});

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -64,4 +64,22 @@ describe('watcher command cleanup ownership', function () {
     assert.strictEqual(result.ownedOverlayExists, true);
     assert.notStrictEqual(result.commandCleanup, null);
   });
+
+  it('attachable-watcher loads and runs persisted cleanup after an early args failure', async function () {
+    const result = await runFixture('attachable-watcher.js', 'invalid-args');
+    assert.strictEqual(result.watcherExit.code, 1, result.watcherOutput);
+    assert.strictEqual(result.cleanupExists, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.commandCleanup, null);
+    assert.match(result.logOutput, /\[CRASH\]/);
+  });
+
+  it('attachable-watcher retains an unsafe persisted receipt after an early args failure', async function () {
+    const result = await runFixture('attachable-watcher.js', 'invalid-args-unowned');
+    assert.strictEqual(result.watcherExit.code, 1, result.watcherOutput);
+    assert.strictEqual(result.cleanupExists, true);
+    assert.strictEqual(result.status, 'failed');
+    assert.notStrictEqual(result.commandCleanup, null);
+    assert.match(result.logOutput, /Refusing unowned temporary directory cleanup/);
+  });
 });

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -41,6 +41,19 @@ describe('watcher command cleanup ownership', function () {
     });
   }
 
+  for (const watcherName of ['watcher.js', 'attachable-watcher.js']) {
+    it(`${watcherName} honors cancellation before provider spawn`, async function () {
+      const result = await runFixture(watcherName, 'cancel-before-start');
+      assert.strictEqual(result.watcherExit.code, 0, result.watcherOutput);
+      assert.strictEqual(result.providerPid, null);
+      assert.strictEqual(result.providerAlive, false);
+      assert.strictEqual(result.cleanupExists, false);
+      assert.strictEqual(result.status, 'killed');
+      assert.strictEqual(result.cancelRequested, false);
+      assert.strictEqual(result.commandCleanup, null);
+    });
+  }
+
   it('cleans an owned overlay after normal completion', async function () {
     const result = await runFixture('watcher.js', 'exit0');
     assert.strictEqual(result.watcherExit.code, 0);

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -54,6 +54,15 @@ describe('watcher command cleanup ownership', function () {
     });
   }
 
+  it('fails durably when the provider executable disappears before spawn', async function () {
+    const result = await runFixture('watcher.js', 'missing-command');
+    assert.strictEqual(result.watcherExit.code, 1, result.watcherOutput);
+    assert.strictEqual(result.status, 'failed');
+    assert.strictEqual(result.commandCleanup, null);
+    assert.strictEqual(result.cleanupExists, false);
+    assert.match(result.logOutput, /ENOENT|no such file/i);
+  });
+
   it('cleans an owned overlay after normal completion', async function () {
     const result = await runFixture('watcher.js', 'exit0');
     assert.strictEqual(result.watcherExit.code, 0);

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -54,6 +54,61 @@ describe('watcher command cleanup ownership', function () {
     });
   }
 
+  for (const watcherName of ['watcher.js', 'attachable-watcher.js']) {
+    it(`${watcherName} retains ownership when a Windows process-tree root is gone`, async function () {
+      const runtime = await import('../../task-lib/watcher-output-runtime.js');
+      const receipt = { cleanup: ['owned-overlay'], cleanupMetadata: [] };
+      const task = {
+        status: 'running',
+        pid: 424242,
+        processGroupId: null,
+        commandCleanup: receipt,
+      };
+      let cleanupRuns = 0;
+      const completionOptions = {
+        taskId: `win-root-gone-${watcherName}`,
+        commandCleanup: {
+          async run() {
+            cleanupRuns++;
+            return true;
+          },
+        },
+        terminateProvider: () =>
+          runtime.terminateWatcherProvider(
+            { pid: task.pid },
+            {
+              platform: 'win32',
+              terminateProcessFn: async () => ({
+                terminated: true,
+                alreadyDead: true,
+                scope: 'process-tree',
+              }),
+            }
+          ),
+        updateTask: async (_taskId, updates) => Object.assign(task, updates),
+        emergencyLog() {},
+      };
+
+      const completed =
+        watcherName === 'watcher.js'
+          ? await runtime.completeWatcherTask({
+              ...completionOptions,
+              completion: { status: 'completed', resolvedCode: 0, error: null },
+            })
+          : await runtime.completeWatcherFailure({
+              ...completionOptions,
+              error: new Error('simulated attachable watcher failure'),
+              source: 'uncaughtException',
+            });
+
+      assert.strictEqual(completed, false);
+      assert.strictEqual(task.status, 'running');
+      assert.strictEqual(task.pid, 424242);
+      assert.strictEqual(task.commandCleanup, receipt);
+      assert.strictEqual(cleanupRuns, 0);
+    });
+  }
+
   it('fails durably when the provider executable disappears before spawn', async function () {
     const result = await runFixture('watcher.js', 'missing-command');
     assert.strictEqual(result.watcherExit.code, 1, result.watcherOutput);

--- a/tests/unit/watcher-cleanup-ownership.test.js
+++ b/tests/unit/watcher-cleanup-ownership.test.js
@@ -68,9 +68,9 @@ describe('watcher command cleanup ownership', function () {
       const completionOptions = {
         taskId: `win-root-gone-${watcherName}`,
         commandCleanup: {
-          async run() {
+          run() {
             cleanupRuns++;
-            return true;
+            return Promise.resolve(true);
           },
         },
         terminateProvider: () =>
@@ -78,14 +78,15 @@ describe('watcher command cleanup ownership', function () {
             { pid: task.pid },
             {
               platform: 'win32',
-              terminateProcessFn: async () => ({
-                terminated: true,
-                alreadyDead: true,
-                scope: 'process-tree',
-              }),
+              terminateProcessFn: () =>
+                Promise.resolve({
+                  terminated: true,
+                  alreadyDead: true,
+                  scope: 'process-tree',
+                }),
             }
           ),
-        updateTask: async (_taskId, updates) => Object.assign(task, updates),
+        updateTask: (_taskId, updates) => Promise.resolve(Object.assign(task, updates)),
         emergencyLog() {},
       };
 
@@ -106,6 +107,40 @@ describe('watcher command cleanup ownership', function () {
       assert.strictEqual(task.pid, 424242);
       assert.strictEqual(task.commandCleanup, receipt);
       assert.strictEqual(cleanupRuns, 0);
+
+      task.status = 'running';
+      task.pid = 424242;
+      task.commandCleanup = receipt;
+      completionOptions.terminateProvider = () =>
+        runtime.terminateWatcherProvider(
+          { pid: task.pid },
+          {
+            platform: 'win32',
+            exitObserved: true,
+            terminateProcessFn: () =>
+              Promise.resolve({
+                terminated: true,
+                alreadyDead: true,
+                scope: 'process-tree',
+              }),
+          }
+        );
+      const observedCompletion =
+        watcherName === 'watcher.js'
+          ? await runtime.completeWatcherTask({
+              ...completionOptions,
+              completion: { status: 'completed', resolvedCode: 0, error: null },
+            })
+          : await runtime.completeWatcherFailure({
+              ...completionOptions,
+              error: new Error('simulated attachable watcher failure'),
+              source: 'uncaughtException',
+            });
+      assert.strictEqual(observedCompletion, true);
+      assert.notStrictEqual(task.status, 'running');
+      assert.strictEqual(task.pid, null);
+      assert.strictEqual(task.commandCleanup, null);
+      assert.strictEqual(cleanupRuns, 1);
     });
   }
 

--- a/tests/unit/watcher-crash-handling.test.js
+++ b/tests/unit/watcher-crash-handling.test.js
@@ -20,6 +20,7 @@
 const { describe, it, beforeEach, afterEach } = require('mocha');
 const { expect } = require('chai');
 const { spawn } = require('child_process');
+const { randomUUID } = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -30,9 +31,11 @@ describe('Watcher Crash Handling', function () {
   let tempDir;
   let logFile;
   let taskId;
+  let schemaRoots;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watcher-test-'));
+    schemaRoots = [];
     taskId = `test-crash-${Date.now()}`;
     logFile = path.join(tempDir, `${taskId}.log`);
   });
@@ -41,6 +44,9 @@ describe('Watcher Crash Handling', function () {
     // Cleanup temp files
     try {
       fs.rmSync(tempDir, { recursive: true, force: true });
+      for (const schemaRoot of schemaRoots) {
+        fs.rmSync(schemaRoot, { recursive: true, force: true });
+      }
     } catch {
       // Ignore cleanup errors
     }
@@ -223,9 +229,16 @@ if (crashType === 'sync-throw') {
     child.on('exit', (code) => done(null, { code }));
   }
 
-  it('removes helper cleanup files after watcher close', (done) => {
-    const cleanupFile = path.join(tempDir, 'schema.json');
+  function createSchemaCleanupFile() {
+    const schemaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-schema-'));
+    schemaRoots.push(schemaRoot);
+    const cleanupFile = path.join(schemaRoot, `${randomUUID()}.json`);
     fs.writeFileSync(cleanupFile, '{}');
+    return cleanupFile;
+  }
+
+  it('removes helper cleanup files after watcher close', (done) => {
+    const cleanupFile = createSchemaCleanupFile();
 
     runWatcher(
       {
@@ -276,8 +289,7 @@ if (crashType === 'sync-throw') {
   });
 
   it('removes helper cleanup files when command spawn fails', (done) => {
-    const cleanupFile = path.join(tempDir, 'schema-error.json');
-    fs.writeFileSync(cleanupFile, '{}');
+    const cleanupFile = createSchemaCleanupFile();
 
     runWatcher(
       {

--- a/tests/unit/windows-hide-spawn-options.test.js
+++ b/tests/unit/windows-hide-spawn-options.test.js
@@ -59,14 +59,15 @@ describe('windowsHide spawn options (Windows console window fix)', function () {
     );
   });
 
-  it('adds windowsHide: true to the watcher child spawn (task-lib/watcher.js)', function () {
-    const source = readSource('task-lib/watcher.js');
-    const match = source.match(/const child = spawn\([\s\S]*?\);/);
-    assert(match, 'watcher child spawn() call not found in task-lib/watcher.js');
+  it('adds windowsHide: true at the shared watcher child spawn site', function () {
+    const source = readSource('task-lib/watcher-output-runtime.js');
+    const match = source.match(/function spawnWatcherProvider\([\s\S]*?\n\}/);
+    assert(match, 'spawnWatcherProvider() not found in watcher-output-runtime.js');
+    assert.match(match[0], /spawn\(/);
     assert.match(
       match[0],
       /windowsHide:\s*true/,
-      'watcher.js must pass windowsHide: true to spawn()'
+      'the shared watcher runtime must pass windowsHide: true to spawn()'
     );
   });
 

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -2,178 +2,78 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const sinon = require('sinon');
 
-const { prepareClaudeConfigDir } = require('../../src/worktree-claude-config');
-const safeExec = require('../../src/lib/safe-exec');
-
-function withPlatform(value, fn) {
-  const original = Object.getOwnPropertyDescriptor(os, 'platform');
-  Object.defineProperty(os, 'platform', { value: () => value, configurable: true });
-  try {
-    return fn();
-  } finally {
-    Object.defineProperty(os, 'platform', original);
-  }
-}
-
-function loadWorktreeClaudeConfigWithStubbedCredentials(execSyncStub) {
-  sinon.stub(safeExec, 'execSync').callsFake(execSyncStub);
-  delete require.cache[require.resolve('../../src/claude-credentials')];
-  delete require.cache[require.resolve('../../src/worktree-claude-config')];
-  return require('../../src/worktree-claude-config');
-}
+const {
+  cleanupClaudeSettingsOverlay,
+  prepareClaudeSettingsOverlay,
+  resolveRepoMcpConfigPath,
+} = require('../../src/worktree-claude-config');
 
 describe('worktree-claude-config', function () {
-  /** @type {string[]} */
-  let tempDirs = [];
+  const tempDirs = [];
+  const settingsOverlays = [];
 
   afterEach(function () {
-    sinon.restore();
-    delete require.cache[require.resolve('../../src/claude-credentials')];
-    delete require.cache[require.resolve('../../src/worktree-claude-config')];
+    for (const settingsPath of settingsOverlays.splice(0)) {
+      cleanupClaudeSettingsOverlay(settingsPath);
+    }
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('returns null when the worktree has no repo-owned claude config', function () {
+  it('creates an AskUserQuestion settings overlay for every Claude run', function () {
+    const settingsPath = prepareClaudeSettingsOverlay();
+    settingsOverlays.push(settingsPath);
+
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.deepStrictEqual(
+      settings.hooks.PreToolUse.map((entry) => entry.matcher),
+      ['AskUserQuestion']
+    );
+    assert.strictEqual(fs.statSync(settingsPath).mode & 0o777, 0o600);
+    assert.ok(
+      fs.existsSync(path.join(path.dirname(settingsPath), 'hooks', 'block-ask-user-question.py'))
+    );
+  });
+
+  it('adds the dangerous-git hook only for worktree runs', function () {
+    const settingsPath = prepareClaudeSettingsOverlay({ includeDangerousGit: true });
+    settingsOverlays.push(settingsPath);
+
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.deepStrictEqual(
+      settings.hooks.PreToolUse.map((entry) => entry.matcher),
+      ['AskUserQuestion', 'Bash']
+    );
+    assert.ok(
+      fs.existsSync(path.join(path.dirname(settingsPath), 'hooks', 'block-dangerous-git.py'))
+    );
+  });
+
+  it('only cleans up Zeroshot-owned settings overlays', function () {
+    const unrelatedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-source-'));
+    const unrelatedSettingsPath = path.join(unrelatedDir, 'settings.json');
+    tempDirs.push(unrelatedDir);
+    fs.writeFileSync(unrelatedSettingsPath, '{}\n', 'utf8');
+
+    const settingsPath = prepareClaudeSettingsOverlay();
+    assert.ok(fs.existsSync(settingsPath));
+
+    assert.strictEqual(cleanupClaudeSettingsOverlay(unrelatedSettingsPath), false);
+    assert.ok(fs.existsSync(unrelatedSettingsPath));
+    assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
+    assert.ok(!fs.existsSync(path.dirname(settingsPath)));
+  });
+
+  it('resolves repository MCP config independently of the Claude settings overlay', function () {
     const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));
     tempDirs.push(worktreeRoot);
     fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
-
-    assert.strictEqual(prepareClaudeConfigDir({ worktreePath: worktreeRoot }), null);
-  });
-
-  it('merges repo-owned settings and MCP config into a temporary overlay config dir', function () {
-    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));
-    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-source-'));
-    tempDirs.push(worktreeRoot, sourceDir);
-
-    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
     fs.mkdirSync(path.join(worktreeRoot, '.claude'), { recursive: true });
-    fs.writeFileSync(
-      path.join(worktreeRoot, '.claude', 'settings.json'),
-      JSON.stringify(
-        {
-          hooks: {
-            PreToolUse: [
-              {
-                matcher: 'Edit|Write',
-                hooks: [
-                  { type: 'command', command: '$CLAUDE_PROJECT_DIR/.claude/hooks/pre_tool_use.sh' },
-                ],
-              },
-            ],
-          },
-        },
-        null,
-        2
-      )
-    );
-    fs.writeFileSync(
-      path.join(worktreeRoot, '.claude', '.mcp.json'),
-      JSON.stringify(
-        {
-          mcpServers: {
-            repo: {
-              command: 'repo-tool',
-              args: ['serve'],
-            },
-          },
-        },
-        null,
-        2
-      )
-    );
+    const mcpPath = path.join(worktreeRoot, '.claude', '.mcp.json');
+    fs.writeFileSync(mcpPath, '{"mcpServers":{}}\n', 'utf8');
 
-    fs.writeFileSync(path.join(sourceDir, '.credentials.json'), '{"token":"secret"}\n', 'utf8');
-    fs.writeFileSync(
-      path.join(sourceDir, 'settings.json'),
-      JSON.stringify(
-        {
-          hooks: {
-            PreToolUse: [
-              {
-                matcher: 'AskUserQuestion',
-                hooks: [{ type: 'command', command: '/tmp/block-ask.py' }],
-              },
-            ],
-          },
-        },
-        null,
-        2
-      )
-    );
-    fs.writeFileSync(
-      path.join(sourceDir, '.mcp.json'),
-      JSON.stringify(
-        {
-          mcpServers: {
-            shared: {
-              command: 'npx',
-              args: ['-y', '@acme/shared-mcp'],
-            },
-          },
-        },
-        null,
-        2
-      )
-    );
-
-    const overlayDir = prepareClaudeConfigDir({ worktreePath: worktreeRoot, sourceDir });
-    tempDirs.push(overlayDir);
-
-    assert.ok(overlayDir, 'expected an overlay config dir');
-    assert.ok(fs.existsSync(path.join(overlayDir, '.credentials.json')));
-
-    const mergedSettings = JSON.parse(
-      fs.readFileSync(path.join(overlayDir, 'settings.json'), 'utf8')
-    );
-    assert.strictEqual(mergedSettings.hooks.PreToolUse.length, 2);
-    assert.deepStrictEqual(mergedSettings.hooks.PreToolUse.map((entry) => entry.matcher).sort(), [
-      'AskUserQuestion',
-      'Edit|Write',
-    ]);
-
-    const mergedMcp = JSON.parse(fs.readFileSync(path.join(overlayDir, '.mcp.json'), 'utf8'));
-    assert.deepStrictEqual(Object.keys(mergedMcp.mcpServers).sort(), ['repo', 'shared']);
-  });
-
-  it('materializes macOS Keychain credentials into the isolated overlay config dir', function () {
-    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));
-    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-source-no-creds-'));
-    tempDirs.push(worktreeRoot, sourceDir);
-
-    fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
-    fs.mkdirSync(path.join(worktreeRoot, '.claude'), { recursive: true });
-    fs.writeFileSync(path.join(worktreeRoot, '.claude', 'settings.json'), '{}\n', 'utf8');
-
-    const keychainJson = '{"claudeAiOauth":{"accessToken":"keychain-token"}}';
-    const { prepareClaudeConfigDir: prepareWithStubbedKeychain } =
-      loadWorktreeClaudeConfigWithStubbedCredentials((command) => {
-        assert.strictEqual(
-          command,
-          'security find-generic-password -s "Claude Code-credentials" -w'
-        );
-        return `${keychainJson}\n`;
-      });
-
-    const overlayDir = withPlatform('darwin', () =>
-      prepareWithStubbedKeychain({ worktreePath: worktreeRoot, sourceDir })
-    );
-    tempDirs.push(overlayDir);
-
-    assert.ok(overlayDir, 'expected an overlay config dir');
-    assert.strictEqual(
-      fs.readFileSync(path.join(overlayDir, '.credentials.json'), 'utf8'),
-      keychainJson,
-      'isolated CLAUDE_CONFIG_DIR must receive materialized Keychain credentials'
-    );
-    assert.strictEqual(
-      fs.statSync(path.join(overlayDir, '.credentials.json')).mode & 0o777,
-      0o600,
-      'materialized credentials should be owner-readable only'
-    );
+    assert.strictEqual(resolveRepoMcpConfigPath({ worktreePath: worktreeRoot }), mcpPath);
   });
 });

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -54,6 +54,30 @@ describe('worktree-claude-config', function () {
     assert.ok(fs.existsSync(retry), 'cleaning one run must not affect the next run');
   });
 
+  it('rewrites hooks when a cleaned overlay path is reused after many runs', function () {
+    const settingsPaths = Array.from({ length: 40 }, () =>
+      prepareClaudeSettingsOverlay({ includeDangerousGit: true })
+    );
+    const reusedDir = path.dirname(settingsPaths[0]);
+    for (const settingsPath of settingsPaths) {
+      assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
+    }
+
+    fs.mkdirSync(reusedDir, { recursive: true });
+    fs.writeFileSync(path.join(reusedDir, 'settings.json'), '{}\n', { mode: 0o600 });
+    ensureAskUserQuestionHook(reusedDir);
+    ensureDangerousGitHook(reusedDir);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(reusedDir, 'settings.json'), 'utf8'));
+    assert.deepStrictEqual(
+      settings.hooks.PreToolUse.map((entry) => entry.matcher),
+      ['AskUserQuestion', 'Bash']
+    );
+    assert.ok(fs.existsSync(path.join(reusedDir, 'hooks', 'block-ask-user-question.py')));
+    assert.ok(fs.existsSync(path.join(reusedDir, 'hooks', 'block-dangerous-git.py')));
+    tempDirs.push(reusedDir);
+  });
+
   it('adds the dangerous-git hook only for worktree runs', function () {
     const settingsPath = prepareClaudeSettingsOverlay({ includeDangerousGit: true });
     settingsOverlays.push(settingsPath);

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -5,6 +5,8 @@ const path = require('path');
 
 const {
   cleanupClaudeSettingsOverlay,
+  ensureAskUserQuestionHook,
+  ensureDangerousGitHook,
   isClaudeSettingsOverlayDirectory,
   isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,
@@ -83,6 +85,23 @@ describe('worktree-claude-config', function () {
     assert.strictEqual(isClaudeSettingsOverlayDirectory(path.dirname(settingsPath)), true);
     assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
     assert.ok(!fs.existsSync(path.dirname(settingsPath)));
+  });
+
+  it('refuses to install safety hooks into arbitrary user directories', function () {
+    const askUserDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-user-ask-'));
+    const dangerousGitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-user-git-'));
+    tempDirs.push(askUserDir, dangerousGitDir);
+
+    assert.throws(
+      () => ensureAskUserQuestionHook(askUserDir),
+      /Zeroshot-owned Claude settings overlay/
+    );
+    assert.throws(
+      () => ensureDangerousGitHook(dangerousGitDir),
+      /Zeroshot-owned Claude settings overlay/
+    );
+    assert.deepStrictEqual(fs.readdirSync(askUserDir), []);
+    assert.deepStrictEqual(fs.readdirSync(dangerousGitDir), []);
   });
 
   it('prefers root MCP config and supports the legacy Claude-directory fallback', function () {

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -7,6 +7,7 @@ const {
   cleanupClaudeSettingsOverlay,
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
+  isCanonicalClaudeSettingsOverlayDirectory,
   isClaudeSettingsOverlayDirectory,
   isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,
@@ -35,8 +36,10 @@ describe('worktree-claude-config', function () {
       settings.hooks.PreToolUse.map((entry) => entry.matcher),
       ['AskUserQuestion']
     );
-    assert.strictEqual(fs.statSync(settingsPath).mode & 0o777, 0o600);
-    assert.strictEqual(fs.statSync(path.dirname(settingsPath)).mode & 0o777, 0o700);
+    if (process.platform !== 'win32') {
+      assert.strictEqual(fs.statSync(settingsPath).mode & 0o777, 0o600);
+      assert.strictEqual(fs.statSync(path.dirname(settingsPath)).mode & 0o777, 0o700);
+    }
     assert.ok(
       fs.existsSync(path.join(path.dirname(settingsPath), 'hooks', 'block-ask-user-question.py'))
     );
@@ -145,6 +148,42 @@ describe('worktree-claude-config', function () {
     );
     assert.deepStrictEqual(fs.readdirSync(insecureDir), []);
   });
+  it('accepts Windows overlay directories without relying on POSIX mode bits', function () {
+    const overlayDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-settings-win-'));
+    const settingsPath = path.join(overlayDir, 'settings.json');
+    tempDirs.push(overlayDir);
+    fs.chmodSync(overlayDir, 0o755);
+
+    assert.strictEqual(isClaudeSettingsOverlayPath(settingsPath), process.platform === 'win32');
+    assert.strictEqual(isClaudeSettingsOverlayPath(settingsPath, 'win32'), true);
+    assert.strictEqual(isClaudeSettingsOverlayPath(settingsPath, 'linux'), false);
+  });
+
+  it('rejects noncanonical overlay directory spellings before path normalization', function () {
+    const settingsPath = prepareClaudeSettingsOverlay();
+    const overlayDir = path.dirname(settingsPath);
+    const variants = [
+      `${overlayDir}${path.sep}.`,
+      `${overlayDir}${path.sep}missing${path.sep}..`,
+      `${overlayDir}${path.sep}${path.sep}`,
+    ];
+
+    assert.strictEqual(isCanonicalClaudeSettingsOverlayDirectory(overlayDir), true);
+    for (const variant of variants) {
+      assert.strictEqual(isCanonicalClaudeSettingsOverlayDirectory(variant), false, variant);
+    }
+
+    assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
+    assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
+    for (const variant of variants) {
+      assert.strictEqual(
+        cleanupClaudeSettingsOverlay(`${variant}${path.sep}settings.json`),
+        false,
+        variant
+      );
+    }
+  });
+
 
 
   it('prefers root MCP config and supports the legacy Claude-directory fallback', function () {

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -36,6 +36,7 @@ describe('worktree-claude-config', function () {
       ['AskUserQuestion']
     );
     assert.strictEqual(fs.statSync(settingsPath).mode & 0o777, 0o600);
+    assert.strictEqual(fs.statSync(path.dirname(settingsPath)).mode & 0o777, 0o700);
     assert.ok(
       fs.existsSync(path.join(path.dirname(settingsPath), 'hooks', 'block-ask-user-question.py'))
     );
@@ -64,6 +65,7 @@ describe('worktree-claude-config', function () {
     }
 
     fs.mkdirSync(reusedDir, { recursive: true });
+    fs.chmodSync(reusedDir, 0o700);
     fs.writeFileSync(path.join(reusedDir, 'settings.json'), '{}\n', { mode: 0o600 });
     ensureAskUserQuestionHook(reusedDir);
     ensureDangerousGitHook(reusedDir);
@@ -127,6 +129,23 @@ describe('worktree-claude-config', function () {
     assert.deepStrictEqual(fs.readdirSync(askUserDir), []);
     assert.deepStrictEqual(fs.readdirSync(dangerousGitDir), []);
   });
+  it('rejects predictable overlay-shaped directories without private ownership mode', function () {
+    const insecureDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'zeroshot-claude-settings-insecure-')
+    );
+    const insecureSettingsPath = path.join(insecureDir, 'settings.json');
+    tempDirs.push(insecureDir);
+    fs.chmodSync(insecureDir, 0o755);
+
+    assert.strictEqual(isClaudeSettingsOverlayPath(insecureSettingsPath), false);
+    assert.strictEqual(isClaudeSettingsOverlayDirectory(insecureDir), false);
+    assert.throws(
+      () => ensureAskUserQuestionHook(insecureDir),
+      /Zeroshot-owned Claude settings overlay/
+    );
+    assert.deepStrictEqual(fs.readdirSync(insecureDir), []);
+  });
+
 
   it('prefers root MCP config and supports the legacy Claude-directory fallback', function () {
     const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));

--- a/tests/unit/worktree-claude-config.test.js
+++ b/tests/unit/worktree-claude-config.test.js
@@ -5,6 +5,8 @@ const path = require('path');
 
 const {
   cleanupClaudeSettingsOverlay,
+  isClaudeSettingsOverlayDirectory,
+  isClaudeSettingsOverlayPath,
   prepareClaudeSettingsOverlay,
   resolveRepoMcpConfigPath,
 } = require('../../src/worktree-claude-config');
@@ -37,6 +39,19 @@ describe('worktree-claude-config', function () {
     );
   });
 
+  it('gives retry and restart runs independently owned overlays', function () {
+    const first = prepareClaudeSettingsOverlay();
+    const retry = prepareClaudeSettingsOverlay();
+    settingsOverlays.push(first, retry);
+
+    assert.notStrictEqual(first, retry);
+    assert.ok(fs.existsSync(first));
+    assert.ok(fs.existsSync(retry));
+    assert.strictEqual(cleanupClaudeSettingsOverlay(first), true);
+    assert.ok(!fs.existsSync(path.dirname(first)));
+    assert.ok(fs.existsSync(retry), 'cleaning one run must not affect the next run');
+  });
+
   it('adds the dangerous-git hook only for worktree runs', function () {
     const settingsPath = prepareClaudeSettingsOverlay({ includeDangerousGit: true });
     settingsOverlays.push(settingsPath);
@@ -61,19 +76,26 @@ describe('worktree-claude-config', function () {
     assert.ok(fs.existsSync(settingsPath));
 
     assert.strictEqual(cleanupClaudeSettingsOverlay(unrelatedSettingsPath), false);
+    assert.strictEqual(isClaudeSettingsOverlayPath(unrelatedSettingsPath), false);
+    assert.strictEqual(isClaudeSettingsOverlayDirectory(unrelatedDir), false);
     assert.ok(fs.existsSync(unrelatedSettingsPath));
+    assert.strictEqual(isClaudeSettingsOverlayPath(settingsPath), true);
+    assert.strictEqual(isClaudeSettingsOverlayDirectory(path.dirname(settingsPath)), true);
     assert.strictEqual(cleanupClaudeSettingsOverlay(settingsPath), true);
     assert.ok(!fs.existsSync(path.dirname(settingsPath)));
   });
 
-  it('resolves repository MCP config independently of the Claude settings overlay', function () {
+  it('prefers root MCP config and supports the legacy Claude-directory fallback', function () {
     const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-claude-worktree-'));
     tempDirs.push(worktreeRoot);
     fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
     fs.mkdirSync(path.join(worktreeRoot, '.claude'), { recursive: true });
-    const mcpPath = path.join(worktreeRoot, '.claude', '.mcp.json');
-    fs.writeFileSync(mcpPath, '{"mcpServers":{}}\n', 'utf8');
+    const legacyMcpPath = path.join(worktreeRoot, '.claude', '.mcp.json');
+    const rootMcpPath = path.join(worktreeRoot, '.mcp.json');
+    fs.writeFileSync(legacyMcpPath, '{"mcpServers":{"legacy":{}}}\n', 'utf8');
 
-    assert.strictEqual(resolveRepoMcpConfigPath({ worktreePath: worktreeRoot }), mcpPath);
+    assert.strictEqual(resolveRepoMcpConfigPath({ worktreePath: worktreeRoot }), legacyMcpPath);
+    fs.writeFileSync(rootMcpPath, '{"mcpServers":{"root":{}}}\n', 'utf8');
+    assert.strictEqual(resolveRepoMcpConfigPath({ worktreePath: worktreeRoot }), rootMcpPath);
   });
 });


### PR DESCRIPTION
## Main-trunk migration

Replaces #806 with the same three isolated commits rebased onto the new `main`. Commit authorship is preserved; the implementation diff is unchanged apart from conflict resolution against the trunk cutover.

## Original PR body
## Summary

- stop installing Zeroshot safety hooks into the user-level Claude settings
- create a mode-0600 temporary settings overlay for each Claude task and load it through the supported --settings flag
- preserve normal user, project, local, credential, plugin, skill, and MCP discovery
- add the dangerous-git hook only for worktree tasks and clean the overlay after the provider exits
- route the overlay path through the provider command contract and cover the isolation behavior with regression tests

## Root cause

The prior project-overlay helper returned null when a repository had no Claude config. The hook installers treated that null as permission to fall back to CLAUDE_CONFIG_DIR or ~/.claude, so the first Zeroshot run mutated global Claude settings.

## Validation

- npm run check:agent-cli-provider:ci — 135 passing
- focused hook/config suite — 52 passing
- npm run check — pass (0 errors; existing warnings only)
- full npm test — 1,697 passing, 18 pending; 7 unrelated PTY tests fail in this worktree because node-pty reports posix_spawnp failed
- Python hooks compile successfully with python3 -m py_compile
- Opcore targeted validation is degraded because this repository has no configured Python type-checker authority for the two comment-only hook files; direct syntax and hook behavior checks pass

## Migration note

This prevents future global settings mutations. It deliberately does not rewrite existing user-level Claude settings to remove hook entries installed by an older Zeroshot version, because an automatic cleanup would itself mutate user-owned global configuration.

Fixes #43