### PR TITLE
feat(cluster-client): add rustls WebSocket dialer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,15 @@ The NDJSON server caps and continuously reaps per-connection request/subscriptio
 per-subscription consumer: local queue overflow closes that stream as `SLOW_CONSUMER` from its
 exact caller-delivered cursor and cancels the server subscription. Watch request IDs are allocated
 by the shared transport, never by individual watch-client facades.
+Outbound Cluster WebSocket TLS is client-only: rustls 0.23/tokio-rustls 0.26 is the sole workspace
+TLS stack, and only `openengine-cluster-client` enables tokio-tungstenite's rustls native-root
+feature. System roots are mandatory by default; private roots and the off-by-default
+`bundled-roots` feature only augment them and never hide system-store load failures. Every `ws://`
+dial, including loopback, requires `WebSocketDialOptions::allow_plaintext(true)` per connection.
+Endpoint preflight rejects non-ws(s), userinfo, query, and fragment before network I/O; redirects
+are never followed or downgraded. Keep `serve_websocket` plaintext/front-proxy terminated and keep
+TLS out of `zeroshot-rust`. Do not introduce native-tls: its Linux `openssl-sys` dependency breaks
+cross-compilation and static-musl builds.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +239,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -273,7 +298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -684,7 +709,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -725,6 +750,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -780,13 +811,19 @@ dependencies = [
  "openengine-cluster-protocol",
  "openengine-cluster-server",
  "parking_lot",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -838,6 +875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +945,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1021,6 +1080,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1162,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,10 +1236,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -1191,6 +1332,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1309,7 +1473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1317,6 +1481,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1378,6 +1548,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1604,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1427,6 +1616,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1448,7 +1647,11 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -1508,6 +1711,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "utf-8",
@@ -1524,6 +1729,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf-8"
@@ -1638,6 +1849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,12 +1887,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1702,6 +1995,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]
@@ -1767,6 +2069,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zeroshot-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,16 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = "0.1"
 tokio-tungstenite = "0.26"
