### PR TITLE
fix(zeroshot-rust): make session loss non-retryable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,8 @@ them in `EngineFault`, observations, protocol responses, persistence, or exports
 injected through `ObservationSink` and uses only the fixed metrics and closed dimensions in
 `observability.rs`; retry disposition is descriptive data, not retry authorization. Do not install
 global telemetry state or caller-defined labels.
+A lost node-instance session terminates the affected execution; its descriptive fault disposition
+must never authorize retry or replacement-session recovery.
 `ClusterLedger` is the only native durable domain authority. Its closed/versioned record algebra,
 identity allocation, replay, lifecycle/CAS/idempotency rules, and safe-fault consequences stay
 above the backend-neutral `LedgerStore` port. Control and verified I/O share one ordered hash

--- a/zeroshot-rust/src/fault/taxonomy.rs
+++ b/zeroshot-rust/src/fault/taxonomy.rs
@@ -71,10 +71,10 @@ const EVIDENCE_SEMANTICS: [EvidenceSemantics; 10] = [
     },
     EvidenceSemantics {
         code: FaultCode::SessionLost,
-        retry_disposition: RetryDisposition::RetryAfterBackoff,
-        user_action: UserAction::RestartOperation,
+        retry_disposition: RetryDisposition::DoNotRetry,
+        user_action: UserAction::ContactSupport,
         severity: FaultSeverity::Error,
-        summary: "A required native engine session was lost.",
+        summary: "A lost native engine session terminated the affected execution.",
     },
     EvidenceSemantics {
         code: FaultCode::InvariantViolation,

--- a/zeroshot-rust/tests/execution_runtime_contract.rs
+++ b/zeroshot-rust/tests/execution_runtime_contract.rs
@@ -1,10 +1,25 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use zeroshot_engine::cluster_ledger::NodeInstanceId;
+use zeroshot_engine::execution::driver::{
+    DriverCancellation, DriverRequest, DriverStartOutcome, ExecutionSiteResolution,
+    ExecutionSiteResolver, ResolvedExecutionSite, SessionCapability, WorkerDriver,
+    WorkspaceCapability,
+};
+use zeroshot_engine::execution::local::LocalExecutionRuntime;
+use zeroshot_engine::fault::{
+    EngineFault, EvidenceClass, FaultContext, FaultFactory, FaultModule, ModuleEvidence,
+    RetryDisposition, UserAction,
+};
+use zeroshot_engine::observability::NoopObservationSink;
 use rust_decimal::Decimal;
 use serde_json::json;
 use zeroshot_engine::cluster_ledger::ExecutionId;
 use zeroshot_engine::execution::{
     CancelObservation, CompletionEvidence, DispatchFence, DispatchObservation, ExecutionCandidate,
     ExecutionCommand, ExecutionControl, ExecutionInput, ExecutionObservation, ExecutionResult,
-    InlineExecutionInput, SessionScope, UsageObservation, UsageObservationSpec,
+    ExecutionRuntime, InlineExecutionInput, SessionScope, UsageObservation, UsageObservationSpec,
     MAX_EXECUTION_CANDIDATE_BYTES, MAX_EXECUTION_INLINE_BYTES,
 };
 
@@ -24,6 +39,140 @@ fn command(input: ExecutionInput) -> ExecutionCommand {
         },
         input,
     )
