### PR TITLE
fix(release): publish Zeroshot 6.7.2 reliability fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,9 +139,7 @@ jobs:
           "$prefix_dir/bin/zeroshot" list
 
       - name: Run semantic-release dry run
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: npx semantic-release --dry-run --branches "$GITHUB_REF_NAME"
+        run: node scripts/release-dry-run.js
 
   release:
     needs: [install-matrix]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            npx semantic-release --dry-run
+            npx semantic-release --dry-run --branches "$GITHUB_REF_NAME"
           else
             npx semantic-release
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,20 +90,68 @@ jobs:
           });
           NODE
 
+  dry-run:
+    needs: [install-matrix]
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      inputs.action == 'dry-run' &&
+      needs.install-matrix.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact dispatched candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install pinned dependencies
+        run: npm ci
+
+      - name: Fetch immutable release history
+        run: git fetch --tags --force
+
+      - name: Release preflight
+        run: npm run release:preflight
+
+      - name: Verify package tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          pack_dir="$(mktemp -d)"
+          prefix_dir="$(mktemp -d)"
+          trap 'rm -rf "$pack_dir" "$prefix_dir"' EXIT
+
+          npm pack --pack-destination "$pack_dir"
+          tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+          npm install --global --prefix "$prefix_dir" "$tarball"
+          "$prefix_dir/bin/zeroshot" --version
+          "$prefix_dir/bin/zeroshot" --help
+          "$prefix_dir/bin/zeroshot" list
+
+      - name: Run semantic-release dry run
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: npx semantic-release --dry-run --branches "$GITHUB_REF_NAME"
+
   release:
     needs: [install-matrix]
     if: |
       always() &&
       needs.install-matrix.result == 'success' &&
-      (
-        (github.event_name == 'workflow_dispatch' && inputs.action == 'dry-run') ||
-        (
-          github.event_name == 'workflow_run' &&
-          github.event.workflow_run.event == 'push' &&
-          github.event.workflow_run.conclusion == 'success' &&
-          vars.RELEASE_AUTOMATION_ENABLED == 'true'
-        )
-      )
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      vars.RELEASE_AUTOMATION_ENABLED == 'true'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -116,7 +164,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Verify this is the CI-tested main commit
         id: candidate
@@ -125,11 +174,6 @@ jobs:
           TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            echo "current=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           current_sha="$(git rev-parse HEAD)"
           remote_sha="$(git ls-remote origin refs/heads/main | cut -f1)"
           if [[ "$current_sha" != "$TESTED_SHA" || "$remote_sha" != "$TESTED_SHA" ]]; then
@@ -176,7 +220,7 @@ jobs:
           "$prefix_dir/bin/zeroshot" list
 
       - name: Recheck main immediately before publication
-        if: steps.candidate.outputs.current == 'true' && github.event_name == 'workflow_run'
+        if: steps.candidate.outputs.current == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -191,15 +235,10 @@ jobs:
         if: steps.candidate.outputs.current == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            npx semantic-release --dry-run --branches "$GITHUB_REF_NAME"
-          else
-            npx semantic-release
-          fi
+        run: npx semantic-release
 
       - name: Assert release state
-        if: steps.candidate.outputs.current == 'true' && github.event_name == 'workflow_run'
+        if: steps.candidate.outputs.current == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: npm run release:assert-published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'main' }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Verify this is the CI-tested main commit
         id: candidate
@@ -176,7 +176,7 @@ jobs:
           "$prefix_dir/bin/zeroshot" list
 
       - name: Recheck main immediately before publication
-        if: steps.candidate.outputs.current == 'true'
+        if: steps.candidate.outputs.current == 'true' && github.event_name == 'workflow_run'
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/releases/v6.7.2.md
+++ b/docs/releases/v6.7.2.md
@@ -1,0 +1,32 @@
+# Zeroshot 6.7.2 — reliability fixes
+
+This patch release improves the reliability of the supported Node.js CLI and its existing
+workflows.
+
+## Reliability
+
+- Resume now tolerates failures while recovering an older ledger or persisted cluster registry, so
+  one damaged historical cluster does not prevent other recoverable work from loading.
+- Strict structured-output Codex tasks now use the attachable PTY path. Attach discovery has better
+  fallbacks and continues to work when task metadata is incomplete.
+- Unix attach sockets now use short, deterministic, per-user paths, avoiding macOS `EINVAL`
+  failures caused by long home or worktree paths.
+- Explicit PR and worktree base branches are freshly fetched from their selected remote before use,
+  in both foreground and detached runs.
+- PR workflows now support repositories whose single usable GitHub remote is not named `origin`,
+  preserve that remote through resume and worktree creation, and fail closed when multiple remotes
+  are ambiguous.
+- Git-pusher command generation now treats issue and remote values as typed, shell-quoted data
+  instead of executable placeholder text.
+
+## Maintenance
+
+- Refreshed the dependency lockfile for the `fast-uri` advisory.
+- Replaced the recurring `dev`-to-`main` promotion topology with one protected `main` trunk,
+  merge-queue validation, immutable release tags, npm trusted publishing, and recoverable
+  semantic-release automation.
+
+## Release scope
+
+Native Rust, OECP, and cluster-protocol work remains experimental. It is excluded from the npm
+package and is not part of Zeroshot 6.7.2.