+rustls = { version = "=0.23.42", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-native-certs = "=0.8.4"
+tokio-rustls = { version = "=0.26.4", default-features = false, features = ["ring", "tls12"] }
+webpki-roots = "=0.26.8"
+rcgen = "=0.13.2"
+time = "=0.3.41"
 futures-util = "0.3"
 jsonschema = { version = "0.29.1", default-features = false }
 rusqlite = { version = "0.37.0", features = ["bundled"] }

--- a/crates/openengine-cluster-client/Cargo.toml
+++ b/crates/openengine-cluster-client/Cargo.toml
@@ -6,6 +6,10 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+bundled-roots = ["dep:webpki-roots"]
+
 [dependencies]
 async-trait.workspace = true
 futures-util.workspace = true
@@ -15,7 +19,15 @@ parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+rustls.workspace = true
+rustls-native-certs.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-tokio-tungstenite.workspace = true
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
 tokio-util.workspace = true
+webpki-roots = { workspace = true, optional = true }
+
+[dev-dependencies]
+rcgen.workspace = true
+tokio-rustls.workspace = true
+time.workspace = true

--- a/crates/openengine-cluster-client/src/websocket.rs
+++ b/crates/openengine-cluster-client/src/websocket.rs
@@ -14,13 +14,202 @@ use async_trait::async_trait;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex as ParkingMutex;
+use rustls::pki_types::CertificateDer;
+use rustls::{ClientConfig, RootCertStore};
+use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
 use tokio::sync::Mutex;
+use tokio_tungstenite::tungstenite::http::{StatusCode, Uri};
+use tokio_tungstenite::tungstenite::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::{Connector, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::connect_async_tls_with_config;
 
 use crate::multiplex;
 use crate::{PendingMap, SubscriptionMap, TransportError};
+
+/// Options applied to one outbound WebSocket connection.
+///
+/// System trust roots are always loaded for `wss://`. Additional roots augment that store; they
+/// never replace system roots. Plaintext is denied unless [`Self::allow_plaintext`] is called with
+/// `true` for this connection.
+#[derive(Debug, Default)]
+pub struct WebSocketDialOptions {
+    allow_plaintext: bool,
+    additional_root_certificates: Vec<CertificateDer<'static>>,
+}
+
+impl WebSocketDialOptions {
+    /// Explicitly opts this connection into or out of plaintext `ws://`.
+    #[must_use]
+    pub fn allow_plaintext(mut self, allow: bool) -> Self {
+        self.allow_plaintext = allow;
+        self
+    }
+
+    /// Adds a DER-encoded trust anchor for a private or local certificate authority.
+    #[must_use]
+    pub fn with_additional_root_certificate(
+        mut self,
+        certificate: CertificateDer<'static>,
+    ) -> Self {
+        self.additional_root_certificates.push(certificate);
+        self
+    }
+}
+
+/// A WebSocket transport returned by [`dial_websocket`].
+pub type DialedWebSocketTransport = WebSocketTransport<MaybeTlsStream<TcpStream>>;
+
+/// A syntactic or policy failure found before any network I/O.
+#[derive(Debug, Error)]
+pub enum WebSocketEndpointError {
+    #[error("WebSocket endpoint is not a valid URI: {0}")]
+    InvalidUri(#[from] tokio_tungstenite::tungstenite::http::uri::InvalidUri),
+    #[error("WebSocket endpoint scheme must be exactly `ws` or `wss`, not `{0}`")]
+    UnsupportedScheme(String),
+    #[error("WebSocket endpoint must include a host")]
+    MissingHost,
+    #[error("WebSocket endpoint must not contain userinfo")]
+    UserInfo,
+    #[error("WebSocket endpoint must not contain a query")]
+    Query,
+    #[error("WebSocket endpoint must not contain a fragment")]
+    Fragment,
+}
+
+/// Failure to establish an outbound WebSocket connection.
+#[derive(Debug, Error)]
+pub enum WebSocketDialError {
+    #[error(transparent)]
+    Endpoint(#[from] WebSocketEndpointError),
+    #[error(
+        "plaintext `ws://` is disabled; set `WebSocketDialOptions::allow_plaintext(true)` for this connection"
+    )]
+    PlaintextNotAllowed,
+    #[error(
+        "failed to load platform/system TLS trust roots (the `bundled-roots` feature is augmentation, not a fallback): {details}"
+    )]
+    SystemTrustRoots { details: String },
+    #[error("a certificate loaded from the platform/system TLS trust store is invalid: {0}")]
+    InvalidSystemTrustCertificate(#[source] rustls::Error),
+    #[error("a configured TLS trust certificate is invalid: {0}")]
+    InvalidTrustCertificate(#[source] rustls::Error),
+    #[error("WebSocket redirect response {status} rejected; redirects are never followed")]
+    RedirectRejected { status: StatusCode },
+    #[error("WebSocket connection failed: {0}")]
+    Connection(#[source] Box<TungsteniteError>),
+}
+
+/// Dials exactly the validated caller-supplied endpoint.
+///
+/// The endpoint is rejected before network I/O unless it has a `ws` or `wss` scheme, a host, and
+/// no userinfo, query, or fragment. Redirect handshake responses are returned as errors and their
+/// targets are never opened.
+pub async fn dial_websocket(
+    endpoint: &str,
+    options: WebSocketDialOptions,
+) -> Result<DialedWebSocketTransport, WebSocketDialError> {
+    let (endpoint, secure) = validate_endpoint(endpoint)?;
+    if !secure && !options.allow_plaintext {
+        return Err(WebSocketDialError::PlaintextNotAllowed);
+    }
+
+    let connector = if secure {
+        Some(build_tls_connector(options.additional_root_certificates)?)
+    } else {
+        None
+    };
+    let result = connect_async_tls_with_config(endpoint, None, false, connector).await;
+    match result {
+        Ok((stream, _response)) => Ok(WebSocketTransport::new(stream)),
+        Err(TungsteniteError::Http(response)) if response.status().is_redirection() => {
+            Err(WebSocketDialError::RedirectRejected {
+                status: response.status(),
+            })
+        }
+        Err(error) => Err(WebSocketDialError::Connection(Box::new(error))),
+    }
+}
+
+fn validate_endpoint(endpoint: &str) -> Result<(Uri, bool), WebSocketEndpointError> {
+    if endpoint.contains('#') {
+        return Err(WebSocketEndpointError::Fragment);
+    }
+    let endpoint: Uri = endpoint.parse()?;
+    if endpoint.query().is_some() {
+        return Err(WebSocketEndpointError::Query);
+    }
+    let authority = endpoint
+        .authority()
+        .ok_or(WebSocketEndpointError::MissingHost)?;
+    if authority.as_str().contains('@') {
+        return Err(WebSocketEndpointError::UserInfo);
+    }
+    if authority.host().is_empty() {
+        return Err(WebSocketEndpointError::MissingHost);
+    }
+    match endpoint.scheme_str() {
+        Some("ws") => Ok((endpoint, false)),
+        Some("wss") => Ok((endpoint, true)),
+        Some(scheme) => Err(WebSocketEndpointError::UnsupportedScheme(scheme.to_owned())),
+        None => Err(WebSocketEndpointError::UnsupportedScheme(
+            "<missing>".to_owned(),
+        )),
+    }
+}
+
+fn build_tls_connector(
+    additional_root_certificates: Vec<CertificateDer<'static>>,
+) -> Result<Connector, WebSocketDialError> {
+    let native = rustls_native_certs::load_native_certs();
+    build_tls_connector_from_native(
+        native.certs,
+        native
+            .errors
+            .into_iter()
+            .map(|error| error.to_string())
+            .collect(),
+        additional_root_certificates,
+    )
+}
+
+fn build_tls_connector_from_native(
+    native_certificates: Vec<CertificateDer<'static>>,
+    native_errors: Vec<String>,
+    additional_root_certificates: Vec<CertificateDer<'static>>,
+) -> Result<Connector, WebSocketDialError> {
+    if !native_errors.is_empty() {
+        return Err(WebSocketDialError::SystemTrustRoots {
+            details: native_errors.join("; "),
+        });
+    }
+    if native_certificates.is_empty() {
+        return Err(WebSocketDialError::SystemTrustRoots {
+            details: "the platform/system trust store contained no certificates".to_owned(),
+        });
+    }
+
+    let mut roots = RootCertStore::empty();
+    for certificate in native_certificates {
+        roots
+            .add(certificate)
+            .map_err(WebSocketDialError::InvalidSystemTrustCertificate)?;
+    }
+    #[cfg(feature = "bundled-roots")]
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    for certificate in additional_root_certificates {
+        roots
+            .add(certificate)
+            .map_err(WebSocketDialError::InvalidTrustCertificate)?;
+    }
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(Connector::Rustls(Arc::new(config)))
+}
 
 /// Sends one already-serialized JSON-RPC frame as a `Message::Text` -- the
 /// [`multiplex::FrameSink`] implementation backing [`WebSocketTransport`].
@@ -113,4 +302,66 @@ async fn run_pump<S>(
         .await;
     }
     multiplex::finish_pump(&pending, &subscriptions);
+}
+
+#[cfg(test)]
+mod tls_trust_policy_tests {
+    use rcgen::{generate_simple_self_signed, CertifiedKey};
+
+    use super::*;
+
+    fn generated_root() -> CertificateDer<'static> {
+        let CertifiedKey { cert, .. } =
+            generate_simple_self_signed(vec!["localhost".to_owned()]).unwrap();
+        cert.der().clone()
+    }
+
+    fn expect_system_trust_error(
+        native_certificates: Vec<CertificateDer<'static>>,
+        native_errors: Vec<String>,
+        additional_root_certificates: Vec<CertificateDer<'static>>,
+    ) -> WebSocketDialError {
+        match build_tls_connector_from_native(
+            native_certificates,
+            native_errors,
+            additional_root_certificates,
+        ) {
+            Ok(_) => panic!("invalid native trust state must fail closed"),
+            Err(error) => error,
+        }
+    }
+
+    #[test]
+    fn empty_system_roots_fail_before_additional_roots_can_rescue() {
+        let error = expect_system_trust_error(Vec::new(), Vec::new(), vec![generated_root()]);
+
+        assert!(matches!(error, WebSocketDialError::SystemTrustRoots { .. }));
+    }
+
+    #[test]
+    fn partial_system_root_load_errors_fail_before_additional_roots_can_rescue() {
+        let error = expect_system_trust_error(
+            vec![generated_root()],
+            vec!["native loader rejected one certificate".to_owned()],
+            vec![generated_root()],
+        );
+
+        assert!(matches!(
+            &error,
+            WebSocketDialError::SystemTrustRoots { .. }
+        ));
+        assert!(
+            error
+                .to_string()
+                .contains("native loader rejected one certificate")
+        );
+    }
+
+    #[cfg(feature = "bundled-roots")]
+    #[test]
+    fn bundled_roots_do_not_fallback_when_system_roots_are_empty() {
+        let error = expect_system_trust_error(Vec::new(), Vec::new(), Vec::new());
+
+        assert!(matches!(error, WebSocketDialError::SystemTrustRoots { .. }));
+    }
 }

--- a/crates/openengine-cluster-client/tests/tls_dialer.rs
+++ b/crates/openengine-cluster-client/tests/tls_dialer.rs
@@ -1,0 +1,256 @@
+//! Real-network coverage for the outbound WebSocket TLS, endpoint, and dependency policies.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openengine_cluster_client::{
+    dial_websocket, WebSocketDialError, WebSocketDialOptions, WebSocketEndpointError,
+};
+use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::ServerConfig;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_rustls::TlsAcceptor;
+use tokio_tungstenite::accept_async;
+
+fn local_tls_acceptor() -> (TlsAcceptor, CertificateDer<'static>) {
+    let CertifiedKey { cert, key_pair } =
+        generate_simple_self_signed(vec![IpAddr::V4(Ipv4Addr::LOCALHOST).to_string()]).unwrap();
+    let certificate = cert.der().clone();
+    let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![certificate.clone()], key)
+        .unwrap();
+    (TlsAcceptor::from(Arc::new(config)), certificate)
+}
+
+async fn spawn_tls_websocket() -> (String, CertificateDer<'static>, JoinHandle<bool>) {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (acceptor, certificate) = local_tls_acceptor();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let Ok(stream) = acceptor.accept(stream).await else {
+            return false;
+        };
+        accept_async(stream).await.is_ok()
+    });
+    (format!("wss://{address}/cluster"), certificate, server)
+}
+
+async fn expect_dial_error(endpoint: &str, options: WebSocketDialOptions) -> WebSocketDialError {
+    match dial_websocket(endpoint, options).await {
+        Ok(_) => panic!("dial unexpectedly succeeded for {endpoint}"),
+        Err(error) => error,
+    }
+}
+
+#[tokio::test]
+async fn wss_trusts_an_explicitly_configured_local_root() {
+    let (endpoint, certificate, server) = spawn_tls_websocket().await;
+    let options = WebSocketDialOptions::default().with_additional_root_certificate(certificate);
+    let transport = dial_websocket(&endpoint, options).await.unwrap();
+    assert!(server.await.unwrap());
+    drop(transport);
+}
+
+#[tokio::test]
+async fn wss_fails_closed_for_an_untrusted_local_root() {
+    let (endpoint, _certificate, server) = spawn_tls_websocket().await;
+    let error = expect_dial_error(&endpoint, WebSocketDialOptions::default()).await;
+    assert!(matches!(error, WebSocketDialError::Connection(_)));
+    assert!(!server.await.unwrap());
+}
+
+#[tokio::test]
+async fn plaintext_is_refused_by_default_without_opening_a_socket() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let endpoint = format!("ws://{}/cluster", listener.local_addr().unwrap());
+    let error = expect_dial_error(&endpoint, WebSocketDialOptions::default()).await;
+    assert!(matches!(&error, WebSocketDialError::PlaintextNotAllowed));
+    assert!(
+        error
+            .to_string()
+            .contains("WebSocketDialOptions::allow_plaintext(true)")
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn explicit_plaintext_opt_in_dials_loopback() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let endpoint = format!("ws://{}/cluster", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        accept_async(stream).await.unwrap();
+    });
+    let transport = dial_websocket(
+        &endpoint,
+        WebSocketDialOptions::default().allow_plaintext(true),
+    )
+    .await
+    .unwrap();
+    server.await.unwrap();
+    drop(transport);
+}
+
+#[tokio::test]
+async fn endpoint_policy_rejects_before_opening_a_socket() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let cases = [
+        (format!("http://{address}/cluster"), "scheme"),
+        (format!("ws://user@{address}/cluster"), "userinfo"),
+        (format!("ws://{address}/cluster?token=secret"), "query"),
+        (format!("ws://{address}/cluster#section"), "fragment"),
+        ("wss:///cluster".to_owned(), "host"),
+    ];
+    for (endpoint, expected) in cases {
+        let error = expect_dial_error(
+            &endpoint,
+            WebSocketDialOptions::default().allow_plaintext(true),
+        )
+        .await;
+        let WebSocketDialError::Endpoint(endpoint_error) = error else {
+            panic!("{endpoint} must fail endpoint preflight, got {error}");
+        };
+        match expected {
+            "scheme" => assert!(matches!(
+                endpoint_error,
+                WebSocketEndpointError::UnsupportedScheme(_)
+            )),
+            "userinfo" => assert!(matches!(endpoint_error, WebSocketEndpointError::UserInfo)),
+            "query" => assert!(matches!(endpoint_error, WebSocketEndpointError::Query)),
+            "fragment" => assert!(matches!(endpoint_error, WebSocketEndpointError::Fragment)),
+            "host" => assert!(matches!(
+                endpoint_error,
+                WebSocketEndpointError::MissingHost | WebSocketEndpointError::InvalidUri(_)
+            )),
+            _ => unreachable!(),
+        }
+    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err()
+    );
+}
+
+async fn read_http_request(stream: &mut (impl AsyncRead + Unpin)) {
+    let mut request = Vec::new();
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let mut buffer = [0_u8; 1024];
+        let count = stream.read(&mut buffer).await.unwrap();
+        assert_ne!(count, 0, "client closed before sending its handshake");
+        request.extend_from_slice(&buffer[..count]);
+    }
+}
+
+#[tokio::test]
+async fn wss_redirect_to_plaintext_is_rejected_without_opening_the_target() {
+    let redirect_target = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let target_address = redirect_target.local_addr().unwrap();
+    let redirect_source = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let source_address = redirect_source.local_addr().unwrap();
+    let (acceptor, certificate) = local_tls_acceptor();
+    let redirect_server = tokio::spawn(async move {
+        let (stream, _) = redirect_source.accept().await.unwrap();
+        let mut stream = acceptor.accept(stream).await.unwrap();
+        read_http_request(&mut stream).await;
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: ws://{target_address}/downgraded\r\nContent-Length: 0\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+    });
+    let endpoint = format!("wss://{source_address}/cluster");
+    let options = WebSocketDialOptions::default().with_additional_root_certificate(certificate);
+    let error = expect_dial_error(&endpoint, options).await;
+    assert!(matches!(
+        error,
+        WebSocketDialError::RedirectRejected { status } if status.as_u16() == 302
+    ));
+    redirect_server.await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), redirect_target.accept())
+            .await
+            .is_err()
+    );
+}
+
+fn lockfile_packages(lockfile: &str) -> impl Iterator<Item = (&str, &str)> {
+    lockfile.split("[[package]]").filter_map(|package| {
+        let mut name = None;
+        let mut version = None;
+        for line in package.lines() {
+            if let Some(value) = line.strip_prefix("name = \"") {
+                name = value.strip_suffix('"');
+            } else if let Some(value) = line.strip_prefix("version = \"") {
+                version = value.strip_suffix('"');
+            }
+            if name.is_some() && version.is_some() {
+                break;
+            }
+        }
+        name.zip(version)
+    })
+}
+
+#[test]
+fn cargo_lock_uses_one_rustls_lineage_and_no_native_tls_implementation() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .unwrap();
+    let lockfile = std::fs::read_to_string(workspace.join("Cargo.lock")).unwrap();
+    let packages: Vec<_> = lockfile_packages(&lockfile).collect();
+    let rustls_versions: Vec<_> = packages
+        .iter()
+        .filter_map(|(name, version)| (*name == "rustls").then_some(*version))
+        .collect();
+    assert_eq!(
+        rustls_versions.len(),
+        1,
+        "Cargo.lock must contain exactly one rustls package, got {rustls_versions:?}"
+    );
+    assert!(
+        rustls_versions[0].starts_with("0.23."),
+        "the selected TLS lineage is rustls 0.23, got {}",
+        rustls_versions[0]
+    );
+    const FORBIDDEN_TLS_PACKAGES: &[&str] = &[
+        "aws-lc-rs",
+        "aws-lc-sys",
+        "native-tls",
+        "openssl",
+        "openssl-sys",
+        "tokio-native-tls",
+        "hyper-tls",
+        "boring",
+        "boring-sys",
+        "tokio-boring",
+        "s2n-tls",
+        "s2n-tls-sys",
+    ];
+    let forbidden_found: Vec<_> = packages
+        .iter()
+        .filter_map(|(name, _)| FORBIDDEN_TLS_PACKAGES.contains(name).then_some(*name))
+        .collect();
+    assert!(
+        forbidden_found.is_empty(),
+        "Cargo.lock contains a second/native TLS implementation: {forbidden_found:?}"
+    );
+}