+}
+
+struct FaultingDriver {
+    starts: Arc<Mutex<Vec<NodeInstanceId>>>,
+    fault: EngineFault,
+}
+
+#[async_trait]
+impl WorkerDriver for FaultingDriver {
+    async fn start(
+        &self,
+        request: DriverRequest,
+        _cancellation: DriverCancellation,
+    ) -> DriverStartOutcome {
+        self.starts
+            .lock()
+            .expect("session start mutex must not be poisoned")
+            .push(request.control.node_instance());
+        DriverStartOutcome::DefinitelyNotStarted {
+            fault: Some(self.fault.clone()),
+        }
+    }
+}
+
+struct FaultingResolver {
+    driver: Arc<dyn WorkerDriver>,
+}
+
+#[async_trait]
+impl ExecutionSiteResolver for FaultingResolver {
+    async fn resolve(&self, command: &ExecutionCommand) -> ExecutionSiteResolution {
+        ExecutionSiteResolution::Resolved(Box::new(ResolvedExecutionSite::Agent {
+            driver: Arc::clone(&self.driver),
+            request: DriverRequest {
+                control: command.control(),
+                input: command.input().clone(),
+                workspace: WorkspaceCapability {
+                    current_dir: "/tmp/zeroshot-runtime".into(),
+                    mode: command.workspace().mode(),
+                },
+                credentials: Vec::new(),
+                provider: None,
+                session: SessionCapability { reuse_key: None },
+                environment: Default::default(),
+            },
+        }))
+    }
+}
+
+fn runtime_for_fault(
+    fault: EngineFault,
+    starts: Arc<Mutex<Vec<NodeInstanceId>>>,
+) -> LocalExecutionRuntime {
+    let driver: Arc<dyn WorkerDriver> = Arc::new(FaultingDriver { starts, fault });
+    LocalExecutionRuntime::new(Arc::new(FaultingResolver { driver }))
+}
+
+#[tokio::test]
+async fn session_loss_terminates_without_authorizing_retry_or_a_replacement_session() {
+    let fault = FaultFactory::new(&NoopObservationSink).create(ModuleEvidence::new(
+        FaultModule::Worker,
+        FaultContext::Execution,
+        EvidenceClass::SessionLost,
+    ));
+    assert_eq!(fault.retry_disposition(), RetryDisposition::DoNotRetry);
+    assert_eq!(fault.user_action(), UserAction::ContactSupport);
+
+    let retryable_fault = FaultFactory::new(&NoopObservationSink).create(ModuleEvidence::new(
+        FaultModule::Worker,
+        FaultContext::Execution,
+        EvidenceClass::ProcessExited,
+    ));
+    assert_eq!(
+        retryable_fault.retry_disposition(),
+        RetryDisposition::RetryAfterBackoff
+    );
+    let retryable_starts = Arc::new(Mutex::new(Vec::new()));
+    let retryable_runtime = runtime_for_fault(retryable_fault, Arc::clone(&retryable_starts));
+    let retryable_command = command_with_input(
+        CommandSpec {
+            execution: 14,
+            fence: 4,
+            recovery: "recovery-14",
+            target: agent_target(true),
+            scope: SessionScope::NodeInstance,
+        },
+        ExecutionInput::Inline(InlineExecutionInput::new("{\"ok\":true}").unwrap()),
+    );
+    let retryable_first = retryable_runtime.dispatch(retryable_command.clone()).await;
+    assert_eq!(
+        retryable_runtime.dispatch(retryable_command.clone()).await,
+        retryable_first
+    );
+    assert_eq!(
+        *retryable_starts
+            .lock()
+            .expect("session start mutex must not be poisoned"),
+        vec![retryable_command.node_instance()],
+        "descriptive backoff disposition must not authorize runtime retry"
+    );
+
+    let starts = Arc::new(Mutex::new(Vec::new()));
+    let runtime = runtime_for_fault(fault.clone(), Arc::clone(&starts));
+    let command = command_with_input(
+        CommandSpec {
+            execution: 15,
+            fence: 4,
+            recovery: "recovery-15",
+            target: agent_target(true),
+            scope: SessionScope::NodeInstance,
+        },
+        ExecutionInput::Inline(InlineExecutionInput::new("{\"ok\":true}").unwrap()),
+    );
+
+    let first = runtime.dispatch(command.clone()).await;
+    assert!(matches!(
+        &first,
+        DispatchObservation::Indeterminate {
+            fault: Some(observed),
+            ..
+        } if observed == &fault
+    ));
+    assert_eq!(runtime.tracked_counts().await, (0, 0, 1));
+    assert!(!runtime.is_recovery_registered(command.recovery_ref()).await);
+
+    let redispatch = runtime.dispatch(command.clone()).await;
+    assert_eq!(redispatch, first);
+    assert_eq!(
+        *starts
+            .lock()
+            .expect("session start mutex must not be poisoned"),
+        vec![command.node_instance()],
+        "terminal session loss must not start a retry or replacement NodeInstance session"
+    );
 }
 
 #[test]

