### PR TITLE
docs: update CONTRIBUTING prerequisites to list all supported providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to Zeroshot! This guide covers every
 - **Node.js 18+** (check: `node --version`)
 - **npm** (bundled with Node)
 - **Docker** (optional, for isolation mode tests)
-- **Claude Code CLI** - `npm i -g @anthropic-ai/claude-code && claude auth login`
+- **AI Provider CLI** - At least one: Claude Code (`npm i -g @anthropic-ai/claude-code`), Codex, Gemini CLI, or OpenCode
 - **GitHub CLI** - Required for PR creation features ([install guide](https://cli.github.com/))
 
 ### Installation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ Thank you for your interest in contributing to Zeroshot! This guide covers every
 - **Node.js 18+** (check: `node --version`)
 - **npm** (bundled with Node)
 - **Docker** (optional, for isolation mode tests)
-- **AI Provider CLI** - At least one: Claude Code (`npm i -g @anthropic-ai/claude-code`), Codex, Gemini CLI, or OpenCode
+- **AI provider** - Configure the bundled Gateway provider or install at least one supported provider
+  CLI: Claude Code, Codex, Gemini, Opencode, Pi, Kiro, or Copilot (see
+  [provider setup and installation instructions](./docs/providers.md))
 - **GitHub CLI** - Required for PR creation features ([install guide](https://cli.github.com/))
 
 ### Installation


### PR DESCRIPTION
## Main-trunk migration

Replaces #435 after the trunk cutover. Only the PR’s intended CONTRIBUTING change was transplanted; unrelated historical branch commits were deliberately excluded. The contributor’s authorship is preserved.

## Original PR body
CONTRIBUTING.md only listed Claude Code as a prerequisite, but zeroshot now supports Codex, Gemini CLI, and OpenCode as well. Update the prerequisites section to reflect all supported providers.