--- a/docs/openengine-cluster-protocol/v1/data-plane.md
+++ b/docs/openengine-cluster-protocol/v1/data-plane.md
@@ -64,6 +64,35 @@ A hosting process is expected to accept the raw connection, resolve and inject t
 `ConnectionContext`, and hand the rest to `serve_websocket`; this document defines only what happens
 from that handoff onward.
 
+## Client dialing and TLS
+
+`openengine-cluster-client::dial_websocket` is the outbound network boundary, separate from the
+plaintext server binding above. It accepts only `ws://` and `wss://` endpoints with a host and
+rejects userinfo, query strings, and fragments before opening a socket. It connects only to the
+validated endpoint supplied by its caller: WebSocket redirect handshake responses are errors, their
+`Location` targets are never opened, and `wss://` is never downgraded to `ws://`.
+
+The workspace TLS implementation is rustls 0.23 with tokio-rustls 0.26, selected through
+tokio-tungstenite's rustls native-root connector. A `wss://` connection loads platform/system roots
+by default and fails closed if they cannot be loaded. Callers may explicitly add private CA roots
+for one connection. The optional `bundled-roots` client feature is disabled by default and augments
+the successfully loaded system store; bundled roots are never an automatic fallback for an
+unavailable system store. A `ws://` endpoint, including loopback, is refused unless that individual
+connection uses `WebSocketDialOptions::allow_plaintext(true)`.
+
+Native TLS is intentionally excluded: on Linux it resolves to `openssl-sys`, imposing a system
+OpenSSL build dependency that breaks cross-compilation and static-musl builds. TLS features are
+enabled only by the dialing client; `openengine-cluster-server::serve_websocket` remains a
+plaintext, accepted-stream binding whose production TLS termination stays in its front proxy.
+
+## Future cloud HTTP binding
+
+A future cloud HTTP binding may use the same rustls/tokio-rustls stack inside
+`openengine-cluster-server`: accept TCP, perform the TLS handshake with a server `rustls`
+configuration, and hand the resulting asynchronous stream to an HTTP server implementation. This
+issue does not implement that listener, certificate provisioning, or HTTP binding. `reqwest` is an
+HTTP client and cannot serve the binding; selecting an HTTP server remains a separate decision.
+
 ## Fixture and test boundary
 
 `crates/openengine-cluster-server/tests/websocket.rs` covers this binding's own framing and
