### PR TITLE
feat(zeroshot-rust): own the versioned worker-provider catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Issue provider contracts     | `zeroshot-rust/src/issue_provider.rs`, `issue_provider/`                |
 | Source provider contracts    | `zeroshot-rust/src/source_code_provider.rs`, `source_code_provider/`    |
 | Provider value bounds        | `zeroshot-rust/src/provider_value.rs`, `provider_value/`                |
+| Native worker catalog        | `zeroshot-rust/src/worker_catalog.rs`                                   |
 | Execution runtime seam       | `zeroshot-rust/src/execution.rs`, `execution/types.rs`                  |
 | Local runtime + drivers      | `zeroshot-rust/src/execution/{local,driver}.rs`                         |
 | Local process runner         | `zeroshot-rust/src/execution/process.rs`                                |
@@ -138,6 +139,10 @@ filesystem store, and must preserve ref-first release plus synchronized blob-the
 Issue and source registries and identifiers remain independent; neither is a worker/model provider.
 Keep protocol, transport, daemon, compatibility, adapter, credential resolution, ledger, and
 workspace behavior outside it.
+`worker_catalog` is the native product's sole hand-authored, versioned worker-provider inventory.
+It owns bounded provider policy and deterministic identity only; keep role contracts, registries,
+configuration, credential acquisition, executable codecs, concrete drivers, protocol descriptors,
+and Node registry synchronization outside it.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair
 scheduler are engine-private seams. They own local dispatch placement, fencing, deadlines,
 workspace conflict arbitration, cancellation, and local-process containment only. They do not own

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -5,6 +5,7 @@ pub mod issue_provider;
 mod provider_value;
 pub mod scheduler;
 pub mod source_code_provider;
