### PR TITLE
chore(release): wait for published artifacts

### DIFF
--- a/scripts/assert-release-published.js
+++ b/scripts/assert-release-published.js
@@ -201,6 +201,33 @@ async function waitForNpmLatest(name, expectedVersion, options = {}) {
   throw new Error(`expected npm latest for ${name} to be ${expectedVersion}, got ${latest}`);
 }
 
+async function waitForPublishedArtifact(label, check, options = {}) {
+  const attempts =
+    options.attempts || Number(process.env.RELEASE_ASSERT_ATTEMPTS || DEFAULT_ATTEMPTS);
+  const delayMs =
+    options.delayMs || Number(process.env.RELEASE_ASSERT_DELAY_MS || DEFAULT_DELAY_MS);
+  const wait = options.sleep || sleep;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await check();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        console.log(
+          `${label} is not ready: ${error.message}; retrying (${attempt}/${attempts})`
+        );
+        await wait(delayMs);
+      }
+    }
+  }
+
+  throw new Error(
+    `${label} did not become ready after ${attempts} attempts: ${lastError?.message || 'unknown error'}`
+  );
+}
+
 async function main() {
   const name = packageName();
   const headTags = tagsPointingAtHead();
@@ -223,25 +250,36 @@ async function main() {
   console.log(`npm latest for ${name}: ${latest}`);
 
   const expectedCommit = run('git', ['rev-parse', 'HEAD']);
-  const metadata = npmReleaseMetadata(name, expectedVersion);
-  if (metadata.version !== expectedVersion) {
-    throw new Error(`npm metadata returned ${metadata.version}; expected ${expectedVersion}`);
-  }
-  if (metadata.gitHead !== expectedCommit) {
-    throw new Error(`npm gitHead ${metadata.gitHead || '(missing)'} does not match HEAD`);
-  }
+  const metadata = await waitForPublishedArtifact('npm release metadata', () => {
+    const result = npmReleaseMetadata(name, expectedVersion);
+    if (result.version !== expectedVersion) {
+      throw new Error(`npm metadata returned ${result.version}; expected ${expectedVersion}`);
+    }
+    if (result.gitHead !== expectedCommit) {
+      throw new Error(`npm gitHead ${result.gitHead || '(missing)'} does not match HEAD`);
+    }
+    if (!result['dist.attestations']?.url) {
+      throw new Error('npm attestation URL is missing');
+    }
+    return result;
+  });
 
-  const attestationUrl = metadata['dist.attestations']?.url;
-  if (!attestationUrl) throw new Error('npm attestation URL is missing');
-  const attestations = await httpsJson(attestationUrl);
-  verifyProvenance(provenanceStatement(attestations), expectedCommit);
+  await waitForPublishedArtifact('npm provenance', async () => {
+    const attestations = await httpsJson(metadata['dist.attestations'].url);
+    verifyProvenance(provenanceStatement(attestations), expectedCommit);
+  });
 
-  const release = githubRelease(expectedTag);
-  if (release.tagName !== expectedTag) {
-    throw new Error(`GitHub Release tag ${release.tagName} does not match ${expectedTag}`);
-  }
-  verifyCuratedNotes(expectedTag, release);
-  verifyInstalledCli(name, expectedVersion);
+  await waitForPublishedArtifact('GitHub Release', () => {
+    const release = githubRelease(expectedTag);
+    if (release.tagName !== expectedTag) {
+      throw new Error(`GitHub Release tag ${release.tagName} does not match ${expectedTag}`);
+    }
+    verifyCuratedNotes(expectedTag, release);
+  });
+
+  await waitForPublishedArtifact('installed CLI', () =>
+    verifyInstalledCli(name, expectedVersion)
+  );
 
   console.log(`Release publication verified: ${name}@${latest}`);
 }
@@ -263,4 +301,5 @@ module.exports = {
   verifyInstalledCli,
   verifyProvenance,
   waitForNpmLatest,
+  waitForPublishedArtifact,
 };

--- a/scripts/assert-release-published.js
+++ b/scripts/assert-release-published.js
@@ -179,22 +179,36 @@ function sleep(ms) {
   });
 }
 