@@ -71,5 +100,7 @@ admission behavior directly against raw tungstenite frames.
 `crates/openengine-cluster-client/tests/websocket.rs` covers the typed `WebSocketTransport` client
 against the same binding. `crates/openengine-cluster-testkit/tests/protocol_websocket.rs` proves
 byte-equivalence against the in-process and NDJSON bindings and exercises two independently
-authorized connections sharing one backend. All three drive `serve_websocket` over an in-memory
-duplex pipe; none of them involve real network I/O, TLS, or the hosting concerns listed above.
+authorized connections sharing one backend. Those established framing suites continue to drive
+`serve_websocket` over an in-memory duplex pipe. Real loopback TCP, TLS trust, plaintext opt-in,
+preflight, and redirect behavior belongs to
+`crates/openengine-cluster-client/tests/tls_dialer.rs`.


### PR DESCRIPTION
## Summary

- select rustls 0.23 + tokio-rustls 0.26 with the ring provider as the sole workspace TLS stack
- add a real outbound WebSocket dialer with mandatory system roots, per-connection private roots, optional bundled-root augmentation, strict endpoint preflight, explicit plaintext opt-in, and no redirect/downgrade following
- keep `serve_websocket` plaintext/duplex-backed and document the client/server TLS boundary plus future cloud HTTP placement

