### PR TITLE
fix: add Bedrock provider model ids

### DIFF
--- a/src/agent-cli-provider/adapters/claude.ts
+++ b/src/agent-cli-provider/adapters/claude.ts
@@ -40,6 +40,7 @@ const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
   'claude-opus-4-6': { rank: 3 },
   'claude-opus-4-7': { rank: 3 },
   'claude-opus-4-8': { rank: 3 },
+  'claude-opus-5': { rank: 3 },
   fable: { rank: 3 },
   'claude-fable-5': { rank: 3 },
   'claude-mythos-5': { rank: 3 },

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -29,8 +29,11 @@ const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
   'gpt-5.5': { rank: 3 },
   'gpt-5.6': { rank: 3 },
   'gpt-5.6-sol': { rank: 3 },
+  'openai.gpt-5.6-sol': { rank: 3 },
   'gpt-5.6-terra': { rank: 2 },
+  'openai.gpt-5.6-terra': { rank: 2 },
   'gpt-5.6-luna': { rank: 1 },
+  'openai.gpt-5.6-luna': { rank: 1 },
 };
 
 const LEVEL_MAPPING: Readonly<Record<ModelLevel, LevelModelSpec>> = {

--- a/tests/agent-cli-provider/current-model-support.test.js
+++ b/tests/agent-cli-provider/current-model-support.test.js
@@ -4,12 +4,24 @@ const { test } = require('node:test');
 const helper = require('../../lib/agent-cli-provider');
 const { runExecutable } = require('./executable-contract-helpers.cjs');
 
-const OPENAI_GPT_56_MODELS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'];
+const BEDROCK_NAMESPACED_CODEX_MODELS = [
+  ['openai.gpt-5.6-sol', 'gpt-5.6-sol'],
+  ['openai.gpt-5.6-terra', 'gpt-5.6-terra'],
+  ['openai.gpt-5.6-luna', 'gpt-5.6-luna'],
+];
+const OPENAI_GPT_56_MODELS = [
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  ...BEDROCK_NAMESPACED_CODEX_MODELS.map(([model]) => model),
+];
 
 const CURRENT_CLAUDE_MODELS = [
   'fable',
   'claude-fable-5',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-opus-4-5',
@@ -32,6 +44,14 @@ test('Codex catalog accepts the GPT-5.6 family and alias', () => {
   }
 });
 
+test('Bedrock-namespaced Codex model ranks match their unprefixed twins', () => {
+  const catalog = helper.getProviderAdapter('codex').modelCatalog;
+
+  for (const [namespacedModel, unprefixedModel] of BEDROCK_NAMESPACED_CODEX_MODELS) {
+    assert.equal(catalog[namespacedModel].rank, catalog[unprefixedModel].rank);
+  }
+});
+
 test('Claude catalog accepts current canonical ids, aliases, and limited-access models', () => {
   const adapter = helper.getProviderAdapter('claude');
 
@@ -40,28 +60,30 @@ test('Claude catalog accepts current canonical ids, aliases, and limited-access 
   }
 });
 
-test('Codex sends max reasoning effort through its config override', () => {
-  const spec = helper.buildProviderCommand('codex', 'test context', {
-    modelSpec: { model: 'gpt-5.6-sol', reasoningEffort: 'max' },
-    cliFeatures: {
-      supportsConfigOverride: true,
-      supportsSkipGitRepoCheck: true,
-    },
-  });
+test('Codex sends Bedrock-namespaced GPT-5.6 models through its command path', () => {
+  for (const [model] of BEDROCK_NAMESPACED_CODEX_MODELS) {
+    const spec = helper.buildProviderCommand('codex', 'test context', {
+      modelSpec: { model, reasoningEffort: 'max' },
+      cliFeatures: {
+        supportsConfigOverride: true,
+        supportsSkipGitRepoCheck: true,
+      },
+    });
 
-  assert.deepEqual(spec.args.slice(spec.args.indexOf('-m'), spec.args.indexOf('-m') + 2), [
-    '-m',
-    'gpt-5.6-sol',
-  ]);
-  assert.deepEqual(
-    spec.args.slice(spec.args.indexOf('--config'), spec.args.indexOf('--config') + 2),
-    ['--config', 'model_reasoning_effort="max"']
-  );
+    assert.deepEqual(spec.args.slice(spec.args.indexOf('-m'), spec.args.indexOf('-m') + 2), [
+      '-m',
+      model,
+    ]);
+    assert.deepEqual(
+      spec.args.slice(spec.args.indexOf('--config'), spec.args.indexOf('--config') + 2),
+      ['--config', 'model_reasoning_effort="max"']
+    );
+  }
 });
 
 test('Claude sends max reasoning effort through the installed CLI effort flag', () => {
   const spec = helper.buildProviderCommand('claude', 'test context', {
-    modelSpec: { model: 'claude-fable-5', reasoningEffort: 'max' },
+    modelSpec: { model: 'claude-opus-5', reasoningEffort: 'max' },
     cliFeatures: {
       supportsModel: true,
       supportsEffort: true,
@@ -70,7 +92,7 @@ test('Claude sends max reasoning effort through the installed CLI effort flag', 
 
   assert.deepEqual(
     spec.args.slice(spec.args.indexOf('--model'), spec.args.indexOf('--model') + 2),
-    ['--model', 'claude-fable-5']
+    ['--model', 'claude-opus-5']
   );
   assert.deepEqual(
     spec.args.slice(spec.args.indexOf('--effort'), spec.args.indexOf('--effort') + 2),


### PR DESCRIPTION
## Summary

Adds the Bedrock-namespaced Codex model ids and `claude-opus-5` to the provider catalogs. The Codex aliases retain the exact ranks of their unprefixed twins; shared model validation remains unchanged.

Closes #822

## Changes

- add `openai.gpt-5.6-sol`, `openai.gpt-5.6-terra`, and `openai.gpt-5.6-luna`
- add `claude-opus-5` at rank 3
- cover catalog acceptance, rank parity, and provider command construction

## Validation

- `npm run check:agent-cli-provider:ci` (135 passing; 0 failures; 2 pre-existing warnings)