### PR TITLE
feat(update): reliably notify interactive users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,6 +520,11 @@ Core principle: tests passing != implementation works. The ONLY verification is:
 | `~/.zeroshot/clusters.json` | Cluster metadata      |
 | `~/.zeroshot/<id>.db`       | SQLite message ledger |
 
+All production writes to the global settings file must use `lib/settings.js::mutateSettings`.
+Callers provide only their intended mutation; they must never write a previously loaded full
+snapshot. The shared primitive re-reads under one `proper-lockfile` lock and publishes by
+same-directory atomic rename. Global settings reads remain lock-free.
+
 Clusters survive crashes. Resume: `zeroshot resume <id>`.
 
 ## Known Limitations

--- a/cli/commands/providers.js
+++ b/cli/commands/providers.js
@@ -1,5 +1,5 @@
 const readline = require('readline');
-const { loadSettings, saveSettings } = require('../../lib/settings');
+const { loadSettings, mutateSettings } = require('../../lib/settings');
 const {
   VALID_PROVIDERS,
   normalizeProviderName,
@@ -55,9 +55,9 @@ function setDefaultCommand(args) {
     process.exit(1);
   }
 
-  const settings = loadSettings();
-  settings.defaultProvider = provider;
-  saveSettings(settings);
+  mutateSettings((settings) => {
+    settings.defaultProvider = provider;
+  });
 
   console.log(`Default provider set to: ${provider}`);
 }
@@ -135,15 +135,15 @@ async function setupCommand(args) {
       }
     }
 
-    const settings = loadSettings();
-    settings.providerSettings = settings.providerSettings || {};
-    settings.providerSettings[provider] = {
-      maxLevel: levelKeys[maxIdx - 1],
-      minLevel: levelKeys[minIdx - 1],
-      defaultLevel: levelKeys[defaultIdxNum - 1],
-      levelOverrides,
-    };
-    saveSettings(settings);
+    mutateSettings((settings) => {
+      settings.providerSettings = settings.providerSettings || {};
+      settings.providerSettings[provider] = {
+        maxLevel: levelKeys[maxIdx - 1],
+        minLevel: levelKeys[minIdx - 1],
+        defaultLevel: levelKeys[defaultIdxNum - 1],
+        levelOverrides,
+      };
+    });
 
     console.log(`\n✓ ${providerModule.displayName} configured successfully`);
   } finally {

--- a/cli/index.js
+++ b/cli/index.js
@@ -45,6 +45,7 @@ const {
   mutateSettings,
   validateSetting,
   coerceValue,
+  SettingsValidationError,
   DEFAULT_SETTINGS,
   settingsFileExists,
 } = require('../lib/settings');
@@ -4298,11 +4299,18 @@ settingsCmd
       }
 
       const parsedValue = parseSettingValue(value);
-      mutateSettings((settings) => {
-        setNestedValue(settings, key, parsedValue);
-        const validationError = validateSetting(rootKey, settings[rootKey]);
-        if (validationError) throw new Error(validationError);
-      });
+      try {
+        mutateSettings((settings) => {
+          setNestedValue(settings, key, parsedValue);
+          const validationError = validateSetting(rootKey, settings[rootKey]);
+          if (validationError) throw new SettingsValidationError(validationError);
+        });
+      } catch (error) {
+        if (!(error instanceof SettingsValidationError)) throw error;
+        console.error(chalk.red(error.message));
+        process.exitCode = 1;
+        return;
+      }
 
       const displayValue =
         typeof parsedValue === 'string' ? parsedValue : JSON.stringify(parsedValue);

--- a/cli/index.js
+++ b/cli/index.js
@@ -86,8 +86,7 @@ const {
   checkForUpdates,
   isAutomaticUpdateEligible,
   printLegacyDistroNotice,
-  runUpdate,
-  shouldForceLegacyUpdate,
+  runLegacyUpdateIfRequested,
 } = require('./lib/update-checker');
 const { checkBinDirOnPath, printPathWarning } = require('../lib/path-check');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
@@ -5940,7 +5939,7 @@ function printMessage(msg, showClusterId = false, watchMode = false, isActive = 
 }
 
 // Main entry point