--- a/zeroshot-rust/tests/fault_contract.rs
+++ b/zeroshot-rust/tests/fault_contract.rs
@@ -8,10 +8,10 @@ use openengine_cluster_server::{
 };
 use serde_json::{json, Value};
 use zeroshot_engine::fault::{
-    BoundedFaultSummary, EngineFault, EvidenceClass, FaultContext, FaultError, FaultFactory,
-    FaultModule, ModuleEvidence, RawDiagnostic, RedactionMarker, SafeSourceFrame,
-    MAX_ENGINE_FAULT_BYTES, MAX_EPHEMERAL_DIAGNOSTIC_BYTES, MAX_FAULT_SOURCES,
-    MAX_FAULT_SUMMARY_BYTES,
+    BoundedFaultSummary, EngineFault, EvidenceClass, FaultCode, FaultContext, FaultError,
+    FaultFactory, FaultModule, FaultSeverity, ModuleEvidence, RawDiagnostic, RedactionMarker,
+    RetryDisposition, SafeSourceFrame, UserAction, MAX_ENGINE_FAULT_BYTES,
+    MAX_EPHEMERAL_DIAGNOSTIC_BYTES, MAX_FAULT_SOURCES, MAX_FAULT_SUMMARY_BYTES,
 };
 use zeroshot_engine::observability::NoopObservationSink;
 
@@ -46,6 +46,49 @@ const CLASSES: [EvidenceClass; 10] = [
     EvidenceClass::InvariantViolation,
 ];
 