+pub mod worker_catalog;
 
 use async_trait::async_trait;
 use openengine_cluster_protocol::{

--- a/zeroshot-rust/src/worker_catalog.rs
+++ b/zeroshot-rust/src/worker_catalog.rs
@@ -1,0 +1,964 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::num::NonZeroU32;
+use std::sync::LazyLock;
+
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+
+use crate::execution::{CatalogDigest, DriverFamilyId, SessionScope};
+use crate::provider_value::{validate_collection_len, validate_serialized};
+
+pub const WORKER_CATALOG_VERSION: u32 = 1;
+pub const WORKER_PROVIDER_COUNT: usize = 8;
+pub const DEFAULT_WORKER_PROVIDER: &str = "claude";
+
+crate::provider_value::contract_error_type!(WorkerCatalogError);
+crate::provider_value::provider_id_type!(ProviderId, WorkerCatalogError, "provider id");
+crate::provider_value::provider_id_type!(ProviderAlias, WorkerCatalogError, "provider alias");
+crate::provider_value::bounded_text_type!(ProviderDisplayName, 64, WorkerCatalogError, "provider display name");
+crate::provider_value::bounded_bytes_type!(ModelId, 128, WorkerCatalogError, "model id");
+crate::provider_value::bounded_bytes_type!(ExecutableName, 128, WorkerCatalogError, "executable name");
+crate::provider_value::bounded_bytes_type!(ExecutableArgument, 256, WorkerCatalogError, "executable argument");
+crate::provider_value::provider_id_type!(CredentialRequirementName, WorkerCatalogError, "credential requirement name");
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DriverFamily {
+    CliProcess,
+    AcpStdio,
+    GatewayHttp,
+}
+
+impl DriverFamily {
+    #[must_use]
+    pub const fn token(self) -> &'static str {
+        match self {
+            Self::CliProcess => "cli-process",
+            Self::AcpStdio => "acp-stdio",
+            Self::GatewayHttp => "gateway-http",
+        }
+    }
+
+    #[must_use]
+    pub fn driver_family_id(self) -> DriverFamilyId {
+        DriverFamilyId::new(self.token()).expect("closed driver-family token is valid")
+    }
+}
+
+impl TryFrom<DriverFamily> for DriverFamilyId {
+    type Error = crate::execution::ExecutionContractError;
+
+    fn try_from(family: DriverFamily) -> Result<Self, Self::Error> {
+        Self::new(family.token())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelLevel {
+    Level1,
+    Level2,
+    Level3,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerCapability {
+    ToolUse,
+    WorkspaceIsolation,
+    McpServers,
+    JsonSchema,
+    StreamEvents,
+    Thinking,
+    ReasoningEffort,
+    SessionResume,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilitySupport {
+    Experimental,
+    Stable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct CapabilityPolicy(BTreeMap<WorkerCapability, CapabilitySupport>);
+
+impl CapabilityPolicy {
+    pub fn new(
+        entries: impl IntoIterator<Item = (WorkerCapability, CapabilitySupport)>,
+    ) -> Result<Self, WorkerCatalogError> {
+        let mut values = BTreeMap::new();
+        for (capability, support) in entries {
+            if values.insert(capability, support).is_some() {
+                return Err(WorkerCatalogError::new(
+                    "capability policy",
+                    "capabilities must be unique",
+                ));
+            }
+        }
+        validate_collection_len(values.len())
+            .map_err(|error| WorkerCatalogError::new("capability policy", error))?;
+        Ok(Self(values))
+    }
+
+    #[must_use]
+    pub fn support(&self, capability: WorkerCapability) -> Option<CapabilitySupport> {
+        self.0.get(&capability).copied()
+    }
+
+    #[must_use]
+    pub fn supports(&self, capability: WorkerCapability) -> bool {
+        self.0.contains_key(&capability)
+    }
+
+    #[must_use]
+    pub fn entries(&self) -> &BTreeMap<WorkerCapability, CapabilitySupport> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelSelection {
+    level: ModelLevel,
+    model: Option<ModelId>,
+    default_reasoning_effort: Option<ReasoningEffort>,
+}
+
+impl ModelSelection {
+    #[must_use]
+    pub const fn new(
+        level: ModelLevel,
+        model: Option<ModelId>,
+        default_reasoning_effort: Option<ReasoningEffort>,
+    ) -> Self {
+        Self {
+            level,
+            model,
+            default_reasoning_effort,
+        }
+    }
+
+    #[must_use]
+    pub const fn level(&self) -> ModelLevel {
+        self.level
+    }
+
+    #[must_use]
+    pub fn model(&self) -> Option<&ModelId> {
+        self.model.as_ref()
+    }
+
+    #[must_use]
+    pub const fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.default_reasoning_effort
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelPolicy {
+    default_level: ModelLevel,
+    levels: BTreeMap<ModelLevel, ModelSelection>,
+}
+
+impl ModelPolicy {
+    pub fn new(
+        default_level: ModelLevel,
+        selections: impl IntoIterator<Item = ModelSelection>,
+    ) -> Result<Self, WorkerCatalogError> {
+        let mut levels = BTreeMap::new();
+        for selection in selections {
+            if levels.insert(selection.level(), selection).is_some() {
+                return Err(WorkerCatalogError::new(
+                    "model policy",
+                    "model levels must be unique",
+                ));
+            }
+        }
+        validate_collection_len(levels.len())
+            .map_err(|error| WorkerCatalogError::new("model policy", error))?;
+        if !levels.contains_key(&default_level) {
+            return Err(WorkerCatalogError::new(
+                "default model level",
+                "default level must be present in the model policy",
+            ));
+        }
+        validate_serialized(&levels)
+            .map_err(|error| WorkerCatalogError::new("model policy", error))?;
+        Ok(Self {
+            default_level,
+            levels,
+        })
+    }
+
+    #[must_use]
+    pub const fn default_level(&self) -> ModelLevel {
+        self.default_level
+    }
+
+    #[must_use]
+    pub fn default_selection(&self) -> &ModelSelection {
+        self.levels
+            .get(&self.default_level)
+            .expect("validated model policy contains its default")
+    }
+
+    #[must_use]
+    pub fn selection(&self, level: ModelLevel) -> Option<&ModelSelection> {
+        self.levels.get(&level)
+    }
+
+    #[must_use]
+    pub fn levels(&self) -> &BTreeMap<ModelLevel, ModelSelection> {
+        &self.levels
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ReasoningPolicy(BTreeSet<ReasoningEffort>);
+
+impl ReasoningPolicy {
+    pub fn new(
+        efforts: impl IntoIterator<Item = ReasoningEffort>,
+    ) -> Result<Self, WorkerCatalogError> {
+        let mut unique = BTreeSet::new();
+        for effort in efforts {
+            if !unique.insert(effort) {
+                return Err(WorkerCatalogError::new(
+                    "reasoning policy",
+                    "reasoning efforts must be unique",
+                ));
+            }
+        }
+        let efforts = unique;
+        validate_collection_len(efforts.len())
+            .map_err(|error| WorkerCatalogError::new("reasoning policy", error))?;
+        Ok(Self(efforts))
+    }
+
+    #[must_use]
+    pub fn supports(&self, effort: ReasoningEffort) -> bool {
+        self.0.contains(&effort)
+    }
+
+    #[must_use]
+    pub fn efforts(&self) -> &BTreeSet<ReasoningEffort> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct SessionPolicy(BTreeSet<SessionScope>);
+
+impl SessionPolicy {
+    pub fn new(
+        scopes: impl IntoIterator<Item = SessionScope>,
+    ) -> Result<Self, WorkerCatalogError> {
+        let mut unique = BTreeSet::new();
+        for scope in scopes {
+            if !unique.insert(scope) {
+                return Err(WorkerCatalogError::new(
+                    "session policy",
+                    "session scopes must be unique",
+                ));
+            }
+        }
+        let scopes = unique;
+        if scopes.is_empty() {
+            return Err(WorkerCatalogError::new(
+                "session policy",
+                "at least one session scope is required",
+            ));
+        }
+        validate_collection_len(scopes.len())
+            .map_err(|error| WorkerCatalogError::new("session policy", error))?;
+        Ok(Self(scopes))
+    }
+
+    #[must_use]
+    pub fn supports(&self, scope: SessionScope) -> bool {
+        self.0.contains(&scope)
+    }
+
+    #[must_use]
+    pub fn scopes(&self) -> &BTreeSet<SessionScope> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProbeStrategy {
+    Version,
+    HelpOrVersion,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutableMetadata {
+    name: ExecutableName,
+    arguments: Vec<ExecutableArgument>,
+    probe: ProbeStrategy,
+}
+
+impl ExecutableMetadata {
+    pub fn new(
+        name: ExecutableName,
+        arguments: Vec<ExecutableArgument>,
+        probe: ProbeStrategy,
+    ) -> Result<Self, WorkerCatalogError> {
+        validate_collection_len(arguments.len())
+            .map_err(|error| WorkerCatalogError::new("executable arguments", error))?;
+        let value = Self {
+            name,
+            arguments,
+            probe,
+        };
+        validate_serialized(&value)
+            .map_err(|error| WorkerCatalogError::new("executable metadata", error))?;
+        Ok(value)
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &ExecutableName {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn arguments(&self) -> &[ExecutableArgument] {
+        &self.arguments
+    }
+
+    #[must_use]
+    pub const fn probe(&self) -> ProbeStrategy {
+        self.probe
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderDescriptorSpec {
+    pub id: ProviderId,
+    pub aliases: Vec<ProviderAlias>,
+    pub display_name: ProviderDisplayName,
+    pub driver_family: DriverFamily,
+    pub models: ModelPolicy,
+    pub reasoning: ReasoningPolicy,
+    pub sessions: SessionPolicy,
+    pub capabilities: CapabilityPolicy,
+    pub executable: Option<ExecutableMetadata>,
+    pub credential_requirements: Vec<CredentialRequirementName>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderDescriptor {
+    id: ProviderId,
+    aliases: Vec<ProviderAlias>,
+    display_name: ProviderDisplayName,
+    driver_family: DriverFamily,
+    models: ModelPolicy,
+    reasoning: ReasoningPolicy,
+    sessions: SessionPolicy,
+    capabilities: CapabilityPolicy,
+    executable: Option<ExecutableMetadata>,
+    credential_requirements: Vec<CredentialRequirementName>,
+}
+
+impl ProviderDescriptor {
+    pub fn new(mut spec: ProviderDescriptorSpec) -> Result<Self, WorkerCatalogError> {
+        spec.aliases.sort();
+        if spec.aliases.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(WorkerCatalogError::new(
+                "provider aliases",
+                "aliases must be unique",
+            ));
+        }
+        if spec
+            .aliases
+            .iter()
+            .any(|alias| alias.as_str() == spec.id.as_str())
+        {
+            return Err(WorkerCatalogError::new(
+                "provider aliases",
+                "an alias must not equal its canonical provider id",
+            ));
+        }
+        validate_collection_len(spec.aliases.len())
+            .map_err(|error| WorkerCatalogError::new("provider aliases", error))?;
+
+        spec.credential_requirements.sort();
+        if spec
+            .credential_requirements
+            .windows(2)
+            .any(|pair| pair[0] == pair[1])
+        {
+            return Err(WorkerCatalogError::new(
+                "credential requirements",
+                "requirement names must be unique",
+            ));
+        }
+        validate_collection_len(spec.credential_requirements.len())
+            .map_err(|error| WorkerCatalogError::new("credential requirements", error))?;
+
+        match (spec.driver_family, spec.executable.is_some()) {
+            (DriverFamily::GatewayHttp, true) => {
+                return Err(WorkerCatalogError::new(
+                    "driver family policy",
+                    "gateway-http providers must not declare process executable metadata",
+                ));
+            }
+            (DriverFamily::CliProcess | DriverFamily::AcpStdio, false) => {
+                return Err(WorkerCatalogError::new(
+                    "driver family policy",
+                    "process-backed providers must declare executable metadata",
+                ));
+            }
+            _ => {}
+        }
+
+        if spec.sessions.supports(SessionScope::NodeInstance) {
+            return Err(WorkerCatalogError::new(
+                "session policy",
+                "worker catalog v1 has no pinned evidence for node-instance sessions",
+            ));
+        }
+        if !spec.sessions.supports(SessionScope::Execution) {
+            return Err(WorkerCatalogError::new(
+                "session policy",
+                "worker catalog v1 providers must support execution scope",
+            ));
+        }
+
+        let supports_reasoning = spec
+            .capabilities
+            .supports(WorkerCapability::ReasoningEffort);
+        if supports_reasoning != !spec.reasoning.efforts().is_empty() {
+            return Err(WorkerCatalogError::new(
+                "reasoning policy",
+                "reasoning efforts and the reasoning capability must be declared together",
+            ));
+        }
+        for selection in spec.models.levels().values() {
+            if let Some(effort) = selection.default_reasoning_effort() {
+                if !spec.reasoning.supports(effort) {
+                    return Err(WorkerCatalogError::new(
+                        "model policy",
+                        "a model default uses an unsupported reasoning effort",
+                    ));
+                }
+            }
+        }
+
+        let value = Self {
+            id: spec.id,
+            aliases: spec.aliases,
+            display_name: spec.display_name,
+            driver_family: spec.driver_family,
+            models: spec.models,
+            reasoning: spec.reasoning,
+            sessions: spec.sessions,
+            capabilities: spec.capabilities,
+            executable: spec.executable,
+            credential_requirements: spec.credential_requirements,
+        };
+        WorkerCatalogError::checked(value)
+    }
+
+    #[must_use]
+    pub fn id(&self) -> &ProviderId {
+        &self.id
+    }
+
+    #[must_use]
+    pub fn aliases(&self) -> &[ProviderAlias] {
+        &self.aliases
+    }
+
+    #[must_use]
+    pub fn display_name(&self) -> &ProviderDisplayName {
+        &self.display_name
+    }
+
+    #[must_use]
+    pub const fn driver_family(&self) -> DriverFamily {
+        self.driver_family
+    }
+
+    #[must_use]
+    pub fn driver_family_id(&self) -> DriverFamilyId {
+        self.driver_family.driver_family_id()
+    }
+
+    #[must_use]
+    pub fn models(&self) -> &ModelPolicy {
+        &self.models
+    }
+
+    #[must_use]
+    pub fn reasoning(&self) -> &ReasoningPolicy {
+        &self.reasoning
+    }
+
+    #[must_use]
+    pub fn sessions(&self) -> &SessionPolicy {
+        &self.sessions
+    }
+
+    #[must_use]
+    pub fn capabilities(&self) -> &CapabilityPolicy {
+        &self.capabilities
+    }
+
+    #[must_use]
+    pub fn executable(&self) -> Option<&ExecutableMetadata> {
+        self.executable.as_ref()
+    }
+
+    #[must_use]
+    pub fn credential_requirements(&self) -> &[CredentialRequirementName] {
+        &self.credential_requirements
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkerCatalogSpec {
+    pub version: u32,
+    pub default_provider: ProviderId,
+    pub providers: Vec<ProviderDescriptor>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkerCatalog {
+    version: NonZeroU32,
+    default_provider: ProviderId,
+    providers: Vec<ProviderDescriptor>,
+    canonical_bytes: Vec<u8>,
+    digest: CatalogDigest,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CanonicalCatalog<'a> {
+    version: u32,
+    default_provider: &'a ProviderId,
+    providers: &'a [ProviderDescriptor],
+}
+
+impl WorkerCatalog {
+    pub fn new(mut spec: WorkerCatalogSpec) -> Result<Self, WorkerCatalogError> {
+        let version = NonZeroU32::new(spec.version).ok_or_else(|| {
+            WorkerCatalogError::new("catalog version", "version must be greater than zero")
+        })?;
+        if spec.providers.is_empty() {
+            return Err(WorkerCatalogError::new(
+                "catalog providers",
+                "at least one provider is required",
+            ));
+        }
+        validate_collection_len(spec.providers.len())
+            .map_err(|error| WorkerCatalogError::new("catalog providers", error))?;
+        spec.providers.sort_by(|left, right| left.id.cmp(&right.id));
+        if spec
+            .providers
+            .windows(2)
+            .any(|pair| pair[0].id == pair[1].id)
+        {
+            return Err(WorkerCatalogError::new(
+                "catalog providers",
+                "canonical provider ids must be unique",
+            ));
+        }
+
+        let canonical_ids = spec
+            .providers
+            .iter()
+            .map(|provider| provider.id.as_str())
+            .collect::<BTreeSet<_>>();
+        if !canonical_ids.contains(spec.default_provider.as_str()) {
+            return Err(WorkerCatalogError::new(
+                "default provider",
+                "default provider must name a canonical provider",
+            ));
+        }
+
+        let mut names = BTreeMap::<&str, &str>::new();
+        for provider in &spec.providers {
+            if let Some(owner) = names.insert(provider.id.as_str(), provider.id.as_str()) {
+                return Err(WorkerCatalogError::new(
+                    "provider identity",
+                    format!("provider identity collides with {owner}"),
+                ));
+            }
+            for alias in &provider.aliases {
+                if let Some(owner) = names.insert(alias.as_str(), provider.id.as_str()) {
+                    return Err(WorkerCatalogError::new(
+                        "provider identity",
+                        format!("provider identity collides with {owner}"),
+                    ));
+                }
+            }
+        }
+
+        let mut display_names = BTreeSet::new();
+        for provider in &spec.providers {
+            let folded = provider.display_name.as_str().to_ascii_lowercase();
+            if !display_names.insert(folded) {
+                return Err(WorkerCatalogError::new(
+                    "provider display names",
+                    "display names must be unique ignoring ASCII case",
+                ));
+            }
+        }
+
+        let canonical_bytes = serde_json::to_vec(&CanonicalCatalog {
+            version: version.get(),
+            default_provider: &spec.default_provider,
+            providers: &spec.providers,
+        })
+        .map_err(|error| WorkerCatalogError::new("canonical catalog", error))?;
+        if canonical_bytes.len() > crate::provider_value::MAX_SERIALIZED_BYTES {
+            return Err(WorkerCatalogError::new(
+                "canonical catalog",
+                "canonical catalog exceeds the serialized-value bound",
+            ));
+        }
+        let mut digest_hex = String::with_capacity(64);
+        for byte in Sha256::digest(&canonical_bytes) {
+            write!(&mut digest_hex, "{byte:02x}").expect("writing to a string cannot fail");
+        }
+        let digest = CatalogDigest::new(digest_hex)
+            .map_err(|error| WorkerCatalogError::new("catalog digest", error))?;
+
+        Ok(Self {
+            version,
+            default_provider: spec.default_provider,
+            providers: spec.providers,
+            canonical_bytes,
+            digest,
+        })
+    }
+
+    #[must_use]
+    pub fn version(&self) -> u32 {
+        self.version.get()
+    }
+
+    #[must_use]
+    pub fn default_provider_id(&self) -> &ProviderId {
+        &self.default_provider
+    }
+
+    #[must_use]
+    pub fn default_provider(&self) -> &ProviderDescriptor {
+        self.resolve(self.default_provider.as_str())
+            .expect("validated catalog contains its default provider")
+    }
+
+    #[must_use]
+    pub fn providers(&self) -> &[ProviderDescriptor] {
+        &self.providers
+    }
+
+    #[must_use]
+    pub fn resolve(&self, identity: &str) -> Option<&ProviderDescriptor> {
+        self.providers
+            .binary_search_by(|provider| provider.id.as_str().cmp(identity))
+            .ok()
+            .map(|index| &self.providers[index])
+            .or_else(|| {
+                self.providers.iter().find(|provider| {
+                    provider
+                        .aliases
+                        .iter()
+                        .any(|alias| alias.as_str() == identity)
+                })
+            })
+    }
+
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    #[must_use]
+    pub fn digest(&self) -> &CatalogDigest {
+        &self.digest
+    }
+}
+
+static WORKER_CATALOG: LazyLock<WorkerCatalog> = LazyLock::new(|| {
+    WorkerCatalog::new(canonical_catalog_spec()).expect("built-in worker catalog is valid")
+});
+
+#[must_use]
+pub fn worker_catalog() -> &'static WorkerCatalog {
+    &WORKER_CATALOG
+}
+
+fn canonical_catalog_spec() -> WorkerCatalogSpec {
+    WorkerCatalogSpec {
+        version: WORKER_CATALOG_VERSION,
+        default_provider: provider_id(DEFAULT_WORKER_PROVIDER),
+        providers: vec![
+            provider(ProviderSource {
+                id: "claude",
+                aliases: &["anthropic"],
+                display_name: "Claude",
+                family: DriverFamily::CliProcess,
+                executable: Some(("claude", &[], ProbeStrategy::Version)),
+                level_models: [Some("haiku"), Some("sonnet"), Some("opus")],
+                level_reasoning: [None, None, None],
+                reasoning: &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::Medium,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Xhigh,
+                    ReasoningEffort::Max,
+                ],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::McpServers),
+                    stable(WorkerCapability::JsonSchema),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                    stable(WorkerCapability::ReasoningEffort),
+                    stable(WorkerCapability::SessionResume),
+                ],
+                credential_requirement: "claude-auth",
+            }),
+            provider(ProviderSource {
+                id: "codex",
+                aliases: &["openai"],
+                display_name: "Codex",
+                family: DriverFamily::CliProcess,
+                executable: Some(("codex", &["exec"], ProbeStrategy::Version)),
+                level_models: [Some("gpt-5.4"), Some("gpt-5.4"), Some("gpt-5.4")],
+                level_reasoning: [
+                    Some(ReasoningEffort::Medium),
+                    Some(ReasoningEffort::High),
+                    Some(ReasoningEffort::Xhigh),
+                ],
+                reasoning: &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::Medium,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Xhigh,
+                    ReasoningEffort::Max,
+                ],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::McpServers),
+                    stable(WorkerCapability::JsonSchema),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                    stable(WorkerCapability::ReasoningEffort),
+                    stable(WorkerCapability::SessionResume),
+                ],
+                credential_requirement: "codex-auth",
+            }),
+            provider(ProviderSource {
+                id: "gateway",
+                aliases: &[],
+                display_name: "Gateway",
+                family: DriverFamily::GatewayHttp,
+                executable: None,
+                level_models: [None, None, None],
+                level_reasoning: [None, None, None],
+                reasoning: &[],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                ],
+                credential_requirement: "gateway-auth",
+            }),
+            provider(ProviderSource {
+                id: "gemini",
+                aliases: &["google"],
+                display_name: "Gemini",
+                family: DriverFamily::CliProcess,
+                executable: Some(("gemini", &[], ProbeStrategy::Version)),
+                level_models: [None, None, None],
+                level_reasoning: [None, None, None],
+                reasoning: &[],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::McpServers),
+                    (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                ],
+                credential_requirement: "gemini-auth",
+            }),
+            provider(ProviderSource {
+                id: "opencode",
+                aliases: &[],
+                display_name: "Opencode",
+                family: DriverFamily::CliProcess,
+                executable: Some(("opencode", &["run"], ProbeStrategy::Version)),
+                level_models: [None, None, None],
+                level_reasoning: [
+                    Some(ReasoningEffort::Low),
+                    Some(ReasoningEffort::Medium),
+                    Some(ReasoningEffort::High),
+                ],
+                reasoning: &[
+                    ReasoningEffort::Low,
+                    ReasoningEffort::Medium,
+                    ReasoningEffort::High,
+                    ReasoningEffort::Xhigh,
+                    ReasoningEffort::Max,
+                ],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::McpServers),
+                    (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                    stable(WorkerCapability::ReasoningEffort),
+                ],
+                credential_requirement: "opencode-auth",
+            }),
+            provider(ProviderSource {
+                id: "pi",
+                aliases: &[],
+                display_name: "Pi",
+                family: DriverFamily::CliProcess,
+                executable: Some(("pi", &[], ProbeStrategy::HelpOrVersion)),
+                level_models: [None, None, None],
+                level_reasoning: [None, None, None],
+                reasoning: &[],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                ],
+                credential_requirement: "pi-auth",
+            }),
+            provider(ProviderSource {
+                id: "kiro",
+                aliases: &[],
+                display_name: "Kiro",
+                family: DriverFamily::AcpStdio,
+                executable: Some(("kiro-cli", &["acp"], ProbeStrategy::Version)),
+                level_models: [None, None, None],
+                level_reasoning: [None, None, None],
+                reasoning: &[],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                ],
+                credential_requirement: "kiro-auth",
+            }),
+            provider(ProviderSource {
+                id: "copilot",
+                aliases: &[],
+                display_name: "Copilot",
+                family: DriverFamily::CliProcess,
+                executable: Some(("copilot", &[], ProbeStrategy::HelpOrVersion)),
+                level_models: [None, None, None],
+                level_reasoning: [None, None, None],
+                reasoning: &[],
+                capabilities: vec![
+                    stable(WorkerCapability::ToolUse),
+                    stable(WorkerCapability::WorkspaceIsolation),
+                    stable(WorkerCapability::McpServers),
+                    stable(WorkerCapability::StreamEvents),
+                    stable(WorkerCapability::Thinking),
+                ],
+                credential_requirement: "copilot-auth",
+            }),
+        ],
+    }
+}
+
+type ExecutableSource = (&'static str, &'static [&'static str], ProbeStrategy);
+
+struct ProviderSource {
+    id: &'static str,
+    aliases: &'static [&'static str],
+    display_name: &'static str,
+    family: DriverFamily,
+    executable: Option<ExecutableSource>,
+    level_models: [Option<&'static str>; 3],
+    level_reasoning: [Option<ReasoningEffort>; 3],
+    reasoning: &'static [ReasoningEffort],
+    capabilities: Vec<(WorkerCapability, CapabilitySupport)>,
+    credential_requirement: &'static str,
+}
+
+fn provider(source: ProviderSource) -> ProviderDescriptor {
+    let levels = [ModelLevel::Level1, ModelLevel::Level2, ModelLevel::Level3]
+        .into_iter()
+        .zip(source.level_models)
+        .zip(source.level_reasoning)
+        .map(|((level, model), effort)| {
+            ModelSelection::new(level, model.map(model_id), effort)
+        });
+    ProviderDescriptor::new(ProviderDescriptorSpec {
+        id: provider_id(source.id),
+        aliases: source.aliases.iter().copied().map(provider_alias).collect(),
+        display_name: ProviderDisplayName::new(source.display_name).expect("built-in display name is valid"),
+        driver_family: source.family,
+        models: ModelPolicy::new(ModelLevel::Level2, levels).expect("built-in model policy is valid"),
+        reasoning: ReasoningPolicy::new(source.reasoning.iter().copied()).expect("built-in reasoning policy is valid"),
+        sessions: SessionPolicy::new([SessionScope::Execution]).expect("built-in session policy is valid"),
+        capabilities: CapabilityPolicy::new(source.capabilities.iter().copied()).expect("built-in capability policy is valid"),
+        executable: source.executable.map(|(name, arguments, probe)| {
+            ExecutableMetadata::new(
+                ExecutableName::new(name).expect("built-in executable name is valid"),
+                arguments
+                    .iter()
+                    .map(|argument| ExecutableArgument::new(*argument).expect("built-in argument is valid"))
+                    .collect(),
+                probe,
+            )
+            .expect("built-in executable metadata is valid")
+        }),
+        credential_requirements: vec![
+            CredentialRequirementName::new(source.credential_requirement)
+                .expect("built-in credential requirement is valid"),
+        ],
+    })
+    .expect("built-in provider descriptor is valid")
+}
+
+const fn stable(capability: WorkerCapability) -> (WorkerCapability, CapabilitySupport) {
+    (capability, CapabilitySupport::Stable)
+}
+
+fn provider_id(value: &str) -> ProviderId {
+    ProviderId::new(value).expect("built-in provider id is valid")
+}
+
+fn provider_alias(value: &str) -> ProviderAlias {
+    ProviderAlias::new(value).expect("built-in provider alias is valid")
+}
+
+fn model_id(value: &str) -> ModelId {
+    ModelId::new(value).expect("built-in model id is valid")
+}

--- a/zeroshot-rust/src/worker_catalog.rs
+++ b/zeroshot-rust/src/worker_catalog.rs
@@ -16,11 +16,30 @@ pub const DEFAULT_WORKER_PROVIDER: &str = "claude";
 crate::provider_value::contract_error_type!(WorkerCatalogError);
 crate::provider_value::provider_id_type!(ProviderId, WorkerCatalogError, "provider id");
 crate::provider_value::provider_id_type!(ProviderAlias, WorkerCatalogError, "provider alias");
-crate::provider_value::bounded_text_type!(ProviderDisplayName, 64, WorkerCatalogError, "provider display name");
+crate::provider_value::bounded_text_type!(
+    ProviderDisplayName,
+    64,
+    WorkerCatalogError,
+    "provider display name"
+);
 crate::provider_value::bounded_bytes_type!(ModelId, 128, WorkerCatalogError, "model id");
-crate::provider_value::bounded_bytes_type!(ExecutableName, 128, WorkerCatalogError, "executable name");
-crate::provider_value::bounded_bytes_type!(ExecutableArgument, 256, WorkerCatalogError, "executable argument");
-crate::provider_value::provider_id_type!(CredentialRequirementName, WorkerCatalogError, "credential requirement name");
+crate::provider_value::bounded_bytes_type!(
+    ExecutableName,
+    128,
+    WorkerCatalogError,
+    "executable name"
+);
+crate::provider_value::bounded_bytes_type!(
+    ExecutableArgument,
+    256,
+    WorkerCatalogError,
+    "executable argument"
+);
+crate::provider_value::provider_id_type!(
+    CredentialRequirementName,
+    WorkerCatalogError,
+    "credential requirement name"
+);
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -267,9 +286,7 @@ impl ReasoningPolicy {
 pub struct SessionPolicy(BTreeSet<SessionScope>);
 
 impl SessionPolicy {
-    pub fn new(
-        scopes: impl IntoIterator<Item = SessionScope>,
-    ) -> Result<Self, WorkerCatalogError> {
+    pub fn new(scopes: impl IntoIterator<Item = SessionScope>) -> Result<Self, WorkerCatalogError> {
         let mut unique = BTreeSet::new();
         for scope in scopes {
             if !unique.insert(scope) {
@@ -804,7 +821,10 @@ fn canonical_catalog_spec() -> WorkerCatalogSpec {
                     stable(WorkerCapability::ToolUse),
                     stable(WorkerCapability::WorkspaceIsolation),
                     stable(WorkerCapability::McpServers),
-                    (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+                    (
+                        WorkerCapability::JsonSchema,
+                        CapabilitySupport::Experimental,
+                    ),
                     stable(WorkerCapability::StreamEvents),
                     stable(WorkerCapability::Thinking),
                 ],
@@ -833,7 +853,10 @@ fn canonical_catalog_spec() -> WorkerCatalogSpec {
                     stable(WorkerCapability::ToolUse),
                     stable(WorkerCapability::WorkspaceIsolation),
                     stable(WorkerCapability::McpServers),
-                    (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+                    (
+                        WorkerCapability::JsonSchema,
+                        CapabilitySupport::Experimental,
+                    ),
                     stable(WorkerCapability::StreamEvents),
                     stable(WorkerCapability::Thinking),
                     stable(WorkerCapability::ReasoningEffort),
@@ -916,24 +939,29 @@ fn provider(source: ProviderSource) -> ProviderDescriptor {
         .into_iter()
         .zip(source.level_models)
         .zip(source.level_reasoning)
-        .map(|((level, model), effort)| {
-            ModelSelection::new(level, model.map(model_id), effort)
-        });
+        .map(|((level, model), effort)| ModelSelection::new(level, model.map(model_id), effort));
     ProviderDescriptor::new(ProviderDescriptorSpec {
         id: provider_id(source.id),
         aliases: source.aliases.iter().copied().map(provider_alias).collect(),
-        display_name: ProviderDisplayName::new(source.display_name).expect("built-in display name is valid"),
+        display_name: ProviderDisplayName::new(source.display_name)
+            .expect("built-in display name is valid"),
         driver_family: source.family,
-        models: ModelPolicy::new(ModelLevel::Level2, levels).expect("built-in model policy is valid"),
-        reasoning: ReasoningPolicy::new(source.reasoning.iter().copied()).expect("built-in reasoning policy is valid"),
-        sessions: SessionPolicy::new([SessionScope::Execution]).expect("built-in session policy is valid"),
-        capabilities: CapabilityPolicy::new(source.capabilities.iter().copied()).expect("built-in capability policy is valid"),
+        models: ModelPolicy::new(ModelLevel::Level2, levels)
+            .expect("built-in model policy is valid"),
+        reasoning: ReasoningPolicy::new(source.reasoning.iter().copied())
+            .expect("built-in reasoning policy is valid"),
+        sessions: SessionPolicy::new([SessionScope::Execution])
+            .expect("built-in session policy is valid"),
+        capabilities: CapabilityPolicy::new(source.capabilities.iter().copied())
+            .expect("built-in capability policy is valid"),
         executable: source.executable.map(|(name, arguments, probe)| {
             ExecutableMetadata::new(
                 ExecutableName::new(name).expect("built-in executable name is valid"),
                 arguments
                     .iter()
-                    .map(|argument| ExecutableArgument::new(*argument).expect("built-in argument is valid"))
+                    .map(|argument| {
+                        ExecutableArgument::new(*argument).expect("built-in argument is valid")
+                    })
                     .collect(),
                 probe,
             )

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -16,6 +16,10 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
     assert!(root.join("Cargo.lock").is_file());
     assert!(!product.join("Cargo.lock").exists());
     assert!(!product.join("package.json").exists());
+    assert!(
+        !product.join("build.rs").exists(),
+        "native product must not add an unowned build script"
+    );
     assert!(!read(&product.join("Cargo.toml")).contains("[workspace]"));
 
     let mut files = BTreeSet::new();
@@ -42,6 +46,7 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         "src/scheduler.rs",
         "src/issue_provider.rs",
         "src/source_code_provider.rs",
+        "src/worker_catalog.rs",
         "tests/architecture.rs",
         "tests/artifact_store.rs",
         "tests/backend_boundary.rs",
@@ -54,6 +59,7 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         "tests/provider_contracts.rs",
         "tests/provider_bounds.rs",
         "tests/scheduler_contract.rs",
+        "tests/worker_catalog.rs",
     ] {
         assert!(files.contains(required), "missing product file: {required}");
     }
@@ -61,6 +67,53 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         assert!(
             file == "Cargo.toml" || file.ends_with(".rs"),
             "native product must remain Rust-only: {file}"
+        );
+    }
+}
+
+#[test]
+fn worker_catalog_has_no_build_or_node_typescript_source_inputs() {
+    let product = product_root();
+    let manifest = read(&product.join("Cargo.toml"));
+    assert!(
+        !manifest
+            .lines()
+            .any(|line| line.trim_start().starts_with("build =")),
+        "native product manifest must not configure a build script"
+    );
+
+    let metadata = workspace_metadata();
+    let has_build_target = product_package(&metadata)["targets"]
+        .as_array()
+        .expect("package targets must be an array")
+        .iter()
+        .any(|target| {
+            target["kind"]
+                .as_array()
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind == "custom-build"))
+        });
+    assert!(
+        !has_build_target,
+        "native product must not have a custom build target"
+    );
+
+    let build_and_source_inputs = format!("{manifest}\n{}", rust_sources(&["src"]));
+    for forbidden in [
+        "agent-cli-provider",
+        "provider-registry",
+        "node_modules",
+        "package.json",
+        "tsconfig",
+        ".ts\"",
+        ".tsx\"",
+        ".js\"",
+        ".jsx\"",
+        "Command::new(\"node\")",
+        "Command::new(\"npm\")",
+    ] {
+        assert!(
+            !build_and_source_inputs.contains(forbidden),
+            "native crate input consumes Node/TypeScript source: {forbidden}"
         );
     }
 }
@@ -402,6 +455,53 @@ fn provider_contracts_add_no_ledger_workspace_worker_protocol_adapter_or_fault_b
         assert!(
             !contracts.contains(forbidden),
             "provider contracts crossed an owned boundary: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn worker_catalog_adds_no_out_of_scope_product_construction() {
+    let product_source = rust_sources(&["src"]);
+    for forbidden in [
+        "pub struct RoleContract",
+        "pub enum RoleContract",
+        "RoleContractPack",
+        "RoleManifest",
+        "pub mod worker_registry",
+        "mod worker_registry;",
+        "struct WorkerRegistry",
+        "impl WorkerRegistry",
+        "impl WorkerRegistry for",
+        "pub mod config",
+        "mod config;",
+        "mod native_config",
+        "struct NativeConfig",
+        "struct WorkerConfig",
+        "struct ProviderConfig",
+        "struct NativeSettings",
+        "mod credentials;",
+        "mod credential;",
+        "CredentialResolver",
+        "CredentialLease",
+        "CredentialCodec",
+        "resolve_credentials",
+        "decode_credentials",
+        "ExecutableCodec",
+        "encode_executable",
+        "decode_executable",
+        "struct GatewayDriver",
+        "struct CliProcessDriver",
+        "struct AcpStdioDriver",
+        "impl WorkerDriver for",
+        "impl BuiltinWorkerDriver for",
+        "struct ProtocolDescriptor",
+        "struct WorkerDescriptor",
+        "WorkerDescriptor::new",
+        "openengine_cluster_protocol::worker",
+    ] {
+        assert!(
+            !product_source.contains(forbidden),
+            "worker catalog crossed an issue-owned product boundary: {forbidden}"
         );
     }
 }

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -97,7 +97,28 @@ fn worker_catalog_has_no_build_or_node_typescript_source_inputs() {
         "native product must not have a custom build target"
     );
 
-    let build_and_source_inputs = format!("{manifest}\n{}", rust_sources(&["src"]));
+    let mut product_files = BTreeSet::new();
+    relative_files(&product, &product, &mut product_files);
+    let mut build_and_source_inputs = manifest;
+    for relative in product_files.iter().filter(|relative| {
+        relative.ends_with(".rs") && relative.as_str() != "tests/architecture.rs"
+    }) {
+        build_and_source_inputs.push('\n');
+        build_and_source_inputs.push_str(&read(&product.join(relative)));
+    }
+    for target in product_package(&metadata)["targets"]
+        .as_array()
+        .expect("package targets must be an array")
+    {
+        let source = target["src_path"]
+            .as_str()
+            .expect("Cargo target must have a source path");
+        let source = std::path::Path::new(source);
+        if source.starts_with(&product) && source != product.join("tests/architecture.rs") {
+            build_and_source_inputs.push('\n');
+            build_and_source_inputs.push_str(&read(source));
+        }
+    }
     for forbidden in [
         "agent-cli-provider",
         "provider-registry",
@@ -461,7 +482,44 @@ fn provider_contracts_add_no_ledger_workspace_worker_protocol_adapter_or_fault_b
 
 #[test]
 fn worker_catalog_adds_no_out_of_scope_product_construction() {
-    let product_source = rust_sources(&["src"]);
+    let product = product_root();
+    let mut product_files = BTreeSet::new();
+    relative_files(&product, &product.join("src"), &mut product_files);
+    let top_level_source_entries = product_files
+        .iter()
+        .filter_map(|relative| {
+            relative
+                .strip_prefix("src/")
+                .and_then(|path| path.split('/').next())
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        top_level_source_entries,
+        BTreeSet::from([
+            "artifact_store",
+            "artifact_store.rs",
+            "cluster_ledger",
+            "cluster_ledger.rs",
+            "execution",
+            "execution.rs",
+            "fault",
+            "fault.rs",
+            "issue_provider",
+            "issue_provider.rs",
+            "lib.rs",
+            "main.rs",
+            "observability.rs",
+            "provider_value",
+            "provider_value.rs",
+            "scheduler.rs",
+            "source_code_provider",
+            "source_code_provider.rs",
+            "worker_catalog.rs",
+        ]),
+        "new product modules require an issue-authorized architecture amendment"
+    );
+
+    let catalog_source = read(&product.join("src/worker_catalog.rs"));
     for forbidden in [
         "pub struct RoleContract",
         "pub enum RoleContract",
@@ -500,8 +558,8 @@ fn worker_catalog_adds_no_out_of_scope_product_construction() {
         "openengine_cluster_protocol::worker",
     ] {
         assert!(
-            !product_source.contains(forbidden),
-            "worker catalog crossed an issue-owned product boundary: {forbidden}"
+            !catalog_source.contains(forbidden),
+            "worker catalog crossed its owned boundary: {forbidden}"
         );
     }
 }

--- a/zeroshot-rust/tests/worker_catalog.rs
+++ b/zeroshot-rust/tests/worker_catalog.rs
@@ -217,7 +217,9 @@ const FIXTURE: &[ExpectedProvider] = &[
 fn canonical_catalog_matches_the_exact_versioned_fixture() {
     let catalog = worker_catalog();
     assert_eq!(catalog.version(), WORKER_CATALOG_VERSION);
-    assert_eq!(catalog.providers().len(), WORKER_PROVIDER_COUNT);
+    assert_eq!(catalog.providers().len(), 8);
+    assert_eq!(WORKER_PROVIDER_COUNT, 8);
+    assert_eq!(FIXTURE.len(), 8);
     assert_eq!(
         catalog.default_provider_id().as_str(),
         DEFAULT_WORKER_PROVIDER
@@ -354,6 +356,10 @@ fn canonical_bytes_and_digest_are_stable_across_order_and_repetition() {
     );
     assert_eq!(built_in.digest(), worker_catalog().digest());
     assert_eq!(built_in.digest().as_str().len(), 64);
+    assert_eq!(
+        built_in.digest().as_str(),
+        "6c0a0ca77d200e7429598b2bc69756a042e4bc6eee101251a04bc9b1facdc3e5"
+    );
 }
 
 #[test]

--- a/zeroshot-rust/tests/worker_catalog.rs
+++ b/zeroshot-rust/tests/worker_catalog.rs
@@ -1,0 +1,485 @@
+use std::collections::BTreeSet;
+
+use zeroshot_engine::execution::SessionScope;
+use zeroshot_engine::worker_catalog::{
+    worker_catalog, CapabilityPolicy, CapabilitySupport, CredentialRequirementName, DriverFamily,
+    ExecutableArgument, ExecutableMetadata, ExecutableName, ModelId, ModelLevel, ModelPolicy,
+    ModelSelection, ProbeStrategy, ProviderAlias, ProviderDescriptor, ProviderDescriptorSpec,
+    ProviderDisplayName, ProviderId, ReasoningEffort, ReasoningPolicy, SessionPolicy,
+    WorkerCapability, WorkerCatalog, WorkerCatalogSpec, DEFAULT_WORKER_PROVIDER,
+    WORKER_CATALOG_VERSION, WORKER_PROVIDER_COUNT,
+};
+
+#[derive(Debug)]
+struct ExpectedProvider {
+    id: &'static str,
+    aliases: &'static [&'static str],
+    display: &'static str,
+    family: DriverFamily,
+    executable: Option<(&'static str, &'static [&'static str], ProbeStrategy)>,
+    models: [Option<&'static str>; 3],
+    reasoning_defaults: [Option<ReasoningEffort>; 3],
+    reasoning: &'static [ReasoningEffort],
+    capabilities: &'static [(WorkerCapability, CapabilitySupport)],
+    credential: &'static str,
+}
+
+const fn stable(capability: WorkerCapability) -> (WorkerCapability, CapabilitySupport) {
+    (capability, CapabilitySupport::Stable)
+}
+
+const FIXTURE: &[ExpectedProvider] = &[
+    ExpectedProvider {
+        id: "claude",
+        aliases: &["anthropic"],
+        display: "Claude",
+        family: DriverFamily::CliProcess,
+        executable: Some(("claude", &[], ProbeStrategy::Version)),
+        models: [Some("haiku"), Some("sonnet"), Some("opus")],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::Xhigh,
+            ReasoningEffort::Max,
+        ],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::McpServers),
+            stable(WorkerCapability::JsonSchema),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+            stable(WorkerCapability::ReasoningEffort),
+            stable(WorkerCapability::SessionResume),
+        ],
+        credential: "claude-auth",
+    },
+    ExpectedProvider {
+        id: "codex",
+        aliases: &["openai"],
+        display: "Codex",
+        family: DriverFamily::CliProcess,
+        executable: Some(("codex", &["exec"], ProbeStrategy::Version)),
+        models: [Some("gpt-5.4"), Some("gpt-5.4"), Some("gpt-5.4")],
+        reasoning_defaults: [
+            Some(ReasoningEffort::Medium),
+            Some(ReasoningEffort::High),
+            Some(ReasoningEffort::Xhigh),
+        ],
+        reasoning: &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::Xhigh,
+            ReasoningEffort::Max,
+        ],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::McpServers),
+            stable(WorkerCapability::JsonSchema),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+            stable(WorkerCapability::ReasoningEffort),
+            stable(WorkerCapability::SessionResume),
+        ],
+        credential: "codex-auth",
+    },
+    ExpectedProvider {
+        id: "copilot",
+        aliases: &[],
+        display: "Copilot",
+        family: DriverFamily::CliProcess,
+        executable: Some(("copilot", &[], ProbeStrategy::HelpOrVersion)),
+        models: [None, None, None],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::McpServers),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+        ],
+        credential: "copilot-auth",
+    },
+    ExpectedProvider {
+        id: "gateway",
+        aliases: &[],
+        display: "Gateway",
+        family: DriverFamily::GatewayHttp,
+        executable: None,
+        models: [None, None, None],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+        ],
+        credential: "gateway-auth",
+    },
+    ExpectedProvider {
+        id: "gemini",
+        aliases: &["google"],
+        display: "Gemini",
+        family: DriverFamily::CliProcess,
+        executable: Some(("gemini", &[], ProbeStrategy::Version)),
+        models: [None, None, None],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::McpServers),
+            (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+        ],
+        credential: "gemini-auth",
+    },
+    ExpectedProvider {
+        id: "kiro",
+        aliases: &[],
+        display: "Kiro",
+        family: DriverFamily::AcpStdio,
+        executable: Some(("kiro-cli", &["acp"], ProbeStrategy::Version)),
+        models: [None, None, None],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+        ],
+        credential: "kiro-auth",
+    },
+    ExpectedProvider {
+        id: "opencode",
+        aliases: &[],
+        display: "Opencode",
+        family: DriverFamily::CliProcess,
+        executable: Some(("opencode", &["run"], ProbeStrategy::Version)),
+        models: [None, None, None],
+        reasoning_defaults: [
+            Some(ReasoningEffort::Low),
+            Some(ReasoningEffort::Medium),
+            Some(ReasoningEffort::High),
+        ],
+        reasoning: &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::Xhigh,
+            ReasoningEffort::Max,
+        ],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::McpServers),
+            (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+            stable(WorkerCapability::ReasoningEffort),
+        ],
+        credential: "opencode-auth",
+    },
+    ExpectedProvider {
+        id: "pi",
+        aliases: &[],
+        display: "Pi",
+        family: DriverFamily::CliProcess,
+        executable: Some(("pi", &[], ProbeStrategy::HelpOrVersion)),
+        models: [None, None, None],
+        reasoning_defaults: [None, None, None],
+        reasoning: &[],
+        capabilities: &[
+            stable(WorkerCapability::ToolUse),
+            stable(WorkerCapability::WorkspaceIsolation),
+            stable(WorkerCapability::StreamEvents),
+            stable(WorkerCapability::Thinking),
+        ],
+        credential: "pi-auth",
+    },
+];
+
+#[test]
+fn canonical_catalog_matches_the_exact_versioned_fixture() {
+    let catalog = worker_catalog();
+    assert_eq!(catalog.version(), WORKER_CATALOG_VERSION);
+    assert_eq!(catalog.providers().len(), WORKER_PROVIDER_COUNT);
+    assert_eq!(catalog.default_provider_id().as_str(), DEFAULT_WORKER_PROVIDER);
+    assert_eq!(catalog.default_provider().id().as_str(), "claude");
+
+    for (provider, expected) in catalog.providers().iter().zip(FIXTURE) {
+        assert_eq!(provider.id().as_str(), expected.id);
+        assert_eq!(
+            provider.aliases().iter().map(ProviderAlias::as_str).collect::<Vec<_>>(),
+            expected.aliases
+        );
+        assert_eq!(provider.display_name().as_str(), expected.display);
+        assert_eq!(provider.driver_family(), expected.family);
+        assert_eq!(provider.driver_family().token(), provider.driver_family_id().as_str());
+
+        match (provider.executable(), expected.executable) {
+            (None, None) => {}
+            (Some(actual), Some((name, arguments, probe))) => {
+                assert_eq!(actual.name().as_str(), name);
+                assert_eq!(
+                    actual
+                        .arguments()
+                        .iter()
+                        .map(ExecutableArgument::as_str)
+                        .collect::<Vec<_>>(),
+                    arguments
+                );
+                assert_eq!(actual.probe(), probe);
+            }
+            pair => panic!("executable fixture mismatch for {}: {pair:?}", expected.id),
+        }
+
+        for (index, level) in [ModelLevel::Level1, ModelLevel::Level2, ModelLevel::Level3]
+            .into_iter()
+            .enumerate()
+        {
+            let selection = provider.models().selection(level).expect("fixture model level");
+            assert_eq!(selection.model().map(ModelId::as_str), expected.models[index]);
+            assert_eq!(
+                selection.default_reasoning_effort(),
+                expected.reasoning_defaults[index]
+            );
+        }
+        assert_eq!(provider.models().default_level(), ModelLevel::Level2);
+        assert_eq!(
+            provider.reasoning().efforts().iter().copied().collect::<Vec<_>>(),
+            expected.reasoning
+        );
+        assert_eq!(
+            provider
+                .capabilities()
+                .entries()
+                .iter()
+                .map(|(capability, support)| (*capability, *support))
+                .collect::<Vec<_>>(),
+            expected.capabilities
+        );
+        assert_eq!(
+            provider.sessions().scopes(),
+            &BTreeSet::from([SessionScope::Execution])
+        );
+        assert!(!provider.sessions().supports(SessionScope::NodeInstance));
+        assert_eq!(
+            provider
+                .credential_requirements()
+                .iter()
+                .map(CredentialRequirementName::as_str)
+                .collect::<Vec<_>>(),
+            [expected.credential]
+        );
+    }
+}
+
+#[test]
+fn canonical_aliases_resolve_directly_to_their_owner() {
+    let catalog = worker_catalog();
+    for (identity, canonical) in [
+        ("claude", "claude"),
+        ("anthropic", "claude"),
+        ("codex", "codex"),
+        ("openai", "codex"),
+        ("gemini", "gemini"),
+        ("google", "gemini"),
+    ] {
+        assert_eq!(catalog.resolve(identity).map(|provider| provider.id().as_str()), Some(canonical));
+    }
+    assert!(catalog.resolve("Anthropic").is_none());
+    assert!(catalog.resolve("unknown").is_none());
+}
+
+#[test]
+fn canonical_bytes_and_digest_are_stable_across_order_and_repetition() {
+    let left = valid_catalog(vec![
+        valid_provider("zeta", "Zeta", &[]),
+        valid_provider("alpha", "Alpha", &["first"]),
+    ]);
+    let right = valid_catalog(vec![
+        valid_provider("alpha", "Alpha", &["first"]),
+        valid_provider("zeta", "Zeta", &[]),
+    ]);
+    assert_eq!(left.canonical_bytes(), right.canonical_bytes());
+    assert_eq!(left.digest(), right.digest());
+    assert_eq!(left.canonical_bytes(), left.canonical_bytes());
+    assert_eq!(left.digest(), left.digest());
+
+    let built_in = worker_catalog();
+    assert_eq!(built_in.canonical_bytes(), worker_catalog().canonical_bytes());
+    assert_eq!(built_in.digest(), worker_catalog().digest());
+    assert_eq!(built_in.digest().as_str().len(), 64);
+}
+
+#[test]
+fn provider_identity_and_display_collisions_fail_closed() {
+    let duplicate_id = WorkerCatalog::new(WorkerCatalogSpec {
+        version: 1,
+        default_provider: provider_id("alpha"),
+        providers: vec![
+            valid_provider("alpha", "Alpha", &[]),
+            valid_provider("alpha", "Other", &[]),
+        ],
+    })
+    .expect_err("duplicate canonical id must fail");
+    assert_eq!(duplicate_id.field(), "catalog providers");
+
+    let alias_collision = WorkerCatalog::new(WorkerCatalogSpec {
+        version: 1,
+        default_provider: provider_id("alpha"),
+        providers: vec![
+            valid_provider("alpha", "Alpha", &["shared"]),
+            valid_provider("beta", "Beta", &["shared"]),
+        ],
+    })
+    .expect_err("alias collision must fail");
+    assert_eq!(alias_collision.field(), "provider identity");
+
+    let canonical_alias_collision = WorkerCatalog::new(WorkerCatalogSpec {
+        version: 1,
+        default_provider: provider_id("alpha"),
+        providers: vec![
+            valid_provider("alpha", "Alpha", &["beta"]),
+            valid_provider("beta", "Beta", &[]),
+        ],
+    })
+    .expect_err("alias-to-canonical collision must fail");
+    assert_eq!(canonical_alias_collision.field(), "provider identity");
+
+    let display_collision = WorkerCatalog::new(WorkerCatalogSpec {
+        version: 1,
+        default_provider: provider_id("alpha"),
+        providers: vec![
+            valid_provider("alpha", "Same", &[]),
+            valid_provider("beta", "same", &[]),
+        ],
+    })
+    .expect_err("display collision must fail");
+    assert_eq!(display_collision.field(), "provider display names");
+}
+
+#[test]
+fn invalid_family_session_model_and_reasoning_policies_fail_closed() {
+    let missing_default = ModelPolicy::new(
+        ModelLevel::Level2,
+        [ModelSelection::new(ModelLevel::Level1, None, None)],
+    )
+    .expect_err("missing default model level must fail");
+    assert_eq!(missing_default.field(), "default model level");
+
+    let duplicate_reasoning =
+        ReasoningPolicy::new([ReasoningEffort::High, ReasoningEffort::High])
+            .expect_err("duplicate reasoning effort must fail");
+    assert_eq!(duplicate_reasoning.field(), "reasoning policy");
+
+    let duplicate_scope =
+        SessionPolicy::new([SessionScope::Execution, SessionScope::Execution])
+            .expect_err("duplicate session scope must fail");
+    assert_eq!(duplicate_scope.field(), "session policy");
+
+    let mut gateway_with_process = valid_spec("gateway", "Gateway", &[]);
+    gateway_with_process.driver_family = DriverFamily::GatewayHttp;
+    let family_error = ProviderDescriptor::new(gateway_with_process)
+        .expect_err("HTTP family with executable must fail");
+    assert_eq!(family_error.field(), "driver family policy");
+
+    let mut process_without_executable = valid_spec("alpha", "Alpha", &[]);
+    process_without_executable.executable = None;
+    let executable_error = ProviderDescriptor::new(process_without_executable)
+        .expect_err("process family without executable must fail");
+    assert_eq!(executable_error.field(), "driver family policy");
+
+    let mut node_scope = valid_spec("alpha", "Alpha", &[]);
+    node_scope.sessions = SessionPolicy::new([SessionScope::Execution, SessionScope::NodeInstance])
+        .expect("bounded scopes");
+    let node_error =
+        ProviderDescriptor::new(node_scope).expect_err("unsupported node-instance scope must fail");
+    assert_eq!(node_error.field(), "session policy");
+
+    let mut unsupported_reasoning = valid_spec("alpha", "Alpha", &[]);
+    unsupported_reasoning.reasoning =
+        ReasoningPolicy::new([ReasoningEffort::High]).expect("bounded reasoning");
+    let reasoning_error = ProviderDescriptor::new(unsupported_reasoning)
+        .expect_err("reasoning policy without capability must fail");
+    assert_eq!(reasoning_error.field(), "reasoning policy");
+
+    let mut invalid_model_default = valid_spec("alpha", "Alpha", &[]);
+    invalid_model_default.models = ModelPolicy::new(
+        ModelLevel::Level2,
+        [
+            ModelSelection::new(ModelLevel::Level1, None, None),
+            ModelSelection::new(
+                ModelLevel::Level2,
+                None,
+                Some(ReasoningEffort::High),
+            ),
+        ],
+    )
+    .expect("model structure is bounded");
+    let model_error = ProviderDescriptor::new(invalid_model_default)
+        .expect_err("unsupported default reasoning must fail");
+    assert_eq!(model_error.field(), "model policy");
+}
+
+fn valid_catalog(providers: Vec<ProviderDescriptor>) -> WorkerCatalog {
+    WorkerCatalog::new(WorkerCatalogSpec {
+        version: 1,
+        default_provider: provider_id("alpha"),
+        providers,
+    })
+    .expect("valid test catalog")
+}
+
+fn valid_provider(id: &str, display: &str, aliases: &[&str]) -> ProviderDescriptor {
+    ProviderDescriptor::new(valid_spec(id, display, aliases)).expect("valid test provider")
+}
+
+fn valid_spec(id: &str, display: &str, aliases: &[&str]) -> ProviderDescriptorSpec {
+    ProviderDescriptorSpec {
+        id: provider_id(id),
+        aliases: aliases
+            .iter()
+            .map(|alias| ProviderAlias::new(*alias).expect("test alias"))
+            .collect(),
+        display_name: ProviderDisplayName::new(display).expect("test display"),
+        driver_family: DriverFamily::CliProcess,
+        models: ModelPolicy::new(
+            ModelLevel::Level2,
+            [
+                ModelSelection::new(ModelLevel::Level1, None, None),
+                ModelSelection::new(ModelLevel::Level2, None, None),
+                ModelSelection::new(ModelLevel::Level3, None, None),
+            ],
+        )
+        .expect("test model policy"),
+        reasoning: ReasoningPolicy::new([]).expect("test reasoning policy"),
+        sessions: SessionPolicy::new([SessionScope::Execution]).expect("test session policy"),
+        capabilities: CapabilityPolicy::new([stable(WorkerCapability::ToolUse)])
+            .expect("test capabilities"),
+        executable: Some(
+            ExecutableMetadata::new(
+                ExecutableName::new("test-provider").expect("test executable"),
+                vec![],
+                ProbeStrategy::Version,
+            )
+            .expect("test executable metadata"),
+        ),
+        credential_requirements: vec![
+            CredentialRequirementName::new("provider-auth").expect("test credential requirement"),
+        ],
+    }
+}
+
+fn provider_id(value: &str) -> ProviderId {
+    ProviderId::new(value).expect("test provider id")
+}

--- a/zeroshot-rust/tests/worker_catalog.rs
+++ b/zeroshot-rust/tests/worker_catalog.rs
@@ -135,7 +135,10 @@ const FIXTURE: &[ExpectedProvider] = &[
             stable(WorkerCapability::ToolUse),
             stable(WorkerCapability::WorkspaceIsolation),
             stable(WorkerCapability::McpServers),
-            (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+            (
+                WorkerCapability::JsonSchema,
+                CapabilitySupport::Experimental,
+            ),
             stable(WorkerCapability::StreamEvents),
             stable(WorkerCapability::Thinking),
         ],
@@ -181,7 +184,10 @@ const FIXTURE: &[ExpectedProvider] = &[
             stable(WorkerCapability::ToolUse),
             stable(WorkerCapability::WorkspaceIsolation),
             stable(WorkerCapability::McpServers),
-            (WorkerCapability::JsonSchema, CapabilitySupport::Experimental),
+            (
+                WorkerCapability::JsonSchema,
+                CapabilitySupport::Experimental,
+            ),
             stable(WorkerCapability::StreamEvents),
             stable(WorkerCapability::Thinking),
             stable(WorkerCapability::ReasoningEffort),
@@ -212,18 +218,28 @@ fn canonical_catalog_matches_the_exact_versioned_fixture() {
     let catalog = worker_catalog();
     assert_eq!(catalog.version(), WORKER_CATALOG_VERSION);
     assert_eq!(catalog.providers().len(), WORKER_PROVIDER_COUNT);
-    assert_eq!(catalog.default_provider_id().as_str(), DEFAULT_WORKER_PROVIDER);
+    assert_eq!(
+        catalog.default_provider_id().as_str(),
+        DEFAULT_WORKER_PROVIDER
+    );
     assert_eq!(catalog.default_provider().id().as_str(), "claude");
 
     for (provider, expected) in catalog.providers().iter().zip(FIXTURE) {
         assert_eq!(provider.id().as_str(), expected.id);
         assert_eq!(
-            provider.aliases().iter().map(ProviderAlias::as_str).collect::<Vec<_>>(),
+            provider
+                .aliases()
+                .iter()
+                .map(ProviderAlias::as_str)
+                .collect::<Vec<_>>(),
             expected.aliases
         );
         assert_eq!(provider.display_name().as_str(), expected.display);
         assert_eq!(provider.driver_family(), expected.family);
-        assert_eq!(provider.driver_family().token(), provider.driver_family_id().as_str());
+        assert_eq!(
+            provider.driver_family().token(),
+            provider.driver_family_id().as_str()
+        );
 
         match (provider.executable(), expected.executable) {
             (None, None) => {}
@@ -246,8 +262,14 @@ fn canonical_catalog_matches_the_exact_versioned_fixture() {
             .into_iter()
             .enumerate()
         {
-            let selection = provider.models().selection(level).expect("fixture model level");
-            assert_eq!(selection.model().map(ModelId::as_str), expected.models[index]);
+            let selection = provider
+                .models()
+                .selection(level)
+                .expect("fixture model level");
+            assert_eq!(
+                selection.model().map(ModelId::as_str),
+                expected.models[index]
+            );
             assert_eq!(
                 selection.default_reasoning_effort(),
                 expected.reasoning_defaults[index]
@@ -255,7 +277,12 @@ fn canonical_catalog_matches_the_exact_versioned_fixture() {
         }
         assert_eq!(provider.models().default_level(), ModelLevel::Level2);
         assert_eq!(
-            provider.reasoning().efforts().iter().copied().collect::<Vec<_>>(),
+            provider
+                .reasoning()
+                .efforts()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
             expected.reasoning
         );
         assert_eq!(
@@ -294,7 +321,12 @@ fn canonical_aliases_resolve_directly_to_their_owner() {
         ("gemini", "gemini"),
         ("google", "gemini"),
     ] {
-        assert_eq!(catalog.resolve(identity).map(|provider| provider.id().as_str()), Some(canonical));
+        assert_eq!(
+            catalog
+                .resolve(identity)
+                .map(|provider| provider.id().as_str()),
+            Some(canonical)
+        );
     }
     assert!(catalog.resolve("Anthropic").is_none());
     assert!(catalog.resolve("unknown").is_none());
@@ -316,7 +348,10 @@ fn canonical_bytes_and_digest_are_stable_across_order_and_repetition() {
     assert_eq!(left.digest(), left.digest());
 
     let built_in = worker_catalog();
-    assert_eq!(built_in.canonical_bytes(), worker_catalog().canonical_bytes());
+    assert_eq!(
+        built_in.canonical_bytes(),
+        worker_catalog().canonical_bytes()
+    );
     assert_eq!(built_in.digest(), worker_catalog().digest());
     assert_eq!(built_in.digest().as_str().len(), 64);
 }
@@ -377,14 +412,12 @@ fn invalid_family_session_model_and_reasoning_policies_fail_closed() {
     .expect_err("missing default model level must fail");
     assert_eq!(missing_default.field(), "default model level");
 
-    let duplicate_reasoning =
-        ReasoningPolicy::new([ReasoningEffort::High, ReasoningEffort::High])
-            .expect_err("duplicate reasoning effort must fail");
+    let duplicate_reasoning = ReasoningPolicy::new([ReasoningEffort::High, ReasoningEffort::High])
+        .expect_err("duplicate reasoning effort must fail");
     assert_eq!(duplicate_reasoning.field(), "reasoning policy");
 
-    let duplicate_scope =
-        SessionPolicy::new([SessionScope::Execution, SessionScope::Execution])
-            .expect_err("duplicate session scope must fail");
+    let duplicate_scope = SessionPolicy::new([SessionScope::Execution, SessionScope::Execution])
+        .expect_err("duplicate session scope must fail");
     assert_eq!(duplicate_scope.field(), "session policy");
 
     let mut gateway_with_process = valid_spec("gateway", "Gateway", &[]);
@@ -418,11 +451,7 @@ fn invalid_family_session_model_and_reasoning_policies_fail_closed() {
         ModelLevel::Level2,
         [
             ModelSelection::new(ModelLevel::Level1, None, None),
-            ModelSelection::new(
-                ModelLevel::Level2,
-                None,
-                Some(ReasoningEffort::High),
-            ),
+            ModelSelection::new(ModelLevel::Level2, None, Some(ReasoningEffort::High)),
         ],
     )
     .expect("model structure is bounded");


### PR DESCRIPTION
## Summary
- add the native product's sole hand-authored, versioned eight-provider worker catalog
- validate bounded provider policy, aliases/collisions, driver/session/model compatibility, and exact one-step resolution
- expose deterministic canonical bytes plus a pinned v1 SHA-256 digest
- enforce Rust-only ownership and current catalog non-goals across Cargo input/module boundaries

## Decision
The catalog is a product-level Rust contract outside `execution/`. It reuses `SessionScope` and projects closed `DriverFamily` values into `DriverFamilyId`; it does not consume the Node registry or construct provider drivers, configuration, credentials, role contracts, or protocol descriptors.

`zeroshot-rust/tests/architecture.rs` was deliberately amended because #670 explicitly requires Node/TypeScript non-consumption and forbids out-of-scope constructions. The guard scans all Cargo Rust inputs while keeping catalog non-goal tokens scoped to `worker_catalog.rs`; a current source-module inventory is intentionally amendable by future issues that authorize new modules.

## Verification
- `cargo test -p zeroshot-rust --test worker_catalog` (5 tests)
- `cargo test -p zeroshot-rust --test architecture` (13 tests)
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` (1953 passing, 18 pending; isolated retry after one environment-sensitive timeout run)
- `opcore check --changed`
- two independent verifiers passed after three rounds; mutation proofs cover count removal, digest drift, Node/TS build and test inputs, alias/session validation, and unowned registry/driver modules

Closes #670