-function main() {
+async function main() {
   printLegacyDistroNotice();
 
   try {
@@ -5953,8 +5952,10 @@ function main() {
   }
 
   const startupArgs = process.argv.slice(2);
-  if (shouldForceLegacyUpdate(startupArgs)) {
-    runUpdate();
+  const legacyUpdate = runLegacyUpdateIfRequested(startupArgs);
+  if (legacyUpdate !== null) {
+    const success = await legacyUpdate;
+    process.exitCode = success ? 0 : 1;
     return;
   }
 
@@ -5993,12 +5994,10 @@ function main() {
 
 // Run main
 if (require.main === module) {
-  try {
-    main();
-  } catch (err) {
+  main().catch((err) => {
     console.error('Fatal error:', err.message);
     process.exit(1);
-  }
+  });
 }
 
 module.exports = {

--- a/cli/index.js
+++ b/cli/index.js
@@ -5929,9 +5929,8 @@ function printMessage(msg, showClusterId = false, watchMode = false, isActive = 
   formatGenericMessage(msg, prefix, timestamp, safePrint);
 }
 
-// Main async entry point
-async function main() {
-
+// Main entry point
+function main() {
   printLegacyDistroNotice();
 
   try {
@@ -5979,10 +5978,12 @@ async function main() {
 
 // Run main
 if (require.main === module) {
-  main().catch((err) => {
+  try {
+    main();
+  } catch (err) {
     console.error('Fatal error:', err.message);
     process.exit(1);
-  });
+  }
 }
 
 module.exports = {

--- a/cli/index.js
+++ b/cli/index.js
@@ -5938,6 +5938,15 @@ function printMessage(msg, showClusterId = false, watchMode = false, isActive = 
   formatGenericMessage(msg, prefix, timestamp, safePrint);
 }
 
+function isStartupUpdateEligible(argv, options = {}) {
+  return isAutomaticUpdateEligible({
+    ...options,
+    argv,
+    commanderProgram: program,
+    defaultCommandName: 'run',
+  });
+}
+
 // Main entry point
 async function main() {
   printLegacyDistroNotice();
@@ -5959,7 +5968,7 @@ async function main() {
     return;
   }
 
-  if (isAutomaticUpdateEligible({ argv: startupArgs })) {
+  if (isStartupUpdateEligible(startupArgs)) {
     checkForUpdates({ argv: startupArgs, eligibilityChecked: true });
   }
 
@@ -6005,5 +6014,6 @@ module.exports = {
   inspectAgentAttachment,
   printAttachableAgentList,
   renderRecentMessagesToTerminal,
+  isStartupUpdateEligible,
   resolveRunMode,
 };

--- a/cli/index.js
+++ b/cli/index.js
@@ -42,7 +42,7 @@ const {
 } = require('./message-formatter-utils');
 const {
   loadSettings,
-  saveSettings,
+  mutateSettings,
   validateSetting,
   coerceValue,
   DEFAULT_SETTINGS,
@@ -81,7 +81,11 @@ const {
 } = require('../lib/detached-startup');
 const { isProcessRunning: isClusterProcessAlive } = require('../lib/process-liveness');
 // Setup wizard removed - use: zeroshot settings set <key> <value>
-const { checkForUpdates, printLegacyDistroNotice } = require('./lib/update-checker');
+const {
+  checkForUpdates,
+  isAutomaticUpdateEligible,
+  printLegacyDistroNotice,
+} = require('./lib/update-checker');
 const { checkBinDirOnPath, printPathWarning } = require('../lib/path-check');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
 const { EVENT_COPY, formatMergeStatus } = require('./event-copy');
@@ -3853,6 +3857,11 @@ for (const providerName of VALID_PROVIDERS) {
 
 // Settings management
 const settingsCmd = program.command('settings').description('Manage zeroshot settings');
+const INTERNAL_SETTINGS_KEYS = new Set(['lastUpdateCheckClaim']);
+
+function visibleSettingKeys() {
+  return Object.keys(DEFAULT_SETTINGS).filter((key) => !INTERNAL_SETTINGS_KEYS.has(key));
+}
 
 function printSettingsUsage() {
   const mountPresetList = Object.keys(MOUNT_PRESETS).join(', ');
@@ -3873,7 +3882,7 @@ function printSettingsUsage() {
 function printNonDockerSettings(settings) {
   const dockerKeys = new Set(['dockerMounts', 'dockerEnvPassthrough', 'dockerContainerHome']);
   for (const [key, value] of Object.entries(settings)) {
-    if (dockerKeys.has(key)) {
+    if (dockerKeys.has(key) || INTERNAL_SETTINGS_KEYS.has(key)) {
       continue;
     }
     const displayValue =
@@ -4227,6 +4236,13 @@ function parseSettingValue(value) {
   }
 }
 
+function resetGlobalSettings() {
+  mutateSettings((settings) => {
+    for (const key of Object.keys(settings)) delete settings[key];
+    Object.assign(settings, JSON.parse(JSON.stringify({ ...DEFAULT_SETTINGS })));
+  });
+}
+
 settingsCmd
   .command('get <key>')
   .description(
@@ -4235,7 +4251,10 @@ settingsCmd
   .action((key) => {
     const settings = loadSettings();
 
-    // Support dot-notation for nested values
+    if (INTERNAL_SETTINGS_KEYS.has(key.split('.')[0])) {
+      console.error(chalk.red(`Setting not found: ${key}`));
+      process.exit(1);
+    }
     if (key.includes('.')) {
       const { value, found } = getNestedValue(settings, key);
       if (!found) {
@@ -4249,7 +4268,7 @@ settingsCmd
     if (!(key in settings)) {
       console.error(chalk.red(`Unknown setting: ${key}`));
       console.log(chalk.dim('\nAvailable settings:'));
-      Object.keys(DEFAULT_SETTINGS).forEach((k) => console.log(chalk.dim(`  - ${k}`)));
+      visibleSettingKeys().forEach((k) => console.log(chalk.dim(`  - ${k}`)));
       process.exit(1);
     }
     console.log(
@@ -4263,34 +4282,28 @@ settingsCmd
     'Set a setting value (supports dot-notation: providerSettings.claude.anthropicApiKey)'
   )
   .action((key, value) => {
-    const settings = loadSettings();
-
+    if (INTERNAL_SETTINGS_KEYS.has(key.split('.')[0])) {
+      console.error(chalk.red(`Unknown setting: ${key}`));
+      process.exit(1);
+    }
     // Support dot-notation for nested values
     if (key.includes('.')) {
-      const parts = key.split('.');
-      const rootKey = parts[0];
+      const rootKey = key.split('.')[0];
 
-      // Validate root key exists in defaults
       if (!(rootKey in DEFAULT_SETTINGS)) {
         console.error(chalk.red(`Unknown setting: ${rootKey}`));
         console.log(chalk.dim('\nAvailable settings:'));
-        Object.keys(DEFAULT_SETTINGS).forEach((k) => console.log(chalk.dim(`  - ${k}`)));
+        visibleSettingKeys().forEach((k) => console.log(chalk.dim(`  - ${k}`)));
         process.exit(1);
       }
 
       const parsedValue = parseSettingValue(value);
+      mutateSettings((settings) => {
+        setNestedValue(settings, key, parsedValue);
+        const validationError = validateSetting(rootKey, settings[rootKey]);
+        if (validationError) throw new Error(validationError);
+      });
 
-      // Set nested value
-      setNestedValue(settings, key, parsedValue);
-
-      // Validate the root key after modification
-      const validationError = validateSetting(rootKey, settings[rootKey]);
-      if (validationError) {
-        console.error(chalk.red(validationError));
-        process.exit(1);
-      }
-
-      saveSettings(settings);
       const displayValue =
         typeof parsedValue === 'string' ? parsedValue : JSON.stringify(parsedValue);
       console.log(chalk.green(`✓ Set ${key} = ${displayValue}`));
@@ -4301,7 +4314,7 @@ settingsCmd
     if (!(key in DEFAULT_SETTINGS)) {
       console.error(chalk.red(`Unknown setting: ${key}`));
       console.log(chalk.dim('\nAvailable settings:'));
-      Object.keys(DEFAULT_SETTINGS).forEach((k) => console.log(chalk.dim(`  - ${k}`)));
+      visibleSettingKeys().forEach((k) => console.log(chalk.dim(`  - ${k}`)));
       process.exit(1);
     }
 
@@ -4321,8 +4334,9 @@ settingsCmd
       process.exit(1);
     }
 
-    settings[key] = parsedValue;
-    saveSettings(settings);
+    mutateSettings((settings) => {
+      settings[key] = parsedValue;
+    });
     console.log(chalk.green(`✓ Set ${key} = ${JSON.stringify(parsedValue)}`));
   });
 
@@ -4344,11 +4358,16 @@ settingsCmd
           console.log('Aborted.');
           return;
         }
-        saveSettings(DEFAULT_SETTINGS);
-        console.log(chalk.green('✓ Settings reset to defaults'));
+        try {
+          resetGlobalSettings();
+          console.log(chalk.green('✓ Settings reset to defaults'));
+        } catch (error) {
+          console.error(chalk.red(error.message));
+          process.exitCode = 1;
+        }
       });
     } else {
-      saveSettings(DEFAULT_SETTINGS);
+      resetGlobalSettings();
       console.log(chalk.green('✓ Settings reset to defaults'));
     }
   });
@@ -5912,8 +5931,6 @@ function printMessage(msg, showClusterId = false, watchMode = false, isActive = 
 
 // Main async entry point
 async function main() {
-  const isTest = process.env.NODE_ENV === 'test';
-  const isQuiet = process.argv.includes('-q') || process.argv.includes('--quiet') || isTest;
 
   printLegacyDistroNotice();
 
@@ -5926,12 +5943,12 @@ async function main() {
     // Never block CLI startup on a PATH check failure
   }
 
-  // Check for updates (non-blocking if offline)
-  if (!isTest) {
-    await checkForUpdates({ quiet: isQuiet });
+  const startupArgs = process.argv.slice(2);
+  if (isAutomaticUpdateEligible({ argv: startupArgs })) {
+    checkForUpdates({ argv: startupArgs, eligibilityChecked: true });
   }
 
-  let args = process.argv.slice(2);
+  let args = startupArgs;
 
   if (args.length === 0) {
     program.outputHelp();

--- a/cli/index.js
+++ b/cli/index.js
@@ -86,6 +86,8 @@ const {
   checkForUpdates,
   isAutomaticUpdateEligible,
   printLegacyDistroNotice,
+  runUpdate,
+  shouldForceLegacyUpdate,
 } = require('./lib/update-checker');
 const { checkBinDirOnPath, printPathWarning } = require('../lib/path-check');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
@@ -5951,6 +5953,11 @@ function main() {
   }
 
   const startupArgs = process.argv.slice(2);
+  if (shouldForceLegacyUpdate(startupArgs)) {
+    runUpdate();
+    return;
+  }
+
   if (isAutomaticUpdateEligible({ argv: startupArgs })) {
     checkForUpdates({ argv: startupArgs, eligibilityChecked: true });
   }

--- a/cli/lib/first-run.js
+++ b/cli/lib/first-run.js
@@ -9,7 +9,7 @@
  */
 
 const readline = require('readline');
-const { loadSettings, saveSettings } = require('../../lib/settings');
+const { loadSettings, mutateSettings } = require('../../lib/settings');
 const { listProviderMetadata } = require('../../lib/provider-names');
 const { detectProviders } = require('../../src/providers');
 
@@ -175,8 +175,9 @@ async function checkFirstRun(options = {}) {
 
   // Quiet mode - use defaults, mark complete
   if (options.quiet) {
-    settings.firstRunComplete = true;
-    saveSettings(settings);
+    mutateSettings((current) => {
+      current.firstRunComplete = true;
+    });
     return true;
   }
 
@@ -188,22 +189,22 @@ async function checkFirstRun(options = {}) {
   try {
     const detected = await detectProviders();
     const provider = await promptProvider(rl, detected);
-    settings.defaultProvider = provider;
-
     // Model ceiling selection
     const model = await promptModel(rl);
-    settings.maxModel = model;
 
     // Auto-update preference
     const autoUpdate = await promptAutoUpdate(rl);
-    settings.autoCheckUpdates = autoUpdate;
 
-    // Mark complete
-    settings.firstRunComplete = true;
-    saveSettings(settings);
+    const savedSettings = mutateSettings((current) => {
+      current.defaultProvider = provider;
+      current.maxModel = model;
+      current.autoCheckUpdates = autoUpdate;
+      current.firstRunComplete = true;
+      return current;
+    });
 
     // Print completion
-    printComplete(settings);
+    printComplete(savedSettings);
 
     return true;
   } finally {

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -1,19 +1,16 @@
 /**
- * Update Checker - Checks npm registry for newer versions
+ * Update Checker - cached startup notices and the explicit npm updater.
  *
- * Features:
- * - 24-hour check interval (avoids registry spam)
- * - 5-second timeout (non-blocking if offline)
- * - Interactive prompt for manual update
- * - Respects quiet mode (no prompts in CI/scripts)
+ * Automatic startup work is notification-only and stale-while-revalidate.
+ * Installation remains exclusive to the explicit `zeroshot update` command.
  */
 
 const https = require('https');
 const childProcess = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const readline = require('readline');
-const { loadSettings, saveSettings } = require('../../lib/settings');
+const { loadSettings, mutateSettings } = require('../../lib/settings');
 
 const NEW_PACKAGE_NAME = '@the-open-engine/zeroshot';
 const LEGACY_PACKAGE_NAME = '@covibes/zeroshot';
@@ -27,6 +24,12 @@ const FETCH_TIMEOUT_MS = 5000;
 
 // npm registry URL
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_PACKAGE_NAME}/latest`;
+
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const STABLE_VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z.-]+)?$/;
+
+let inFlightRefresh = null;
 
 function getPackageMetadata() {
   return require('../../package.json');
@@ -199,89 +202,130 @@ function buildInstallArgs(updateTarget) {
   return args;
 }
 
+function parseStableVersion(version) {
+  if (typeof version !== 'string') return null;
+  const match = STABLE_VERSION_PATTERN.exec(version);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
 /**
- * Compare semver versions
- * @param {string} current - Current version (e.g., "1.5.0")
- * @param {string} latest - Latest version (e.g., "1.6.0")
- * @returns {boolean} True if latest > current
+ * Compare validated stable semver versions.
+ * @param {string} current
+ * @param {string} latest
+ * @returns {boolean}
  */
 function isNewerVersion(current, latest) {
-  const currentParts = current.split('.').map(Number);
-  const latestParts = latest.split('.').map(Number);
+  const currentParts = parseStableVersion(current);
+  const latestParts = parseStableVersion(latest);
+  if (!currentParts || !latestParts) return false;
 
-  for (let i = 0; i < 3; i++) {
-    const c = currentParts[i] || 0;
-    const l = latestParts[i] || 0;
-    if (l > c) return true;
-    if (l < c) return false;
+  for (let index = 0; index < 3; index += 1) {
+    if (latestParts[index] > currentParts[index]) return true;
+    if (latestParts[index] < currentParts[index]) return false;
   }
   return false;
 }
 
+function validatedManifestVersion(manifest) {
+  if (
+    !manifest ||
+    typeof manifest !== 'object' ||
+    manifest.name !== NEW_PACKAGE_NAME ||
+    !parseStableVersion(manifest.version) ||
+    !manifest.dist ||
+    typeof manifest.dist !== 'object' ||
+    typeof manifest.dist.tarball !== 'string' ||
+    !manifest.dist.tarball.trim().startsWith('https://') ||
+    typeof manifest.dist.integrity !== 'string' ||
+    manifest.dist.integrity.trim().length === 0
+  ) {
+    return null;
+  }
+  return manifest.version;
+}
+
 /**
- * Fetch latest version from npm registry
- * @returns {Promise<string|null>} Latest version or null on failure
+ * Fetch and validate the installable npm latest manifest.
+ * @param {object} options
+ * @returns {Promise<string|null>}
  */
-function fetchLatestVersion() {
+function fetchLatestVersion(options = {}) {
+  const httpsModule = options.httpsModule || https;
+  const timeoutMs = options.timeoutMs ?? FETCH_TIMEOUT_MS;
+  const maxResponseBytes = options.maxResponseBytes ?? MAX_RESPONSE_BYTES;
+  const scheduleTimeout = options.setTimeout || setTimeout;
+  const cancelTimeout = options.clearTimeout || clearTimeout;
+
   return new Promise((resolve) => {
-    const req = https.get(REGISTRY_URL, { timeout: FETCH_TIMEOUT_MS }, (res) => {
-      if (res.statusCode !== 200) {
-        resolve(null);
-        return;
-      }
+    let request;
+    let safetyTimer;
+    let settled = false;
 
-      let data = '';
-      res.on('data', (chunk) => {
-        data += chunk;
-      });
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      if (safetyTimer) cancelTimeout(safetyTimer);
+      request?.setTimeout?.(0);
+      resolve(value);
+    };
 
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data);
-          resolve(json.version || null);
-        } catch {
-          resolve(null);
+    try {
+      request = httpsModule.get(REGISTRY_URL, { timeout: timeoutMs }, (response) => {
+        if (response.statusCode !== 200) {
+          response.destroy?.();
+          request.destroy?.();
+          finish(null);
+          return;
         }
+
+        const chunks = [];
+        let size = 0;
+        response.on('data', (chunk) => {
+          if (settled) return;
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          size += buffer.length;
+          if (size > maxResponseBytes) {
+            response.destroy?.();
+            request.destroy?.();
+            finish(null);
+            return;
+          }
+          chunks.push(buffer);
+        });
+        response.on('error', () => finish(null));
+        response.on('end', () => {
+          if (settled) return;
+          try {
+            const manifest = JSON.parse(Buffer.concat(chunks, size).toString('utf8'));
+            finish(validatedManifestVersion(manifest));
+          } catch {
+            finish(null);
+          }
+        });
       });
-    });
+    } catch {
+      finish(null);
+      return;
+    }
 
-    req.on('error', () => {
-      resolve(null);
+    request.on('error', () => finish(null));
+    request.on('timeout', () => {
+      request.destroy();
+      finish(null);
     });
+    if (options.unref) {
+      request.on('socket', (socket) => socket.unref?.());
+    }
 
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(null);
-    });
-
-    // Additional safety timeout
-    setTimeout(() => {
-      req.destroy();
-      resolve(null);
-    }, FETCH_TIMEOUT_MS + 1000);
+    safetyTimer = scheduleTimeout(() => {
+      request.destroy();
+      finish(null);
+    }, timeoutMs + 1000);
+    safetyTimer.unref?.();
   });
 }
 
-/**
- * Prompt user for update confirmation
- * @param {string} currentVersion
- * @param {string} latestVersion
- * @returns {Promise<boolean>} True if user wants to update
- */
-function promptForUpdate(currentVersion, latestVersion) {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-
-    console.log(`\n📦 Update available: ${currentVersion} → ${latestVersion}`);
-    rl.question('   Install now? [y/N] ', (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
-    });
-  });
-}
 
 /**
  * Check if we have write permission to npm global directory
@@ -349,98 +393,224 @@ function runUpdate(options = {}) {
   });
 }
 
-/**
- * Check if update check should run
- * @param {object} settings - Current settings
- * @returns {boolean}
- */
-function shouldCheckForUpdates(settings) {
-  // Disabled by user
-  if (!settings.autoCheckUpdates) {
-    return false;
+function optionIndex(argv, longName, shortName = null) {
+  const end = argv.indexOf('--');
+  const limit = end === -1 ? argv.length : end;
+  for (let index = 0; index < limit; index += 1) {
+    const token = argv[index];
+    if (token === longName || (shortName && token === shortName)) return index;
+    if (token.startsWith(`${longName}=`)) return index;
   }
+  return -1;
+}
 
-  // Never checked before
-  if (!settings.lastUpdateCheckAt) {
-    return true;
+function optionValue(argv, longName) {
+  const index = optionIndex(argv, longName);
+  if (index === -1) return null;
+  const token = argv[index];
+  if (token.startsWith(`${longName}=`)) return token.slice(longName.length + 1);
+  return argv[index + 1] ?? null;
+}
+
+function commandPath(argv) {
+  const positional = [];
+  const optionsWithValues = new Set([
+    '--format',
+    '--output-format',
+    '--json-schema',
+    '--mcp-config',
+  ]);
+  const end = argv.indexOf('--');
+  const limit = end === -1 ? argv.length : end;
+
+  for (let index = 0; index < limit; index += 1) {
+    const token = argv[index];
+    if (optionsWithValues.has(token)) {
+      index += 1;
+      continue;
+    }
+    if (!token.startsWith('-')) positional.push(token);
   }
-
-  // Check if 24 hours have passed
-  const elapsed = Date.now() - settings.lastUpdateCheckAt;
-  return elapsed >= CHECK_INTERVAL_MS;
+  return positional;
 }
 
 /**
- * Main entry point - check for updates
- * @param {object} options
- * @param {boolean} options.quiet - Skip interactive prompts
- * @returns {Promise<void>}
+ * Pure classification for optional automatic update work.
  */
-async function checkForUpdates(options = {}) {
-  const settings = loadSettings();
+function isAutomaticUpdateEligible(options = {}) {
+  const argv = options.argv || process.argv.slice(2);
+  const env = options.env || process.env;
+  const stdin = options.stdin || process.stdin;
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+  const currentVersion = options.currentVersion || getCurrentVersion();
+  const packageName = options.packageName || getCurrentPackageName();
 
-  // Skip check if not due
-  if (!shouldCheckForUpdates(settings)) {
-    return;
+  if (
+    packageName !== NEW_PACKAGE_NAME ||
+    !parseStableVersion(currentVersion) ||
+    argv.length === 0 ||
+    stdin.isTTY !== true ||
+    stdout.isTTY !== true ||
+    stderr.isTTY !== true ||
+    (env.CI !== undefined && env.CI !== null && String(env.CI).length > 0) ||
+    env.ZEROSHOT_DAEMON === '1'
+  ) {
+    return false;
   }
 
-  const currentVersion = getCurrentVersion();
-  const latestVersion = await fetchLatestVersion();
-
-  // Update last check timestamp regardless of result
-  settings.lastUpdateCheckAt = Date.now();
-  saveSettings(settings);
-
-  // Network failure - silently skip
-  if (!latestVersion) {
-    return;
+  if (
+    optionIndex(argv, '--quiet', '-q') !== -1 ||
+    optionIndex(argv, '--help', '-h') !== -1 ||
+    optionIndex(argv, '--version', '-V') !== -1 ||
+    optionIndex(argv, '--completion') !== -1
+  ) {
+    return false;
   }
 
-  // No update available
-  if (!isNewerVersion(currentVersion, latestVersion)) {
-    return;
+  const [command, subcommand] = commandPath(argv);
+  if (
+    command === 'update' ||
+    command === 'get-log-path' ||
+    (command === 'task' && subcommand === 'run') ||
+    (command === 'setup' && ['plan', 'apply', 'undo'].includes(subcommand)) ||
+    (command === 'cmdproof' && ['prove', 'verify', 'check'].includes(subcommand))
+  ) {
+    return false;
   }
 
-  // Already notified about this version
-  if (settings.lastSeenVersion === latestVersion) {
-    return;
+  if (
+    optionIndex(argv, '--json') !== -1 ||
+    optionIndex(argv, '--silent-json-output') !== -1 ||
+    optionIndex(argv, '--json-schema') !== -1
+  ) {
+    return false;
   }
 
-  // Update lastSeenVersion so we don't nag about the same version
-  settings.lastSeenVersion = latestVersion;
-  saveSettings(settings);
+  const outputFormat = optionValue(argv, '--output-format');
+  if (outputFormat === 'json' || outputFormat === 'stream-json') return false;
+  if (command === 'export' && optionValue(argv, '--format') === 'json') return false;
 
-  // Check write permissions upfront
-  const hasWriteAccess = canWriteToNpmGlobal();
+  return true;
+}
 
-  // Quiet mode - just inform, no prompt
-  if (options.quiet) {
-    console.log(`📦 Update available: ${currentVersion} → ${latestVersion}`);
-    if (hasWriteAccess) {
-      console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), false)}\n`);
-    } else {
-      console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), true)}\n`);
+function shouldCheckForUpdates(settings, now = Date.now()) {
+  if (settings.autoCheckUpdates !== true) return false;
+  const timestamp = settings.lastUpdateCheckAt;
+  if (!Number.isFinite(timestamp) || timestamp < 0 || timestamp > now) return true;
+  return now - timestamp >= CHECK_INTERVAL_MS;
+}
+
+async function refreshUpdateCache(options) {
+  const now = options.now || Date.now;
+  const transaction = options.mutateSettings || mutateSettings;
+  const fetcher = options.fetchLatestVersion || fetchLatestVersion;
+  const generateClaimId = options.generateClaimId || (() => crypto.randomUUID());
+  const attemptAt = now();
+  const claimId = generateClaimId();
+  let claim;
+
+  try {
+    claim = transaction(
+      (settings) => {
+        if (!shouldCheckForUpdates(settings, attemptAt)) return null;
+        settings.lastUpdateCheckAt = attemptAt;
+        settings.lastUpdateCheckClaim = claimId;
+        return { attemptAt, claimId };
+      },
+      { lockTimeoutMs: 0 }
+    );
+  } catch {
+    return;
+  }
+  if (!claim) return;
+
+  let latestVersion;
+  try {
+    latestVersion = await fetcher({ unref: true });
+  } catch {
+    return;
+  }
+  if (!parseStableVersion(latestVersion)) return;
+
+  try {
+    transaction(
+      (settings) => {
+        if (
+          settings.autoCheckUpdates !== true ||
+          settings.lastUpdateCheckAt !== attemptAt ||
+          settings.lastUpdateCheckClaim !== claimId
+        ) {
+          return false;
+        }
+        settings.lastSeenVersion = latestVersion;
+        settings.lastUpdateCheckClaim = null;
+        return true;
+      },
+      { lockTimeoutMs: 0 }
+    );
+  } catch {
+    // Optional cache persistence must never affect command dispatch or output.
+  }
+}
+
+/**
+ * Synchronously render the startup cache and begin a due refresh without awaiting it.
+ * @returns {Promise<void>|null} the shared refresh, exposed for deterministic tests
+ */
+function checkForUpdates(options = {}) {
+  if (!options.eligibilityChecked && !isAutomaticUpdateEligible(options)) return null;
+
+  const currentVersion = options.currentVersion || getCurrentVersion();
+  if (!parseStableVersion(currentVersion)) return null;
+  const readSettings = options.loadSettings || loadSettings;
+  let settings;
+  try {
+    settings = readSettings({ silent: true });
+  } catch {
+    return null;
+  }
+  if (settings.autoCheckUpdates !== true) return null;
+
+  if (
+    parseStableVersion(settings.lastSeenVersion) &&
+    isNewerVersion(currentVersion, settings.lastSeenVersion)
+  ) {
+    try {
+      const stderr = options.stderr || process.stderr;
+      stderr.write(
+        `Update available: ${currentVersion} → ${settings.lastSeenVersion}. Run \`zeroshot update\`.\n`
+      );
+    } catch {
+      // Optional notification output failures are contained.
     }
-    return;
   }
 
-  // No write permission - inform user but don't offer interactive prompt
-  // (they'd say yes then get an error, which is frustrating UX)
-  if (!hasWriteAccess) {
-    console.log(`\n📦 Update available: ${currentVersion} → ${latestVersion}`);
-    console.log(`   Run: ${buildManualInstallCommand(getInstallPrefix(), true)}\n`);
-    return;
-  }
+  const now = options.now || Date.now;
+  if (!shouldCheckForUpdates(settings, now())) return null;
+  if (inFlightRefresh) return inFlightRefresh;
 
-  // Interactive mode - prompt for update (only if we have write access)
-  const wantsUpdate = await promptForUpdate(currentVersion, latestVersion);
-  if (wantsUpdate) {
-    await runUpdate();
-  }
+  const refresh = new Promise((resolve) => {
+    const schedule = options.scheduleRefresh || setImmediate;
+    const handle = schedule(() => {
+      Promise.resolve(refreshUpdateCache(options))
+        .catch(() => {})
+        .then(resolve);
+    });
+    handle?.unref?.();
+  });
+  inFlightRefresh = refresh;
+  refresh.then(() => {
+    if (inFlightRefresh === refresh) inFlightRefresh = null;
+  });
+  return refresh;
 }
 
 module.exports = {
   checkForUpdates,
+  isAutomaticUpdateEligible,
+  parseStableVersion,
+  validatedManifestVersion,
   // Exported for testing and CLI update command
   NEW_PACKAGE_NAME,
   LEGACY_PACKAGE_NAME,
@@ -459,4 +629,5 @@ module.exports = {
   shouldCheckForUpdates,
   canWriteToNpmGlobal,
   CHECK_INTERVAL_MS,
+  MAX_RESPONSE_BYTES,
 };

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -436,6 +436,138 @@ function hasGroupedGlobalShortFlag(argv) {
   return false;
 }
 
+function findSubcommand(command, name) {
+  return (command.commands || []).find((candidate) => {
+    return candidate.name() === name || candidate.aliases().includes(name);
+  });
+}
+
+function optionMaps(commandHierarchy) {
+  const short = new Map();
+  const long = new Map();
+  for (const command of commandHierarchy) {
+    const helpOption = command._getHelpOption?.();
+    for (const option of [helpOption, ...(command.options || [])]) {
+      if (!option) continue;
+      if (option.short) short.set(option.short, option);
+      if (option.long) long.set(option.long, option);
+    }
+  }
+  return { short, long };
+}
+
+function optionOccurrence(option, value = null) {
+  return { short: option.short || null, long: option.long || null, value };
+}
+
+function matchLongOption(token, maps) {
+  const equalsIndex = token.indexOf('=');
+  const name = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+  const option = maps.long.get(name);
+  if (!option) return null;
+  if (equalsIndex !== -1 && !option.required && !option.optional) return null;
+  const value = equalsIndex === -1 ? null : token.slice(equalsIndex + 1);
+  return {
+    occurrences: [optionOccurrence(option, value)],
+    needsValue: equalsIndex === -1 && (option.required || option.optional),
+    optionalValue: option.optional,
+  };
+}
+
+function matchShortOptions(token, maps) {
+  const exact = maps.short.get(token);
+  if (exact) {
+    return {
+      occurrences: [optionOccurrence(exact)],
+      needsValue: exact.required || exact.optional,
+      optionalValue: exact.optional,
+    };
+  }
+  if (token.length < 3 || !token.startsWith('-') || token.startsWith('--')) return null;
+
+  const occurrences = [];
+  for (let index = 1; index < token.length; index += 1) {
+    const option = maps.short.get(`-${token[index]}`);
+    if (!option) return null;
+    if (option.required || option.optional) {
+      occurrences.push(optionOccurrence(option, token.slice(index + 1) || null));
+      return {
+        occurrences,
+        needsValue: index === token.length - 1,
+        optionalValue: option.optional,
+      };
+    }
+    occurrences.push(optionOccurrence(option));
+  }
+  return { occurrences, needsValue: false, optionalValue: false };
+}
+
+function consumeOptionValue(match, argv, index, limit) {
+  if (!match.needsValue || index + 1 >= limit) return 0;
+  const value = argv[index + 1];
+  if (match.optionalValue && value.startsWith('-')) return 0;
+  match.occurrences[match.occurrences.length - 1].value = value;
+  return 1;
+}
+
+function classifyCommanderArguments(program, argv, defaultCommandName) {
+  const commandPath = [];
+  const occurrences = [];
+  const hierarchy = [program];
+  let command = program;
+  let positionalSeen = false;
+  const end = argv.indexOf('--');
+  const limit = end === -1 ? argv.length : end;
+
+  for (let index = 0; index < limit; index += 1) {
+    const token = argv[index];
+    const maps = optionMaps(hierarchy);
+    const match = token.startsWith('--')
+      ? matchLongOption(token, maps)
+      : matchShortOptions(token, maps);
+    if (match) {
+      index += consumeOptionValue(match, argv, index, limit);
+      occurrences.push(...match.occurrences);
+      continue;
+    }
+    if (token.startsWith('-')) continue;
+
+    const child = positionalSeen ? null : findSubcommand(command, token);
+    if (child) {
+      command = child;
+      hierarchy.push(child);
+      commandPath.push(child.name());
+      positionalSeen = false;
+      continue;
+    }
+    if (command === program && commandPath.length === 0 && defaultCommandName) {
+      const defaultCommand = findSubcommand(program, defaultCommandName);
+      if (defaultCommand) {
+        command = defaultCommand;
+        hierarchy.push(defaultCommand);
+        commandPath.push(defaultCommand.name());
+      }
+    }
+    positionalSeen = true;
+  }
+  return { commandPath, occurrences };
+}
+
+function parsedOptionPresent(metadata, argv, longName, shortName = null) {
+  if (!metadata) return optionIndex(argv, longName, shortName) !== -1;
+  return metadata.occurrences.some((entry) => {
+    return entry.long === longName || (shortName && entry.short === shortName);
+  });
+}
+
+function parsedOptionValue(metadata, argv, longName, shortName = null) {
+  if (!metadata) return optionValue(argv, longName, shortName);
+  const occurrence = metadata.occurrences.find((entry) => {
+    return entry.long === longName || (shortName && entry.short === shortName);
+  });
+  return occurrence?.value ?? null;
+}
+
 function optionIndex(argv, longName, shortName = null) {
   const end = argv.indexOf('--');
   const limit = end === -1 ? argv.length : end;
@@ -516,17 +648,30 @@ function isAutomaticUpdateEligible(options = {}) {
     return false;
   }
 
+  let metadata = null;
+  if (options.commanderProgram) {
+    try {
+      metadata = classifyCommanderArguments(
+        options.commanderProgram,
+        argv,
+        options.defaultCommandName
+      );
+    } catch {
+      return false;
+    }
+  }
+
   if (
-    optionIndex(argv, '--quiet', '-q') !== -1 ||
-    optionIndex(argv, '--help', '-h') !== -1 ||
-    optionIndex(argv, '--version', '-V') !== -1 ||
-    hasGroupedGlobalShortFlag(argv) ||
+    parsedOptionPresent(metadata, argv, '--quiet', '-q') ||
+    parsedOptionPresent(metadata, argv, '--help', '-h') ||
+    parsedOptionPresent(metadata, argv, '--version', '-V') ||
+    (!metadata && hasGroupedGlobalShortFlag(argv)) ||
     optionIndex(argv, '--completion') !== -1
   ) {
     return false;
   }
 
-  const [command, subcommand] = commandPath(argv);
+  const [command, subcommand] = metadata ? metadata.commandPath : commandPath(argv);
   if (!command) return false;
   if (
     command === 'update' ||
@@ -539,16 +684,18 @@ function isAutomaticUpdateEligible(options = {}) {
   }
 
   if (
-    optionIndex(argv, '--json') !== -1 ||
-    optionIndex(argv, '--silent-json-output') !== -1 ||
-    optionIndex(argv, '--json-schema') !== -1
+    parsedOptionPresent(metadata, argv, '--json') ||
+    parsedOptionPresent(metadata, argv, '--silent-json-output') ||
+    parsedOptionPresent(metadata, argv, '--json-schema')
   ) {
     return false;
   }
 
-  const outputFormat = optionValue(argv, '--output-format');
+  const outputFormat = parsedOptionValue(metadata, argv, '--output-format');
   if (outputFormat === 'json' || outputFormat === 'stream-json') return false;
-  if (command === 'export' && optionValue(argv, '--format', '-f') === 'json') return false;
+  if (command === 'export' && parsedOptionValue(metadata, argv, '--format', '-f') === 'json') {
+    return false;
+  }
 
   return true;
 }

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -511,22 +511,25 @@ function consumeOptionValue(match, argv, index, limit) {
 }
 
 function classifyCommanderArguments(program, argv, defaultCommandName) {
-  const commandPath = [];
+  const selectedCommandPath = [];
   const occurrences = [];
   const hierarchy = [program];
+  let consumedValueIndex = -1;
   let command = program;
   let positionalSeen = false;
-  const end = argv.indexOf('--');
-  const limit = end === -1 ? argv.length : end;
 
-  for (let index = 0; index < limit; index += 1) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (index === consumedValueIndex) continue;
     const token = argv[index];
+    if (token === '--') break;
     const maps = optionMaps(hierarchy);
     const match = token.startsWith('--')
       ? matchLongOption(token, maps)
       : matchShortOptions(token, maps);
     if (match) {
-      index += consumeOptionValue(match, argv, index, limit);
+      if (consumeOptionValue(match, argv, index, argv.length) === 1) {
+        consumedValueIndex = index + 1;
+      }
       occurrences.push(...match.occurrences);
       continue;
     }
@@ -536,21 +539,21 @@ function classifyCommanderArguments(program, argv, defaultCommandName) {
     if (child) {
       command = child;
       hierarchy.push(child);
-      commandPath.push(child.name());
+      selectedCommandPath.push(child.name());
       positionalSeen = false;
       continue;
     }
-    if (command === program && commandPath.length === 0 && defaultCommandName) {
+    if (command === program && selectedCommandPath.length === 0 && defaultCommandName) {
       const defaultCommand = findSubcommand(program, defaultCommandName);
       if (defaultCommand) {
         command = defaultCommand;
         hierarchy.push(defaultCommand);
-        commandPath.push(defaultCommand.name());
+        selectedCommandPath.push(defaultCommand.name());
       }
     }
     positionalSeen = true;
   }
-  return { commandPath, occurrences };
+  return { selectedCommandPath, occurrences };
 }
 
 function parsedOptionPresent(metadata, argv, longName, shortName = null) {
@@ -562,10 +565,13 @@ function parsedOptionPresent(metadata, argv, longName, shortName = null) {
 
 function parsedOptionValue(metadata, argv, longName, shortName = null) {
   if (!metadata) return optionValue(argv, longName, shortName);
-  const occurrence = metadata.occurrences.find((entry) => {
-    return entry.long === longName || (shortName && entry.short === shortName);
-  });
-  return occurrence?.value ?? null;
+  for (let index = metadata.occurrences.length - 1; index >= 0; index -= 1) {
+    const entry = metadata.occurrences[index];
+    if (entry.long === longName || (shortName && entry.short === shortName)) {
+      return entry.value;
+    }
+  }
+  return null;
 }
 
 function optionIndex(argv, longName, shortName = null) {
@@ -671,7 +677,7 @@ function isAutomaticUpdateEligible(options = {}) {
     return false;
   }
 
-  const [command, subcommand] = metadata ? metadata.commandPath : commandPath(argv);
+  const [command, subcommand] = metadata ? metadata.selectedCommandPath : commandPath(argv);
   if (!command) return false;
   if (
     command === 'update' ||

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -402,6 +402,13 @@ function runUpdate(options = {}) {
   });
 }
 
+function runLegacyUpdateIfRequested(argv, options = {}) {
+  const packageName = options.packageName || getCurrentPackageName();
+  if (!shouldForceLegacyUpdate(argv, packageName)) return null;
+  const installer = options.runUpdate || runUpdate;
+  return Promise.resolve(installer());
+}
+
 function optionIndex(argv, longName, shortName = null) {
   const end = argv.indexOf('--');
   const limit = end === -1 ? argv.length : end;
@@ -651,6 +658,7 @@ module.exports = {
   isNewerVersion,
   fetchLatestVersion,
   runUpdate,
+  runLegacyUpdateIfRequested,
   shouldCheckForUpdates,
   canWriteToNpmGlobal,
   CHECK_INTERVAL_MS,

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -408,11 +408,19 @@ function optionIndex(argv, longName, shortName = null) {
 }
 
 function optionValue(argv, longName, shortName = null) {
-  const index = optionIndex(argv, longName, shortName);
-  if (index === -1) return null;
-  const token = argv[index];
-  if (token.startsWith(`${longName}=`)) return token.slice(longName.length + 1);
-  return argv[index + 1] ?? null;
+  const end = argv.indexOf('--');
+  const limit = end === -1 ? argv.length : end;
+  for (let index = 0; index < limit; index += 1) {
+    const token = argv[index];
+    if (token === longName || (shortName && token === shortName)) {
+      return argv[index + 1] ?? null;
+    }
+    if (token.startsWith(`${longName}=`)) return token.slice(longName.length + 1);
+    if (shortName && token.startsWith(shortName) && token.length > shortName.length) {
+      return token.slice(shortName.length);
+    }
+  }
+  return null;
 }
 
 function commandPath(argv) {

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -26,8 +26,8 @@ const FETCH_TIMEOUT_MS = 5000;
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_PACKAGE_NAME}/latest`;
 
 const MAX_RESPONSE_BYTES = 64 * 1024;
-const STABLE_VERSION_PATTERN =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const STABLE_CORE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const BUILD_IDENTIFIER_PATTERN = /^[0-9A-Za-z-]+$/;
 const MAX_VERSION_LENGTH = 256;
 
 let inFlightRefresh = null;
@@ -209,7 +209,15 @@ function buildInstallArgs(updateTarget) {
 
 function parseStableVersion(version) {
   if (typeof version !== 'string' || version.length > MAX_VERSION_LENGTH) return null;
-  const match = STABLE_VERSION_PATTERN.exec(version);
+  const plusIndex = version.indexOf('+');
+  const core = plusIndex === -1 ? version : version.slice(0, plusIndex);
+  if (plusIndex !== -1) {
+    const build = version.slice(plusIndex + 1);
+    if (!build || build.split('.').some((part) => !BUILD_IDENTIFIER_PATTERN.test(part))) {
+      return null;
+    }
+  }
+  const match = STABLE_CORE_VERSION_PATTERN.exec(core);
   if (!match) return null;
   const parts = [Number(match[1]), Number(match[2]), Number(match[3])];
   return parts.every(Number.isSafeInteger) ? parts : null;

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -27,7 +27,8 @@ const REGISTRY_URL = `https://registry.npmjs.org/${NEW_PACKAGE_NAME}/latest`;
 
 const MAX_RESPONSE_BYTES = 64 * 1024;
 const STABLE_VERSION_PATTERN =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z.-]+)?$/;
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const MAX_VERSION_LENGTH = 256;
 
 let inFlightRefresh = null;
 
@@ -49,6 +50,10 @@ function getCurrentVersion() {
 
 function isLegacyDistro(packageName = getCurrentPackageName()) {
   return packageName === LEGACY_PACKAGE_NAME;
+}
+
+function shouldForceLegacyUpdate(argv, packageName = getCurrentPackageName()) {
+  return isLegacyDistro(packageName) && Array.isArray(argv) && argv[0] === 'update';
 }
 
 function printLegacyDistroNotice(packageName = getCurrentPackageName()) {
@@ -203,10 +208,11 @@ function buildInstallArgs(updateTarget) {
 }
 
 function parseStableVersion(version) {
-  if (typeof version !== 'string') return null;
+  if (typeof version !== 'string' || version.length > MAX_VERSION_LENGTH) return null;
   const match = STABLE_VERSION_PATTERN.exec(version);
   if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+  const parts = [Number(match[1]), Number(match[2]), Number(match[3])];
+  return parts.every(Number.isSafeInteger) ? parts : null;
 }
 
 /**
@@ -636,6 +642,7 @@ module.exports = {
   getCurrentPackageName,
   isLegacyDistro,
   printLegacyDistroNotice,
+  shouldForceLegacyUpdate,
   deriveInstallPrefixFromPackageRoot,
   getInstallPrefix,
   resolveNpmCommand,

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -417,6 +417,25 @@ function runLegacyUpdateIfRequested(argv, options = {}) {
   return Promise.resolve(installer());
 }
 
+const GROUPABLE_GLOBAL_SHORT_FLAGS = new Set(['q', 'h', 'V']);
+
+function hasGroupedGlobalShortFlag(argv) {
+  const end = argv.indexOf('--');
+  const limit = end === -1 ? argv.length : end;
+  for (let index = 0; index < limit; index += 1) {
+    const token = argv[index];
+    if (
+      token.length > 2 &&
+      token.startsWith('-') &&
+      !token.startsWith('--') &&
+      [...token.slice(1)].every((flag) => GROUPABLE_GLOBAL_SHORT_FLAGS.has(flag))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function optionIndex(argv, longName, shortName = null) {
   const end = argv.indexOf('--');
   const limit = end === -1 ? argv.length : end;
@@ -501,6 +520,7 @@ function isAutomaticUpdateEligible(options = {}) {
     optionIndex(argv, '--quiet', '-q') !== -1 ||
     optionIndex(argv, '--help', '-h') !== -1 ||
     optionIndex(argv, '--version', '-V') !== -1 ||
+    hasGroupedGlobalShortFlag(argv) ||
     optionIndex(argv, '--completion') !== -1
   ) {
     return false;

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -210,15 +210,18 @@ function parseStableVersion(version) {
 }
 
 /**
- * Compare validated stable semver versions.
+ * Compare a running version with a validated stable registry release.
+ * Non-release source versions are older for the explicit update command;
+ * automatic eligibility independently rejects them before checker work.
  * @param {string} current
  * @param {string} latest
  * @returns {boolean}
  */
 function isNewerVersion(current, latest) {
-  const currentParts = parseStableVersion(current);
   const latestParts = parseStableVersion(latest);
-  if (!currentParts || !latestParts) return false;
+  if (!latestParts) return false;
+  const currentParts = parseStableVersion(current);
+  if (!currentParts) return true;
 
   for (let index = 0; index < 3; index += 1) {
     if (latestParts[index] > currentParts[index]) return true;
@@ -404,8 +407,8 @@ function optionIndex(argv, longName, shortName = null) {
   return -1;
 }
 
-function optionValue(argv, longName) {
-  const index = optionIndex(argv, longName);
+function optionValue(argv, longName, shortName = null) {
+  const index = optionIndex(argv, longName, shortName);
   if (index === -1) return null;
   const token = argv[index];
   if (token.startsWith(`${longName}=`)) return token.slice(longName.length + 1);
@@ -416,17 +419,23 @@ function commandPath(argv) {
   const positional = [];
   const optionsWithValues = new Set([
     '--format',
+    '-f',
     '--output-format',
     '--json-schema',
     '--mcp-config',
   ]);
   const end = argv.indexOf('--');
   const limit = end === -1 ? argv.length : end;
+  let skipNext = false;
 
   for (let index = 0; index < limit; index += 1) {
     const token = argv[index];
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
     if (optionsWithValues.has(token)) {
-      index += 1;
+      skipNext = true;
       continue;
     }
     if (!token.startsWith('-')) positional.push(token);
@@ -490,7 +499,7 @@ function isAutomaticUpdateEligible(options = {}) {
 
   const outputFormat = optionValue(argv, '--output-format');
   if (outputFormat === 'json' || outputFormat === 'stream-json') return false;
-  if (command === 'export' && optionValue(argv, '--format') === 'json') return false;
+  if (command === 'export' && optionValue(argv, '--format', '-f') === 'json') return false;
 
   return true;
 }

--- a/cli/lib/update-checker.js
+++ b/cli/lib/update-checker.js
@@ -469,6 +469,7 @@ function isAutomaticUpdateEligible(options = {}) {
   }
 
   const [command, subcommand] = commandPath(argv);
+  if (!command) return false;
   if (
     command === 'update' ||
     command === 'get-log-path' ||

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -332,21 +332,24 @@ function readSettingsForMutation(settingsFile) {
       requiresRecovery: false,
     };
   }
+  let parsed;
   try {
-    const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
-    const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
-    return {
-      settings: mergeLoadedSettings(parsed),
-      requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
-      requiresRecovery: false,
-    };
-  } catch {
+    parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error;
     return {
       settings: resolvedDefaultSettings(),
       requiresClaimInvalidation: false,
       requiresRecovery: true,
     };
   }
+
+  const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
+  return {
+    settings: mergeLoadedSettings(parsed),
+    requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
+    requiresRecovery: false,
+  };
 }
 
 function atomicWriteSettings(settingsFile, settings) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -336,19 +336,23 @@ function atomicWriteSettings(settingsFile, settings) {
     `.${path.basename(settingsFile)}.${process.pid}.${crypto.randomUUID()}.tmp`
   );
 
+  let operationError;
   try {
     fs.writeFileSync(temporaryFile, JSON.stringify(settings, null, 2), {
       encoding: 'utf8',
       flag: 'wx',
     });
     fs.renameSync(temporaryFile, settingsFile);
-  } finally {
-    try {
-      fs.unlinkSync(temporaryFile);
-    } catch (error) {
-      if (error.code !== 'ENOENT') throw error;
-    }
+  } catch (error) {
+    operationError = error;
   }
+
+  try {
+    fs.unlinkSync(temporaryFile);
+  } catch (error) {
+    if (error.code !== 'ENOENT' && !operationError) operationError = error;
+  }
+  if (operationError) throw operationError;
 }
 
 function acquireSettingsLock(settingsFile, lockfilePath, timeoutMs) {
@@ -384,6 +388,7 @@ function mutateSettings(mutator, options = {}) {
   const dir = path.dirname(settingsFile);
   const lockfilePath = `${settingsFile}.lock`;
   let release;
+  let result;
   let mutationError;
 
   try {
@@ -396,7 +401,7 @@ function mutateSettings(mutator, options = {}) {
 
     const { settings, requiresClaimInvalidation } = readSettingsForMutation(settingsFile);
     const before = JSON.stringify(settings);
-    const result = mutator(settings);
+    result = mutator(settings);
     if (result && typeof result.then === 'function') {
       throw new TypeError('Global settings mutations must be synchronous');
     }
@@ -406,23 +411,25 @@ function mutateSettings(mutator, options = {}) {
     if (requiresClaimInvalidation || JSON.stringify(settings) !== before) {
       atomicWriteSettings(settingsFile, settings);
     }
-    return result;
   } catch (error) {
-    mutationError = error;
-    throw new Error(`Unable to persist global settings: ${error.message}`, { cause: error });
+    mutationError = new Error(`Unable to persist global settings: ${error.message}`, {
+      cause: error,
+    });
   } finally {
     if (release) {
       try {
         release();
       } catch (error) {
         if (!mutationError) {
-          throw new Error(`Unable to release global settings lock: ${error.message}`, {
+          mutationError = new Error(`Unable to release global settings lock: ${error.message}`, {
             cause: error,
           });
         }
       }
     }
   }
+  if (mutationError) throw mutationError;
+  return result;
 }
 
 /**

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -343,6 +343,14 @@ function readSettingsForMutation(settingsFile) {
       requiresRecovery: true,
     };
   }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      settings: resolvedDefaultSettings(),
+      requiresClaimInvalidation: false,
+      requiresRecovery: true,
+    };
+  }
+
 
   const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
   return {
@@ -350,6 +358,15 @@ function readSettingsForMutation(settingsFile) {
     requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
     requiresRecovery: false,
   };
+}
+
+function getAtomicSettingsMode(settingsFile) {
+  try {
+    return fs.statSync(settingsFile).mode & 0o600;
+  } catch (error) {
+    if (error.code === 'ENOENT') return 0o600;
+    throw error;
+  }
 }
 
 function atomicWriteSettings(settingsFile, settings) {
@@ -364,6 +381,7 @@ function atomicWriteSettings(settingsFile, settings) {
     fs.writeFileSync(temporaryFile, JSON.stringify(settings, null, 2), {
       encoding: 'utf8',
       flag: 'wx',
+      mode: getAtomicSettingsMode(settingsFile),
     });
     fs.renameSync(temporaryFile, settingsFile);
   } catch (error) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -20,6 +20,13 @@ const SETTINGS_LOCK_TIMEOUT_MS = 500;
 const SETTINGS_LOCK_RETRY_MS = 20;
 const SETTINGS_LOCK_SLEEP = new Int32Array(new SharedArrayBuffer(4));
 
+class SettingsValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SettingsValidationError';
+  }
+}
+
 // Lazy-loaded to avoid circular dependency (issue-providers → settings → issue-providers)
 let _issueProviderFns = null;
 function getIssueProviderFns() {
@@ -319,14 +326,27 @@ function loadSettings(options = {}) {
 
 function readSettingsForMutation(settingsFile) {
   if (!fs.existsSync(settingsFile)) {
-    return { settings: resolvedDefaultSettings(), requiresClaimInvalidation: false };
+    return {
+      settings: resolvedDefaultSettings(),
+      requiresClaimInvalidation: false,
+      requiresRecovery: false,
+    };
   }
-  const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
-  const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
-  return {
-    settings: mergeLoadedSettings(parsed),
-    requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
-  };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
+    return {
+      settings: mergeLoadedSettings(parsed),
+      requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
+      requiresRecovery: false,
+    };
+  } catch {
+    return {
+      settings: resolvedDefaultSettings(),
+      requiresClaimInvalidation: false,
+      requiresRecovery: true,
+    };
+  }
 }
 
 function atomicWriteSettings(settingsFile, settings) {
@@ -399,7 +419,8 @@ function mutateSettings(mutator, options = {}) {
       options.lockTimeoutMs ?? SETTINGS_LOCK_TIMEOUT_MS
     );
 
-    const { settings, requiresClaimInvalidation } = readSettingsForMutation(settingsFile);
+    const { settings, requiresClaimInvalidation, requiresRecovery } =
+      readSettingsForMutation(settingsFile);
     const before = JSON.stringify(settings);
     result = mutator(settings);
     if (result && typeof result.then === 'function') {
@@ -408,13 +429,14 @@ function mutateSettings(mutator, options = {}) {
     if (settings.autoCheckUpdates === false || settings.updatePolicy === 'off') {
       settings.lastUpdateCheckClaim = null;
     }
-    if (requiresClaimInvalidation || JSON.stringify(settings) !== before) {
+    if (requiresRecovery || requiresClaimInvalidation || JSON.stringify(settings) !== before) {
       atomicWriteSettings(settingsFile, settings);
     }
   } catch (error) {
-    mutationError = new Error(`Unable to persist global settings: ${error.message}`, {
-      cause: error,
-    });
+    mutationError =
+      error instanceof SettingsValidationError
+        ? error
+        : new Error(`Unable to persist global settings: ${error.message}`, { cause: error });
   } finally {
     if (release) {
       try {
@@ -668,6 +690,7 @@ module.exports = {
   mutateSettings,
   validateSetting,
   coerceValue,
+  SettingsValidationError,
   DEFAULT_SETTINGS,
   getSettingsFile,
   settingsFileExists,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -6,12 +6,19 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
+const lockfile = require('proper-lockfile');
 const { validateMountConfig, validateEnvPassthrough } = require('./docker-config');
 const {
   VALID_PROVIDERS,
   normalizeProviderName,
   normalizeProviderSettings,
 } = require('./provider-names');
+
+const SETTINGS_LOCK_STALE_MS = 5000;
+const SETTINGS_LOCK_TIMEOUT_MS = 500;
+const SETTINGS_LOCK_RETRY_MS = 20;
+const SETTINGS_LOCK_SLEEP = new Int32Array(new SharedArrayBuffer(4));
 
 // Lazy-loaded to avoid circular dependency (issue-providers → settings → issue-providers)
 let _issueProviderFns = null;
@@ -115,10 +122,11 @@ const DEFAULT_SETTINGS_BASE = {
   defaultDelivery: 'none', // 'none' | 'pr' | 'ship' - folded into resolveEffectiveRunPlan same as defaultDocker
   strictSchema: true, // true = reliable json output (default), false = live streaming (may crash - see bold-meadow-11)
   logLevel: 'normal',
-  // Auto-update settings
+  // Automatic update notification cache
   autoCheckUpdates: true, // Check npm registry for newer versions
-  lastUpdateCheckAt: null, // Unix timestamp of last check (null = never checked)
-  lastSeenVersion: null, // Don't re-prompt for same version
+  lastUpdateCheckAt: null, // Unix timestamp of last automatic attempt (null = never checked)
+  lastSeenVersion: null, // Compatibility key containing the cached valid npm-latest version
+  lastUpdateCheckClaim: null, // Opaque ownership token for an in-flight automatic refresh
   // Claude command - customize how to invoke Claude CLI (default: 'claude')
   // Example: 'ccr code' for claude-code-router integration
   claudeCommand: 'claude',
@@ -260,48 +268,161 @@ function normalizeLoadedSettings(parsed) {
   if (parsed.providerSettings) {
     normalized.providerSettings = normalizeProviderSettings(parsed.providerSettings);
   }
+  if (
+    normalized.autoCheckUpdates === false ||
+    typeof normalized.lastUpdateCheckClaim !== 'string' ||
+    normalized.lastUpdateCheckClaim.trim().length === 0
+  ) {
+    normalized.lastUpdateCheckClaim = null;
+  }
   return normalized;
+}
+
+function resolvedDefaultSettings() {
+  return {
+    ...DEFAULT_SETTINGS,
+    providerSettings: mergeProviderSettings(getProviderDefaults()),
+  };
+}
+
+function mergeLoadedSettings(parsed) {
+  const normalized = normalizeLoadedSettings(parsed);
+  const merged = { ...resolvedDefaultSettings(), ...normalized };
+  merged.defaultProvider =
+    normalizeProviderName(merged.defaultProvider) || DEFAULT_SETTINGS.defaultProvider;
+  merged.providerSettings = mergeProviderSettings(getProviderDefaults(), normalized.providerSettings);
+  if (
+    merged.autoCheckUpdates === false ||
+    typeof merged.lastUpdateCheckClaim !== 'string' ||
+    merged.lastUpdateCheckClaim.trim().length === 0
+  ) {
+    merged.lastUpdateCheckClaim = null;
+  }
+  return applyLegacyModelBounds(merged);
 }
 
 /**
  * Load settings from disk, merging with defaults
  */
-function loadSettings() {
+function loadSettings(options = {}) {
   const settingsFile = getSettingsFile();
   if (!fs.existsSync(settingsFile)) {
-    // Return a copy with resolved providerSettings
-    return {
-      ...DEFAULT_SETTINGS,
-      providerSettings: getProviderDefaults(),
-    };
+    return resolvedDefaultSettings();
   }
   try {
-    const data = fs.readFileSync(settingsFile, 'utf8');
-    const parsed = normalizeLoadedSettings(JSON.parse(data));
-    const merged = { ...DEFAULT_SETTINGS, ...parsed };
-    merged.defaultProvider =
-      normalizeProviderName(merged.defaultProvider) || DEFAULT_SETTINGS.defaultProvider;
-    merged.providerSettings = mergeProviderSettings(getProviderDefaults(), parsed.providerSettings);
-    return applyLegacyModelBounds(merged);
+    return mergeLoadedSettings(JSON.parse(fs.readFileSync(settingsFile, 'utf8')));
   } catch {
-    console.error('Warning: Could not load settings, using defaults');
-    return {
-      ...DEFAULT_SETTINGS,
-      providerSettings: getProviderDefaults(),
-    };
+    if (!options.silent) console.error('Warning: Could not load settings, using defaults');
+    return resolvedDefaultSettings();
+  }
+}
+
+function readSettingsForMutation(settingsFile) {
+  if (!fs.existsSync(settingsFile)) {
+    return { settings: resolvedDefaultSettings(), requiresClaimInvalidation: false };
+  }
+  const parsed = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+  const updatesDisabled = parsed.autoCheckUpdates === false || parsed.updatePolicy === 'off';
+  return {
+    settings: mergeLoadedSettings(parsed),
+    requiresClaimInvalidation: updatesDisabled && parsed.lastUpdateCheckClaim !== null,
+  };
+}
+
+function atomicWriteSettings(settingsFile, settings) {
+  const dir = path.dirname(settingsFile);
+  const temporaryFile = path.join(
+    dir,
+    `.${path.basename(settingsFile)}.${process.pid}.${crypto.randomUUID()}.tmp`
+  );
+
+  try {
+    fs.writeFileSync(temporaryFile, JSON.stringify(settings, null, 2), {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    fs.renameSync(temporaryFile, settingsFile);
+  } finally {
+    try {
+      fs.unlinkSync(temporaryFile);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+}
+
+function acquireSettingsLock(settingsFile, lockfilePath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      return lockfile.lockSync(settingsFile, {
+        lockfilePath,
+        realpath: false,
+        stale: SETTINGS_LOCK_STALE_MS,
+      });
+    } catch (error) {
+      if (error.code !== 'ELOCKED' || Date.now() >= deadline) throw error;
+      Atomics.wait(SETTINGS_LOCK_SLEEP, 0, 0, SETTINGS_LOCK_RETRY_MS);
+    }
   }
 }
 
 /**
- * Save settings to disk
+ * Atomically mutate global settings under the process-shared settings lock.
+ * The mutator receives only the freshly re-read, normalized state.
+ *
+ * @param {(settings: object) => any} mutator
+ * @param {object} [options]
+ * @returns {any} the mutator's return value
  */
-function saveSettings(settings) {
+function mutateSettings(mutator, options = {}) {
+  if (typeof mutator !== 'function') {
+    throw new TypeError('Global settings mutation requires a callback');
+  }
+
   const settingsFile = getSettingsFile();
   const dir = path.dirname(settingsFile);
-  if (!fs.existsSync(dir)) {
+  const lockfilePath = `${settingsFile}.lock`;
+  let release;
+  let mutationError;
+
+  try {
     fs.mkdirSync(dir, { recursive: true });
+    release = acquireSettingsLock(
+      settingsFile,
+      lockfilePath,
+      options.lockTimeoutMs ?? SETTINGS_LOCK_TIMEOUT_MS
+    );
+
+    const { settings, requiresClaimInvalidation } = readSettingsForMutation(settingsFile);
+    const before = JSON.stringify(settings);
+    const result = mutator(settings);
+    if (result && typeof result.then === 'function') {
+      throw new TypeError('Global settings mutations must be synchronous');
+    }
+    if (settings.autoCheckUpdates === false || settings.updatePolicy === 'off') {
+      settings.lastUpdateCheckClaim = null;
+    }
+    if (requiresClaimInvalidation || JSON.stringify(settings) !== before) {
+      atomicWriteSettings(settingsFile, settings);
+    }
+    return result;
+  } catch (error) {
+    mutationError = error;
+    throw new Error(`Unable to persist global settings: ${error.message}`, { cause: error });
+  } finally {
+    if (release) {
+      try {
+        release();
+      } catch (error) {
+        if (!mutationError) {
+          throw new Error(`Unable to release global settings lock: ${error.message}`, {
+            cause: error,
+          });
+        }
+      }
+    }
   }
-  fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2), 'utf8');
 }
 
 /**
@@ -537,7 +658,7 @@ function getClaudeCommand() {
 
 module.exports = {
   loadSettings,
-  saveSettings,
+  mutateSettings,
   validateSetting,
   coerceValue,
   DEFAULT_SETTINGS,

--- a/lib/setup-apply.js
+++ b/lib/setup-apply.js
@@ -111,7 +111,7 @@ function convertDecisionValue({ decisionId, value, globalSettings, deps }) {
 
 function defaultApplyDeps() {
   const fs = require('fs');
-  const { loadSettings, saveSettings } = require('./settings');
+  const { loadSettings, mutateSettings } = require('./settings');
   const { readRepoSettings, writeRepoSettings } = require('./repo-settings');
   const { checkGhAuth } = require('../src/preflight');
   const { listProviders: listIssueProviders } = require('../src/issue-providers');
@@ -119,7 +119,7 @@ function defaultApplyDeps() {
   return {
     readFile: (filePath) => fs.readFileSync(filePath, 'utf8'),
     loadSettings,
-    saveSettings,
+    mutateSettings,
     readRepoSettings,
     writeRepoSettings,
     checkGhAuth,
@@ -194,48 +194,62 @@ function applyWrite(write, { repoRoot, journal, deps }) {
   return write.scope;
 }
 
-function persistIfDirty({
-  globalDirty,
-  repoDirty,
-  globalSettings,
-  repoSettings,
-  repoRoot,
-  journal,
-  deps,
-}) {
-  if (globalDirty) deps.saveSettings(globalSettings);
-  if (repoDirty) deps.writeRepoSettings(repoRoot, repoSettings);
-  if (globalDirty || repoDirty) saveJournal(journal);
-}
 
-// Phase 2: write every resolved decision, journaling each mutation and
-// skipping (never throwing) decisions that are unchanged, risky-without-optin,
-// or targeted at a settings key no resolver consumes.
+// Phase 2: resolve each global outcome against the locked, freshly read state.
+// Repo-local settings remain intentionally outside the global settings lock.
 function writeResolvedDecisions(
   resolved,
-  { globalSettings, repoSettings, repoRoot, journal, allowRiskyDefaults, deps }
+  { repoSettings, repoRoot, journal, allowRiskyDefaults, deps }
 ) {
-  const results = [];
-  let globalDirty = false;
+  const resultsById = new Map();
   let repoDirty = false;
+  let globalDirty = false;
+  const globalDecisions = resolved.filter((decision) => decision.target.scope === 'global');
 
-  for (const decision of resolved) {
+  if (globalDecisions.length > 0) {
+    const globalResults = deps.mutateSettings((freshGlobalSettings) => {
+      const results = [];
+      for (const decision of globalDecisions) {
+        const freshDecision = {
+          ...decision,
+          writeValue: convertDecisionValue({
+            decisionId: decision.decisionId,
+            value: decision.inputValue,
+            globalSettings: freshGlobalSettings,
+            deps,
+          }),
+        };
+        const { result, write } = resolveDecisionOutcome(freshDecision, {
+          globalSettings: freshGlobalSettings,
+          repoSettings,
+          allowRiskyDefaults,
+        });
+        results.push(result);
+        if (write) {
+          applyWrite(write, { repoRoot, journal, deps });
+          globalDirty = true;
+        }
+      }
+      return results;
+    });
+    for (const result of globalResults) resultsById.set(result.decisionId, result);
+  }
+
+  for (const decision of resolved.filter((item) => item.target.scope === 'repo')) {
     const { result, write } = resolveDecisionOutcome(decision, {
-      globalSettings,
+      globalSettings: {},
       repoSettings,
       allowRiskyDefaults,
     });
-    results.push(result);
+    resultsById.set(result.decisionId, result);
     if (!write) continue;
-
-    const scope = applyWrite(write, { repoRoot, journal, deps });
-    if (scope === 'repo') repoDirty = true;
-    else globalDirty = true;
+    applyWrite(write, { repoRoot, journal, deps });
+    repoDirty = true;
   }
 
-  persistIfDirty({ globalDirty, repoDirty, globalSettings, repoSettings, repoRoot, journal, deps });
-
-  return results;
+  if (repoDirty) deps.writeRepoSettings(repoRoot, repoSettings);
+  if (globalDirty || repoDirty) saveJournal(journal);
+  return resolved.map((decision) => resultsById.get(decision.decisionId));
 }
 
 /**
@@ -268,7 +282,6 @@ function applyDecisions({ decisionsPath, cwd, allowRiskyDefaults = false, deps =
   const resolved = resolveAndValidateDecisions(input, globalSettings, resolvedDeps);
 
   const results = writeResolvedDecisions(resolved, {
-    globalSettings,
     repoSettings,
     repoRoot,
     journal: loadJournal(),

--- a/lib/setup-undo.js
+++ b/lib/setup-undo.js
@@ -18,10 +18,10 @@ const {
 } = require('./setup-journal');
 
 function defaultUndoDeps() {
-  const { loadSettings, saveSettings } = require('./settings');
+  const { mutateSettings } = require('./settings');
   const { readRepoSettings, writeRepoSettings } = require('./repo-settings');
 
-  return { loadSettings, saveSettings, readRepoSettings, writeRepoSettings };
+  return { mutateSettings, readRepoSettings, writeRepoSettings };
 }
 
 /**
@@ -35,9 +35,7 @@ function undo({ deps = {} } = {}) {
   const resolvedDeps = { ...defaultUndoDeps(), ...deps };
   const journal = loadJournal();
 
-  const globalSettings = resolvedDeps.loadSettings();
   const repoSettingsCache = new Map();
-  let globalDirty = false;
   const dirtyRepoRoots = new Set();
 
   function repoSettingsFor(repoRoot) {
@@ -48,41 +46,52 @@ function undo({ deps = {} } = {}) {
     return repoSettingsCache.get(repoRoot);
   }
 
-  const results = journal.entries.map((entry) => {
-    const settingsObj = entry.scope === 'repo' ? repoSettingsFor(entry.repoRoot) : globalSettings;
+  function restoreEntry(entry, settingsObj) {
     const current = getNestedValue(settingsObj, entry.path) ?? null;
-
     if (deepEqual(current, entry.priorValue)) {
       return { ...entry, status: 'already-restored' };
     }
-
     if (!deepEqual(current, entry.appliedValue)) {
       return { ...entry, status: 'skipped-modified', current, wouldRestore: entry.priorValue };
     }
-
     if (entry.priorValue === null) {
       deleteNestedKey(settingsObj, entry.path);
     } else {
       setNestedValue(settingsObj, entry.path, entry.priorValue);
     }
-
-    if (entry.scope === 'repo') {
-      dirtyRepoRoots.add(entry.repoRoot);
-    } else {
-      globalDirty = true;
-    }
-
     return { ...entry, status: entry.priorValue === null ? 'deleted' : 'restored' };
+  }
+
+  const resultsByIndex = new Map();
+  const globalEntries = journal.entries
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => entry.scope === 'global');
+
+  if (globalEntries.length > 0) {
+    const globalResults = resolvedDeps.mutateSettings((freshGlobalSettings) =>
+      globalEntries.map(({ entry }) => restoreEntry(entry, freshGlobalSettings))
+    );
+    globalEntries.forEach(({ index }, resultIndex) => {
+      resultsByIndex.set(index, globalResults[resultIndex]);
+    });
+  }
+
+  journal.entries.forEach((entry, index) => {
+    if (entry.scope !== 'repo') return;
+    const result = restoreEntry(entry, repoSettingsFor(entry.repoRoot));
+    resultsByIndex.set(index, result);
+    if (result.status === 'restored' || result.status === 'deleted') {
+      dirtyRepoRoots.add(entry.repoRoot);
+    }
   });
 
-  if (globalDirty) resolvedDeps.saveSettings(globalSettings);
   for (const repoRoot of dirtyRepoRoots) {
     resolvedDeps.writeRepoSettings(repoRoot, repoSettingsFor(repoRoot));
   }
 
   // Journal entries are left in place (not cleared) so a re-run reports
   // 'already-restored' instead of finding nothing to undo.
-  return results;
+  return journal.entries.map((_, index) => resultsByIndex.get(index));
 }
 
 module.exports = { undo };

--- a/src/issue-providers/linear-provider.js
+++ b/src/issue-providers/linear-provider.js
@@ -239,10 +239,10 @@ class LinearProvider extends IssueProvider {
     }
 
     const key = teams[0].key;
-    const { loadSettings, saveSettings } = require('../../lib/settings');
-    const current = loadSettings();
-    current.linearTeam = key;
-    saveSettings(current);
+    const { mutateSettings } = require('../../lib/settings');
+    mutateSettings((current) => {
+      current.linearTeam = key;
+    });
     return key;
   }
 

--- a/tests/agent-cli-provider/providers-command-parity.test.js
+++ b/tests/agent-cli-provider/providers-command-parity.test.js
@@ -21,7 +21,7 @@ afterEach(() => {
   console.log = originalConsoleLog;
 });
 
-function loadCommands({ detected, providerFactory, settings, saveSettings = () => {} }) {
+function loadCommands({ detected, providerFactory, settings, mutateSettings }) {
   require.cache[providersModulePath].exports = {
     ...originalProvidersModule,
     detectProviders: async () => {
@@ -33,7 +33,7 @@ function loadCommands({ detected, providerFactory, settings, saveSettings = () =
   require.cache[settingsModulePath].exports = {
     ...originalSettingsModule,
     loadSettings: () => settings,
-    saveSettings,
+    mutateSettings: mutateSettings || ((mutator) => mutator(settings)),
   };
   delete require.cache[commandModulePath];
   return require(commandModulePath);
@@ -116,7 +116,10 @@ test('provider setup prints install and auth instructions from registry metadata
   const { setupCommand } = loadCommands({
     detected: {},
     settings,
-    saveSettings: (next) => saved.push(next),
+    mutateSettings: (mutator) => {
+      mutator(settings);
+      saved.push(structuredClone(settings));
+    },
     providerFactory: () => ({
       displayName: metadata.displayName,
       cliCommand: metadata.binary,

--- a/tests/agent-cli-provider/providers-command-parity.test.js
+++ b/tests/agent-cli-provider/providers-command-parity.test.js
@@ -118,7 +118,7 @@ test('provider setup prints install and auth instructions from registry metadata
     settings,
     mutateSettings: (mutator) => {
       mutator(settings);
-      saved.push(structuredClone(settings));
+      saved.push(JSON.parse(JSON.stringify(settings)));
     },
     providerFactory: () => ({
       displayName: metadata.displayName,

--- a/tests/cli-run-mode.test.js
+++ b/tests/cli-run-mode.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { resolveRunMode } = require('../cli/index.js');
+const { isStartupUpdateEligible, resolveRunMode } = require('../cli/index.js');
 
 describe('resolveRunMode', () => {
   it('returns "ship" when options.ship is set', () => {
@@ -34,6 +34,44 @@ describe('resolveRunMode', () => {
     assert.strictEqual(
       resolveRunMode({ ship: true, pr: true, docker: true, worktree: true }),
       'ship+docker'
+    );
+  });
+});
+
+describe('startup update option integration', function () {
+  const tty = { isTTY: true };
+  const options = {
+    currentVersion: '1.2.3',
+    packageName: '@the-open-engine/zeroshot',
+    stdin: tty,
+    stdout: tty,
+    stderr: tty,
+    env: {},
+  };
+
+  it('uses the built CLI metadata for mixed global and export short options', function () {
+    assert.strictEqual(
+      isStartupUpdateEligible(['export', 'nonexistent', '-qfjson'], options),
+      false
+    );
+    assert.strictEqual(isStartupUpdateEligible(['export', 'nonexistent', '-fq'], options), true);
+    assert.strictEqual(isStartupUpdateEligible(['export', 'nonexistent', '-oq'], options), true);
+  });
+
+  it('combines global flags with compatible subcommand booleans only', function () {
+    assert.strictEqual(isStartupUpdateEligible(['logs', 'nonexistent', '-fq'], options), false);
+    assert.strictEqual(isStartupUpdateEligible(['run', 'hello', '-qX'], options), true);
+    assert.strictEqual(isStartupUpdateEligible(['run', 'hello', '-query'], options), true);
+  });
+
+  it('does not parse prompt text or tokens after the option terminator', function () {
+    assert.strictEqual(
+      isStartupUpdateEligible(['run', 'Explain -qfjson and -query'], options),
+      true
+    );
+    assert.strictEqual(
+      isStartupUpdateEligible(['export', 'nonexistent', '--', '-qfjson'], options),
+      true
     );
   });
 });

--- a/tests/cli-run-mode.test.js
+++ b/tests/cli-run-mode.test.js
@@ -58,6 +58,23 @@ describe('startup update option integration', function () {
     assert.strictEqual(isStartupUpdateEligible(['export', 'nonexistent', '-oq'], options), true);
   });
 
+  it('uses the final repeated production option value', function () {
+    assert.strictEqual(
+      isStartupUpdateEligible(
+        ['export', 'nonexistent', '--format', 'markdown', '--format', 'json'],
+        options
+      ),
+      false
+    );
+    assert.strictEqual(
+      isStartupUpdateEligible(
+        ['export', 'nonexistent', '--format', 'json', '--format', 'markdown'],
+        options
+      ),
+      true
+    );
+  });
+
   it('combines global flags with compatible subcommand booleans only', function () {
     assert.strictEqual(isStartupUpdateEligible(['logs', 'nonexistent', '-fq'], options), false);
     assert.strictEqual(isStartupUpdateEligible(['run', 'hello', '-qX'], options), true);

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -362,6 +362,30 @@ function registerTransactionalRecoveryTests() {
       assert.strictEqual(JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')).logLevel, 'verbose');
     });
 
+    it('surfaces a settings read failure without replacing the existing file', function () {
+      writeSettingsFile({ logLevel: 'verbose', unrelated: 'preserved' });
+      const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
+      const originalReadFileSync = fs.readFileSync;
+      fs.readFileSync = (filePath, ...args) => {
+        if (path.resolve(filePath) === path.resolve(TEST_SETTINGS_FILE)) {
+          throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+        }
+        return originalReadFileSync(filePath, ...args);
+      };
+      try {
+        assert.throws(
+          () =>
+            settingsModule.mutateSettings((settings) => {
+              settings.logLevel = 'normal';
+            }),
+          /Unable to persist global settings: permission denied/
+        );
+      } finally {
+        fs.readFileSync = originalReadFileSync;
+      }
+      assert.strictEqual(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'), before);
+    });
+
     it('reports an invalid nested provider level without persistence wording or a write', function () {
       writeSettingsFile({});
       const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -33,6 +33,7 @@ function runSettingsCli(args) {
 }
 
 let settingsModule;
+let originalSettingsFileEnv;
 
 function writeSettingsFile(settings) {
   const dir = path.dirname(TEST_SETTINGS_FILE);
@@ -52,15 +53,11 @@ function loadSettingsWithDefaults() {
 
 function registerSettingsHooks() {
   before(function () {
-    if (!fs.existsSync(TEST_STORAGE_DIR)) {
-      fs.mkdirSync(TEST_STORAGE_DIR, { recursive: true });
-    }
-
+    originalSettingsFileEnv = process.env.ZEROSHOT_SETTINGS_FILE;
+    process.env.ZEROSHOT_SETTINGS_FILE = TEST_SETTINGS_FILE;
+    fs.mkdirSync(TEST_STORAGE_DIR, { recursive: true });
     settingsModule = require('../lib/settings');
-    Object.defineProperty(settingsModule, 'SETTINGS_FILE', {
-      value: TEST_SETTINGS_FILE,
-      writable: false,
-    });
+    assert.strictEqual(path.resolve(settingsModule.SETTINGS_FILE), path.resolve(TEST_SETTINGS_FILE));
   });
 
   after(function () {
@@ -68,10 +65,18 @@ function registerSettingsHooks() {
       fs.rmSync(TEST_STORAGE_DIR, { recursive: true, force: true });
     } catch (e) {
       console.error('Cleanup failed:', e.message);
+    } finally {
+      if (originalSettingsFileEnv === undefined) {
+        delete process.env.ZEROSHOT_SETTINGS_FILE;
+      } else {
+        process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFileEnv;
+      }
     }
   });
 
   beforeEach(function () {
+    assert.strictEqual(process.env.ZEROSHOT_SETTINGS_FILE, TEST_SETTINGS_FILE);
+    assert.strictEqual(path.resolve(settingsModule.SETTINGS_FILE), path.resolve(TEST_SETTINGS_FILE));
     if (fs.existsSync(TEST_SETTINGS_FILE)) {
       fs.unlinkSync(TEST_SETTINGS_FILE);
     }
@@ -332,12 +337,15 @@ function registerStrictSchemaPropagationTests() {
     });
   });
 }
-
 function registerTransactionalRecoveryTests() {
   describe('transactional malformed-file recovery and diagnostics', function () {
-    function writeMalformedSettings() {
+    function writeRawSettings(raw) {
       fs.mkdirSync(TEST_STORAGE_DIR, { recursive: true });
-      fs.writeFileSync(TEST_SETTINGS_FILE, '{"truncated":', 'utf8');
+      fs.writeFileSync(TEST_SETTINGS_FILE, raw, 'utf8');
+    }
+
+    function writeMalformedSettings() {
+      writeRawSettings('{"truncated":');
     }
 
     it('repairs malformed settings through reset --yes even when defaults are a semantic no-op', function () {
@@ -362,8 +370,38 @@ function registerTransactionalRecoveryTests() {
       assert.strictEqual(JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')).logLevel, 'verbose');
     });
 
+    it('repairs a null settings document through reset --yes', function () {
+      writeRawSettings('null');
+      const result = runSettingsCli(['reset', '--yes']);
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      const repaired = JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'));
+      assert.strictEqual(repaired.autoCheckUpdates, true);
+      assert.strictEqual(repaired.lastUpdateCheckClaim, null);
+    });
+
+    for (const [name, raw] of [
+      ['null', 'null'],
+      ['boolean', 'true'],
+      ['number', '42'],
+      ['string', '"invalid"'],
+      ['array', '[]'],
+    ]) {
+      it(`repairs a ${name} settings document while applying settings set`, function () {
+        writeRawSettings(raw);
+        const result = runSettingsCli(['set', 'logLevel', 'verbose']);
+
+        assert.strictEqual(result.status, 0, result.stderr);
+        assert.strictEqual(
+          JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')).logLevel,
+          'verbose'
+        );
+      });
+    }
+
     it('surfaces a settings read failure without replacing the existing file', function () {
       writeSettingsFile({ logLevel: 'verbose', unrelated: 'preserved' });
+      assert.strictEqual(path.resolve(settingsModule.SETTINGS_FILE), path.resolve(TEST_SETTINGS_FILE));
       const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
       const originalReadFileSync = fs.readFileSync;
       fs.readFileSync = (filePath, ...args) => {
@@ -383,6 +421,50 @@ function registerTransactionalRecoveryTests() {
       } finally {
         fs.readFileSync = originalReadFileSync;
       }
+      assert.strictEqual(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'), before);
+    });
+
+    for (const [name, initialMode, expectedMode] of [
+      ['broad permissions', 0o644, 0o600],
+      ['stricter permissions', 0o400, 0o400],
+    ]) {
+      it(`publishes atomic settings with ${name} restricted`, function () {
+        writeSettingsFile({ logLevel: 'normal' });
+        fs.chmodSync(TEST_SETTINGS_FILE, initialMode);
+        settingsModule.mutateSettings((settings) => {
+          settings.logLevel = 'verbose';
+        });
+
+        assert.strictEqual(fs.statSync(TEST_SETTINGS_FILE).mode & 0o777, expectedMode);
+      });
+    }
+
+    it('removes its restricted temporary file after an atomic rename failure', function () {
+      writeSettingsFile({ logLevel: 'normal' });
+      const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
+      const originalRenameSync = fs.renameSync;
+      let temporaryFile;
+      fs.renameSync = (source, destination) => {
+        if (path.resolve(destination) === path.resolve(TEST_SETTINGS_FILE)) {
+          temporaryFile = source;
+          assert.strictEqual(fs.statSync(source).mode & 0o777, 0o600);
+          throw Object.assign(new Error('rename denied'), { code: 'EACCES' });
+        }
+        return originalRenameSync(source, destination);
+      };
+      try {
+        assert.throws(
+          () =>
+            settingsModule.mutateSettings((settings) => {
+              settings.logLevel = 'verbose';
+            }),
+          /Unable to persist global settings: rename denied/
+        );
+      } finally {
+        fs.renameSync = originalRenameSync;
+      }
+      assert.ok(temporaryFile);
+      assert.strictEqual(fs.existsSync(temporaryFile), false);
       assert.strictEqual(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'), before);
     });
 

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -358,7 +358,7 @@ function registerTransactionalRecoveryTests() {
       const result = runSettingsCli(['set', 'logLevel', 'verbose']);
 
       assert.strictEqual(result.status, 0, result.stderr);
-      assert.ok(result.stdout.includes('Set logLevel = \"verbose\"'));
+      assert.ok(result.stdout.includes('Set logLevel = "verbose"'));
       assert.strictEqual(JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')).logLevel, 'verbose');
     });
 

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -66,7 +66,8 @@ function registerSettingsHooks() {
 function registerSettingsExportsTests() {
   it('should export required functions and constants', function () {
     assert.ok(typeof settingsModule.loadSettings === 'function');
-    assert.ok(typeof settingsModule.saveSettings === 'function');
+    assert.ok(typeof settingsModule.mutateSettings === 'function');
+    assert.strictEqual(settingsModule.saveSettings, undefined);
     assert.ok(typeof settingsModule.validateSetting === 'function');
     assert.ok(typeof settingsModule.coerceValue === 'function');
     assert.ok(typeof settingsModule.DEFAULT_SETTINGS === 'object');
@@ -84,6 +85,10 @@ function registerSettingsDefaultTests() {
     assert.strictEqual(DEFAULT_SETTINGS.logLevel, 'normal');
     assert.strictEqual(DEFAULT_SETTINGS.defaultProvider, 'claude');
     assert.ok(DEFAULT_SETTINGS.providerSettings);
+    assert.strictEqual(DEFAULT_SETTINGS.autoCheckUpdates, true);
+    assert.strictEqual(DEFAULT_SETTINGS.lastUpdateCheckAt, null);
+    assert.strictEqual(DEFAULT_SETTINGS.lastSeenVersion, null);
+    assert.strictEqual(DEFAULT_SETTINGS.lastUpdateCheckClaim, null);
   });
 
   it('should load default settings when file does not exist', function () {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -12,10 +12,25 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 
 // Test storage directory (isolated)
 const TEST_STORAGE_DIR = path.join(os.tmpdir(), 'zeroshot-settings-test-' + Date.now());
 const TEST_SETTINGS_FILE = path.join(TEST_STORAGE_DIR, 'settings.json');
+const CLI_ENTRY = path.join(__dirname, '..', 'cli', 'index.js');
+
+function runSettingsCli(args) {
+  return spawnSync(process.execPath, [CLI_ENTRY, 'settings', ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CI: '1',
+      NODE_ENV: 'test',
+      ZEROSHOT_DAEMON: '1',
+      ZEROSHOT_SETTINGS_FILE: TEST_SETTINGS_FILE,
+    },
+  });
+}
 
 let settingsModule;
 
@@ -318,6 +333,70 @@ function registerStrictSchemaPropagationTests() {
   });
 }
 
+function registerTransactionalRecoveryTests() {
+  describe('transactional malformed-file recovery and diagnostics', function () {
+    function writeMalformedSettings() {
+      fs.mkdirSync(TEST_STORAGE_DIR, { recursive: true });
+      fs.writeFileSync(TEST_SETTINGS_FILE, '{"truncated":', 'utf8');
+    }
+
+    it('repairs malformed settings through reset --yes even when defaults are a semantic no-op', function () {
+      writeMalformedSettings();
+      const result = runSettingsCli(['reset', '--yes']);
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('Settings reset to defaults'));
+      const repaired = JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'));
+      assert.strictEqual(repaired.autoCheckUpdates, true);
+      assert.strictEqual(repaired.lastUpdateCheckAt, null);
+      assert.strictEqual(repaired.lastSeenVersion, null);
+      assert.strictEqual(repaired.lastUpdateCheckClaim, null);
+    });
+
+    it('repairs malformed settings while applying an intended settings set mutation', function () {
+      writeMalformedSettings();
+      const result = runSettingsCli(['set', 'logLevel', 'verbose']);
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('Set logLevel = \"verbose\"'));
+      assert.strictEqual(JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')).logLevel, 'verbose');
+    });
+
+    it('reports an invalid nested provider level without persistence wording or a write', function () {
+      writeSettingsFile({});
+      const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
+      const result = runSettingsCli([
+        'set',
+        'providerSettings.claude.defaultLevel',
+        'level9',
+      ]);
+
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes('Invalid defaultLevel for claude: level9'));
+      assert.ok(!result.stderr.includes('Unable to persist global settings'));
+      assert.ok(!result.stdout.includes('✓ Set'));
+      assert.strictEqual(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'), before);
+    });
+
+    it('distinguishes a persistence failure and never prints false success', function () {
+      writeSettingsFile({ logLevel: 'normal' });
+      const before = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
+      const lockPath = `${TEST_SETTINGS_FILE}.lock`;
+      fs.mkdirSync(lockPath);
+      try {
+        const result = runSettingsCli(['set', 'logLevel', 'verbose']);
+        assert.strictEqual(result.status, 1);
+        assert.ok(result.stderr.includes('Unable to persist global settings'));
+        assert.ok(!result.stderr.includes('Invalid defaultLevel'));
+        assert.ok(!result.stdout.includes('✓ Set'));
+        assert.strictEqual(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8'), before);
+      } finally {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+      }
+    });
+  });
+}
+
 describe('Settings System', function () {
   this.timeout(10000);
 
@@ -329,4 +408,5 @@ describe('Settings System', function () {
   registerSettingsCoercionTests();
   registerSettingsFileFormatTests();
   registerStrictSchemaPropagationTests();
+  registerTransactionalRecoveryTests();
 });

--- a/tests/unit/cli-stdin-input.test.js
+++ b/tests/unit/cli-stdin-input.test.js
@@ -88,4 +88,38 @@ describe('CLI stdin task input', function () {
     assert.strictEqual(result.status, 0, result.stderr);
     assert.deepStrictEqual(JSON.parse(result.stdout), { text: taskBody });
   });
+
+  it('excludes piped run input before settings, registry, or stdin work', function () {
+    const { checkForUpdates } = require('../../cli/lib/update-checker');
+    const sentinel = Readable.from(['byte-for-byte input']);
+    let settingsLoads = 0;
+    let fetches = 0;
+
+    const result = checkForUpdates({
+      argv: ['run', '-'],
+      env: {},
+      packageName: '@the-open-engine/zeroshot',
+      currentVersion: '1.0.0',
+      stdin: sentinel,
+      stdout: { isTTY: false },
+      stderr: { isTTY: false, write: () => assert.fail('unexpected update notice') },
+      loadSettings: () => {
+        settingsLoads += 1;
+        return {
+          autoCheckUpdates: true,
+          lastSeenVersion: '2.0.0',
+          lastUpdateCheckAt: null,
+        };
+      },
+      fetchLatestVersion: async () => {
+        fetches += 1;
+        return '2.0.0';
+      },
+    });
+
+    assert.strictEqual(result, null);
+    assert.strictEqual(settingsLoads, 0);
+    assert.strictEqual(fetches, 0);
+    assert.strictEqual(sentinel.read().toString(), 'byte-for-byte input');
+  });
 });

--- a/tests/unit/cli-stdin-input.test.js
+++ b/tests/unit/cli-stdin-input.test.js
@@ -111,7 +111,7 @@ describe('CLI stdin task input', function () {
           lastUpdateCheckAt: null,
         };
       },
-      fetchLatestVersion: async () => {
+      fetchLatestVersion: () => {
         fetches += 1;
         return '2.0.0';
       },

--- a/tests/unit/setup-apply.test.js
+++ b/tests/unit/setup-apply.test.js
@@ -231,7 +231,9 @@ describe('setup-apply', function () {
   it('prints a login command and stores nothing when applying defaultIssueSource=github unauthenticated', function () {
     // Default settings already default to defaultIssueSource='github', so start
     // from a different value to force an actual write (not a no-op 'unchanged').
-    settingsModule.saveSettings({ ...settingsModule.loadSettings(), defaultIssueSource: 'gitlab' });
+    settingsModule.mutateSettings((settings) => {
+      settings.defaultIssueSource = 'gitlab';
+    });
 
     const logs = [];
     const originalLog = console.log;

--- a/tests/unit/setup-undo.test.js
+++ b/tests/unit/setup-undo.test.js
@@ -155,7 +155,7 @@ describe('setup-undo', function () {
 
   it('full round trip: plan -> apply -> undo returns global settings to exact pre-apply bytes', function () {
     const { buildSetupPlan } = require('../../lib/setup-plan');
-    const { loadSettings, saveSettings, settingsFileExists } = require('../../lib/settings');
+    const { loadSettings, mutateSettings, settingsFileExists } = require('../../lib/settings');
     const { readRepoSettings } = require('../../lib/repo-settings');
 
     // Establish a concrete pre-apply settings file (simulates a user who has
@@ -164,8 +164,9 @@ describe('setup-undo', function () {
     // (which recomputes providerSettings.claude.maxLevel on every loadSettings()
     // call) - picking it keeps this test isolated to the apply/undo round trip.
     const preExisting = loadSettings();
-    preExisting.logLevel = 'verbose';
-    saveSettings(preExisting);
+    mutateSettings((settings) => {
+      Object.assign(settings, preExisting);
+    });
     const preApplyBytes = fs.readFileSync(TEST_SETTINGS_FILE, 'utf8');
 
     const cwd = repoRoot;

--- a/tests/unit/setup-undo.test.js
+++ b/tests/unit/setup-undo.test.js
@@ -164,6 +164,7 @@ describe('setup-undo', function () {
     // (which recomputes providerSettings.claude.maxLevel on every loadSettings()
     // call) - picking it keeps this test isolated to the apply/undo round trip.
     const preExisting = loadSettings();
+    preExisting.logLevel = 'verbose';
     mutateSettings((settings) => {
       Object.assign(settings, preExisting);
     });

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -95,6 +95,7 @@ describe('Update Checker', function () {
       ['short quiet after command', ['list', '-q']],
       ['long quiet before command', ['--quiet', 'list']],
       ['CI pseudo-TTY', ['list'], { env: { CI: 'false' } }],
+      ['boolean CI pseudo-TTY', ['list'], { env: { CI: true } }],
       ['option terminator without a command', ['--']],
       ['daemon child', ['list'], { env: { ZEROSHOT_DAEMON: '1' } }],
       ['short help', ['list', '-h']],

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { Command } = require('commander');
 
 const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-update-checker-'));
 const TEST_SETTINGS_FILE = path.join(TEST_DIR, 'settings.json');
@@ -23,6 +24,20 @@ const PUBLISHED = {
   stderr: TTY,
   env: {},
 };
+
+function buildCommanderEligibilityFixture() {
+  const cli = new Command();
+  cli.name('zeroshot').version('1.2.3').option('-q, --quiet');
+  cli.command('run <input>').option('-d, --detach').option('-o, --output-format <format>');
+  cli
+    .command('export <cluster-id>')
+    .option('-f, --format <format>')
+    .option('-o, --output <file>');
+  cli.command('logs [id]').option('-f, --follow').option('-w, --watch');
+  const task = cli.command('task');
+  task.command('run <prompt>').option('-o, --output-format <format>');
+  return cli;
+}
 
 function resetSettingsFile() {
   fs.rmSync(TEST_SETTINGS_FILE, { force: true });
@@ -198,6 +213,52 @@ describe('Update Checker', function () {
         true
       );
     });
+  });
+
+  describe('Commander option metadata integration', function () {
+    const commanderProgram = buildCommanderEligibilityFixture();
+
+    function eligible(argv) {
+      return updateChecker.isAutomaticUpdateEligible({
+        ...PUBLISHED,
+        argv,
+        commanderProgram,
+        defaultCommandName: 'run',
+      });
+    }
+
+    for (const [name, argv] of [
+      ['quiet plus joined JSON export format', ['export', 'id', '-qfjson']],
+      ['quiet plus separated JSON export format', ['export', 'id', '-qf', 'json']],
+      ['quiet after a compatible command flag', ['logs', 'id', '-fq']],
+      ['quiet before a compatible command flag', ['logs', 'id', '-qf']],
+      ['help after a compatible command flag', ['logs', 'id', '-fh']],
+      ['version before a compatible command flag', ['logs', 'id', '-Vw']],
+      ['multiple globals before a joined value option', ['export', 'id', '-qhVfjson']],
+      ['global quiet before the subcommand', ['-q', 'export', 'id', '-fmarkdown']],
+    ]) {
+      it(`rejects ${name}`, function () {
+        assert.strictEqual(eligible(argv), false);
+      });
+    }
+
+    for (const [name, argv] of [
+      ['joined format value containing q', ['export', 'id', '-fq']],
+      ['joined output path containing q', ['export', 'id', '-oq']],
+      ['unknown mixed short cluster', ['run', 'hello', '-qX']],
+      ['long-looking single-dash word', ['run', 'hello', '-query']],
+      ['joined non-JSON export format', ['export', 'id', '-fmarkdown']],
+      ['joined format word', ['export', 'id', '-follow']],
+      [
+        'option text inside one prompt argument',
+        ['run', 'Explain -qfjson, -query, -follow, and -fmarkdown'],
+      ],
+      ['options after the terminator', ['export', 'id', '--', '-qfjson']],
+    ]) {
+      it(`accepts ${name}`, function () {
+        assert.strictEqual(eligible(argv), true);
+      });
+    }
   });
 
   describe('version and attempt validation', function () {

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -95,6 +95,7 @@ describe('Update Checker', function () {
       ['short quiet after command', ['list', '-q']],
       ['long quiet before command', ['--quiet', 'list']],
       ['CI pseudo-TTY', ['list'], { env: { CI: 'false' } }],
+      ['option terminator without a command', ['--']],
       ['daemon child', ['list'], { env: { ZEROSHOT_DAEMON: '1' } }],
       ['short help', ['list', '-h']],
       ['long help', ['--help']],

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -196,6 +196,19 @@ describe('Update Checker', function () {
       assert.strictEqual(updateChecker.isNewerVersion('1.0.0-rc.1', '2.0.0'), true);
     });
 
+    it('accepts only finite stable SemVer with well-formed build identifiers', function () {
+      assert.deepStrictEqual(updateChecker.parseStableVersion('2.0.0+build.7'), [2, 0, 0]);
+      for (const version of [
+        '2.0.0+foo..bar',
+        '2.0.0+.foo',
+        '2.0.0+foo.',
+        '9007199254740992.0.0',
+        `1.0.0+${'a'.repeat(257)}`,
+      ]) {
+        assert.strictEqual(updateChecker.parseStableVersion(version), null, version);
+      }
+    });
+
     it('uses the exact 24-hour boundary', function () {
       const now = 10 * updateChecker.CHECK_INTERVAL_MS;
       assert.strictEqual(
@@ -620,6 +633,23 @@ describe('Update Checker', function () {
       assert.deepStrictEqual(
         updateChecker.buildInstallArgs({ installPrefix: '/tmp/prefix', legacy: false }),
         ['install', '-g', '--prefix', '/tmp/prefix', '@the-open-engine/zeroshot@latest']
+      );
+    });
+
+    it('forces every legacy first-argument update form through takeover', function () {
+      for (const argv of [['update'], ['update', '--check']]) {
+        assert.strictEqual(
+          updateChecker.shouldForceLegacyUpdate(argv, '@covibes/zeroshot'),
+          true
+        );
+      }
+      assert.strictEqual(
+        updateChecker.shouldForceLegacyUpdate(['update', '--check'], '@the-open-engine/zeroshot'),
+        false
+      );
+      assert.strictEqual(
+        updateChecker.shouldForceLegacyUpdate(['list'], '@covibes/zeroshot'),
+        false
       );
     });
 

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -259,6 +259,45 @@ describe('Update Checker', function () {
         assert.strictEqual(eligible(argv), true);
       });
     }
+
+    for (const [name, argv, expected] of [
+      [
+        'repeated long options ending in JSON',
+        ['export', 'id', '--format', 'markdown', '--format', 'json'],
+        false,
+      ],
+      [
+        'repeated long options ending in markdown',
+        ['export', 'id', '--format', 'json', '--format', 'markdown'],
+        true,
+      ],
+      ['repeated joined shorts ending in JSON', ['export', 'id', '-fmarkdown', '-fjson'], false],
+      ['repeated joined shorts ending in markdown', ['export', 'id', '-fjson', '-fmarkdown'], true],
+      [
+        'repeated separated shorts ending in JSON',
+        ['export', 'id', '-f', 'markdown', '-f', 'json'],
+        false,
+      ],
+      [
+        'repeated separated shorts ending in markdown',
+        ['export', 'id', '-f', 'json', '-f', 'markdown'],
+        true,
+      ],
+      [
+        'mixed forms ending in JSON',
+        ['export', 'id', '--format', 'markdown', '-fjson'],
+        false,
+      ],
+      [
+        'mixed forms ending in markdown',
+        ['export', 'id', '-fjson', '--format', 'markdown'],
+        true,
+      ],
+    ]) {
+      it(`uses the final value for ${name}`, function () {
+        assert.strictEqual(eligible(argv), expected);
+      });
+    }
   });
 
   describe('version and attempt validation', function () {

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -1,261 +1,611 @@
-/**
- * Test: Update Checker
- *
- * Tests auto-update checking functionality
- * - Version comparison (semver)
- * - Check interval logic (24 hours)
- * - Settings persistence
- * - Quiet mode behavior
- */
-
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
 const assert = require('assert');
-const EventEmitter = require('events');
 const childProcess = require('child_process');
+const EventEmitter = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-// Test storage directory (isolated)
-const TEST_STORAGE_DIR = path.join(os.tmpdir(), 'zeroshot-update-checker-test-' + Date.now());
-const TEST_SETTINGS_FILE = path.join(TEST_STORAGE_DIR, 'settings.json');
+const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-update-checker-'));
+const TEST_SETTINGS_FILE = path.join(TEST_DIR, 'settings.json');
+const originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+process.env.ZEROSHOT_SETTINGS_FILE = TEST_SETTINGS_FILE;
+
+const settings = require('../lib/settings');
+const updateChecker = require('../cli/lib/update-checker');
+
+const TTY = { isTTY: true };
+const NOT_TTY = { isTTY: false };
+const PUBLISHED = {
+  currentVersion: '1.2.3',
+  packageName: '@the-open-engine/zeroshot',
+  stdin: TTY,
+  stdout: TTY,
+  stderr: TTY,
+  env: {},
+};
+
+function resetSettingsFile() {
+  fs.rmSync(TEST_SETTINGS_FILE, { force: true });
+  fs.rmSync(`${TEST_SETTINGS_FILE}.lock`, { recursive: true, force: true });
+}
+
+function validManifest(version = '2.0.0') {
+  return {
+    name: '@the-open-engine/zeroshot',
+    version,
+    dist: {
+      tarball: `https://registry.npmjs.org/@the-open-engine/zeroshot/-/zeroshot-${version}.tgz`,
+      integrity: 'sha512-test-integrity',
+    },
+  };
+}
+
+function fakeHttps({ statusCode = 200, body = validManifest(), responseError, requestEvent } = {}) {
+  const calls = [];
+  return {
+    calls,
+    get(url, options, callback) {
+      calls.push({ url, options });
+      const request = new EventEmitter();
+      request.destroyed = false;
+      request.destroy = () => {
+        request.destroyed = true;
+      };
+      process.nextTick(() => {
+        if (requestEvent) {
+          request.emit(requestEvent);
+          return;
+        }
+        const response = new EventEmitter();
+        response.statusCode = statusCode;
+        response.resume = () => {};
+        response.destroy = () => {};
+        callback(response);
+        process.nextTick(() => {
+          if (responseError) {
+            response.emit('error', new Error(responseError));
+            return;
+          }
+          if (body !== undefined) response.emit('data', Buffer.from(String(body)));
+          response.emit('end');
+        });
+      });
+      return request;
+    },
+  };
+}
 
 describe('Update Checker', function () {
-  this.timeout(10000);
-
-  let updateChecker;
-  let settingsModule;
-
-  before(function () {
-    if (!fs.existsSync(TEST_STORAGE_DIR)) {
-      fs.mkdirSync(TEST_STORAGE_DIR, { recursive: true });
-    }
-
-    // Load settings module and override SETTINGS_FILE path
-    settingsModule = require('../lib/settings');
-    Object.defineProperty(settingsModule, 'SETTINGS_FILE', {
-      value: TEST_SETTINGS_FILE,
-      writable: false,
-    });
-
-    // Load update checker module
-    updateChecker = require('../cli/lib/update-checker');
-  });
-
   after(function () {
-    try {
-      fs.rmSync(TEST_STORAGE_DIR, { recursive: true, force: true });
-    } catch (e) {
-      console.error('Cleanup failed:', e.message);
-    }
+    if (originalSettingsFile === undefined) delete process.env.ZEROSHOT_SETTINGS_FILE;
+    else process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
   beforeEach(function () {
-    // Clean settings file before each test
-    if (fs.existsSync(TEST_SETTINGS_FILE)) {
-      fs.unlinkSync(TEST_SETTINGS_FILE);
+    resetSettingsFile();
+  });
+
+  describe('pure automatic eligibility', function () {
+    const ineligible = [
+      ['no arguments', []],
+      ['stdin is not a TTY', ['list'], { stdin: NOT_TTY }],
+      ['stdout is not a TTY', ['list'], { stdout: NOT_TTY }],
+      ['stderr is not a TTY', ['list'], { stderr: NOT_TTY }],
+      ['short quiet after command', ['list', '-q']],
+      ['long quiet before command', ['--quiet', 'list']],
+      ['CI pseudo-TTY', ['list'], { env: { CI: 'false' } }],
+      ['daemon child', ['list'], { env: { ZEROSHOT_DAEMON: '1' } }],
+      ['short help', ['list', '-h']],
+      ['long help', ['--help']],
+      ['short version', ['-V']],
+      ['long version', ['--version']],
+      ['completion', ['--completion']],
+      ['explicit update', ['update']],
+      ['explicit update check', ['update', '--check']],
+      ['task run', ['task', 'run', 'hello']],
+      ['get-log-path', ['get-log-path', 'task-id']],
+      ['cmdproof prove', ['cmdproof', 'prove']],
+      ['cmdproof verify', ['cmdproof', 'verify']],
+      ['cmdproof check', ['cmdproof', 'check']],
+      ['setup plan', ['setup', 'plan']],
+      ['setup apply', ['setup', 'apply']],
+      ['setup undo', ['setup', 'undo']],
+      ['json flag', ['list', '--json']],
+      ['silent JSON', ['run', 'hello', '--silent-json-output']],
+      ['JSON schema separated', ['run', 'hello', '--json-schema', '{}']],
+      ['JSON schema equals', ['run', 'hello', '--json-schema={}']],
+      ['JSON output separated', ['run', 'hello', '--output-format', 'json']],
+      ['stream JSON output equals', ['run', 'hello', '--output-format=stream-json']],
+      ['JSON export separated', ['export', 'id', '--format', 'json']],
+      ['JSON export equals', ['export', 'id', '--format=json']],
+      ['development build', ['list'], { currentVersion: '0.0.0-development' }],
+      ['prerelease build', ['list'], { currentVersion: '1.0.0-rc.1' }],
+      ['legacy package', ['list'], { packageName: '@covibes/zeroshot' }],
+    ];
+
+    for (const [name, argv, overrides = {}] of ineligible) {
+      it(`rejects ${name}`, function () {
+        assert.strictEqual(
+          updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv, ...overrides }),
+          false
+        );
+      });
     }
+
+    it('accepts a normal foreground human TTY route', function () {
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['list'] }),
+        true
+      );
+    });
+
+    it('does not classify option-looking prompt text as an option', function () {
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({
+          ...PUBLISHED,
+          argv: ['run', 'Explain why --json and --output-format=json are mentioned'],
+        }),
+        true
+      );
+    });
+
+    it('honors the option terminator', function () {
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', '--', '--json'] }),
+        true
+      );
+    });
   });
 
-  describe('isNewerVersion()', function () {
-    it('should return true when latest is newer (patch)', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.0.1'), true);
-    });
-
-    it('should return true when latest is newer (minor)', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.1.0'), true);
-    });
-
-    it('should return true when latest is newer (major)', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '2.0.0'), true);
-    });
-
-    it('should return false when versions are equal', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('1.5.0', '1.5.0'), false);
-    });
-
-    it('should return false when current is newer', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('2.0.0', '1.5.0'), false);
-    });
-
-    it('should handle versions with different lengths', function () {
-      assert.strictEqual(updateChecker.isNewerVersion('1.0', '1.0.1'), true);
-      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.1'), true);
-    });
-
-    it('should handle complex version comparisons', function () {
+  describe('version and attempt validation', function () {
+    it('compares only stable semantic versions', function () {
       assert.strictEqual(updateChecker.isNewerVersion('1.9.9', '1.10.0'), true);
-      assert.strictEqual(updateChecker.isNewerVersion('1.10.0', '1.9.9'), false);
-      assert.strictEqual(updateChecker.isNewerVersion('0.9.9', '1.0.0'), true);
-    });
-  });
-
-  describe('shouldCheckForUpdates()', function () {
-    it('should return false when autoCheckUpdates is disabled', function () {
-      const settings = {
-        autoCheckUpdates: false,
-        lastUpdateCheckAt: null,
-      };
-      assert.strictEqual(updateChecker.shouldCheckForUpdates(settings), false);
+      assert.strictEqual(updateChecker.isNewerVersion('2.0.0', '1.9.9'), false);
+      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.0.0'), false);
+      assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.1.0-rc.1'), false);
+      assert.strictEqual(updateChecker.isNewerVersion('development', '2.0.0'), false);
     });
 
-    it('should return true when lastUpdateCheckAt is null (never checked)', function () {
-      const settings = {
-        autoCheckUpdates: true,
-        lastUpdateCheckAt: null,
-      };
-      assert.strictEqual(updateChecker.shouldCheckForUpdates(settings), true);
-    });
-
-    it('should return false when less than 24 hours have passed', function () {
-      const settings = {
-        autoCheckUpdates: true,
-        lastUpdateCheckAt: Date.now() - 12 * 60 * 60 * 1000, // 12 hours ago
-      };
-      assert.strictEqual(updateChecker.shouldCheckForUpdates(settings), false);
-    });
-
-    it('should return true when more than 24 hours have passed', function () {
-      const settings = {
-        autoCheckUpdates: true,
-        lastUpdateCheckAt: Date.now() - 25 * 60 * 60 * 1000, // 25 hours ago
-      };
-      assert.strictEqual(updateChecker.shouldCheckForUpdates(settings), true);
-    });
-
-    it('should return true when exactly 24 hours have passed', function () {
-      const settings = {
-        autoCheckUpdates: true,
-        lastUpdateCheckAt: Date.now() - 24 * 60 * 60 * 1000, // 24 hours ago
-      };
-      assert.strictEqual(updateChecker.shouldCheckForUpdates(settings), true);
-    });
-  });
-
-  describe('getCurrentVersion()', function () {
-    it('should return a valid version string', function () {
-      const version = updateChecker.getCurrentVersion();
-      assert.ok(typeof version === 'string');
-      assert.ok(/^\d+\.\d+\.\d+/.test(version), `Version should be semver format: ${version}`);
-    });
-  });
-
-  describe('CHECK_INTERVAL_MS', function () {
-    it('should be 24 hours in milliseconds', function () {
-      const expectedMs = 24 * 60 * 60 * 1000;
-      assert.strictEqual(updateChecker.CHECK_INTERVAL_MS, expectedMs);
-    });
-  });
-
-  describe('legacy package migration', function () {
-    it('detects the legacy covibes package name', function () {
-      assert.strictEqual(updateChecker.isLegacyDistro('@covibes/zeroshot'), true);
-      assert.strictEqual(updateChecker.isLegacyDistro('@the-open-engine/zeroshot'), false);
-    });
-
-    it('prints the legacy distro notice to stderr', function () {
-      const originalError = console.error;
-      const messages = [];
-      console.error = (message) => messages.push(message);
-
-      try {
-        const printed = updateChecker.printLegacyDistroNotice('@covibes/zeroshot');
-
-        assert.strictEqual(printed, true);
-        assert.ok(messages.join('\n').includes('@covibes/zeroshot has moved'));
-        assert.ok(messages.join('\n').includes('@the-open-engine/zeroshot'));
-      } finally {
-        console.error = originalError;
-      }
-    });
-
-    it('does not print the legacy distro notice for the new package', function () {
-      const originalError = console.error;
-      const messages = [];
-      console.error = (message) => messages.push(message);
-
-      try {
-        const printed = updateChecker.printLegacyDistroNotice('@the-open-engine/zeroshot');
-
-        assert.strictEqual(printed, false);
-        assert.deepStrictEqual(messages, []);
-      } finally {
-        console.error = originalError;
-      }
-    });
-  });
-
-  describe('install target resolution', function () {
-    it('derives a Unix npm prefix from a scoped global package root', function () {
-      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
-        '/opt/homebrew/lib/node_modules/@the-open-engine/zeroshot',
-        '@the-open-engine/zeroshot'
+    it('uses the exact 24-hour boundary', function () {
+      const now = 10 * updateChecker.CHECK_INTERVAL_MS;
+      assert.strictEqual(
+        updateChecker.shouldCheckForUpdates(
+          { autoCheckUpdates: true, lastUpdateCheckAt: now - updateChecker.CHECK_INTERVAL_MS + 1 },
+          now
+        ),
+        false
       );
-
-      assert.strictEqual(prefix, '/opt/homebrew');
-    });
-
-    it('derives a Unix npm prefix from the legacy scoped package root', function () {
-      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
-        '/Users/tom/.hermes/node/lib/node_modules/@covibes/zeroshot',
-        '@covibes/zeroshot'
+      assert.strictEqual(
+        updateChecker.shouldCheckForUpdates(
+          { autoCheckUpdates: true, lastUpdateCheckAt: now - updateChecker.CHECK_INTERVAL_MS },
+          now
+        ),
+        true
       );
-
-      assert.strictEqual(prefix, '/Users/tom/.hermes/node');
     });
 
-    it('returns null for a local development checkout', function () {
-      const prefix = updateChecker.deriveInstallPrefixFromPackageRoot(
-        '/Users/tom/code/covibes/zeroshot',
-        '@the-open-engine/zeroshot'
-      );
-
-      assert.strictEqual(prefix, null);
-    });
-
-    it('uses --force only when migrating the legacy package', function () {
-      const legacyArgs = updateChecker.buildInstallArgs({
-        installPrefix: '/tmp/prefix',
-        legacy: true,
+    for (const timestamp of [undefined, null, '1', -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      it(`treats ${String(timestamp)} as due`, function () {
+        assert.strictEqual(
+          updateChecker.shouldCheckForUpdates(
+            { autoCheckUpdates: true, lastUpdateCheckAt: timestamp },
+            1000
+          ),
+          true
+        );
       });
-      const newArgs = updateChecker.buildInstallArgs({
-        installPrefix: '/tmp/prefix',
-        legacy: false,
+    }
+
+    it('treats a future timestamp as due and disabled settings as never due', function () {
+      assert.strictEqual(
+        updateChecker.shouldCheckForUpdates(
+          { autoCheckUpdates: true, lastUpdateCheckAt: 1001 },
+          1000
+        ),
+        true
+      );
+      assert.strictEqual(
+        updateChecker.shouldCheckForUpdates(
+          { autoCheckUpdates: false, lastUpdateCheckAt: null },
+          1000
+        ),
+        false
+      );
+    });
+  });
+
+  describe('cached notices and claim lifecycle', function () {
+    function checkerOptions(state, overrides = {}) {
+      return {
+        eligibilityChecked: true,
+        currentVersion: '1.0.0',
+        loadSettings: () => ({ ...state }),
+        mutateSettings: (mutator) => {
+          const result = mutator(state);
+          if (state.autoCheckUpdates === false) state.lastUpdateCheckClaim = null;
+          return result;
+        },
+        now: () => 100 * updateChecker.CHECK_INTERVAL_MS,
+        generateClaimId: () => 'claim-a',
+        stderr: { write: () => {} },
+        ...overrides,
+      };
+    }
+
+    it('writes the exact cached notice on every eligible invocation and never stdout', function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: '2.0.0',
+        lastUpdateCheckAt: 100 * updateChecker.CHECK_INTERVAL_MS,
+        lastUpdateCheckClaim: null,
+      };
+      let stderr = '';
+      const stdout = { write: () => assert.fail('automatic checker wrote stdout') };
+      const stdin = { read: () => assert.fail('automatic checker read stdin') };
+      const options = checkerOptions(state, {
+        stdin,
+        stdout,
+        stderr: { write: (chunk) => (stderr += chunk) },
       });
 
-      assert.deepStrictEqual(legacyArgs, [
-        'install',
-        '-g',
-        '--prefix',
-        '/tmp/prefix',
-        '--force',
-        '@the-open-engine/zeroshot@latest',
-      ]);
-      assert.deepStrictEqual(newArgs, [
-        'install',
-        '-g',
-        '--prefix',
-        '/tmp/prefix',
-        '@the-open-engine/zeroshot@latest',
-      ]);
+      assert.strictEqual(updateChecker.checkForUpdates(options), null);
+      assert.strictEqual(updateChecker.checkForUpdates(options), null);
+      assert.strictEqual(
+        stderr,
+        'Update available: 1.0.0 → 2.0.0. Run `zeroshot update`.\n'.repeat(2)
+      );
     });
 
-    it('runs npm with the resolved prefix when updating the legacy package', async function () {
+    it('ignores older, equal, malformed, and disabled cache values', function () {
+      for (const lastSeenVersion of ['0.9.0', '1.0.0', 'not-a-version', null]) {
+        let stderr = '';
+        const state = {
+          autoCheckUpdates: true,
+          lastSeenVersion,
+          lastUpdateCheckAt: 100 * updateChecker.CHECK_INTERVAL_MS,
+        };
+        updateChecker.checkForUpdates(
+          checkerOptions(state, { stderr: { write: (chunk) => (stderr += chunk) } })
+        );
+        assert.strictEqual(stderr, '');
+      }
+
+      let touched = false;
+      updateChecker.checkForUpdates(
+        checkerOptions(
+          { autoCheckUpdates: false, lastSeenVersion: '2.0.0', lastUpdateCheckAt: null },
+          { mutateSettings: () => (touched = true) }
+        )
+      );
+      assert.strictEqual(touched, false);
+    });
+
+    it('claims before fetching and commits only exact timestamp and ID ownership', async function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: '1.5.0',
+        lastUpdateCheckAt: null,
+        lastUpdateCheckClaim: null,
+        unrelated: 'preserved',
+      };
+      let fetches = 0;
+      const refresh = updateChecker.checkForUpdates(
+        checkerOptions(state, {
+          fetchLatestVersion: async () => {
+            fetches += 1;
+            assert.strictEqual(state.lastUpdateCheckClaim, 'claim-a');
+            return '2.0.0';
+          },
+        })
+      );
+      await refresh;
+
+      assert.strictEqual(fetches, 1);
+      assert.strictEqual(state.lastSeenVersion, '2.0.0');
+      assert.strictEqual(state.lastUpdateCheckClaim, null);
+      assert.strictEqual(state.unrelated, 'preserved');
+    });
+
+    it('defers claim and rejection work until after synchronous command dispatch', async function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: null,
+        lastUpdateCheckAt: null,
+        lastUpdateCheckClaim: null,
+      };
+      let scheduled;
+      let claims = 0;
+      const base = checkerOptions(state);
+      const refresh = updateChecker.checkForUpdates({
+        ...base,
+        scheduleRefresh: (callback) => {
+          scheduled = callback;
+          return { unref() {} };
+        },
+        mutateSettings: (mutator) => {
+          claims += 1;
+          return base.mutateSettings(mutator);
+        },
+        fetchLatestVersion: async () => {
+          throw new Error('offline');
+        },
+      });
+
+      assert.strictEqual(claims, 0);
+      assert.strictEqual(typeof scheduled, 'function');
+      scheduled();
+      await refresh;
+      assert.strictEqual(claims, 1);
+      assert.strictEqual(state.lastUpdateCheckClaim, 'claim-a');
+    });
+
+    it('coalesces concurrent in-process calls into one request', async function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: null,
+        lastUpdateCheckAt: null,
+        lastUpdateCheckClaim: null,
+      };
+      let resolveFetch;
+      let fetches = 0;
+      const options = checkerOptions(state, {
+        fetchLatestVersion: () => {
+          fetches += 1;
+          return new Promise((resolve) => {
+            resolveFetch = resolve;
+          });
+        },
+      });
+
+      const first = updateChecker.checkForUpdates(options);
+      const second = updateChecker.checkForUpdates(options);
+      assert.strictEqual(first, second);
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(fetches, 1);
+      resolveFetch('2.0.0');
+      await first;
+    });
+
+    it('retains failed ownership and replaces it with a distinct same-millisecond claim', async function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: '1.5.0',
+        lastUpdateCheckAt: null,
+        lastUpdateCheckClaim: null,
+      };
+      const claimIds = ['claim-a', 'claim-b'];
+      const options = checkerOptions(state, {
+        generateClaimId: () => claimIds.shift(),
+        fetchLatestVersion: async () => null,
+      });
+
+      await updateChecker.checkForUpdates(options);
+      assert.strictEqual(state.lastUpdateCheckClaim, 'claim-a');
+      const firstAttemptAt = state.lastUpdateCheckAt;
+
+      state.lastUpdateCheckAt = null;
+      await updateChecker.checkForUpdates(options);
+      assert.strictEqual(state.lastUpdateCheckClaim, 'claim-b');
+      assert.strictEqual(state.lastUpdateCheckAt, firstAttemptAt);
+    });
+
+    it('discards a flight after disable then re-enable invalidates its claim', async function () {
+      const state = {
+        autoCheckUpdates: true,
+        lastSeenVersion: '1.5.0',
+        lastUpdateCheckAt: null,
+        lastUpdateCheckClaim: null,
+      };
+      let resolveFetch;
+      const options = checkerOptions(state, {
+        fetchLatestVersion: () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          }),
+      });
+
+      const refresh = updateChecker.checkForUpdates(options);
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.strictEqual(state.lastUpdateCheckClaim, 'claim-a');
+      state.autoCheckUpdates = false;
+      state.lastUpdateCheckClaim = null;
+      state.autoCheckUpdates = true;
+      resolveFetch('2.0.0');
+      await refresh;
+
+      assert.strictEqual(state.lastSeenVersion, '1.5.0');
+      assert.strictEqual(state.lastUpdateCheckClaim, null);
+    });
+
+    it('silently skips network when claim persistence fails', async function () {
+      let fetches = 0;
+      const refresh = updateChecker.checkForUpdates(
+        checkerOptions(
+          { autoCheckUpdates: true, lastSeenVersion: null, lastUpdateCheckAt: null },
+          {
+            mutateSettings: () => {
+              throw new Error('lock unavailable');
+            },
+            fetchLatestVersion: async () => {
+              fetches += 1;
+              return '2.0.0';
+            },
+          }
+        )
+      );
+      await refresh;
+      assert.strictEqual(fetches, 0);
+    });
+  });
+
+  describe('npm manifest fetching', function () {
+    it('accepts only the expected installable stable manifest', function () {
+      assert.strictEqual(updateChecker.validatedManifestVersion(validManifest('2.0.0')), '2.0.0');
+      assert.strictEqual(
+        updateChecker.validatedManifestVersion({ ...validManifest(), name: 'other' }),
+        null
+      );
+      assert.strictEqual(updateChecker.validatedManifestVersion(validManifest('2.0.0-rc.1')), null);
+      assert.strictEqual(
+        updateChecker.validatedManifestVersion({ ...validManifest(), dist: { integrity: 'x' } }),
+        null
+      );
+      assert.strictEqual(
+        updateChecker.validatedManifestVersion({ ...validManifest(), dist: { tarball: 'https://x' } }),
+        null
+      );
+    });
+
+    it('uses one fixed HTTPS request and clears the safety timer', async function () {
+      const httpsModule = fakeHttps({ body: JSON.stringify(validManifest('2.1.0')) });
+      let timerCleared = false;
+      const version = await updateChecker.fetchLatestVersion({
+        httpsModule,
+        setTimeout: () => ({ unref() {} }),
+        clearTimeout: () => {
+          timerCleared = true;
+        },
+      });
+
+      assert.strictEqual(version, '2.1.0');
+      assert.strictEqual(httpsModule.calls.length, 1);
+      assert.strictEqual(
+        httpsModule.calls[0].url,
+        'https://registry.npmjs.org/@the-open-engine/zeroshot/latest'
+      );
+      assert.strictEqual(timerCleared, true);
+    });
+
+    const failures = [
+      ['non-200 response', { statusCode: 503, body: '' }],
+      ['malformed JSON', { body: '{' }],
+      ['wrong package', { body: JSON.stringify({ ...validManifest(), name: 'wrong' }) }],
+      ['prerelease', { body: JSON.stringify(validManifest('2.0.0-rc.1')) }],
+      ['missing tarball', { body: JSON.stringify({ ...validManifest(), dist: { integrity: 'x' } }) }],
+      ['missing integrity', { body: JSON.stringify({ ...validManifest(), dist: { tarball: 'https://x' } }) }],
+      ['request error', { requestEvent: 'error' }],
+      ['request timeout', { requestEvent: 'timeout' }],
+    ];
+
+    for (const [name, spec] of failures) {
+      it(`returns null for ${name}`, async function () {
+        const httpsModule = fakeHttps(spec);
+        const version = await updateChecker.fetchLatestVersion({ httpsModule, timeoutMs: 10 });
+        assert.strictEqual(version, null);
+      });
+    }
+
+    it('rejects an oversized response', async function () {
+      const httpsModule = fakeHttps({ body: 'x'.repeat(65) });
+      const version = await updateChecker.fetchLatestVersion({ httpsModule, maxResponseBytes: 64 });
+      assert.strictEqual(version, null);
+    });
+  });
+
+  describe('transactional global settings', function () {
+    it('normalizes claims and invalidates ownership on every disable', function () {
+      settings.mutateSettings((current) => {
+        current.autoCheckUpdates = true;
+        current.lastUpdateCheckAt = 123;
+        current.lastUpdateCheckClaim = 'claim-one';
+        current.lastSeenVersion = '2.0.0';
+        current.unrelated = 'keep';
+      });
+      settings.mutateSettings((current) => {
+        current.defaultProvider = 'codex';
+      });
+      assert.strictEqual(settings.loadSettings().lastUpdateCheckClaim, 'claim-one');
+      assert.strictEqual(settings.loadSettings().unrelated, 'keep');
+
+      settings.mutateSettings((current) => {
+        current.autoCheckUpdates = false;
+      });
+      assert.strictEqual(settings.loadSettings().lastUpdateCheckClaim, null);
+      settings.mutateSettings((current) => {
+        current.autoCheckUpdates = true;
+      });
+      assert.strictEqual(settings.loadSettings().lastUpdateCheckClaim, null);
+      assert.strictEqual(settings.loadSettings().lastSeenVersion, '2.0.0');
+    });
+
+    it('normalizes old, malformed, and disabled claims to null', function () {
+      fs.writeFileSync(
+        TEST_SETTINGS_FILE,
+        JSON.stringify({ autoCheckUpdates: true, lastUpdateCheckClaim: 42 }),
+        'utf8'
+      );
+      assert.strictEqual(settings.loadSettings().lastUpdateCheckClaim, null);
+      fs.writeFileSync(
+        TEST_SETTINGS_FILE,
+        JSON.stringify({ autoCheckUpdates: false, lastUpdateCheckClaim: 'old' }),
+        'utf8'
+      );
+      assert.strictEqual(settings.loadSettings().lastUpdateCheckClaim, null);
+    });
+
+    it('returns callback results and atomically preserves unrelated fields', function () {
+      const result = settings.mutateSettings((current) => {
+        current.providerSettings.claude.defaultLevel = 'level1';
+        current.unrelated = { nested: true };
+        return 'committed';
+      });
+      assert.strictEqual(result, 'committed');
+      assert.deepStrictEqual(settings.loadSettings().unrelated, { nested: true });
+      assert.strictEqual(settings.loadSettings().providerSettings.claude.defaultLevel, 'level1');
+      assert.doesNotThrow(() => JSON.parse(fs.readFileSync(TEST_SETTINGS_FILE, 'utf8')));
+      assert.deepStrictEqual(
+        fs.readdirSync(TEST_DIR).filter((name) => name.endsWith('.tmp')),
+        []
+      );
+    });
+
+    it('surfaces bounded lock acquisition failures actionably', function () {
+      const properLockfile = require('proper-lockfile');
+      const originalLockSync = properLockfile.lockSync;
+      properLockfile.lockSync = () => {
+        throw new Error('busy');
+      };
+      try {
+        assert.throws(
+          () => settings.mutateSettings((current) => (current.logLevel = 'verbose')),
+          /Unable to persist global settings: busy/
+        );
+      } finally {
+        properLockfile.lockSync = originalLockSync;
+      }
+    });
+  });
+
+  describe('explicit installer compatibility', function () {
+    it('keeps the legacy forced takeover argv and current-package argv', function () {
+      assert.deepStrictEqual(
+        updateChecker.buildInstallArgs({ installPrefix: '/tmp/prefix', legacy: true }),
+        [
+          'install',
+          '-g',
+          '--prefix',
+          '/tmp/prefix',
+          '--force',
+          '@the-open-engine/zeroshot@latest',
+        ]
+      );
+      assert.deepStrictEqual(
+        updateChecker.buildInstallArgs({ installPrefix: '/tmp/prefix', legacy: false }),
+        ['install', '-g', '--prefix', '/tmp/prefix', '@the-open-engine/zeroshot@latest']
+      );
+    });
+
+    it('spawns resolved npm with inherited stdio and shell disabled', async function () {
       const originalSpawn = childProcess.spawn;
-      const installPrefix = path.join(TEST_STORAGE_DIR, 'legacy-prefix');
+      const installPrefix = path.join(TEST_DIR, 'legacy-prefix');
       fs.mkdirSync(path.join(installPrefix, 'lib', 'node_modules'), { recursive: true });
-
-      let spawnCommand = null;
-      let spawnArgs = null;
-      let spawnOptions = null;
-
+      let observed;
       childProcess.spawn = (command, args, options) => {
-        spawnCommand = command;
-        spawnArgs = args;
-        spawnOptions = options;
-
-        const proc = new EventEmitter();
-        process.nextTick(() => proc.emit('close', 0));
-        return proc;
+        observed = { command, args, options };
+        const child = new EventEmitter();
+        process.nextTick(() => child.emit('close', 0));
+        return child;
       };
 
       try {
@@ -264,37 +614,21 @@ describe('Update Checker', function () {
           installPrefix,
           npmCommand: '/tmp/npm-for-test',
         });
-
         assert.strictEqual(success, true);
-        assert.strictEqual(spawnCommand, '/tmp/npm-for-test');
-        assert.deepStrictEqual(spawnArgs, [
-          'install',
-          '-g',
-          '--prefix',
-          installPrefix,
-          '--force',
-          '@the-open-engine/zeroshot@latest',
-        ]);
-        assert.deepStrictEqual(spawnOptions, {
-          stdio: 'inherit',
-          shell: false,
+        assert.deepStrictEqual(observed, {
+          command: '/tmp/npm-for-test',
+          args: [
+            'install',
+            '-g',
+            '--prefix',
+            installPrefix,
+            '--force',
+            '@the-open-engine/zeroshot@latest',
+          ],
+          options: { stdio: 'inherit', shell: false },
         });
       } finally {
         childProcess.spawn = originalSpawn;
-      }
-    });
-  });
-
-  describe('fetchLatestVersion()', function () {
-    it('should return null or string (network dependent)', async function () {
-      this.timeout(10000); // Network request may take time
-
-      const version = await updateChecker.fetchLatestVersion();
-
-      // Version should be null (network failure/timeout) or a valid semver string
-      if (version !== null) {
-        assert.ok(typeof version === 'string');
-        assert.ok(/^\d+\.\d+\.\d+/.test(version), `Version should be semver format: ${version}`);
       }
     });
   });

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -121,6 +121,7 @@ describe('Update Checker', function () {
       ['stream JSON output equals', ['run', 'hello', '--output-format=stream-json']],
       ['JSON export separated', ['export', 'id', '--format', 'json']],
       ['JSON export equals', ['export', 'id', '--format=json']],
+      ['JSON export short format', ['export', 'id', '-f', 'json']],
       ['development build', ['list'], { currentVersion: '0.0.0-development' }],
       ['prerelease build', ['list'], { currentVersion: '1.0.0-rc.1' }],
       ['legacy package', ['list'], { packageName: '@covibes/zeroshot' }],
@@ -146,7 +147,7 @@ describe('Update Checker', function () {
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({
           ...PUBLISHED,
-          argv: ['run', 'Explain why --json and --output-format=json are mentioned'],
+          argv: ['run', 'Explain why --json, -f json, and --output-format=json are mentioned'],
         }),
         true
       );
@@ -161,12 +162,13 @@ describe('Update Checker', function () {
   });
 
   describe('version and attempt validation', function () {
-    it('compares only stable semantic versions', function () {
+    it('compares stable releases and treats non-release current builds as explicitly updatable', function () {
       assert.strictEqual(updateChecker.isNewerVersion('1.9.9', '1.10.0'), true);
       assert.strictEqual(updateChecker.isNewerVersion('2.0.0', '1.9.9'), false);
       assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.0.0'), false);
       assert.strictEqual(updateChecker.isNewerVersion('1.0.0', '1.1.0-rc.1'), false);
-      assert.strictEqual(updateChecker.isNewerVersion('development', '2.0.0'), false);
+      assert.strictEqual(updateChecker.isNewerVersion('0.0.0-development', '2.0.0'), true);
+      assert.strictEqual(updateChecker.isNewerVersion('1.0.0-rc.1', '2.0.0'), true);
     });
 
     it('uses the exact 24-hour boundary', function () {
@@ -294,7 +296,7 @@ describe('Update Checker', function () {
       let fetches = 0;
       const refresh = updateChecker.checkForUpdates(
         checkerOptions(state, {
-          fetchLatestVersion: async () => {
+          fetchLatestVersion: () => {
             fetches += 1;
             assert.strictEqual(state.lastUpdateCheckClaim, 'claim-a');
             return '2.0.0';
@@ -329,9 +331,7 @@ describe('Update Checker', function () {
           claims += 1;
           return base.mutateSettings(mutator);
         },
-        fetchLatestVersion: async () => {
-          throw new Error('offline');
-        },
+        fetchLatestVersion: () => Promise.reject(new Error('offline')),
       });
 
       assert.strictEqual(claims, 0);
@@ -379,7 +379,7 @@ describe('Update Checker', function () {
       const claimIds = ['claim-a', 'claim-b'];
       const options = checkerOptions(state, {
         generateClaimId: () => claimIds.shift(),
-        fetchLatestVersion: async () => null,
+        fetchLatestVersion: () => null,
       });
 
       await updateChecker.checkForUpdates(options);
@@ -429,7 +429,7 @@ describe('Update Checker', function () {
             mutateSettings: () => {
               throw new Error('lock unavailable');
             },
-            fetchLatestVersion: async () => {
+            fetchLatestVersion: () => {
               fetches += 1;
               return '2.0.0';
             },
@@ -598,6 +598,51 @@ describe('Update Checker', function () {
       );
     });
 
+
+    it('keeps source-build explicit checks available and installs the current package without force', async function () {
+      assert.strictEqual(updateChecker.isNewerVersion('0.0.0-development', '2.0.0'), true);
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({
+          ...PUBLISHED,
+          argv: ['list'],
+          currentVersion: '0.0.0-development',
+        }),
+        false
+      );
+
+      const originalSpawn = childProcess.spawn;
+      const installPrefix = path.join(TEST_DIR, 'source-prefix');
+      fs.mkdirSync(path.join(installPrefix, 'lib', 'node_modules'), { recursive: true });
+      let observed;
+      childProcess.spawn = (command, args, options) => {
+        observed = { command, args, options };
+        const child = new EventEmitter();
+        process.nextTick(() => child.emit('close', 0));
+        return child;
+      };
+
+      try {
+        const success = await updateChecker.runUpdate({
+          packageName: '@the-open-engine/zeroshot',
+          installPrefix,
+          npmCommand: '/tmp/npm-for-test',
+        });
+        assert.strictEqual(success, true);
+        assert.deepStrictEqual(observed, {
+          command: '/tmp/npm-for-test',
+          args: [
+            'install',
+            '-g',
+            '--prefix',
+            installPrefix,
+            '@the-open-engine/zeroshot@latest',
+          ],
+          options: { stdio: 'inherit', shell: false },
+        });
+      } finally {
+        childProcess.spawn = originalSpawn;
+      }
+    });
     it('spawns resolved npm with inherited stdio and shell disabled', async function () {
       const originalSpawn = childProcess.spawn;
       const installPrefix = path.join(TEST_DIR, 'legacy-prefix');

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -122,6 +122,7 @@ describe('Update Checker', function () {
       ['JSON export separated', ['export', 'id', '--format', 'json']],
       ['JSON export equals', ['export', 'id', '--format=json']],
       ['JSON export short format', ['export', 'id', '-f', 'json']],
+      ['JSON export joined short format', ['export', 'id', '-fjson']],
       ['development build', ['list'], { currentVersion: '0.0.0-development' }],
       ['prerelease build', ['list'], { currentVersion: '1.0.0-rc.1' }],
       ['legacy package', ['list'], { packageName: '@covibes/zeroshot' }],
@@ -147,7 +148,7 @@ describe('Update Checker', function () {
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({
           ...PUBLISHED,
-          argv: ['run', 'Explain why --json, -f json, and --output-format=json are mentioned'],
+          argv: ['run', 'Explain why --json, -f json, -fjson, and --output-format=json are mentioned'],
         }),
         true
       );
@@ -156,6 +157,30 @@ describe('Update Checker', function () {
     it('honors the option terminator', function () {
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', '--', '--json'] }),
+        true
+      );
+    });
+
+    it('does not overmatch non-JSON joined short values or unrelated short-looking flags', function () {
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({
+          ...PUBLISHED,
+          argv: ['export', 'id', '-fmarkdown'],
+        }),
+        true
+      );
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', 'hello', '-follow'] }),
+        true
+      );
+    });
+
+    it('ignores a joined short value after the option terminator', function () {
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({
+          ...PUBLISHED,
+          argv: ['run', '--', '-fjson'],
+        }),
         true
       );
     });

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -636,20 +636,35 @@ describe('Update Checker', function () {
       );
     });
 
-    it('forces every legacy first-argument update form through takeover', function () {
-      for (const argv of [['update'], ['update', '--check']]) {
-        assert.strictEqual(
-          updateChecker.shouldForceLegacyUpdate(argv, '@covibes/zeroshot'),
-          true
-        );
+    it('dispatches every legacy first-argument update form and preserves its result', async function () {
+      const invocations = [];
+      for (const [argv, success] of [
+        [['update'], true],
+        [['update', '--check'], false],
+      ]) {
+        const result = await updateChecker.runLegacyUpdateIfRequested(argv, {
+          packageName: '@covibes/zeroshot',
+          runUpdate: () => {
+            invocations.push(argv);
+            return success;
+          },
+        });
+        assert.strictEqual(result, success);
       }
+      assert.deepStrictEqual(invocations, [['update'], ['update', '--check']]);
       assert.strictEqual(
-        updateChecker.shouldForceLegacyUpdate(['update', '--check'], '@the-open-engine/zeroshot'),
-        false
+        updateChecker.runLegacyUpdateIfRequested(['update', '--check'], {
+          packageName: '@the-open-engine/zeroshot',
+          runUpdate: () => assert.fail('current-package check must not force takeover'),
+        }),
+        null
       );
       assert.strictEqual(
-        updateChecker.shouldForceLegacyUpdate(['list'], '@covibes/zeroshot'),
-        false
+        updateChecker.runLegacyUpdateIfRequested(['list'], {
+          packageName: '@covibes/zeroshot',
+          runUpdate: () => assert.fail('non-update command must not force takeover'),
+        }),
+        null
       );
     });
 

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -272,6 +272,13 @@ describe('Update Checker', function () {
   });
 
   describe('cached notices and claim lifecycle', function () {
+    function scheduleLifecycleRefresh(callback) {
+      setImmediate(callback);
+      const lifecycleHandle = {};
+      assert.strictEqual(typeof lifecycleHandle.unref, 'undefined');
+      return lifecycleHandle;
+    }
+
     function checkerOptions(state, overrides = {}) {
       return {
         eligibilityChecked: true,
@@ -285,7 +292,7 @@ describe('Update Checker', function () {
         now: () => 100 * updateChecker.CHECK_INTERVAL_MS,
         generateClaimId: () => 'claim-a',
         stderr: { write: () => {} },
-        scheduleRefresh: (callback) => setImmediate(callback),
+        scheduleRefresh: scheduleLifecycleRefresh,
         ...overrides,
       };
     }

--- a/tests/update-checker.test.js
+++ b/tests/update-checker.test.js
@@ -94,6 +94,9 @@ describe('Update Checker', function () {
       ['stderr is not a TTY', ['list'], { stderr: NOT_TTY }],
       ['short quiet after command', ['list', '-q']],
       ['long quiet before command', ['--quiet', 'list']],
+      ['grouped quiet and version before command', ['-qV', 'list']],
+      ['grouped quiet and help after command', ['list', '-qh']],
+      ['grouped version and quiet before command', ['-Vq', 'list']],
       ['CI pseudo-TTY', ['list'], { env: { CI: 'false' } }],
       ['boolean CI pseudo-TTY', ['list'], { env: { CI: true } }],
       ['option terminator without a command', ['--']],
@@ -148,7 +151,10 @@ describe('Update Checker', function () {
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({
           ...PUBLISHED,
-          argv: ['run', 'Explain why --json, -f json, -fjson, and --output-format=json are mentioned'],
+          argv: [
+            'run',
+            'Explain why --json, -qV, -f json, -fjson, and --output-format=json are mentioned',
+          ],
         }),
         true
       );
@@ -157,6 +163,10 @@ describe('Update Checker', function () {
     it('honors the option terminator', function () {
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', '--', '--json'] }),
+        true
+      );
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', '--', '-qV'] }),
         true
       );
     });
@@ -171,6 +181,10 @@ describe('Update Checker', function () {
       );
       assert.strictEqual(
         updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', 'hello', '-follow'] }),
+        true
+      );
+      assert.strictEqual(
+        updateChecker.isAutomaticUpdateEligible({ ...PUBLISHED, argv: ['run', 'hello', '-qX'] }),
         true
       );
     });
@@ -271,6 +285,7 @@ describe('Update Checker', function () {
         now: () => 100 * updateChecker.CHECK_INTERVAL_MS,
         generateClaimId: () => 'claim-a',
         stderr: { write: () => {} },
+        scheduleRefresh: (callback) => setImmediate(callback),
         ...overrides,
       };
     }
@@ -349,7 +364,7 @@ describe('Update Checker', function () {
       assert.strictEqual(state.unrelated, 'preserved');
     });
 
-    it('defers claim and rejection work until after synchronous command dispatch', async function () {
+    it('production scheduling is unrefed and defers work until after command dispatch', async function () {
       const state = {
         autoCheckUpdates: true,
         lastSeenVersion: null,
@@ -357,22 +372,34 @@ describe('Update Checker', function () {
         lastUpdateCheckClaim: null,
       };
       let scheduled;
+      let unrefs = 0;
       let claims = 0;
-      const base = checkerOptions(state);
-      const refresh = updateChecker.checkForUpdates({
-        ...base,
-        scheduleRefresh: (callback) => {
-          scheduled = callback;
-          return { unref() {} };
-        },
-        mutateSettings: (mutator) => {
-          claims += 1;
-          return base.mutateSettings(mutator);
-        },
-        fetchLatestVersion: () => Promise.reject(new Error('offline')),
-      });
+      const originalSetImmediate = global.setImmediate;
+      global.setImmediate = (callback) => {
+        scheduled = callback;
+        return {
+          unref() {
+            unrefs += 1;
+          },
+        };
+      };
+      const base = checkerOptions(state, { scheduleRefresh: undefined });
+      let refresh;
+      try {
+        refresh = updateChecker.checkForUpdates({
+          ...base,
+          mutateSettings: (mutator) => {
+            claims += 1;
+            return base.mutateSettings(mutator);
+          },
+          fetchLatestVersion: () => Promise.reject(new Error('offline')),
+        });
+      } finally {
+        global.setImmediate = originalSetImmediate;
+      }
 
       assert.strictEqual(claims, 0);
+      assert.strictEqual(unrefs, 1);
       assert.strictEqual(typeof scheduled, 'function');
       scheduled();
       await refresh;


### PR DESCRIPTION
## Problem

The startup update check currently blocks unrelated commands, can consume interactive streams, contaminates machine output, and permanently suppresses a release after one attempted prompt. Concurrent whole-file global-settings writes can also lose newer cache state or unrelated user preferences.

## Decision

- Gate automatic awareness with a pure argv/environment/three-stream-TTY predicate before loading update settings.
- Render only a validated cached newer release, once per eligible invocation on stderr, and never prompt or install automatically.
- Refresh npm `latest` with stale-while-revalidate scheduling, a 24-hour atomic timestamp/opaque claim, strict bounded manifest parsing, stale-good retention, and unref'd cleanup resources.
- Keep `zeroshot update` as the sole mutation path and preserve current/legacy package install argv, PATH diagnosis, source-build behavior, and #608 policy boundaries.
- Serialize every production global-settings mutation through one `proper-lockfile` transaction with a locked re-read and same-directory atomic rename; migrate settings, provider, first-run, setup apply/undo, Linear, and checker writers.
- Document the global persistence convention in `AGENTS.md`.

## Test plan

Deterministic coverage replaces the live registry test and covers eligibility matrix rows, cached stderr cadence, timestamp validation, claim/commit ownership and invalidation, in-process coalescing, deferred command dispatch, strict npm manifest/failure/size/timeout handling, lock and atomic persistence semantics, explicit installer argv, provider/setup migration seams, and piped `run -` stdin preservation. All tests isolate `ZEROSHOT_SETTINGS_FILE`; none contact npm or operator settings.

Per the issue execution contract, validation commands were intentionally not run on this contributor branch. Repository CI should run the committed deterministic suite and standard checks.

## Release requirement

Merge alone does not complete the issue. After semantic-release publishes a real non-`0.0.0-development` npm artifact, verify the published version and release URL, then run the issue's installed-artifact smoke plan for help/version/machine output, repeated eligible pseudo-TTY notices, and `update --check` before closing.

Closes #825