### PR TITLE
fix: surface actionable hint when Claude model unavailable on Vertex

### DIFF
--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -597,6 +597,22 @@ async function runTaskAttempt(agent, triggeringMessage) {
   await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
 }
 
+function detectVertexModelError(errorMessage) {
+  try {
+    const parsed = JSON.parse(errorMessage);
+    if (parsed.api_error_status !== 404) return null;
+    const result = parsed.result || '';
+    const isVertexModelError =
+      result.includes('vertex deployment') ||
+      result.includes('may not exist or you may not have access');
+    if (!isVertexModelError) return null;
+    const modelMatch = result.match(/model\s+\(([^)]+)\)/);
+    return { model: modelMatch ? modelMatch[1] : null };
+  } catch {
+    return null;
+  }
+}
+
 function logTaskAttemptFailure(agent, attempt, maxRetries, error) {
   // Log attempt failure
   console.error(`
@@ -604,6 +620,20 @@ ${'='.repeat(80)}`);
   console.error(`🔴 TASK EXECUTION FAILED - AGENT: ${agent.id} (Attempt ${attempt}/${maxRetries})`);
   console.error(`${'='.repeat(80)}`);
   console.error(`Error: ${error.message}`);
+
+  const vertexError = detectVertexModelError(error.message);
+  if (vertexError) {
+    const model = vertexError.model ? `"${vertexError.model}" is` : 'Selected model is';
+    console.error(`
+⚠️  ${model} not available on your Vertex AI deployment.
+    Fix: set explicit model IDs that are enabled on your deployment:
+
+    zeroshot settings set providerSettings.claude.levelOverrides '{"level1": {"model": "claude-sonnet-4-6"}, "level2": {"model": "claude-sonnet-4-6"}, "level3": {"model": "claude-sonnet-4-6"}}'
+
+    Replace "claude-sonnet-4-6" with whichever Claude model your deployment has enabled.
+    You can test a model with: claude --dangerously-skip-permissions -p "hi" --model <model-id>
+`);
+  }
 }
 
 async function handleLockContention() {
@@ -982,6 +1012,11 @@ async function executeTask(agent, triggeringMessage) {
       }
       if (error instanceof HookExecutionError) {
         // Hook failures are deterministic; do not waste tokens retrying the provider task.
+        await handleFinalFailure(agent, triggeringMessage, error, 1);
+        return;
+      }
+      if (detectVertexModelError(error.message)) {
+        // Model unavailability on Vertex is deterministic — retrying wastes nothing but time.
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;
       }

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -574,6 +574,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
     const error = new Error(result.error || 'Task execution failed');
     error.code = result.code || result.errorType || null;
     error.taskId = result.taskId || null;
+    error.vertexModelError = result.vertexModelError || null;
     throw error;
   }
 
@@ -597,22 +598,6 @@ async function runTaskAttempt(agent, triggeringMessage) {
   await executeOnCompleteHookWithRetry(agent, triggeringMessage, result);
 }
 
