### PR TITLE
fix: fail closed on interactive Keychain use in darwin workers

### DIFF
--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -19,6 +19,7 @@ const { getTask, getTaskBySpawnOwnershipToken } = require('../../task-lib/store.
 const { loadSettings } = require('../../lib/settings.js');
 const { resolveClaudeAuth } = require('../../lib/settings/claude-auth.js');
 const { prependWorktreeToolBinToEnv } = require('../worktree-tooling-env.js');
+const { applyDarwinKeychainBoundaryToEnv } = require('../darwin-keychain-boundary.js');
 const {
   CLAUDE_SETTINGS_ENV,
   cleanupClaudeSettingsOverlay,
@@ -723,6 +724,13 @@ function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
       spawnEnv.ZEROSHOT_WORKTREE = '1';
     }
   }
+
+  // KEYCHAIN BOUNDARY (darwin only): non-interactive local/worktree worker
+  // descendants must not reach the user's GUI Keychain session (issue #704).
+  // Docker isolation never reaches buildSpawnEnv (see spawnClaudeTaskIsolated).
+  // Applied before the worktree tool bins so repo-managed tool substitutes
+  // stay first on PATH.
+  applyDarwinKeychainBoundaryToEnv(spawnEnv);
 
   prependWorktreeToolBinToEnv(spawnEnv, {
     cwd: agentCwd,
@@ -2628,6 +2636,7 @@ module.exports = {
   ensureAskUserQuestionHook,
   ensureDangerousGitHook,
   resolveMcpConfigArgs,
+  buildSpawnEnv,
   spawnClaudeTask,
   spawnTaskProcess,
   followClaudeTaskLogs,

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -690,7 +690,10 @@ function buildFinalContext({ agent, context, desiredOutputFormat, runOutputForma
 }
 
 function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
-  const { claudeSettingsPath = null } = options;
+  const {
+    claudeSettingsPath = null,
+    applyDarwinKeychainBoundary = applyDarwinKeychainBoundaryToEnv,
+  } = options;
   const spawnEnv = { ...process.env };
   const agentCwd = agent.config?.cwd || agent.worktree?.path || process.cwd();
   const clusterId = agent.cluster?.id || agent.cluster_id || process.env.ZEROSHOT_CLUSTER_ID;
@@ -730,7 +733,7 @@ function buildSpawnEnv(agent, providerName, modelSpec, options = {}) {
   // Docker isolation never reaches buildSpawnEnv (see spawnClaudeTaskIsolated).
   // Applied before the worktree tool bins so repo-managed tool substitutes
   // stay first on PATH.
-  applyDarwinKeychainBoundaryToEnv(spawnEnv);
+  applyDarwinKeychainBoundary(spawnEnv);
 
   prependWorktreeToolBinToEnv(spawnEnv, {
     cwd: agentCwd,
@@ -830,14 +833,7 @@ function createPendingTaskLaunchHandle({
   return handle;
 }
 
-function spawnTaskProcess({
-  agent,
-  ctPath,
-  args,
-  cwd,
-  spawnEnv,
-  spawnTimeoutMs = 30000,
-}) {
+function spawnTaskProcess({ agent, ctPath, args, cwd, spawnEnv, spawnTimeoutMs = 30000 }) {
   // Timeout for spawn phase - if CLI hangs during init (e.g., opencode 429 bug), kill it.
   const SPAWN_TIMEOUT_MS = spawnTimeoutMs;
   // spawn() throws on null bytes in argv; strip them before they get there.
@@ -886,10 +882,7 @@ function spawnTaskProcess({
     const classifyCleanupOwnership = trackTaskWrapperCleanupOwnership(findPersistedTaskId);
     const rejectWithOwnership = async (error) => {
       const classifiedError = classifyCleanupOwnership(error);
-      if (
-        !callerOwnsCommandCleanup(classifiedError) &&
-        agent.currentTask === pendingLaunch
-      ) {
+      if (!callerOwnsCommandCleanup(classifiedError) && agent.currentTask === pendingLaunch) {
         let termination;
         try {
           termination = await pendingLaunch.kill(classifiedError.message);
@@ -2205,7 +2198,6 @@ function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLi
     agent._log(`[${agent.id}] tail process error: ${err.message}`);
   });
 }
-
 
 async function checkIsolatedStatus({
   agent,

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -380,13 +380,15 @@ class ClaudeTaskRunner extends TaskRunner {
     const spawnEnv = {
       ...process.env,
     };
+    let claudeSettingsPath = null;
     if (providerName === 'claude' && resolvedModelSpec?.model) {
       spawnEnv.ANTHROPIC_MODEL = resolvedModelSpec.model;
     }
     if (providerName === 'claude') {
-      spawnEnv[CLAUDE_SETTINGS_ENV] = prepareClaudeSettingsOverlay({
+      claudeSettingsPath = prepareClaudeSettingsOverlay({
         includeDangerousGit: Boolean(worktreePath),
       });
+      spawnEnv[CLAUDE_SETTINGS_ENV] = claudeSettingsPath;
       const mcpConfigPath = resolveRepoMcpConfigPath({ cwd, worktreePath });
       if (mcpConfigPath) {
         spawnEnv[CLAUDE_MCP_CONFIG_ENV] = mcpConfigPath;
@@ -395,7 +397,12 @@ class ClaudeTaskRunner extends TaskRunner {
 
     // KEYCHAIN BOUNDARY (darwin only): keep non-interactive worker descendants
     // away from the user's GUI Keychain session (issue #704).
-    this.applyDarwinKeychainBoundary(spawnEnv);
+    try {
+      this.applyDarwinKeychainBoundary(spawnEnv);
+    } catch (error) {
+      if (claudeSettingsPath) cleanupClaudeSettingsOverlay(claudeSettingsPath);
+      throw error;
+    }
 
     prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });
 

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -12,6 +12,7 @@ const { loadSettings } = require('../lib/settings');
 const { normalizeProviderName } = require('../lib/provider-names');
 const { getProvider } = require('./providers');
 const { prependWorktreeToolBinToEnv } = require('./worktree-tooling-env');
+const { applyDarwinKeychainBoundaryToEnv } = require('./darwin-keychain-boundary');
 const { getTask, getTaskBySpawnOwnershipToken } = require('../task-lib/store.js');
 const {
   TASK_SPAWN_OWNERSHIP_TOKEN_ENV,
@@ -388,6 +389,10 @@ class ClaudeTaskRunner extends TaskRunner {
         spawnEnv[CLAUDE_MCP_CONFIG_ENV] = mcpConfigPath;
       }
     }
+
+    // KEYCHAIN BOUNDARY (darwin only): keep non-interactive worker descendants
+    // away from the user's GUI Keychain session (issue #704).
+    applyDarwinKeychainBoundaryToEnv(spawnEnv);
 
     prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });
 

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -152,6 +152,7 @@ class ClaudeTaskRunner extends TaskRunner {
    * @param {boolean} [options.quiet] - Suppress console logging
    * @param {number} [options.timeout] - Task timeout in ms (default: 1 hour)
    * @param {Function} [options.onOutput] - Callback for output lines
+   * @param {Function} [options.applyDarwinKeychainBoundary] - Boundary injection seam for tests
    */
   constructor(options = {}) {
     super();
@@ -159,6 +160,8 @@ class ClaudeTaskRunner extends TaskRunner {
     this.quiet = options.quiet || false;
     this.timeout = options.timeout || 60 * 60 * 1000;
     this.onOutput = options.onOutput || null;
+    this.applyDarwinKeychainBoundary =
+      options.applyDarwinKeychainBoundary || applyDarwinKeychainBoundaryToEnv;
   }
 
   /**
@@ -392,7 +395,7 @@ class ClaudeTaskRunner extends TaskRunner {
 
     // KEYCHAIN BOUNDARY (darwin only): keep non-interactive worker descendants
     // away from the user's GUI Keychain session (issue #704).
-    applyDarwinKeychainBoundaryToEnv(spawnEnv);
+    this.applyDarwinKeychainBoundary(spawnEnv);
 
     prependWorktreeToolBinToEnv(spawnEnv, { cwd, worktreePath });
 

--- a/src/darwin-keychain-boundary.js
+++ b/src/darwin-keychain-boundary.js
@@ -19,14 +19,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { randomUUID } = require('node:crypto');
 
 const SHIM_DIR_RELATIVE_PATH = path.join('.zeroshot', 'keychain-shim');
 const REAL_SECURITY_PATH = '/usr/bin/security';
 const OPT_OUT_ENV_VAR = 'ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN';
-
-function pathKeyForEnv(env) {
-  return Object.keys(env).find((key) => key.toUpperCase() === 'PATH') || 'PATH';
-}
 
 function shellQuote(value) {
   return `'${String(value).replace(/'/g, `'\\''`)}'`;
@@ -96,10 +93,27 @@ function ensureDarwinKeychainShimDir(options = {}) {
     // Missing or unreadable: (re)write below.
   }
   if (existing !== script) {
-    fs.writeFileSync(shimPath, script, { mode: 0o755 });
+    const tempPath = path.join(shimDir, `.security.${process.pid}.${randomUUID()}.tmp`);
+    try {
+      fs.writeFileSync(tempPath, script, { mode: 0o755, flag: 'wx' });
+      // The creation mode is subject to umask. Set the final mode before the
+      // rename so the live path is never observable as non-executable.
+      fs.chmodSync(tempPath, 0o755);
+      fs.renameSync(tempPath, shimPath);
+    } catch (error) {
+      try {
+        // Remove any unpublished partial file without masking the publication
+        // failure that caused this cleanup path.
+        fs.rmSync(tempPath, { force: true });
+      } catch (cleanupError) {
+        error.message += ` Cleanup also failed: ${cleanupError.message}.`;
+      }
+      throw error;
+    }
+  } else {
+    // An existing matching shim may have drifted permissions.
+    fs.chmodSync(shimPath, 0o755);
   }
-  // writeFileSync's mode only applies on creation; enforce it unconditionally.
-  fs.chmodSync(shimPath, 0o755);
 
   return shimDir;
 }
@@ -139,11 +153,18 @@ function applyDarwinKeychainBoundaryToEnv(env, options = {}) {
     );
   }
 
-  const pathKey = pathKeyForEnv(env);
-  const existingEntries = (env[pathKey] || '')
-    .split(path.delimiter)
-    .filter((entry) => entry && entry !== shimDir);
-  env[pathKey] = [shimDir, ...existingEntries].join(path.delimiter);
+  // Darwin environment keys are case-sensitive: descendants consult PATH,
+  // never a differently-cased key such as Path. Preserve empty components
+  // because POSIX interprets them as the current directory. An absent PATH
+  // becomes only the shim, while an explicitly empty PATH retains its empty
+  // component after the shim (`<shim>:`).
+  const existingEntries =
+    env.PATH === undefined
+      ? []
+      : String(env.PATH)
+          .split(path.delimiter)
+          .filter((entry) => entry !== shimDir);
+  env.PATH = [shimDir, ...existingEntries].join(path.delimiter);
   return env;
 }
 

--- a/src/darwin-keychain-boundary.js
+++ b/src/darwin-keychain-boundary.js
@@ -1,0 +1,153 @@
+/**
+ * Darwin worker Keychain boundary (issue #704).
+ *
+ * Non-interactive local/worktree workers are spawned with the host environment,
+ * so worker descendants (e.g. `claude doctor` probing Keychain writes through
+ * `security -i`) reach the logged-in user's GUI Keychain session and launch
+ * SecurityAgent dialogs from a supposedly non-interactive cluster.
+ *
+ * On darwin, worker spawn envs get a managed shim directory prepended to PATH
+ * containing a `security` wrapper that fails closed on interactive invocations
+ * (`-i`, `-p`, or no arguments) with a deterministic diagnostic, and execs the
+ * real /usr/bin/security for every other subcommand so provider authentication
+ * (e.g. `security find-generic-password`) keeps working.
+ *
+ * Docker isolation never reaches this code path, and non-darwin platforms are
+ * left untouched. Set ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN=1 to opt out.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SHIM_DIR_RELATIVE_PATH = path.join('.zeroshot', 'keychain-shim');
+const REAL_SECURITY_PATH = '/usr/bin/security';
+const OPT_OUT_ENV_VAR = 'ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN';
+
+function pathKeyForEnv(env) {
+  return Object.keys(env).find((key) => key.toUpperCase() === 'PATH') || 'PATH';
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function buildSecurityShimScript(realSecurityPath) {
+  return `#!/bin/sh
+# Managed by Zeroshot (src/darwin-keychain-boundary.js). Do not edit.
+#
+# Non-interactive Zeroshot workers must not open the logged-in user's GUI
+# Keychain session (SecurityAgent). Interactive \`security\` invocations fail
+# closed here; every other subcommand is passed through to the real binary so
+# provider authentication keeps working.
+
+REAL_SECURITY=${shellQuote(realSecurityPath)}
+
+if [ "\${${OPT_OUT_ENV_VAR}:-0}" = "1" ]; then
+  exec "$REAL_SECURITY" "$@"
+fi
+
+fail_closed() {
+  echo "zeroshot: blocked interactive 'security' invocation from a non-interactive worker (argv: $*)." >&2
+  echo "zeroshot: this cluster has no interactive Keychain session, so SecurityAgent prompts are disabled." >&2
+  echo "zeroshot: run the cluster with Docker isolation or configure explicit credentials for the tool that attempted Keychain access." >&2
+  echo "zeroshot: set ${OPT_OUT_ENV_VAR}=1 to restore interactive Keychain access." >&2
+  exit 1
+}
+
+# \`security\` without arguments enters interactive mode.
+[ "$#" -eq 0 ] && fail_closed
+
+# Global options precede the subcommand. -i (interactive) and -p (prompt,
+# implies -i) must not reach the real binary; option letters may be bundled
+# (e.g. -qi). Scanning stops at the first non-option token (the subcommand).
+for arg in "$@"; do
+  case "$arg" in
+    -*i*|-*p*) fail_closed "$@" ;;
+    -*) ;;
+    *) break ;;
+  esac
+done
+
+exec "$REAL_SECURITY" "$@"
+`;
+}
+
+/**
+ * Create (or refresh) the managed shim directory containing the `security`
+ * wrapper. Idempotent: the script is only rewritten when its content changes.
+ *
+ * @param {object} [options]
+ * @param {string} [options.shimBaseDir] - Shim directory (tests only); defaults to ~/.zeroshot/keychain-shim.
+ * @param {string} [options.realSecurityPath] - Real binary to exec (tests only); defaults to /usr/bin/security.
+ * @returns {string} Absolute path of the shim directory.
+ */
+function ensureDarwinKeychainShimDir(options = {}) {
+  const shimDir = options.shimBaseDir || path.join(os.homedir(), SHIM_DIR_RELATIVE_PATH);
+  const script = buildSecurityShimScript(options.realSecurityPath || REAL_SECURITY_PATH);
+  const shimPath = path.join(shimDir, 'security');
+
+  fs.mkdirSync(shimDir, { recursive: true });
+
+  let existing = null;
+  try {
+    existing = fs.readFileSync(shimPath, 'utf8');
+  } catch {
+    // Missing or unreadable: (re)write below.
+  }
+  if (existing !== script) {
+    fs.writeFileSync(shimPath, script, { mode: 0o755 });
+  }
+  // writeFileSync's mode only applies on creation; enforce it unconditionally.
+  fs.chmodSync(shimPath, 0o755);
+
+  return shimDir;
+}
+
+/**
+ * Prepend the Keychain boundary shim to a worker spawn env's PATH.
+ *
+ * No-op off darwin and when the operator opted out via
+ * ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN=1. Fails closed (throws) when the shim
+ * cannot be installed: spawning the worker anyway would silently re-expose the
+ * interactive Keychain session.
+ *
+ * @param {object} env - Spawn env to mutate (also returned).
+ * @param {object} [options]
+ * @param {string} [options.platform] - Platform override (tests only).
+ * @param {string} [options.shimBaseDir] - See ensureDarwinKeychainShimDir.
+ * @param {string} [options.realSecurityPath] - See ensureDarwinKeychainShimDir.
+ * @returns {object} The same env object.
+ */
+function applyDarwinKeychainBoundaryToEnv(env, options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform !== 'darwin') {
+    return env;
+  }
+  if (env[OPT_OUT_ENV_VAR] === '1' || process.env[OPT_OUT_ENV_VAR] === '1') {
+    return env;
+  }
+
+  let shimDir;
+  try {
+    shimDir = ensureDarwinKeychainShimDir(options);
+  } catch (error) {
+    throw new Error(
+      `Failed to install the darwin Keychain boundary shim: ${error.message}. ` +
+        `Non-interactive workers must not reach the interactive Keychain session; ` +
+        `use Docker isolation or set ${OPT_OUT_ENV_VAR}=1 to opt out.`
+    );
+  }
+
+  const pathKey = pathKeyForEnv(env);
+  const existingEntries = (env[pathKey] || '')
+    .split(path.delimiter)
+    .filter((entry) => entry && entry !== shimDir);
+  env[pathKey] = [shimDir, ...existingEntries].join(path.delimiter);
+  return env;
+}
+
+module.exports = {
+  applyDarwinKeychainBoundaryToEnv,
+  ensureDarwinKeychainShimDir,
+};

--- a/src/darwin-keychain-boundary.js
+++ b/src/darwin-keychain-boundary.js
@@ -156,11 +156,11 @@ function applyDarwinKeychainBoundaryToEnv(env, options = {}) {
   // Darwin environment keys are case-sensitive: descendants consult PATH,
   // never a differently-cased key such as Path. Preserve empty components
   // because POSIX interprets them as the current directory. An absent PATH
-  // becomes only the shim, while an explicitly empty PATH retains its empty
-  // component after the shim (`<shim>:`).
+  // retains Node/libuv's default Unix search path after the shim, while an
+  // explicitly empty PATH retains its empty component (`<shim>:`).
   const existingEntries =
     env.PATH === undefined
-      ? []
+      ? ['/usr/bin', '/bin']
       : String(env.PATH)
           .split(path.delimiter)
           .filter((entry) => entry !== shimDir);

--- a/src/worktree-tooling-env.js
+++ b/src/worktree-tooling-env.js
@@ -6,6 +6,9 @@ const DEFAULT_TOOL_BIN_RELATIVE_PATHS = ['.zeroshot/bin', '.worktree-tool-bin'];
 const FALLBACK_BIN_PREFIX = '.worktree-tool-bin.';
 
 function pathKeyForEnv(env) {
+  if (Object.prototype.hasOwnProperty.call(env, 'PATH')) {
+    return 'PATH';
+  }
   return Object.keys(env).find((key) => key.toUpperCase() === 'PATH') || 'PATH';
 }
 

--- a/tests/unit/claude-task-runner-worktree-env.test.js
+++ b/tests/unit/claude-task-runner-worktree-env.test.js
@@ -157,6 +157,25 @@ describe('ClaudeTaskRunner worktree env forwarding', function () {
     );
     assert.ok(!fs.existsSync(path.dirname(settingsPath)));
   });
+
+  it('cleans the overlay when the darwin Keychain boundary fails closed', function () {
+    let settingsPath;
+    const runner = new ClaudeTaskRunner({
+      quiet: true,
+      applyDarwinKeychainBoundary(spawnEnv) {
+        settingsPath = spawnEnv[CLAUDE_SETTINGS_ENV];
+        settingsOverlays.push(settingsPath);
+        assert.ok(fs.existsSync(settingsPath), 'the overlay must exist before boundary setup');
+        throw new Error('Keychain boundary installation failed');
+      },
+    });
+
+    assert.throws(
+      () => runner._buildSpawnEnv('claude', null),
+      /Keychain boundary installation failed/
+    );
+    assert.ok(!fs.existsSync(path.dirname(settingsPath)));
+  });
 });
 
 describe('ClaudeTaskRunner isolated MCP forwarding', function () {

--- a/tests/unit/darwin-keychain-boundary.test.js
+++ b/tests/unit/darwin-keychain-boundary.test.js
@@ -38,6 +38,7 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
   /** @type {string[]} */
   let tempDirs = [];
   let originalPath;
+  let originalMixedCasePath;
 
   function makeTempDir(prefix) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -47,6 +48,7 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
 
   beforeEach(function () {
     originalPath = process.env.PATH;
+    originalMixedCasePath = process.env.Path;
   });
 
   afterEach(function () {
@@ -54,6 +56,11 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
       delete process.env.PATH;
     } else {
       process.env.PATH = originalPath;
+    }
+    if (originalMixedCasePath === undefined) {
+      delete process.env.Path;
+    } else {
+      process.env.Path = originalMixedCasePath;
     }
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -298,6 +305,7 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
       const fallbackBinDir = path.join(worktreeRoot, 'fallback-bin');
       const cwd = path.join(worktreeRoot, 'nested', 'cwd');
       const shimBaseDir = path.join(worktreeRoot, 'managed-keychain-shim');
+      const nonAuthoritativePath = path.join(worktreeRoot, 'non-authoritative-path');
       fs.mkdirSync(toolBinDir, { recursive: true });
       fs.mkdirSync(fallbackBinDir, { recursive: true });
       fs.mkdirSync(cwd, { recursive: true });
@@ -316,6 +324,7 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
         toolBinDir,
         fallbackBinDir,
         cwd,
+        nonAuthoritativePath,
         shimBaseDir,
         fakePath,
         logFile,
@@ -329,6 +338,12 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
           shimBaseDir: fixture.shimBaseDir,
           realSecurityPath: fixture.fakePath,
         });
+    }
+
+    function setBothPathKeys(fixture) {
+      delete process.env.PATH;
+      process.env.Path = fixture.nonAuthoritativePath;
+      process.env.PATH = fixture.fallbackBinDir;
     }
 
     function runPathResolvedInteractiveSecurityGrandchild(spawnEnv) {
@@ -394,6 +409,23 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
       assertProductionBoundary(spawnEnv, fixture);
     });
 
+    it('buildSpawnEnv keeps worktree tools on exact PATH when Path also exists', function () {
+      const fixture = createProductionFixture();
+      setBothPathKeys(fixture);
+      const spawnEnv = executor.buildSpawnEnv(
+        {
+          config: { cwd: fixture.cwd },
+          worktree: { enabled: true, path: fixture.worktreeRoot },
+        },
+        'codex',
+        { model: 'gpt-5-codex' },
+        { applyDarwinKeychainBoundary: injectDarwinBoundary(fixture) }
+      );
+
+      assertProductionBoundary(spawnEnv, fixture);
+      assert.strictEqual(spawnEnv.Path, fixture.nonAuthoritativePath);
+    });
+
     it('ClaudeTaskRunner._buildSpawnEnv enforces the same production boundary', function () {
       const fixture = createProductionFixture();
       process.env.PATH = fixture.fallbackBinDir;
@@ -407,6 +439,22 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
       });
 
       assertProductionBoundary(spawnEnv, fixture);
+    });
+
+    it('ClaudeTaskRunner keeps worktree tools on exact PATH when Path also exists', function () {
+      const fixture = createProductionFixture();
+      setBothPathKeys(fixture);
+      const runner = new ClaudeTaskRunner({
+        quiet: true,
+        applyDarwinKeychainBoundary: injectDarwinBoundary(fixture),
+      });
+      const spawnEnv = runner._buildSpawnEnv('codex', null, {
+        cwd: fixture.cwd,
+        worktreePath: fixture.worktreeRoot,
+      });
+
+      assertProductionBoundary(spawnEnv, fixture);
+      assert.strictEqual(spawnEnv.Path, fixture.nonAuthoritativePath);
     });
   });
 });

--- a/tests/unit/darwin-keychain-boundary.test.js
+++ b/tests/unit/darwin-keychain-boundary.test.js
@@ -152,7 +152,10 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
         shimBaseDir: emptyShimDir,
       });
 
-      assert.strictEqual(unsetEnv.PATH, unsetShimDir);
+      assert.strictEqual(
+        unsetEnv.PATH,
+        [unsetShimDir, '/usr/bin', '/bin'].join(path.delimiter)
+      );
       assert.strictEqual(emptyEnv.PATH, `${emptyShimDir}${path.delimiter}`);
     });
 

--- a/tests/unit/darwin-keychain-boundary.test.js
+++ b/tests/unit/darwin-keychain-boundary.test.js
@@ -21,14 +21,12 @@ try {
 const executor = require('../../src/agent/agent-task-executor');
 const ClaudeTaskRunner = require('../../src/claude-task-runner');
 
-const SHIM_DIR_SUFFIX = path.join('.zeroshot', 'keychain-shim');
-
 // The shim is a POSIX sh script; process-level tests cannot run on Windows.
 const describeExec = process.platform === 'win32' ? describe.skip : describe;
 
-function writeFakeRealSecurity(dir, { exitCode = 0 } = {}) {
+function writeFakeRealSecurity(dir, { exitCode = 0, fileName = 'fake-real-security' } = {}) {
   const logFile = path.join(dir, 'real-security-invocations.log');
-  const fakePath = path.join(dir, 'fake-real-security');
+  const fakePath = path.join(dir, fileName);
   fs.writeFileSync(fakePath, `#!/bin/sh\necho "argv: $*" >> "${logFile}"\nexit ${exitCode}\n`, {
     mode: 0o755,
   });
@@ -39,6 +37,7 @@ function writeFakeRealSecurity(dir, { exitCode = 0 } = {}) {
 describe('darwin worker Keychain boundary (issue #704)', function () {
   /** @type {string[]} */
   let tempDirs = [];
+  let originalPath;
 
   function makeTempDir(prefix) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -46,7 +45,16 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
     return dir;
   }
 
+  beforeEach(function () {
+    originalPath = process.env.PATH;
+  });
+
   afterEach(function () {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -99,6 +107,55 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
       assert.strictEqual(dedupedEntries.filter((entry) => entry === shimBaseDir).length, 1);
     });
 
+    it('updates the exact PATH key when differently-cased keys coexist', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
+      const env = {
+        Path: `/unrelated${path.delimiter}/case-insensitive-only`,
+        PATH: `/usr/bin${path.delimiter}/bin`,
+      };
+
+      boundary.applyDarwinKeychainBoundaryToEnv(env, { platform: 'darwin', shimBaseDir });
+
+      assert.strictEqual(env.Path, `/unrelated${path.delimiter}/case-insensitive-only`);
+      assert.deepStrictEqual(env.PATH.split(path.delimiter), [shimBaseDir, '/usr/bin', '/bin']);
+    });
+
+    it('preserves empty PATH components while removing only duplicate shim entries', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
+      const env = {
+        PATH: ['/usr/bin', '', shimBaseDir, '/bin', '', shimBaseDir].join(path.delimiter),
+      };
+
+      boundary.applyDarwinKeychainBoundaryToEnv(env, { platform: 'darwin', shimBaseDir });
+
+      assert.deepStrictEqual(env.PATH.split(path.delimiter), [
+        shimBaseDir,
+        '/usr/bin',
+        '',
+        '/bin',
+        '',
+      ]);
+    });
+
+    it('distinguishes an unset PATH from an explicitly empty PATH', function () {
+      const unsetShimDir = path.join(makeTempDir('zeroshot-keychain-shim-unset-'), 'shim');
+      const emptyShimDir = path.join(makeTempDir('zeroshot-keychain-shim-empty-'), 'shim');
+      const unsetEnv = {};
+      const emptyEnv = { PATH: '' };
+
+      boundary.applyDarwinKeychainBoundaryToEnv(unsetEnv, {
+        platform: 'darwin',
+        shimBaseDir: unsetShimDir,
+      });
+      boundary.applyDarwinKeychainBoundaryToEnv(emptyEnv, {
+        platform: 'darwin',
+        shimBaseDir: emptyShimDir,
+      });
+
+      assert.strictEqual(unsetEnv.PATH, unsetShimDir);
+      assert.strictEqual(emptyEnv.PATH, `${emptyShimDir}${path.delimiter}`);
+    });
+
     it('honors the ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN opt-out', function () {
       const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
       const env = {
@@ -110,6 +167,44 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
 
       assert.strictEqual(env.PATH, `/usr/bin${path.delimiter}/bin`);
       assert.ok(!fs.existsSync(shimBaseDir));
+    });
+  });
+
+  describe('atomic shim publication', function () {
+    before(function () {
+      if (!boundary) this.skip();
+    });
+
+    it('keeps the live shim intact and cleans the temporary file when rename fails', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-atomic-'), 'shim');
+      const shimPath = path.join(shimBaseDir, 'security');
+      const existingScript = '#!/bin/sh\nexit 42\n';
+      fs.mkdirSync(shimBaseDir, { recursive: true });
+      fs.writeFileSync(shimPath, existingScript, { mode: 0o755 });
+
+      const originalRenameSync = fs.renameSync;
+      fs.renameSync = function failShimPublish(sourcePath, destinationPath) {
+        if (destinationPath === shimPath) {
+          throw new Error(`simulated atomic publish failure for ${path.basename(sourcePath)}`);
+        }
+        return originalRenameSync(sourcePath, destinationPath);
+      };
+
+      try {
+        assert.throws(
+          () =>
+            boundary.ensureDarwinKeychainShimDir({
+              shimBaseDir,
+              realSecurityPath: '/different/security',
+            }),
+          /simulated atomic publish failure/
+        );
+      } finally {
+        fs.renameSync = originalRenameSync;
+      }
+
+      assert.strictEqual(fs.readFileSync(shimPath, 'utf8'), existingScript);
+      assert.deepStrictEqual(fs.readdirSync(shimBaseDir), ['security']);
     });
   });
 
@@ -194,10 +289,85 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
   });
 
   describe('worker spawn env integration', function () {
+    function createProductionFixture() {
+      const worktreeRoot = makeTempDir('zeroshot-keychain-worktree-');
+      const toolBinDir = path.join(worktreeRoot, '.zeroshot', 'bin');
+      const fallbackBinDir = path.join(worktreeRoot, 'fallback-bin');
+      const cwd = path.join(worktreeRoot, 'nested', 'cwd');
+      const shimBaseDir = path.join(worktreeRoot, 'managed-keychain-shim');
+      fs.mkdirSync(toolBinDir, { recursive: true });
+      fs.mkdirSync(fallbackBinDir, { recursive: true });
+      fs.mkdirSync(cwd, { recursive: true });
+      fs.writeFileSync(
+        path.join(worktreeRoot, '.zeroshot', 'tooling-env.json'),
+        JSON.stringify({ version: 1, worktreeRoot, toolBinDir }),
+        'utf8'
+      );
+      fs.writeFileSync(path.join(worktreeRoot, '.git'), 'gitdir: test\n', 'utf8');
+      const { fakePath, logFile } = writeFakeRealSecurity(fallbackBinDir, {
+        fileName: 'security',
+      });
+
+      return {
+        worktreeRoot,
+        toolBinDir,
+        fallbackBinDir,
+        cwd,
+        shimBaseDir,
+        fakePath,
+        logFile,
+      };
+    }
+
+    function injectDarwinBoundary(fixture) {
+      return (env) =>
+        boundary.applyDarwinKeychainBoundaryToEnv(env, {
+          platform: 'darwin',
+          shimBaseDir: fixture.shimBaseDir,
+          realSecurityPath: fixture.fakePath,
+        });
+    }
+
+    function runPathResolvedInteractiveSecurityGrandchild(spawnEnv) {
+      const workerScript = `
+        const { spawnSync } = require('child_process');
+        const result = spawnSync('security', ['-i'], { encoding: 'utf8' });
+        process.stdout.write(JSON.stringify({
+          status: result.status,
+          stderr: result.stderr,
+          errorCode: result.error ? result.error.code : null,
+        }));
+      `;
+      const worker = spawnSync(process.execPath, ['-e', workerScript], {
+        encoding: 'utf8',
+        env: spawnEnv,
+      });
+
+      assert.strictEqual(worker.status, 0, worker.stderr);
+      return JSON.parse(worker.stdout);
+    }
+
+    function assertProductionBoundary(spawnEnv, fixture) {
+      const grandchild = runPathResolvedInteractiveSecurityGrandchild(spawnEnv);
+      assert.strictEqual(grandchild.errorCode, null);
+      assert.strictEqual(grandchild.status, 1);
+      assert.match(grandchild.stderr, /blocked interactive 'security' invocation/);
+      assert.ok(
+        !fs.existsSync(fixture.logFile),
+        'PATH resolution must reach the blocking shim, not the fallback security executable'
+      );
+
+      assert.deepStrictEqual(spawnEnv.PATH.split(path.delimiter).slice(0, 3), [
+        fixture.toolBinDir,
+        fixture.shimBaseDir,
+        fixture.fallbackBinDir,
+      ]);
+    }
+
     // Docker isolation is unaffected by design: spawnClaudeTask returns through
     // spawnClaudeTaskIsolated before buildSpawnEnv runs, so the shim only ever
     // reaches local/worktree workers.
-    it('buildSpawnEnv installs the boundary for darwin local/worktree workers only', function () {
+    it('buildSpawnEnv enforces the darwin boundary through the real worktree PATH', function () {
       assert.strictEqual(
         typeof executor.buildSpawnEnv,
         'function',
@@ -206,42 +376,34 @@ describe('darwin worker Keychain boundary (issue #704)', function () {
           '/usr/bin/security and interactive `security -i` descendants are not intercepted'
       );
 
-      const cwd = makeTempDir('zeroshot-keychain-agent-cwd-');
-      const spawnEnv = executor.buildSpawnEnv({ config: { cwd } }, 'codex', {
-        model: 'gpt-5-codex',
-      });
+      const fixture = createProductionFixture();
+      process.env.PATH = fixture.fallbackBinDir;
+      const spawnEnv = executor.buildSpawnEnv(
+        {
+          config: { cwd: fixture.cwd },
+          worktree: { enabled: true, path: fixture.worktreeRoot },
+        },
+        'codex',
+        { model: 'gpt-5-codex' },
+        { applyDarwinKeychainBoundary: injectDarwinBoundary(fixture) }
+      );
 
-      const entries = (spawnEnv.PATH || '').split(path.delimiter);
-      const shimIndex = entries.findIndex((entry) => entry.endsWith(SHIM_DIR_SUFFIX));
-
-      if (process.platform === 'darwin') {
-        assert.notStrictEqual(shimIndex, -1, 'darwin spawn env must contain the security shim');
-        assert.ok(fs.existsSync(path.join(entries[shimIndex], 'security')));
-        const usrBinIndex = entries.indexOf('/usr/bin');
-        if (usrBinIndex !== -1) {
-          assert.ok(
-            shimIndex < usrBinIndex,
-            'the shim must shadow /usr/bin/security in PATH resolution'
-          );
-        }
-      } else {
-        assert.strictEqual(shimIndex, -1, 'non-darwin spawn envs must not contain the shim');
-      }
+      assertProductionBoundary(spawnEnv, fixture);
     });
 
-    it('ClaudeTaskRunner._buildSpawnEnv applies the same boundary', function () {
-      const cwd = makeTempDir('zeroshot-keychain-runner-cwd-');
-      const runner = new ClaudeTaskRunner({ quiet: true });
-      const spawnEnv = runner._buildSpawnEnv('codex', null, { cwd });
+    it('ClaudeTaskRunner._buildSpawnEnv enforces the same production boundary', function () {
+      const fixture = createProductionFixture();
+      process.env.PATH = fixture.fallbackBinDir;
+      const runner = new ClaudeTaskRunner({
+        quiet: true,
+        applyDarwinKeychainBoundary: injectDarwinBoundary(fixture),
+      });
+      const spawnEnv = runner._buildSpawnEnv('codex', null, {
+        cwd: fixture.cwd,
+        worktreePath: fixture.worktreeRoot,
+      });
 
-      const entries = (spawnEnv.PATH || '').split(path.delimiter);
-      const shimIndex = entries.findIndex((entry) => entry.endsWith(SHIM_DIR_SUFFIX));
-
-      if (process.platform === 'darwin') {
-        assert.notStrictEqual(shimIndex, -1);
-      } else {
-        assert.strictEqual(shimIndex, -1);
-      }
+      assertProductionBoundary(spawnEnv, fixture);
     });
   });
 });

--- a/tests/unit/darwin-keychain-boundary.test.js
+++ b/tests/unit/darwin-keychain-boundary.test.js
@@ -1,0 +1,247 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// Issue #704: local/worktree workers on macOS inherit the host environment, so
+// worker descendants (e.g. `claude doctor` probing Keychain writes through
+// `security -i`) reach the logged-in user's GUI Keychain session and launch
+// SecurityAgent dialogs from a supposedly non-interactive cluster.
+//
+// The boundary module is absent on unfixed builds; keep the require lazy so the
+// remaining assertions can report the defect instead of crashing the file.
+let boundary = null;
+try {
+  boundary = require('../../src/darwin-keychain-boundary');
+} catch {
+  // Missing module: worker spawn envs carry no Keychain boundary.
+}
+
+const executor = require('../../src/agent/agent-task-executor');
+const ClaudeTaskRunner = require('../../src/claude-task-runner');
+
+const SHIM_DIR_SUFFIX = path.join('.zeroshot', 'keychain-shim');
+
+// The shim is a POSIX sh script; process-level tests cannot run on Windows.
+const describeExec = process.platform === 'win32' ? describe.skip : describe;
+
+function writeFakeRealSecurity(dir, { exitCode = 0 } = {}) {
+  const logFile = path.join(dir, 'real-security-invocations.log');
+  const fakePath = path.join(dir, 'fake-real-security');
+  fs.writeFileSync(fakePath, `#!/bin/sh\necho "argv: $*" >> "${logFile}"\nexit ${exitCode}\n`, {
+    mode: 0o755,
+  });
+  fs.chmodSync(fakePath, 0o755);
+  return { fakePath, logFile };
+}
+
+describe('darwin worker Keychain boundary (issue #704)', function () {
+  /** @type {string[]} */
+  let tempDirs = [];
+
+  function makeTempDir(prefix) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(function () {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ships a Keychain boundary module for darwin worker spawns', function () {
+    assert.ok(
+      boundary,
+      'src/darwin-keychain-boundary is missing: local/worktree worker spawn envs have no ' +
+        'Keychain boundary, so darwin worker descendants can open the interactive GUI ' +
+        'Keychain session (SecurityAgent) via `security -i`'
+    );
+  });
+
+  describe('applyDarwinKeychainBoundaryToEnv', function () {
+    before(function () {
+      if (!boundary) this.skip();
+    });
+
+    it('leaves non-darwin platforms untouched (no shim installed)', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
+      const env = { PATH: `/usr/bin${path.delimiter}/bin` };
+
+      const result = boundary.applyDarwinKeychainBoundaryToEnv(env, {
+        platform: 'linux',
+        shimBaseDir,
+      });
+
+      assert.strictEqual(result.PATH, `/usr/bin${path.delimiter}/bin`);
+      assert.ok(!fs.existsSync(shimBaseDir), 'no shim directory may be created off darwin');
+    });
+
+    it('prepends the managed security shim to PATH for darwin spawn envs', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
+      const env = { PATH: `/usr/bin${path.delimiter}/bin` };
+
+      boundary.applyDarwinKeychainBoundaryToEnv(env, { platform: 'darwin', shimBaseDir });
+
+      const entries = env.PATH.split(path.delimiter);
+      assert.strictEqual(entries[0], shimBaseDir);
+      assert.ok(entries.includes('/usr/bin'));
+
+      const shimSecurity = path.join(shimBaseDir, 'security');
+      assert.ok(fs.existsSync(shimSecurity), 'shim must provide a `security` executable');
+      fs.accessSync(shimSecurity, fs.constants.X_OK);
+
+      // Applying twice must not duplicate the PATH entry.
+      boundary.applyDarwinKeychainBoundaryToEnv(env, { platform: 'darwin', shimBaseDir });
+      const dedupedEntries = env.PATH.split(path.delimiter);
+      assert.strictEqual(dedupedEntries.filter((entry) => entry === shimBaseDir).length, 1);
+    });
+
+    it('honors the ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN opt-out', function () {
+      const shimBaseDir = path.join(makeTempDir('zeroshot-keychain-shim-'), 'shim');
+      const env = {
+        PATH: `/usr/bin${path.delimiter}/bin`,
+        ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN: '1',
+      };
+
+      boundary.applyDarwinKeychainBoundaryToEnv(env, { platform: 'darwin', shimBaseDir });
+
+      assert.strictEqual(env.PATH, `/usr/bin${path.delimiter}/bin`);
+      assert.ok(!fs.existsSync(shimBaseDir));
+    });
+  });
+
+  describeExec('security shim process behavior', function () {
+    before(function () {
+      if (!boundary) this.skip();
+    });
+
+    function installShim({ exitCode = 0 } = {}) {
+      const base = makeTempDir('zeroshot-keychain-shim-');
+      const { fakePath, logFile } = writeFakeRealSecurity(base, { exitCode });
+      const shimBaseDir = path.join(base, 'shim');
+      boundary.ensureDarwinKeychainShimDir({ shimBaseDir, realSecurityPath: fakePath });
+      return { shimSecurity: path.join(shimBaseDir, 'security'), logFile };
+    }
+
+    it('fails closed on `security -i` without invoking the real binary', function () {
+      const { shimSecurity, logFile } = installShim();
+
+      const result = spawnSync(shimSecurity, ['-i'], {
+        encoding: 'utf8',
+        input:
+          'add-generic-password -U -a "unknown" -s "Claude Code-doctor-probe" -X "70726f6265"\n',
+      });
+
+      assert.notStrictEqual(result.status, 0, 'interactive invocation must fail');
+      assert.match(result.stderr, /non-interactive worker/);
+      assert.match(result.stderr, /Docker isolation/);
+      assert.ok(!fs.existsSync(logFile), 'the real security binary must never be invoked');
+    });
+
+    it('fails closed when invoked with no arguments (implicit interactive mode)', function () {
+      const { shimSecurity, logFile } = installShim();
+
+      const result = spawnSync(shimSecurity, [], { encoding: 'utf8', input: '' });
+
+      assert.notStrictEqual(result.status, 0);
+      assert.match(result.stderr, /non-interactive worker/);
+      assert.ok(!fs.existsSync(logFile));
+    });
+
+    it('fails closed on `-p` prompts and bundled interactive flags', function () {
+      const { shimSecurity, logFile } = installShim();
+
+      for (const argv of [['-p', 'custom prompt'], ['-qi']]) {
+        const result = spawnSync(shimSecurity, argv, { encoding: 'utf8' });
+        assert.notStrictEqual(result.status, 0, `argv ${argv.join(' ')} must fail`);
+        assert.match(result.stderr, /non-interactive worker/);
+      }
+      assert.ok(!fs.existsSync(logFile));
+    });
+
+    it('transparently passes non-interactive subcommands to the real binary', function () {
+      const { shimSecurity, logFile } = installShim();
+
+      const result = spawnSync(
+        shimSecurity,
+        ['find-generic-password', '-s', 'zeroshot-test-service'],
+        { encoding: 'utf8' }
+      );
+
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stderr, '');
+      assert.match(
+        fs.readFileSync(logFile, 'utf8'),
+        /argv: find-generic-password -s zeroshot-test-service/
+      );
+    });
+
+    it('stops flag scanning at the subcommand and preserves the exit code', function () {
+      const { shimSecurity, logFile } = installShim({ exitCode: 3 });
+
+      // `find-identity` contains the letter i and -p follows the subcommand;
+      // neither may be mistaken for interactive mode.
+      const result = spawnSync(shimSecurity, ['-q', 'find-identity', '-p', 'codesigning'], {
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(result.status, 3, 'the real binary exit code must propagate');
+      assert.match(fs.readFileSync(logFile, 'utf8'), /argv: -q find-identity -p codesigning/);
+    });
+  });
+
+  describe('worker spawn env integration', function () {
+    // Docker isolation is unaffected by design: spawnClaudeTask returns through
+    // spawnClaudeTaskIsolated before buildSpawnEnv runs, so the shim only ever
+    // reaches local/worktree workers.
+    it('buildSpawnEnv installs the boundary for darwin local/worktree workers only', function () {
+      assert.strictEqual(
+        typeof executor.buildSpawnEnv,
+        'function',
+        'agent-task-executor must expose buildSpawnEnv with the darwin Keychain boundary; ' +
+          'without it, darwin local/worktree worker spawn envs resolve `security` straight to ' +
+          '/usr/bin/security and interactive `security -i` descendants are not intercepted'
+      );
+
+      const cwd = makeTempDir('zeroshot-keychain-agent-cwd-');
+      const spawnEnv = executor.buildSpawnEnv({ config: { cwd } }, 'codex', {
+        model: 'gpt-5-codex',
+      });
+
+      const entries = (spawnEnv.PATH || '').split(path.delimiter);
+      const shimIndex = entries.findIndex((entry) => entry.endsWith(SHIM_DIR_SUFFIX));
+
+      if (process.platform === 'darwin') {
+        assert.notStrictEqual(shimIndex, -1, 'darwin spawn env must contain the security shim');
+        assert.ok(fs.existsSync(path.join(entries[shimIndex], 'security')));
+        const usrBinIndex = entries.indexOf('/usr/bin');
+        if (usrBinIndex !== -1) {
+          assert.ok(
+            shimIndex < usrBinIndex,
+            'the shim must shadow /usr/bin/security in PATH resolution'
+          );
+        }
+      } else {
+        assert.strictEqual(shimIndex, -1, 'non-darwin spawn envs must not contain the shim');
+      }
+    });
+
+    it('ClaudeTaskRunner._buildSpawnEnv applies the same boundary', function () {
+      const cwd = makeTempDir('zeroshot-keychain-runner-cwd-');
+      const runner = new ClaudeTaskRunner({ quiet: true });
+      const spawnEnv = runner._buildSpawnEnv('codex', null, { cwd });
+
+      const entries = (spawnEnv.PATH || '').split(path.delimiter);
+      const shimIndex = entries.findIndex((entry) => entry.endsWith(SHIM_DIR_SUFFIX));
+
+      if (process.platform === 'darwin') {
+        assert.notStrictEqual(shimIndex, -1);
+      } else {
+        assert.strictEqual(shimIndex, -1);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Non-interactive local/worktree worker clusters on macOS can pop GUI Keychain password prompts (SecurityAgent). `buildSpawnEnv` spawns workers with the inherited host environment, and `task-lib/watcher.js` passes it through to every worker grandchild, so a descendant like `claude doctor` probing Keychain writes via `security -i` reaches the logged-in user's GUI Keychain session.

Fixes https://github.com/the-open-engine/zeroshot/issues/704

## Fix (fail closed, option 1 from the issue)

On darwin only, worker spawn envs now get a managed shim directory (`~/.zeroshot/keychain-shim`) prepended to the exact `PATH` key. Its `security` wrapper:

- fails closed (exit 1) on interactive invocations — `-i`, `-p` (implies interactive), bundled global flags like `-qi`, or a zero-argument implicit interactive session — with a deterministic diagnostic naming the non-interactive worker boundary and pointing at Docker isolation or explicit credential configuration;
- transparently `exec`s `/usr/bin/security "$@"` for every other subcommand, so provider authentication such as `security find-generic-password` keeps working (flag scanning stops at the first subcommand token, and exit codes pass through).

`ZEROSHOT_ALLOW_INTERACTIVE_KEYCHAIN=1` opts out. If the shim cannot be installed, the spawn fails rather than silently re-exposing the interactive Keychain session.

The managed executable is refreshed through a same-directory temporary file, chmodded before an atomic rename over the live path, and cleaned up on publication failure. PATH handling preserves inherited empty components (the POSIX current-directory entry), distinguishes unset PATH from an explicitly empty PATH, and removes only duplicate shim entries.

Scope guarantees:

- Docker isolation never reaches `buildSpawnEnv`, so containerized runs are untouched.
- Non-darwin platforms get no shim.
- Worktree tool-bin directories stay ahead of the shim, so repo-managed tool substitutes keep winning.

## Tests

- `tests/unit/darwin-keychain-boundary.test.js` now has 15 cases covering interactive blocking, non-interactive pass-through and exit propagation, opt-out behavior, exact `PATH` casing when `Path` also exists, empty/unset PATH semantics, idempotency, atomic publication failure, and non-darwin behavior.
- Both production spawn-env builders expose a narrow boundary-injection seam. Their tests force the darwin path on every CI platform, use real worktree tooling metadata, and launch a worker process whose PATH-resolved `security -i` grandchild must hit the shim rather than a logging fallback executable.
- Focused boundary + adjacent worktree/runner tests: 24 passing.
- Full unit suite, lint, and typecheck complete successfully.

## Notes

A PATH shim intercepts PATH-resolved lookups; descendants invoking `/usr/bin/security` by absolute path bypass it. The reported probe resolves via PATH, so the defect in the issue is covered; this is a guardrail for well-behaved tools, not a sandbox against adversarial code.
