### PR TITLE
chore(release): repair published CLI verification

### DIFF
--- a/scripts/assert-release-published.js
+++ b/scripts/assert-release-published.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const https = require('https');
+const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { releaseTypeForMessages } = require('./release-preflight');
@@ -9,8 +10,8 @@ const { releaseTypeForMessages } = require('./release-preflight');
 const DEFAULT_ATTEMPTS = 24;
 const DEFAULT_DELAY_MS = 5000;
 
-function run(command, args) {
-  return execFileSync(command, args, { encoding: 'utf8' }).trim();
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: 'utf8', ...options }).trim();
 }
 
 function packageName() {
@@ -85,21 +86,50 @@ function verifyCuratedNotes(tag, release) {
   }
 }
 
-function verifyInstalledCli(name, version) {
+function verifyInstalledCli(name, version, options = {}) {
   const packageSpec = `${name}@${version}`;
-  const reported = run('npm', [
-    'exec',
-    '--yes',
-    `--package=${packageSpec}`,
-    '--',
-    'zeroshot',
-    '--version',
-  ]);
-  if (!reported.split(/\s+/).includes(version)) {
-    throw new Error(`installed CLI reported ${reported}; expected ${version}`);
+  const execute = options.execute || run;
+  const makeTempRoot =
+    options.makeTempRoot ||
+    (() => fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-release-cli-')));
+  const removeTempRoot =
+    options.removeTempRoot ||
+    ((root) => {
+      fs.rmSync(root, { recursive: true, force: true });
+    });
+  const platform = options.platform || process.platform;
+  const prefix = makeTempRoot();
+
+  try {
+    execute('npm', [
+      'install',
+      '--global',
+      '--prefix',
+      prefix,
+      '--no-audit',
+      '--no-fund',
+      packageSpec,
+    ]);
+
+    const executable = path.join(
+      prefix,
+      platform === 'win32' ? 'zeroshot.cmd' : 'bin',
+      ...(platform === 'win32' ? [] : ['zeroshot'])
+    );
+    const isolatedEnv = {
+      ...process.env,
+      HOME: prefix,
+      USERPROFILE: prefix,
+    };
+    const reported = execute(executable, ['--version'], { env: isolatedEnv });
+    if (!reported.split(/\s+/).includes(version)) {
+      throw new Error(`installed CLI reported ${reported}; expected ${version}`);
+    }
+    execute(executable, ['--help'], { env: isolatedEnv });
+    execute(executable, ['list'], { env: isolatedEnv });
+  } finally {
+    removeTempRoot(prefix);
   }
-  run('npm', ['exec', '--yes', `--package=${packageSpec}`, '--', 'zeroshot', '--help']);
-  run('npm', ['exec', '--yes', `--package=${packageSpec}`, '--', 'zeroshot', 'list']);
 }
 
 function tagsPointingAtHead() {
@@ -230,6 +260,7 @@ module.exports = {
   npmLatest,
   provenanceStatement,
   tagsPointingAtHead,
+  verifyInstalledCli,
   verifyProvenance,
   waitForNpmLatest,
 };

--- a/tests/assert-release-published.test.js
+++ b/tests/assert-release-published.test.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const {
   latestReleaseTag,
   provenanceStatement,
+  verifyInstalledCli,
   verifyProvenance,
 } = require('../scripts/assert-release-published');
 const { releaseTypeForMessages } = require('../scripts/release-preflight');
@@ -58,5 +59,77 @@ describe('release publication assertion', () => {
     };
 
     assert.deepStrictEqual(provenanceStatement(attestations), statement);
+  });
+
+  it('verifies the published CLI through a clean global-prefix install', () => {
+    const calls = [];
+    const execute = (command, args, options) => {
+      calls.push({ command, args, options });
+      if (args.includes('--version')) return 'zeroshot 6.7.2';
+      return '';
+    };
+    let removed = null;
+
+    verifyInstalledCli('@the-open-engine/zeroshot', '6.7.2', {
+      execute,
+      makeTempRoot: () => '/tmp/zeroshot-release-proof',
+      removeTempRoot: (root) => {
+        removed = root;
+      },
+      platform: 'linux',
+    });
+
+    assert.deepStrictEqual(calls[0], {
+      command: 'npm',
+      args: [
+        'install',
+        '--global',
+        '--prefix',
+        '/tmp/zeroshot-release-proof',
+        '--no-audit',
+        '--no-fund',
+        '@the-open-engine/zeroshot@6.7.2',
+      ],
+      options: undefined,
+    });
+    assert.deepStrictEqual(
+      calls.slice(1).map(({ command, args }) => ({ command, args })),
+      [
+        {
+          command: '/tmp/zeroshot-release-proof/bin/zeroshot',
+          args: ['--version'],
+        },
+        {
+          command: '/tmp/zeroshot-release-proof/bin/zeroshot',
+          args: ['--help'],
+        },
+        {
+          command: '/tmp/zeroshot-release-proof/bin/zeroshot',
+          args: ['list'],
+        },
+      ]
+    );
+    assert.strictEqual(removed, '/tmp/zeroshot-release-proof');
+  });
+
+  it('cleans up the temporary install when CLI verification fails', () => {
+    let removed = null;
+
+    assert.throws(
+      () =>
+        verifyInstalledCli('@the-open-engine/zeroshot', '6.7.2', {
+          execute: (command, args) => {
+            if (args.includes('--version')) return 'zeroshot 6.7.1';
+            return '';
+          },
+          makeTempRoot: () => '/tmp/zeroshot-release-proof-failure',
+          removeTempRoot: (root) => {
+            removed = root;
+          },
+          platform: 'linux',
+        }),
+      /expected 6.7.2/
+    );
+    assert.strictEqual(removed, '/tmp/zeroshot-release-proof-failure');
   });
 });


### PR DESCRIPTION
## Summary

- replace the failing scoped-package `npm exec` publication proof with a clean temporary global-prefix installation
- invoke the installed `zeroshot` executable for `--version`, `--help`, and `list` under an isolated home
- always remove the temporary installation and cover success/failure cleanup with focused tests

## Evidence

Release workflow run 30277903920 successfully published `v6.7.2`, npm `latest` and `gitHead` are correct, provenance and the curated GitHub Release exist, but the final assertion failed because npm could not resolve the scoped package's bin through `npm exec --package=...`.

This is a `chore:` release-process correction and is intentionally a semantic-release no-op.

## Validation

The complete CI, including the integration suite, must run on GitHub-hosted workers. Locally I only ran syntax and diff checks.