+function nextRetryDelay(attempt, attempts, delayMs, options) {
+  if (attempt >= attempts) return null;
+  if (options.deadline === undefined) return delayMs;
+
+  const now = options.now || Date.now;
+  const remainingMs = options.deadline - now();
+  if (remainingMs <= 0) return null;
+  return Math.min(delayMs, remainingMs);
+}
+
 async function waitForNpmLatest(name, expectedVersion, options = {}) {
   const attempts =
     options.attempts || Number(process.env.RELEASE_ASSERT_ATTEMPTS || DEFAULT_ATTEMPTS);
   const delayMs =
     options.delayMs || Number(process.env.RELEASE_ASSERT_DELAY_MS || DEFAULT_DELAY_MS);
+  const wait = options.sleep || sleep;
 
   let latest = null;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     latest = npmLatest(name);
     if (latest === expectedVersion) return latest;
 
-    if (attempt < attempts) {
+    const retryDelay = nextRetryDelay(attempt, attempts, delayMs, options);
+    if (retryDelay !== null) {
       console.log(
         `npm latest for ${name} is ${latest}; waiting for ${expectedVersion} (${attempt}/${attempts})`
       );
-      await sleep(delayMs);
+      await wait(retryDelay);
+    } else {
+      break;
     }
   }
 
@@ -208,23 +222,28 @@ async function waitForPublishedArtifact(label, check, options = {}) {
     options.delayMs || Number(process.env.RELEASE_ASSERT_DELAY_MS || DEFAULT_DELAY_MS);
   const wait = options.sleep || sleep;
   let lastError = null;
+  let attemptsMade = 0;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    attemptsMade = attempt;
     try {
       return await check();
     } catch (error) {
       lastError = error;
-      if (attempt < attempts) {
+      const retryDelay = nextRetryDelay(attempt, attempts, delayMs, options);
+      if (retryDelay !== null) {
         console.log(
           `${label} is not ready: ${error.message}; retrying (${attempt}/${attempts})`
         );
-        await wait(delayMs);
+        await wait(retryDelay);
+      } else {
+        break;
       }
     }
   }
 
   throw new Error(
-    `${label} did not become ready after ${attempts} attempts: ${lastError?.message || 'unknown error'}`
+    `${label} did not become ready after ${attemptsMade} attempts: ${lastError?.message || 'unknown error'}`
   );
 }
 
@@ -245,40 +264,61 @@ async function main() {
 
   console.log(`tags on HEAD: ${headTags.join(', ') || '(none)'}`);
   const expectedVersion = expectedTag.slice(1);
-  const latest = await waitForNpmLatest(name, expectedVersion);
+  const retryAttempts = Number(process.env.RELEASE_ASSERT_ATTEMPTS || DEFAULT_ATTEMPTS);
+  const retryDelayMs = Number(process.env.RELEASE_ASSERT_DELAY_MS || DEFAULT_DELAY_MS);
+  const retryOptions = {
+    attempts: retryAttempts,
+    delayMs: retryDelayMs,
+    deadline: Date.now() + retryAttempts * retryDelayMs,
+  };
+  const latest = await waitForNpmLatest(name, expectedVersion, retryOptions);
 
   console.log(`npm latest for ${name}: ${latest}`);
 
   const expectedCommit = run('git', ['rev-parse', 'HEAD']);
-  const metadata = await waitForPublishedArtifact('npm release metadata', () => {
-    const result = npmReleaseMetadata(name, expectedVersion);
-    if (result.version !== expectedVersion) {
-      throw new Error(`npm metadata returned ${result.version}; expected ${expectedVersion}`);
-    }
-    if (result.gitHead !== expectedCommit) {
-      throw new Error(`npm gitHead ${result.gitHead || '(missing)'} does not match HEAD`);
-    }
-    if (!result['dist.attestations']?.url) {
-      throw new Error('npm attestation URL is missing');
-    }
-    return result;
-  });
+  const metadata = await waitForPublishedArtifact(
+    'npm release metadata',
+    () => {
+      const result = npmReleaseMetadata(name, expectedVersion);
+      if (result.version !== expectedVersion) {
+        throw new Error(`npm metadata returned ${result.version}; expected ${expectedVersion}`);
+      }
+      if (result.gitHead !== expectedCommit) {
+        throw new Error(`npm gitHead ${result.gitHead || '(missing)'} does not match HEAD`);
+      }
+      if (!result['dist.attestations']?.url) {
+        throw new Error('npm attestation URL is missing');
+      }
+      return result;
+    },
+    retryOptions
+  );
 
-  await waitForPublishedArtifact('npm provenance', async () => {
-    const attestations = await httpsJson(metadata['dist.attestations'].url);
-    verifyProvenance(provenanceStatement(attestations), expectedCommit);
-  });
+  await waitForPublishedArtifact(
+    'npm provenance',
+    async () => {
+      const attestations = await httpsJson(metadata['dist.attestations'].url);
+      verifyProvenance(provenanceStatement(attestations), expectedCommit);
+    },
+    retryOptions
+  );
 
-  await waitForPublishedArtifact('GitHub Release', () => {
-    const release = githubRelease(expectedTag);
-    if (release.tagName !== expectedTag) {
-      throw new Error(`GitHub Release tag ${release.tagName} does not match ${expectedTag}`);
-    }
-    verifyCuratedNotes(expectedTag, release);
-  });
+  await waitForPublishedArtifact(
+    'GitHub Release',
+    () => {
+      const release = githubRelease(expectedTag);
+      if (release.tagName !== expectedTag) {
+        throw new Error(`GitHub Release tag ${release.tagName} does not match ${expectedTag}`);
+      }
+      verifyCuratedNotes(expectedTag, release);
+    },
+    retryOptions
+  );
 
-  await waitForPublishedArtifact('installed CLI', () =>
-    verifyInstalledCli(name, expectedVersion)
+  await waitForPublishedArtifact(
+    'installed CLI',
+    () => verifyInstalledCli(name, expectedVersion),
+    retryOptions
   );
 
   console.log(`Release publication verified: ${name}@${latest}`);

--- a/tests/assert-release-published.test.js
+++ b/tests/assert-release-published.test.js
@@ -180,4 +180,46 @@ describe('release publication assertion', () => {
     );
     assert.strictEqual(checks, 2);
   });
+
+  it('shares one deadline across sequential publication checks', async () => {
+    let now = 0;
+    let checks = 0;
+    const retryOptions = {
+      attempts: 24,
+      delayMs: 5,
+      deadline: 10,
+      now: () => now,
+      sleep: (delay) => {
+        now += delay;
+        return Promise.resolve();
+      },
+    };
+
+    await assert.rejects(
+      waitForPublishedArtifact(
+        'npm provenance',
+        () => {
+          checks += 1;
+          throw new Error('not ready');
+        },
+        retryOptions
+      ),
+      /after 3 attempts/
+    );
+    assert.strictEqual(now, 10);
+
+    await assert.rejects(
+      waitForPublishedArtifact(
+        'GitHub Release',
+        () => {
+          checks += 1;
+          throw new Error('not ready');
+        },
+        retryOptions
+      ),
+      /after 1 attempts/
+    );
+    assert.strictEqual(checks, 4);
+    assert.strictEqual(now, 10);
+  });
 });