--- a/scripts/release-dry-run.js
+++ b/scripts/release-dry-run.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+
+function runGit(args) {
+  execFileSync('git', args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function pluginName(plugin) {
+  return Array.isArray(plugin) ? plugin[0] : plugin;
+}
+
+function validationPlugins(releaseConfig) {
+  const allowed = new Set([
+    '@semantic-release/commit-analyzer',
+    './scripts/semantic-release-notes.js',
+  ]);
+  return releaseConfig.plugins.filter((plugin) => allowed.has(pluginName(plugin)));
+}
+
+async function main() {
+  const branch = process.env.GITHUB_REF_NAME?.trim();
+  if (!branch) throw new Error('GITHUB_REF_NAME is required for a release dry run');
+  runGit(['check-ref-format', `refs/heads/${branch}`]);
+
+  const packageJson = require('../package.json');
+  const releaseConfig = packageJson.release;
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-release-dry-run-'));
+  const mirrorPath = path.join(tempRoot, 'candidate.git');
+
+  try {
+    runGit(['init', '--bare', mirrorPath]);
+    runGit([
+      '--git-dir',
+      mirrorPath,
+      'fetch',
+      projectRoot,
+      `+HEAD:refs/heads/${branch}`,
+      '+refs/tags/*:refs/tags/*',
+    ]);
+    runGit(['--git-dir', mirrorPath, 'symbolic-ref', 'HEAD', `refs/heads/${branch}`]);
+
+    const semanticRelease = (await import('semantic-release')).default;
+    const result = await semanticRelease(
+      {
+        ...releaseConfig,
+        branches: [branch],
+        repositoryUrl: mirrorPath,
+        plugins: validationPlugins(releaseConfig),
+        dryRun: true,
+        ci: false,
+      },
+      {
+        cwd: projectRoot,
+        env: process.env,
+      }
+    );
+
+    if (!result) {
+      console.log('RELEASE_DRY_RUN_RESULT=no-release');
+      return;
+    }
+
+    console.log(`RELEASE_DRY_RUN_RESULT=${result.nextRelease.version}`);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/setup-merge-queue.sh
+++ b/scripts/setup-merge-queue.sh
@@ -127,7 +127,6 @@ JSON
 
 gh api --method PUT "repos/$REPO/environments/release" --input - <<'JSON' >/dev/null
 {
-  "prevent_self_review": false,
   "deployment_branch_policy": {
     "protected_branches": false,
     "custom_branch_policies": true

--- a/tests/unit/release-topology.test.js
+++ b/tests/unit/release-topology.test.js
@@ -36,6 +36,10 @@ describe('release topology', function () {
       'manual dry runs must bind to the exact dispatched commit'
     );
     assert(
+      /semantic-release --dry-run --branches "\$GITHUB_REF_NAME"/.test(releaseWorkflow),
+      'manual dry runs must analyze the dispatched candidate as a release branch'
+    );
+    assert(
       /Recheck main immediately before publication/.test(releaseWorkflow),
       'release must fail closed if main moves after validation'
     );

--- a/tests/unit/release-topology.test.js
+++ b/tests/unit/release-topology.test.js
@@ -32,6 +32,10 @@ describe('release topology', function () {
       'release jobs must bind to the exact CI-tested main commit'
     );
     assert(
+      /workflow_run\.head_sha \|\| github\.sha/.test(releaseWorkflow),
+      'manual dry runs must bind to the exact dispatched commit'
+    );
+    assert(
       /Recheck main immediately before publication/.test(releaseWorkflow),
       'release must fail closed if main moves after validation'
     );

--- a/tests/unit/release-topology.test.js
+++ b/tests/unit/release-topology.test.js
@@ -74,6 +74,10 @@ describe('release topology', function () {
     assert(/required_review_thread_resolution/.test(setup), 'main must resolve review threads');
     assert(/"context": "required"/.test(setup), 'main must require aggregate CI');
     assert(/"context": "semantic"/.test(setup), 'main must require semantic policy');
+    assert(
+      !/prevent_self_review/.test(setup),
+      'release environment setup must not send reviewer-only fields without reviewers'
+    );
 
     assert(/branches:\s*\[main\]/.test(prPolicy), 'PR policy must target main');
     assert(/merge_group:/.test(prPolicy), 'semantic policy must run in the merge queue');

--- a/tests/unit/release-topology.test.js
+++ b/tests/unit/release-topology.test.js
@@ -19,6 +19,14 @@ describe('release topology', function () {
     const agents = readText('AGENTS.md');
     const repoSettings = JSON.parse(readText('.zeroshot/settings.json'));
     const packageJson = JSON.parse(readText('package.json'));
+    const dryRunJob = releaseWorkflow.slice(
+      releaseWorkflow.indexOf('\n  dry-run:'),
+      releaseWorkflow.indexOf('\n  release:')
+    );
+    const publishJob = releaseWorkflow.slice(
+      releaseWorkflow.indexOf('\n  release:'),
+      releaseWorkflow.indexOf('\n  recover:')
+    );
 
     assert(!/\bbranches:\s*\[main,\s*dev\]/.test(ci), 'CI must not target a retired dev branch');
     assert(!/enforce-main-pr-source/.test(ci), 'CI must not require dev-to-main promotions');
@@ -39,6 +47,12 @@ describe('release topology', function () {
       /semantic-release --dry-run --branches "\$GITHUB_REF_NAME"/.test(releaseWorkflow),
       'manual dry runs must analyze the dispatched candidate as a release branch'
     );
+    assert(/contents:\s*read/.test(dryRunJob), 'dry runs must remain read-only');
+    assert(!/environment:\s*release/.test(dryRunJob), 'dry runs must not enter release environment');
+    assert(!/id-token:\s*write/.test(dryRunJob), 'dry runs must not receive npm OIDC authority');
+    assert(/environment:\s*release/.test(publishJob), 'publishing must use release environment');
+    assert(/contents:\s*write/.test(publishJob), 'publishing must be allowed to create releases');
+    assert(/id-token:\s*write/.test(publishJob), 'publishing must receive npm OIDC authority');
     assert(
       /Recheck main immediately before publication/.test(releaseWorkflow),
       'release must fail closed if main moves after validation'

--- a/tests/unit/release-topology.test.js
+++ b/tests/unit/release-topology.test.js
@@ -44,7 +44,7 @@ describe('release topology', function () {
       'manual dry runs must bind to the exact dispatched commit'
     );
     assert(
-      /semantic-release --dry-run --branches "\$GITHUB_REF_NAME"/.test(releaseWorkflow),
+      /node scripts\/release-dry-run\.js/.test(releaseWorkflow),
       'manual dry runs must analyze the dispatched candidate as a release branch'
     );
     assert(/contents:\s*read/.test(dryRunJob), 'dry runs must remain read-only');


### PR DESCRIPTION
## Summary

- add curated Zeroshot 6.7.2 reliability notes for supported Node.js/CLI behavior
- explicitly exclude experimental native Rust, OECP, and protocol work from this npm release
- remove an invalid reviewer-only field from release-environment setup and add topology regression guards
- bind manual dry runs to the exact dispatched commit and validate version/notes through a local Git mirror with read-only GitHub permissions
- keep the protected release environment plus write/OIDC authority exclusive to automatic publication and recovery

## Version decision

`6.7.2` is the correct semantic version: all supported product changes since `6.7.1` are reliability fixes or maintenance, with no supported public feature or breaking API. The `fix(release):` squash commit therefore selects a patch release.

## Validation

- local scope limited to `git diff --check`, shell/JavaScript/YAML syntax, release-config invariants, and current npm/tag verification
- full Node, Rust/protocol, package, Linux/macOS install, and slow integration validation runs only on GitHub-hosted PR and merge-queue workers
- the read-only release dry run must report `RELEASE_DRY_RUN_RESULT=6.7.2` before merge
- release automation remains disabled until this PR is ready to enter the merge queue

## Live baseline

- npm latest: `6.7.1` at `83e5fa334bed57737d8e7fd706d893ef281889f5`
- next expected release: `v6.7.2` from this PR’s tested squash commit