-function detectVertexModelError(errorMessage) {
-  try {
-    const parsed = JSON.parse(errorMessage);
-    if (parsed.api_error_status !== 404) return null;
-    const result = parsed.result || '';
-    const isVertexModelError =
-      result.includes('vertex deployment') ||
-      result.includes('may not exist or you may not have access');
-    if (!isVertexModelError) return null;
-    const modelMatch = result.match(/model\s+\(([^)]+)\)/);
-    return { model: modelMatch ? modelMatch[1] : null };
-  } catch {
-    return null;
-  }
-}
-
 function logTaskAttemptFailure(agent, attempt, maxRetries, error) {
   // Log attempt failure
   console.error(`
@@ -621,7 +606,7 @@ ${'='.repeat(80)}`);
   console.error(`${'='.repeat(80)}`);
   console.error(`Error: ${error.message}`);
 
-  const vertexError = detectVertexModelError(error.message);
+  const vertexError = error.vertexModelError;
   if (vertexError) {
     const model = vertexError.model ? `"${vertexError.model}" is` : 'Selected model is';
     console.error(`
@@ -717,6 +702,22 @@ ${'='.repeat(80)}`);
           hookRetries: error.hookRetries ?? null,
           originalHookError: error.originalHookError ?? null,
           error: error.message,
+        },
+      },
+    });
+  }
+
+  if (error?.vertexModelError) {
+    agent._publish({
+      topic: 'CLUSTER_FAILED',
+      receiver: 'broadcast',
+      content: {
+        text: `Cluster failed: Claude model is unavailable on Vertex for ${agent.id}`,
+        data: {
+          reason: 'vertex_model_unavailable',
+          agentId: agent.id,
+          role: agent.role,
+          model: error.vertexModelError.model,
         },
       },
     });
@@ -1015,10 +1016,18 @@ async function executeTask(agent, triggeringMessage) {
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;
       }
-      if (detectVertexModelError(error.message)) {
-        logTaskAttemptFailure(agent, 1, 1, error);
+      if (error.vertexModelError) {
+        agent._publishLifecycle('TASK_FAILED', {
+          iteration: agent.iteration,
+          taskId: error.taskId || agent.currentTaskId,
+          error: error.message,
+          code: error.code || null,
+          attempt,
+        });
+        clearTransientTaskState(agent);
+        logTaskAttemptFailure(agent, attempt, maxRetries, error);
         // Model unavailability on Vertex is deterministic — retrying wastes nothing but time.
-        await handleFinalFailure(agent, triggeringMessage, error, 1);
+        await handleFinalFailure(agent, triggeringMessage, error, attempt);
         return;
       }
       agent._publishLifecycle('TASK_FAILED', {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -1016,6 +1016,7 @@ async function executeTask(agent, triggeringMessage) {
         return;
       }
       if (detectVertexModelError(error.message)) {
+        logTaskAttemptFailure(agent, 1, 1, error);
         // Model unavailability on Vertex is deterministic — retrying wastes nothing but time.
         await handleFinalFailure(agent, triggeringMessage, error, 1);
         return;

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1215,7 +1215,11 @@ function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
 async function buildCompletionResult({ agent, taskId, providerName, state, stdout, success }) {
   const classified = await evaluateStructuredSuccess({ agent, taskId, state, success });
   const vertexModelError =
-    providerName === 'claude' ? extractClaudeVertexModelError(state.output) : null;
+    providerName === 'claude'
+      ? extractClaudeVertexModelError(state.output, {
+          useVertex: process.env.CLAUDE_CODE_USE_VERTEX === '1',
+        })
+      : null;
   if (vertexModelError) {
     classified.success = false;
   }
@@ -1805,7 +1809,11 @@ function settleIsolatedTerminalStatus({
     }
 
     const vertexModelError =
-      providerName === 'claude' ? extractClaudeVertexModelError(state.fullOutput) : null;
+      providerName === 'claude'
+        ? extractClaudeVertexModelError(state.fullOutput, {
+            useVertex: process.env.CLAUDE_CODE_USE_VERTEX === '1',
+          })
+        : null;
     const success = status === 'completed' && !vertexModelError;
     const errorContext = !success
       ? extractErrorContext({

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -28,6 +28,7 @@ const {
   wrapTaskRunWithIsolatedSettings,
 } = require('../task-run-model-args.js');
 const { buildRawLogOnlyMetadata } = require('./context-replay-policy');
+const { extractClaudeVertexModelError } = require('./output-extraction');
 
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -1213,6 +1214,11 @@ function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
 
 async function buildCompletionResult({ agent, taskId, providerName, state, stdout, success }) {
   const classified = await evaluateStructuredSuccess({ agent, taskId, state, success });
+  const vertexModelError =
+    providerName === 'claude' ? extractClaudeVertexModelError(state.output) : null;
+  if (vertexModelError) {
+    classified.success = false;
+  }
   let errorContext = classified.error;
   if (!errorContext && !classified.success) {
     errorContext = buildFailureContext({ agent, taskId, providerName, state, stdout });
@@ -1223,6 +1229,7 @@ async function buildCompletionResult({ agent, taskId, providerName, state, stdou
     output: state.output,
     error: errorContext,
     tokenUsage: extractTokenUsage(state.output, providerName),
+    vertexModelError,
   };
 }
 
@@ -1797,7 +1804,9 @@ function settleIsolatedTerminalStatus({
       }
     }
 
-    const success = status === 'completed';
+    const vertexModelError =
+      providerName === 'claude' ? extractClaudeVertexModelError(state.fullOutput) : null;
+    const success = status === 'completed' && !vertexModelError;
     const errorContext = !success
       ? extractErrorContext({
           output: state.fullOutput,
@@ -1816,7 +1825,7 @@ function settleIsolatedTerminalStatus({
           },
         })
       : null;
-    const parsedResult = await agent._parseResultOutput(state.fullOutput);
+    const parsedResult = vertexModelError ? null : await agent._parseResultOutput(state.fullOutput);
 
     settleIsolatedFollower({
       agent,
@@ -1830,6 +1839,7 @@ function settleIsolatedTerminalStatus({
         result: parsedResult,
         error: errorContext,
         tokenUsage: extractTokenUsage(state.fullOutput, providerName),
+        vertexModelError,
       },
     });
   })().catch((error) => {

--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -235,6 +235,44 @@ function extractDirectJson(text) {
 }
 
 /**
+ * Extract deterministic Claude Vertex model-unavailability metadata from the raw CLI envelope.
+ *
+ * @param {string} output - Raw Claude CLI output
+ * @returns {{model: string|null}|null} Vertex model metadata or null
+ */
+function extractClaudeVertexModelError(output) {
+  if (!output || typeof output !== 'string') return null;
+
+  for (const line of output.split('\n')) {
+    const content = stripTimestamp(line);
+    if (!content.startsWith('{')) continue;
+
+    try {
+      const parsed = JSON.parse(content);
+      if (
+        parsed.type !== 'result' ||
+        parsed.is_error !== true ||
+        parsed.api_error_status !== 404 ||
+        typeof parsed.result !== 'string'
+      ) {
+        continue;
+      }
+      const isVertexModelError =
+        parsed.result.includes('vertex deployment') ||
+        parsed.result.includes('may not exist or you may not have access');
+      if (!isVertexModelError) continue;
+
+      const modelMatch = parsed.result.match(/model\s+\(([^)]+)\)/);
+      return { model: modelMatch ? modelMatch[1] : null };
+    } catch {
+      // Not a JSON result envelope.
+    }
+  }
+
+  return null;
+}
+
+/**
  * Extract CLI error from provider output (all providers).
  * Returns the error message if the CLI reported an error, null otherwise.
  *
@@ -358,6 +396,7 @@ function extractJsonFromOutput(output, providerName = 'claude') {
 module.exports = {
   extractJsonFromOutput,
   extractCliError,
+  extractClaudeVertexModelError,
   extractFromResultWrapper,
   extractFromTextEvents,
   extractFromMarkdown,

--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -238,9 +238,10 @@ function extractDirectJson(text) {
  * Extract deterministic Claude Vertex model-unavailability metadata from the raw CLI envelope.
  *
  * @param {string} output - Raw Claude CLI output
- * @returns {{model: string|null}|null} Vertex model metadata or null
+ * @param {{useVertex?: boolean}} [options] - Whether the Claude task was configured for Vertex
+ * @returns {{model: string}|null} Vertex model metadata or null
  */
-function extractClaudeVertexModelError(output) {
+function extractClaudeVertexModelError(output, { useVertex = false } = {}) {
   if (!output || typeof output !== 'string') return null;
 
   for (const line of output.split('\n')) {
@@ -257,13 +258,13 @@ function extractClaudeVertexModelError(output) {
       ) {
         continue;
       }
-      const isVertexModelError =
-        parsed.result.includes('vertex deployment') ||
-        parsed.result.includes('may not exist or you may not have access');
-      if (!isVertexModelError) continue;
-
       const modelMatch = parsed.result.match(/model\s+\(([^)]+)\)/);
-      return { model: modelMatch ? modelMatch[1] : null };
+      const hasExplicitVertexSignal = parsed.result.includes('vertex deployment');
+      const isVertexFallback =
+        useVertex && parsed.result.includes('may not exist or you may not have access');
+      if (!modelMatch || (!hasExplicitVertexSignal && !isVertexFallback)) continue;
+
+      return { model: modelMatch[1] };
     } catch {
       // Not a JSON result envelope.
     }

--- a/tests/vertex-model-error.test.js
+++ b/tests/vertex-model-error.test.js
@@ -1,8 +1,25 @@
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 const { executeTask } = require('../src/agent/agent-lifecycle');
+const {
+  buildCompletionResult,
+  parseResultOutput,
+} = require('../src/agent/agent-task-executor');
 
-function createAgent(errorMessage) {
+function claudeErrorEnvelope(status, result) {
+  return `[1234567890123]${JSON.stringify({
+    type: 'result',
+    subtype: 'error_during_execution',
+    is_error: true,
+    api_error_status: status,
+    result,
+  })}`;
+}
+
+function createAgent(rawOutputs) {
   const lifecycleEvents = [];
   const published = [];
   let spawnCalls = 0;
@@ -10,19 +27,26 @@ function createAgent(errorMessage) {
     id: 'vertex-worker',
     role: 'implementation',
     cluster: { id: 'vertex-cluster' },
-    config: { hooks: {}, maxRetries: 3 },
+    config: { hooks: {}, maxRetries: 3, outputFormat: 'json' },
     iteration: 0,
     maxIterations: 10,
     running: true,
     state: 'idle',
     testMode: true,
     quiet: true,
+    currentTask: null,
     currentTaskId: null,
+    processPid: null,
+    lastOutputTime: null,
+    taskStartedAt: null,
     messageBus: { publish() {} },
     _buildContext: () => 'task context',
     _selectModel: () => 'sonnet',
     _resolveModelSpec: () => null,
     _resolveProvider: () => 'claude',
+    _parseResultOutput(output) {
+      return parseResultOutput(this, output);
+    },
     _log() {},
     _publishLifecycle(event, data) {
       lifecycleEvents.push({ event, data });
@@ -30,10 +54,25 @@ function createAgent(errorMessage) {
     _publish(message) {
       published.push(message);
     },
-    _spawnClaudeTask() {
+    async _spawnClaudeTask() {
+      const output = rawOutputs[spawnCalls];
       spawnCalls += 1;
-      this.currentTaskId = `vertex-task-${spawnCalls}`;
-      return { success: false, error: errorMessage, taskId: this.currentTaskId };
+      const taskId = `vertex-task-${spawnCalls}`;
+      this.currentTask = { id: taskId };
+      this.currentTaskId = taskId;
+      this.processPid = 1234;
+      this.lastOutputTime = Date.now();
+      this.taskStartedAt = Date.now();
+      const result = await buildCompletionResult({
+        agent: this,
+        taskId,
+        providerName: 'claude',
+        state: { output },
+        stdout: 'Status: completed',
+        success: true,
+      });
+      result.taskId = taskId;
+      return result;
     },
   };
 
@@ -41,42 +80,103 @@ function createAgent(errorMessage) {
 }
 
 describe('Vertex model failure handling', function () {
-  it('logs the enabled-model command and stops after one deterministic failure', async function () {
-    const errorMessage = JSON.stringify({
-      type: 'result',
-      subtype: 'error_during_execution',
-      is_error: true,
-      api_error_status: 404,
-      result:
-        'API Error: model (claude-sonnet-4-5@20250929) is not available in this vertex deployment',
-    });
-    const { agent, lifecycleEvents, published, getSpawnCalls } = createAgent(errorMessage);
+  let originalSettingsFile;
+  let settingsDir;
+
+  beforeEach(function () {
+    originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-vertex-error-'));
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(settingsDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+    );
+  });
+
+  afterEach(function () {
+    if (originalSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+    fs.rmSync(settingsDir, { recursive: true, force: true });
+  });
+
+  it('carries raw Vertex metadata through parsing and terminalizes the second attempt', async function () {
+    const rawOutputs = [
+      claudeErrorEnvelope(500, 'API Error: transient backend failure'),
+      claudeErrorEnvelope(
+        404,
+        'API Error: model (claude-sonnet-4-5@20250929) is not available in this vertex deployment'
+      ),
+    ];
+    const { agent, lifecycleEvents, published, getSpawnCalls } = createAgent(rawOutputs);
     const errors = [];
     const originalConsoleError = console.error;
+    const originalConsoleWarn = console.warn;
     console.error = (...args) => errors.push(args.join(' '));
+    console.warn = () => {};
 
     try {
       await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
     } finally {
       console.error = originalConsoleError;
+      console.warn = originalConsoleWarn;
     }
 
     const log = errors.join('\n');
-    assert.strictEqual(getSpawnCalls(), 1, 'deterministic model failure must not be retried');
+    assert.strictEqual(getSpawnCalls(), 2, 'Vertex failure must stop after the current attempt');
+    assert.match(log, /TASK EXECUTION FAILED - AGENT: vertex-worker \(Attempt 2\/3\)/);
     assert.match(
       log,
       /"claude-sonnet-4-5@20250929" is not available on your Vertex AI deployment/
     );
-    assert.match(
-      log,
-      /zeroshot settings set providerSettings\.claude\.levelOverrides/
+    assert.match(log, /zeroshot settings set providerSettings\.claude\.levelOverrides/);
+
+    const failedEvents = lifecycleEvents.filter(({ event }) => event === 'TASK_FAILED');
+    assert.deepStrictEqual(
+      failedEvents.map(({ data }) => data.attempt),
+      [1, 2]
     );
     assert.strictEqual(
-      lifecycleEvents.some(({ event }) => event === 'RETRY_SCHEDULED'),
-      false
+      lifecycleEvents.filter(({ event }) => event === 'RETRY_SCHEDULED').length,
+      1
     );
+
+    const clusterFailed = published.find(({ topic }) => topic === 'CLUSTER_FAILED');
+    assert(clusterFailed, 'terminal Vertex failure must signal the orchestrator');
+    assert.strictEqual(clusterFailed.content.data.reason, 'vertex_model_unavailable');
+    assert.strictEqual(clusterFailed.content.data.model, 'claude-sonnet-4-5@20250929');
+
     const agentError = published.find(({ topic }) => topic === 'AGENT_ERROR');
     assert(agentError, 'final AGENT_ERROR must be published');
-    assert.strictEqual(agentError.content.data.attempts, 1);
+    assert.strictEqual(agentError.content.data.attempts, 2);
+    assert.strictEqual(agent.cluster.failureInfo.attempts, 2);
+    assert.strictEqual(agent.cluster.failureInfo.taskId, 'vertex-task-2');
+    assert.strictEqual(agent.state, 'idle');
+    assert.strictEqual(agent.currentTask, null);
+    assert.strictEqual(agent.currentTaskId, null);
+    assert.strictEqual(agent.processPid, null);
+    assert.strictEqual(agent.lastOutputTime, null);
+    assert.strictEqual(agent.taskStartedAt, null);
+  });
+
+  it('does not classify matching text from another provider', async function () {
+    const { agent } = createAgent([]);
+    const result = await buildCompletionResult({
+      agent,
+      taskId: 'codex-task',
+      providerName: 'codex',
+      state: {
+        output: claudeErrorEnvelope(
+          404,
+          'API Error: model (other-model) is not available in this vertex deployment'
+        ),
+      },
+      stdout: 'Status: failed',
+      success: false,
+    });
+
+    assert.strictEqual(result.vertexModelError, null);
   });
 });

--- a/tests/vertex-model-error.test.js
+++ b/tests/vertex-model-error.test.js
@@ -30,7 +30,7 @@ function createAgent(errorMessage) {
     _publish(message) {
       published.push(message);
     },
-    async _spawnClaudeTask() {
+    _spawnClaudeTask() {
       spawnCalls += 1;
       this.currentTaskId = `vertex-task-${spawnCalls}`;
       return { success: false, error: errorMessage, taskId: this.currentTaskId };

--- a/tests/vertex-model-error.test.js
+++ b/tests/vertex-model-error.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+
+const { executeTask } = require('../src/agent/agent-lifecycle');
+
+function createAgent(errorMessage) {
+  const lifecycleEvents = [];
+  const published = [];
+  let spawnCalls = 0;
+  const agent = {
+    id: 'vertex-worker',
+    role: 'implementation',
+    cluster: { id: 'vertex-cluster' },
+    config: { hooks: {}, maxRetries: 3 },
+    iteration: 0,
+    maxIterations: 10,
+    running: true,
+    state: 'idle',
+    testMode: true,
+    quiet: true,
+    currentTaskId: null,
+    messageBus: { publish() {} },
+    _buildContext: () => 'task context',
+    _selectModel: () => 'sonnet',
+    _resolveModelSpec: () => null,
+    _resolveProvider: () => 'claude',
+    _log() {},
+    _publishLifecycle(event, data) {
+      lifecycleEvents.push({ event, data });
+    },
+    _publish(message) {
+      published.push(message);
+    },
+    async _spawnClaudeTask() {
+      spawnCalls += 1;
+      this.currentTaskId = `vertex-task-${spawnCalls}`;
+      return { success: false, error: errorMessage, taskId: this.currentTaskId };
+    },
+  };
+
+  return { agent, lifecycleEvents, published, getSpawnCalls: () => spawnCalls };
+}
+
+describe('Vertex model failure handling', function () {
+  it('logs the enabled-model command and stops after one deterministic failure', async function () {
+    const errorMessage = JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      api_error_status: 404,
+      result:
+        'API Error: model (claude-sonnet-4-5@20250929) is not available in this vertex deployment',
+    });
+    const { agent, lifecycleEvents, published, getSpawnCalls } = createAgent(errorMessage);
+    const errors = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => errors.push(args.join(' '));
+
+    try {
+      await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    const log = errors.join('\n');
+    assert.strictEqual(getSpawnCalls(), 1, 'deterministic model failure must not be retried');
+    assert.match(
+      log,
+      /"claude-sonnet-4-5@20250929" is not available on your Vertex AI deployment/
+    );
+    assert.match(
+      log,
+      /zeroshot settings set providerSettings\.claude\.levelOverrides/
+    );
+    assert.strictEqual(
+      lifecycleEvents.some(({ event }) => event === 'RETRY_SCHEDULED'),
+      false
+    );
+    const agentError = published.find(({ topic }) => topic === 'AGENT_ERROR');
+    assert(agentError, 'final AGENT_ERROR must be published');
+    assert.strictEqual(agentError.content.data.attempts, 1);
+  });
+});

--- a/tests/vertex-model-error.test.js
+++ b/tests/vertex-model-error.test.js
@@ -81,10 +81,13 @@ function createAgent(rawOutputs) {
 
 describe('Vertex model failure handling', function () {
   let originalSettingsFile;
+  let originalUseVertex;
   let settingsDir;
 
   beforeEach(function () {
     originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    originalUseVertex = process.env.CLAUDE_CODE_USE_VERTEX;
+    delete process.env.CLAUDE_CODE_USE_VERTEX;
     settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-vertex-error-'));
     process.env.ZEROSHOT_SETTINGS_FILE = path.join(settingsDir, 'settings.json');
     fs.writeFileSync(
@@ -98,6 +101,11 @@ describe('Vertex model failure handling', function () {
       delete process.env.ZEROSHOT_SETTINGS_FILE;
     } else {
       process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+    if (originalUseVertex === undefined) {
+      delete process.env.CLAUDE_CODE_USE_VERTEX;
+    } else {
+      process.env.CLAUDE_CODE_USE_VERTEX = originalUseVertex;
     }
     fs.rmSync(settingsDir, { recursive: true, force: true });
   });
@@ -178,5 +186,39 @@ describe('Vertex model failure handling', function () {
     });
 
     assert.strictEqual(result.vertexModelError, null);
+  });
+
+  it('requires Vertex configuration and a model for the generic Claude 404 fallback', async function () {
+    const { agent } = createAgent([]);
+    const buildClaudeFailure = (result) =>
+      buildCompletionResult({
+        agent,
+        taskId: 'claude-task',
+        providerName: 'claude',
+        state: { output: claudeErrorEnvelope(404, result) },
+        stdout: 'Status: failed',
+        success: false,
+      });
+
+    const genericResource = await buildClaudeFailure(
+      'API Error: resource may not exist or you may not have access'
+    );
+    const unconfiguredModel = await buildClaudeFailure(
+      'API Error: model (claude-sonnet-4-5@20250929) may not exist or you may not have access'
+    );
+    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+    const vertexResource = await buildClaudeFailure(
+      'API Error: resource may not exist or you may not have access'
+    );
+    const vertexModel = await buildClaudeFailure(
+      'API Error: model (claude-sonnet-4-5@20250929) may not exist or you may not have access'
+    );
+
+    assert.strictEqual(genericResource.vertexModelError, null);
+    assert.strictEqual(unconfiguredModel.vertexModelError, null);
+    assert.strictEqual(vertexResource.vertexModelError, null);
+    assert.deepStrictEqual(vertexModel.vertexModelError, {
+      model: 'claude-sonnet-4-5@20250929',
+    });
   });
 });


### PR DESCRIPTION
## Main-trunk migration

Replaces #486 after the trunk cutover. The contributor commit now starts from the new `main`; Vilde Gjærum’s authorship is preserved. The deterministic Vertex error check is placed ahead of the newer recoverable-stuck-task path.

## Original PR body
## Context

When running zeroshot with `CLAUDE_CODE_USE_VERTEX=1`, the Claude CLI resolves model shorthands (`sonnet`, `haiku`) to versioned Vertex model names (e.g. `claude-sonnet-4-5@20250929`) that may not be enabled on the user's Vertex deployment. The resulting 404 error was swallowed into a raw JSON blob with no guidance on how to fix it.

## Changes

- Added `detectVertexModelError()` to parse the Claude CLI result JSON and identify Vertex model 404 errors
- `logTaskAttemptFailure` now prints an actionable fix with the exact `zeroshot settings set` command when this error is detected
- Vertex model errors short-circuit the retry loop immediately (like `HookExecutionError`) — the model being unavailable is deterministic, so retrying wastes time

## Alternatives considered

**Option B — Skip `--model` on Vertex:** When `CLAUDE_CODE_USE_VERTEX=1` is set and no `levelOverrides` are configured, pass no `--model` flag and let the CLI use the deployment default. Avoids the error entirely but surrenders model-level control.

**Option C — Inherit the parent session model:** When running under Vertex, the model the parent Claude Code session is using is guaranteed to work. Zeroshot could detect `CLAUDE_CODE_USE_VERTEX=1` and default to that model. The challenge is there's no clean way to read which model the parent session resolved to — `ANTHROPIC_MODEL` in the environment is empty even when a model is active.

🤖 Generated with [Claude Code](https://claude.ai/code)