--- a/tests/assert-release-published.test.js
+++ b/tests/assert-release-published.test.js
@@ -5,6 +5,7 @@ const {
   provenanceStatement,
   verifyInstalledCli,
   verifyProvenance,
+  waitForPublishedArtifact,
 } = require('../scripts/assert-release-published');
 const { releaseTypeForMessages } = require('../scripts/release-preflight');
 
@@ -131,5 +132,51 @@ describe('release publication assertion', () => {
       /expected 6.7.2/
     );
     assert.strictEqual(removed, '/tmp/zeroshot-release-proof-failure');
+  });
+
+  it('retries eventually consistent publication artifacts', async () => {
+    let checks = 0;
+    const delays = [];
+
+    const result = await waitForPublishedArtifact(
+      'npm provenance',
+      async () => {
+        checks += 1;
+        if (checks < 3) throw new Error('HTTP 404: Not found');
+        return 'ready';
+      },
+      {
+        attempts: 3,
+        delayMs: 25,
+        sleep: async (delay) => {
+          delays.push(delay);
+        },
+      }
+    );
+
+    assert.strictEqual(result, 'ready');
+    assert.strictEqual(checks, 3);
+    assert.deepStrictEqual(delays, [25, 25]);
+  });
+
+  it('reports the last publication propagation failure after exhausting retries', async () => {
+    let checks = 0;
+
+    await assert.rejects(
+      waitForPublishedArtifact(
+        'npm provenance',
+        async () => {
+          checks += 1;
+          throw new Error(`not ready ${checks}`);
+        },
+        {
+          attempts: 2,
+          delayMs: 0,
+          sleep: async () => {},
+        }
+      ),
+      /npm provenance did not become ready after 2 attempts: not ready 2/
+    );
+    assert.strictEqual(checks, 2);
   });
 });

--- a/tests/assert-release-published.test.js
+++ b/tests/assert-release-published.test.js
@@ -140,7 +140,7 @@ describe('release publication assertion', () => {
 
     const result = await waitForPublishedArtifact(
       'npm provenance',
-      async () => {
+      () => {
         checks += 1;
         if (checks < 3) throw new Error('HTTP 404: Not found');
         return 'ready';
@@ -148,8 +148,9 @@ describe('release publication assertion', () => {
       {
         attempts: 3,
         delayMs: 25,
-        sleep: async (delay) => {
+        sleep: (delay) => {
           delays.push(delay);
+          return Promise.resolve();
         },
       }
     );
@@ -165,14 +166,14 @@ describe('release publication assertion', () => {
     await assert.rejects(
       waitForPublishedArtifact(
         'npm provenance',
-        async () => {
+        () => {
           checks += 1;
           throw new Error(`not ready ${checks}`);
         },
         {
           attempts: 2,
           delayMs: 0,
-          sleep: async () => {},
+          sleep: () => Promise.resolve(),
         }
       ),
       /npm provenance did not become ready after 2 attempts: not ready 2/


### PR DESCRIPTION
## Summary

- retry npm metadata, provenance, GitHub Release, and installed-CLI proof while newly published artifacts propagate
- validate exact version, `gitHead`, workflow provenance, release notes, and CLI behavior on every successful retry boundary
- keep the bounded 24-attempt / five-second release assertion window and report the final propagation error

## Evidence

The automatic `v6.8.0` release published successfully from exact tested SHA `a5d080236a28952e54b50449bd5f6fbfe300ca4b`. Its assertion queried npm provenance roughly eleven seconds after publication and received a transient 404; the same attestation endpoint returned 200 seconds later with two attestations.

This is a `chore:` release-process correction and is intentionally a semantic-release no-op.

## Validation

The complete CI, including the integration suite, must run on GitHub-hosted workers. Locally I only ran syntax and diff checks.