+const GOLDEN_EXECUTION_FAULTS: [(EvidenceClass, &str); 10] = [
+    (
+        EvidenceClass::Unavailable,
+        r#"{"code":"unavailable","consequence":"execution_interrupted","retryDisposition":"retry_after_backoff","userAction":"retry_later","severity":"error","summary":"A required engine resource is unavailable.","sources":[{"module":"worker","context":"execution","evidenceClass":"unavailable"}]}"#,
+    ),
+    (
+        EvidenceClass::ResourceExhausted,
+        r#"{"code":"resource_exhausted","consequence":"execution_interrupted","retryDisposition":"retry_after_backoff","userAction":"free_resources","severity":"error","summary":"A required engine resource is exhausted.","sources":[{"module":"worker","context":"execution","evidenceClass":"resource_exhausted"}]}"#,
+    ),
+    (
+        EvidenceClass::Timeout,
+        r#"{"code":"timeout","consequence":"execution_interrupted","retryDisposition":"retry_after_backoff","userAction":"retry_later","severity":"warning","summary":"A native engine operation timed out.","sources":[{"module":"worker","context":"execution","evidenceClass":"timeout"}]}"#,
+    ),
+    (
+        EvidenceClass::PermissionDenied,
+        r#"{"code":"permission_denied","consequence":"execution_interrupted","retryDisposition":"retry_after_user_action","userAction":"grant_permission","severity":"error","summary":"A required engine permission was denied.","sources":[{"module":"worker","context":"execution","evidenceClass":"permission_denied"}]}"#,
+    ),
+    (
+        EvidenceClass::AuthenticationRequired,
+        r#"{"code":"authentication_required","consequence":"execution_interrupted","retryDisposition":"retry_after_user_action","userAction":"authenticate","severity":"error","summary":"Authentication is required for a native engine operation.","sources":[{"module":"worker","context":"execution","evidenceClass":"authentication_required"}]}"#,
+    ),
+    (
+        EvidenceClass::MalformedExternalData,
+        r#"{"code":"malformed_external_data","consequence":"execution_interrupted","retryDisposition":"retry_after_user_action","userAction":"repair_external_data","severity":"error","summary":"External data did not satisfy the native engine contract.","sources":[{"module":"worker","context":"execution","evidenceClass":"malformed_external_data"}]}"#,
+    ),
+    (
+        EvidenceClass::IntegrityFailure,
+        r#"{"code":"integrity_failure","consequence":"execution_interrupted","retryDisposition":"do_not_retry","userAction":"contact_support","severity":"critical","summary":"Native engine integrity verification failed.","sources":[{"module":"worker","context":"execution","evidenceClass":"integrity_failure"}]}"#,
+    ),
+    (
+        EvidenceClass::ProcessExited,
+        r#"{"code":"process_exited","consequence":"execution_interrupted","retryDisposition":"retry_after_backoff","userAction":"restart_operation","severity":"error","summary":"A required native process exited unexpectedly.","sources":[{"module":"worker","context":"execution","evidenceClass":"process_exited"}]}"#,
+    ),
+    (
+        EvidenceClass::SessionLost,
+        r#"{"code":"session_lost","consequence":"execution_interrupted","retryDisposition":"do_not_retry","userAction":"contact_support","severity":"error","summary":"A lost native engine session terminated the affected execution.","sources":[{"module":"worker","context":"execution","evidenceClass":"session_lost"}]}"#,
+    ),
+    (
+        EvidenceClass::InvariantViolation,
+        r#"{"code":"invariant_violation","consequence":"execution_interrupted","retryDisposition":"do_not_retry","userAction":"contact_support","severity":"critical","summary":"A native engine invariant was violated.","sources":[{"module":"worker","context":"execution","evidenceClass":"invariant_violation"}]}"#,
+    ),
+];
+
 fn factory() -> FaultFactory<'static> {
     static SINK: NoopObservationSink = NoopObservationSink;
     FaultFactory::new(&SINK)
@@ -75,6 +118,60 @@ fn every_closed_evidence_triple_is_deterministic() {
                 assert!(first.summary().len() <= MAX_FAULT_SUMMARY_BYTES);
                 assert!(first.encode_json().unwrap().len() <= MAX_ENGINE_FAULT_BYTES);
             }
+        }
+    }
+}
+
+#[test]
+fn canonical_fault_encodings_are_exhaustive_and_byte_compatible() {
+    for (class, golden) in GOLDEN_EXECUTION_FAULTS {
+        let fault = factory().create(ModuleEvidence::new(
+            FaultModule::Worker,
+            FaultContext::Execution,
+            class,
+        ));
+        assert_eq!(
+            fault.encode_json().unwrap(),
+            golden.as_bytes(),
+            "encoded fixture drifted for {class:?}"
+        );
+        assert_eq!(
+            EngineFault::decode_json(golden.as_bytes()).unwrap(),
+            fault,
+            "golden fixture failed canonical decode for {class:?}"
+        );
+    }
+}
+
+#[test]
+fn session_loss_is_identically_non_retryable_for_every_source_context() {
+    const SUMMARY: &str = "A lost native engine session terminated the affected execution.";
+
+    for module in MODULES {
+        for context in CONTEXTS {
+            let fault = factory().create(ModuleEvidence::new(
+                module,
+                context,
+                EvidenceClass::SessionLost,
+            ));
+            assert_eq!(fault.code(), FaultCode::SessionLost);
+            assert_eq!(fault.retry_disposition(), RetryDisposition::DoNotRetry);
+            assert_eq!(fault.user_action(), UserAction::ContactSupport);
+            assert_eq!(fault.severity(), FaultSeverity::Error);
+            assert_eq!(fault.summary(), SUMMARY);
+            let encoded = fault.encode_json().unwrap();
+            assert_eq!(
+                EngineFault::decode_json(&encoded).unwrap(),
+                fault,
+                "{module:?}/{context:?}"
+            );
+            let mut legacy_retry: Value = serde_json::from_slice(&encoded).unwrap();
+            legacy_retry["retryDisposition"] = json!("retry_after_backoff");
+            assert_eq!(
+                EngineFault::decode_json(&serde_json::to_vec(&legacy_retry).unwrap()),
+                Err(FaultError::InvalidFaultSemantics),
+                "legacy retry semantics decoded for {module:?}/{context:?}"
+            );
         }
     }
 }