## Decisions

`native-tls` was rejected because Linux resolves it through `openssl-sys`, adding a system OpenSSL build dependency that breaks cross-compilation and static-musl releases. The `bundled-roots` feature is off by default and only augments a successfully loaded system store; it never masks unavailable or partially failed native roots. `ws://`, including loopback, requires `WebSocketDialOptions::allow_plaintext(true)` for each connection.

The redirect acceptance language cannot prevent the initial socket needed to receive an HTTP redirect. The implementation validates malformed/downgrade endpoints before any network I/O, rejects redirect handshake responses, and proves that the redirect target is never opened.

## Scope

- `openengine-cluster-server` implementation and framing/admission tests remain unchanged and plaintext.
- `zeroshot-rust/tests/architecture.rs` remains unamended; `zeroshot-rust` gains no TLS dependency.
- No protocol, generated artifact, schema, HTTP client/server, mTLS, auth, certificate provisioning, or Node behavior change.

## Verification

Focused issue targets, all non-zero:

- `cargo test -p openengine-cluster-client --test tls_dialer` — 7 passed
- `cargo test -p openengine-cluster-client --test websocket` — 4 passed
- `cargo test -p openengine-cluster-server --test websocket` — 9 passed
- `cargo test -p zeroshot-rust --test architecture` — 11 passed
- `cargo test -p openengine-cluster-client --features bundled-roots tls_trust_policy_tests` — 3 passed

Common and acceptance gates:

- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test:unit` (1953 passing, 18 pending)
- `opcore check --changed`
- `cargo build --locked --workspace`
- `cargo check -p openengine-cluster-client --features bundled-roots`

Two independent verifier rounds ran commands and reviewed correctness, scope, maintainability, and test mutation sensitivity. Round-one findings added AWS-LC to the ring-only lock guard and deterministic native-root/bundled-no-fallback tests. Round two passed with no remaining findings. Two unrelated scheduler-sensitive Rust tests each failed once during repeated full-gate runs, passed on focused rerun, and the exact full `npm run rust:check` subsequently passed both for the lead and an independent verifier.

Closes #833