--- a/zeroshot-rust/tests/observability_contract.rs
+++ b/zeroshot-rust/tests/observability_contract.rs
@@ -1,6 +1,6 @@
 use zeroshot_engine::fault::{
-    EvidenceClass, FaultContext, FaultFactory, FaultModule, ModuleEvidence, RawDiagnostic,
-    RedactionMarker,
+    EvidenceClass, FaultCode, FaultConsequence, FaultContext, FaultFactory, FaultModule,
+    FaultSeverity, ModuleEvidence, RawDiagnostic, RedactionMarker,
 };
 use zeroshot_engine::observability::{
     CounterMetricName, HistogramMetricName, InMemoryObservationSink, NoopObservationSink,
@@ -40,6 +40,42 @@ fn fault_creation_emits_exactly_one_bounded_typed_observation() {
     assert_eq!(record.severity, fault.severity());
     assert!(record.diagnostic_redacted);
     assert!(!format!("{snapshot:?}").contains(secret));
+}
+
+#[test]
+fn session_loss_observation_is_terminal_typed_and_identifier_free() {
+    let sink = InMemoryObservationSink::default();
+    let identifier = "private-node-session-42";
+    let fault = FaultFactory::new(&sink).create(
+        ModuleEvidence::new(
+            FaultModule::Worker,
+            FaultContext::Execution,
+            EvidenceClass::SessionLost,
+        )
+        .with_diagnostic(
+            RawDiagnostic::new(RedactionMarker::SessionIdentifier, identifier).unwrap(),
+        ),
+    );
+
+    let snapshot = sink.snapshot();
+    assert_eq!(snapshot.faults_total, 1);
+    assert_eq!(snapshot.diagnostics_redacted_total, 1);
+    assert_eq!(snapshot.faults.len(), 1);
+    assert_eq!(
+        snapshot.fault_size_bytes,
+        vec![fault.encode_json().unwrap().len() as u16]
+    );
+    let record = snapshot.faults[0];
+    assert_eq!(record.module, ObservationModule::Worker);
+    assert_eq!(record.operation, ObservationOperation::Execution);
+    assert_eq!(record.outcome, ObservationOutcome::Faulted);
+    assert_eq!(record.fault_code, FaultCode::SessionLost);
+    assert_eq!(record.consequence, FaultConsequence::ExecutionInterrupted);
+    assert_eq!(record.severity, FaultSeverity::Error);
+    assert!(record.diagnostic_redacted);
+    let observed = format!("{snapshot:?}");
+    assert!(!observed.contains(identifier));
+    assert!(!observed.contains("RetryAfter"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make canonical `SESSION_LOST` semantics `DoNotRetry` with execution-terminating engine guidance
- lock FaultFactory/decode/golden/observability semantics for every source context
- prove descriptive retry disposition never authorizes redispatch or replacement `NodeInstance` sessions

## Decision
The existing `RetryAfterBackoff` mapping contradicted the native session ownership contract. The corrected taxonomy terminalizes the affected execution; no protocol or driver retry mechanism was added.

## Verification
- `cargo test -p zeroshot-rust --test fault_contract` (9 tests)
- `cargo test -p zeroshot-rust --test execution_runtime_contract` (8 tests)
- `cargo test -p zeroshot-rust --test architecture` (11 tests)
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` (1953 passing, 18 pending)
- `opcore check --changed`
- two independent verifier passes, including mutation proof against the former taxonomy and a forced redispatch

Closes #775