### PR TITLE
refactor(cluster-protocol): split decoding from routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | NDJSON stdio binding         | `crates/openengine-cluster-server/src/stdio.rs`                         |
 | NDJSON watch client          | `crates/openengine-cluster-client/src/ndjson_watch.rs`                  |
 | Connection core/admission    | `crates/openengine-cluster-server/src/connection.rs`, `connection/`     |
+| JSON-RPC envelope/routing    | `crates/openengine-cluster-server/src/dispatch.rs`                      |
 | NDJSON response pump         | `crates/openengine-cluster-client/src/ndjson_pump.rs`                   |
 | Cluster typed transports     | `crates/openengine-cluster-client/`                                     |
 | Cluster fixtures/artifacts   | `crates/openengine-cluster-testkit/`                                    |
@@ -240,6 +241,11 @@ Endpoint preflight rejects non-ws(s), userinfo, query, and fragment before netwo
 are never followed or downgraded. Keep `serve_websocket` plaintext/front-proxy terminated and keep
 TLS out of `zeroshot-rust`. Do not introduce native-tls: its Linux `openssl-sys` dependency breaks
 cross-compilation and static-musl builds.
+Each binding parses inbound JSON once into the duplicate-preserving connection frame. Preserve the
+legacy typed-request classification used for duplicate-ID and task-slot admission before the strict
+envelope outcome; malformed and wrong-version responses still cross that shared admission boundary.
+`Dispatcher::dispatch_decoded` owns method lookup before params-shape validation, while
+`Dispatcher::dispatch` is only the JSON-RPC envelope decoder.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait

--- a/crates/openengine-cluster-server/src/connection.rs
+++ b/crates/openengine-cluster-server/src/connection.rs
@@ -4,6 +4,7 @@
 pub(crate) mod admission;
 pub(crate) mod agent_attach;
 pub(crate) mod dispatch;
+mod frame;
 pub(crate) mod logs;
 pub(crate) mod subscription;
 
@@ -11,6 +12,7 @@ pub(crate) use dispatch::{
     dispatch_classified_request, new_connection_setup, shutdown_connection, ConnectionSetup,
     DispatchCtx, RequestDispatch, ShutdownArgs,
 };
+pub(crate) use frame::DecodedFrame;
 
 use admission::InFlightIds;
 
@@ -20,8 +22,8 @@ use std::sync::Arc;
 
 use openengine_cluster_protocol::{
     DomainErrorData, EventNotification, JsonRpcNotification, RequestId,
-    SubscriptionClosedNotification, SubscriptionId, WatchParams, INVALID_PARAMS, JSON_RPC_VERSION,
-    SCHEMA_VIOLATION,
+    SubscriptionClosedNotification, SubscriptionId, WatchParams, INVALID_PARAMS, INVALID_REQUEST,
+    JSON_RPC_VERSION, SCHEMA_VIOLATION,
 };
 use parking_lot::Mutex;
 use serde_json::Value;
@@ -29,6 +31,71 @@ use tokio::sync::{mpsc, Notify};
 
 use crate::watch::{WatchEventStream, WatchHandle, WatchStreamItem};
 use crate::{serialize_backend_error, serialize_error, serialize_success, ClusterBackend, Dispatcher};
+
+/// A JSON-RPC request after transport framing and envelope decoding, but before method lookup or
+/// typed parameter decoding.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct DecodedRequest {
+    pub(crate) id: RequestId,
+    pub(crate) method: String,
+    pub(crate) params: Value,
+}
+
+impl DecodedRequest {
+    pub(crate) fn decode(input: &str) -> Result<Self, String> {
+        DecodedFrame::decode(input).and_then(|frame| Self::from_value(frame.into_value()))
+    }
+
+    pub(crate) fn from_value(value: Value) -> Result<Self, String> {
+        let Value::Object(mut object) = value else {
+            return Err(serialize_error(
+                None,
+                INVALID_REQUEST,
+                "Invalid Request",
+                None,
+            ));
+        };
+
+        if object.remove("jsonrpc") != Some(Value::String(JSON_RPC_VERSION.to_owned())) {
+            return Err(serialize_error(
+                None,
+                INVALID_REQUEST,
+                "Invalid Request",
+                None,
+            ));
+        }
+        let Some(Value::String(method)) = object.remove("method") else {
+            return Err(serialize_error(
+                None,
+                INVALID_REQUEST,
+                "Invalid Request",
+                None,
+            ));
+        };
+        let Some(id_value) = object.remove("id") else {
+            return Err(serialize_error(
+                None,
+                INVALID_REQUEST,
+                "Invalid Request",
+                None,
+            ));
+        };
+        let Some(id) = RequestId::from_json_value(&id_value) else {
+            return Err(serialize_error(
+                None,
+                INVALID_REQUEST,
+                "Invalid Request",
+                None,
+            ));
+        };
+
+        Ok(Self {
+            id,
+            method,
+            params: object.remove("params").unwrap_or(Value::Null),
+        })
+    }
+}
 
 /// Per-subscription cancellation signal: notifying it wakes `run_watch_subscription`'s streaming
 /// loop immediately, even while parked awaiting the next live event, instead of relying solely on
@@ -65,16 +132,32 @@ pub(crate) async fn race_cancel_or_next<T>(
     }
 }
 
-/// A decoded request classified for the shared connection multiplexer. `Passthrough` carries the
-/// request id when the input was a well-formed non-subscription request, so the connection can
-/// apply duplicate-in-flight-id detection to ordinary unary methods; it is `None` for malformed
-/// inputs or notifications, which [`Dispatcher::dispatch`] handles on its own.
+/// A decoded passthrough result. Envelope failures are pre-encoded so they can retain the legacy
+/// admission boundary without reparsing the frame in a dispatcher task.
+pub(crate) enum DecodedOutcome {
+    Request(DecodedRequest),
+    Response(String),
+}
+
+/// A decoded request classified for the shared connection multiplexer.
 pub(crate) enum RequestKind {
-    Watch { id: RequestId, params: Value },
-    Logs { id: RequestId, params: Value },
-    AgentAttach { id: RequestId, params: Value },
+    Watch {
+        id: RequestId,
+        params: Value,
+    },
+    Logs {
+        id: RequestId,
+        params: Value,
+    },
+    AgentAttach {
+        id: RequestId,
+        params: Value,
+    },
     Cancel(SubscriptionId),
-    Passthrough { id: Option<RequestId> },
+    Passthrough {
+        admission_id: Option<RequestId>,
+        outcome: DecodedOutcome,
+    },
 }
 
 /// Establishes a `watch` subscription and, on success, streams its `event`/`subscription/closed`

--- a/crates/openengine-cluster-server/src/connection/dispatch.rs
+++ b/crates/openengine-cluster-server/src/connection/dispatch.rs
@@ -2,9 +2,9 @@
 //! classify-then-spawn loop so results, events, and errors stay byte-equivalent between bindings.
 
 use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
-use std::future::Future;
 
 use openengine_cluster_protocol::RequestId;
 use parking_lot::Mutex;
@@ -13,7 +13,10 @@ use tokio::sync::{mpsc, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, JoinSet};
 
 use super::admission::{acquire_task_slot, reject_duplicate, InFlightIds, MAX_CONNECTION_TASKS};
-use super::{agent_attach, logs, run_watch_subscription, ConnectionState, RequestKind, SubscriptionMap};
+use super::{
+    agent_attach, logs, run_watch_subscription, ConnectionState, DecodedOutcome, RequestKind,
+    SubscriptionMap,
+};
 use crate::{ClusterBackend, Dispatcher};
 
 /// Grace period given to already-spawned bounded backend dispatches to finish once the connection
@@ -28,7 +31,8 @@ const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(200);
 pub(crate) enum RequestDispatch {
     Handled,
     Passthrough {
-        id: Option<RequestId>,
+        admission_id: Option<RequestId>,
+        outcome: DecodedOutcome,
         permit: OwnedSemaphorePermit,
     },
 }
@@ -105,21 +109,29 @@ where
                 .await;
             RequestDispatch::Handled
         }
-        RequestKind::Passthrough { id } => {
-            if let Some(id) = id.clone() {
+        RequestKind::Passthrough {
+            admission_id,
+            outcome,
+        } => {
+            if let Some(id) = admission_id.clone() {
                 if reject_duplicate(&ctx.state.in_flight_ids, &ctx.state.outbound_tx, id).await {
                     return RequestDispatch::Handled;
                 }
             }
             let Some(permit) =
-                acquire_task_slot(ctx.task_slots, &ctx.state.outbound_tx, id.clone()).await
+                acquire_task_slot(ctx.task_slots, &ctx.state.outbound_tx, admission_id.clone())
+                    .await
             else {
-                if let Some(id) = id {
+                if let Some(id) = admission_id {
                     ctx.state.in_flight_ids.lock().remove(&id);
                 }
                 return RequestDispatch::Handled;
             };
-            RequestDispatch::Passthrough { id, permit }
+            RequestDispatch::Passthrough {
+                admission_id,
+                outcome,
+                permit,
+            }
         }
     }
 }

--- a/crates/openengine-cluster-server/src/connection/frame.rs
+++ b/crates/openengine-cluster-server/src/connection/frame.rs
@@ -1,0 +1,242 @@
+//! Duplicate-preserving, single-pass JSON-RPC frame decoding and request classification.
+
+use openengine_cluster_protocol::{RequestId, SubscriptionId, PARSE_ERROR};
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+
+use super::{DecodedOutcome, DecodedRequest, RequestKind};
+use crate::serialize_error;
+
+/// One-pass JSON tree retaining duplicate object members until transport-specific notification
+/// recognition and legacy admission classification are complete.
+enum JsonNode {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    String(String),
+    Array(Vec<Self>),
+    Object(Vec<(String, Self)>),
+}
+
+impl JsonNode {
+    fn unique_field(&self, name: &str) -> Option<&Self> {
+        let Self::Object(entries) = self else {
+            return None;
+        };
+        let mut matching = entries
+            .iter()
+            .filter_map(|(key, value)| (key == name).then_some(value));
+        let value = matching.next()?;
+        matching.next().is_none().then_some(value)
+    }
+
+    fn request_id(&self) -> Option<RequestId> {
+        match self {
+            Self::String(value) => Some(RequestId::String(value.clone())),
+            Self::Number(value) => value.as_i64().map(RequestId::Integer),
+            _ => None,
+        }
+    }
+
+    fn into_value(self) -> Value {
+        match self {
+            Self::Null => Value::Null,
+            Self::Bool(value) => Value::Bool(value),
+            Self::Number(value) => Value::Number(value),
+            Self::String(value) => Value::String(value),
+            Self::Array(values) => Value::Array(values.into_iter().map(Self::into_value).collect()),
+            Self::Object(entries) => Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, value.into_value()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn as_string(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+struct JsonNodeVisitor;
+
+impl<'de> Visitor<'de> for JsonNodeVisitor {
+    type Value = JsonNode;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a JSON value")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(JsonNode::Null)
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(JsonNode::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(JsonNode::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(JsonNode::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(JsonNode::Number)
+            .ok_or_else(|| E::custom("invalid JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(JsonNode::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(JsonNode::String(value))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(JsonNode::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut entries = Vec::new();
+        while let Some(entry) = map.next_entry()? {
+            entries.push(entry);
+        }
+        Ok(JsonNode::Object(entries))
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonNode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(JsonNodeVisitor)
+    }
+}
+
+struct LegacyRequest {
+    id: RequestId,
+}
+
+/// A frame parsed once while retaining enough source structure to preserve the pre-refactor
+/// typed-envelope classification and duplicate-field behavior.
+pub(crate) struct DecodedFrame {
+    root: JsonNode,
+}
+
+impl DecodedFrame {
+    pub(crate) fn decode(input: &str) -> Result<Self, String> {
+        serde_json::from_str(input)
+            .map(|root| Self { root })
+            .map_err(|_| serialize_error(None, PARSE_ERROR, "Parse error", None))
+    }
+
+    fn legacy_request(&self) -> Option<LegacyRequest> {
+        self.root.unique_field("jsonrpc")?.as_string()?;
+        let id = self.root.unique_field("id")?.request_id()?;
+        self.root.unique_field("method")?.as_string()?;
+        self.root.unique_field("params")?;
+        Some(LegacyRequest { id })
+    }
+
+    fn notification_params(&self, method: &str) -> Option<&[(String, JsonNode)]> {
+        self.root.unique_field("jsonrpc")?.as_string()?;
+        if self.root.unique_field("method")?.as_string()? != method {
+            return None;
+        }
+        match self.root.unique_field("params")? {
+            JsonNode::Object(entries) => Some(entries),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn cancel_request_id(&self) -> Option<RequestId> {
+        let entries = self.notification_params("$/cancelRequest")?;
+        if entries.len() != 1 || entries[0].0 != "id" {
+            return None;
+        }
+        entries[0].1.request_id()
+    }
+
+    fn subscription_cancel_id(&self) -> Option<SubscriptionId> {
+        let entries = self.notification_params("subscription/cancel")?;
+        if entries.len() != 1 || entries[0].0 != "subscriptionId" {
+            return None;
+        }
+        Some(SubscriptionId::new(entries[0].1.as_string()?))
+    }
+
+    pub(crate) fn into_request_kind(self) -> RequestKind {
+        let legacy = self.legacy_request();
+        let legacy_classified = legacy.is_some();
+        if !legacy_classified {
+            if let Some(subscription_id) = self.subscription_cancel_id() {
+                return RequestKind::Cancel(subscription_id);
+            }
+        }
+
+        let admission_id = legacy.map(|request| request.id);
+        match DecodedRequest::from_value(self.root.into_value()) {
+            Ok(request) => {
+                if legacy_classified {
+                    match request.method.as_str() {
+                        "watch" => {
+                            return RequestKind::Watch {
+                                id: request.id,
+                                params: request.params,
+                            };
+                        }
+                        "logs" => {
+                            return RequestKind::Logs {
+                                id: request.id,
+                                params: request.params,
+                            };
+                        }
+                        "agent/attach" => {
+                            return RequestKind::AgentAttach {
+                                id: request.id,
+                                params: request.params,
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+                RequestKind::Passthrough {
+                    admission_id,
+                    outcome: DecodedOutcome::Request(request),
+                }
+            }
+            Err(response) => RequestKind::Passthrough {
+                admission_id,
+                outcome: DecodedOutcome::Response(response),
+            },
+        }
+    }
+
+    pub(super) fn into_value(self) -> Value {
+        self.root.into_value()
+    }
+}

--- a/crates/openengine-cluster-server/src/dispatch.rs
+++ b/crates/openengine-cluster-server/src/dispatch.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 use openengine_cluster_protocol::{
     ApplyParams, DeleteParams, DomainErrorData, GetParams, InitializeParams, PlanParams, RequestId,
     ResubmitParams, RetryParams, StopParams, UpdateParams, APPLICATION_ERROR, INTERNAL_ERROR_CODE,
-    INVALID_PARAMS, INVALID_REQUEST, JSON_RPC_VERSION, METHOD_NOT_FOUND, PARSE_ERROR,
-    PROTOCOL_VERSION, SCHEMA_VIOLATION, UNSUPPORTED_PROTOCOL_VERSION,
+    INVALID_PARAMS, METHOD_NOT_FOUND, PROTOCOL_VERSION, SCHEMA_VIOLATION,
+    UNSUPPORTED_PROTOCOL_VERSION,
 };
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 
+use crate::connection::DecodedRequest;
 use crate::{
     serialize_backend_error, serialize_error, serialize_success, BackendError, ClusterBackend,
     ConnectionContext, Dispatcher,
@@ -41,90 +42,22 @@ where
     }
 
     pub async fn dispatch(&self, input: &str) -> String {
-        let value = match serde_json::from_str::<Value>(input) {
-            Ok(value) => value,
-            Err(_) => return serialize_error(None, PARSE_ERROR, "Parse error", None),
-        };
-
-        let object = match value {
-            Value::Object(object) => object,
-            Value::Array(_) => {
-                return serialize_error(None, INVALID_REQUEST, "Invalid Request", None);
-            }
-            _ => return serialize_error(None, INVALID_REQUEST, "Invalid Request", None),
-        };
-
-        self.dispatch_object(object).await
-    }
-
-    async fn dispatch_object(&self, object: Map<String, Value>) -> String {
-        let (id, method, params) = match Self::parse_request(&object) {
-            Ok(parsed) => parsed,
+        let request = match DecodedRequest::decode(input) {
+            Ok(request) => request,
             Err(response) => return response,
         };
-
-        self.route(method, id, params).await
+        let DecodedRequest { id, method, params } = request;
+        self.dispatch_decoded(id, &method, params).await
     }
 
-    fn parse_request(
-        object: &Map<String, Value>,
-    ) -> Result<(RequestId, ImplementedMethod, Value), String> {
-        if object.get("jsonrpc") != Some(&Value::String(JSON_RPC_VERSION.to_owned())) {
-            return Err(serialize_error(
-                None,
-                INVALID_REQUEST,
-                "Invalid Request",
-                None,
-            ));
+    pub async fn dispatch_decoded(&self, id: RequestId, method: &str, params: Value) -> String {
+        let Some(method) = ImplementedMethod::from_name(method) else {
+            return serialize_error(Some(id), METHOD_NOT_FOUND, "Method not found", None);
+        };
+        if !params.is_object() {
+            return serialize_error(Some(id), INVALID_PARAMS, "Invalid params", None);
         }
-
-        let Some(Value::String(method_name)) = object.get("method") else {
-            return Err(serialize_error(
-                None,
-                INVALID_REQUEST,
-                "Invalid Request",
-                None,
-            ));
-        };
-        let Some(id_value) = object.get("id") else {
-            return Err(serialize_error(
-                None,
-                INVALID_REQUEST,
-                "Invalid Request",
-                None,
-            ));
-        };
-        let Some(id) = RequestId::from_json_value(id_value) else {
-            return Err(serialize_error(
-                None,
-                INVALID_REQUEST,
-                "Invalid Request",
-                None,
-            ));
-        };
-
-        let Some(method) = ImplementedMethod::from_name(method_name) else {
-            return Err(serialize_error(
-                Some(id),
-                METHOD_NOT_FOUND,
-                "Method not found",
-                None,
-            ));
-        };
-
-        let params = match object.get("params") {
-            Some(Value::Object(params)) => Value::Object(params.clone()),
-            _ => {
-                return Err(serialize_error(
-                    Some(id),
-                    INVALID_PARAMS,
-                    "Invalid params",
-                    None,
-                ));
-            }
-        };
-
-        Ok((id, method, params))
+        self.route(method, id, params).await
     }
 
     async fn route(&self, method: ImplementedMethod, id: RequestId, params: Value) -> String {

--- a/crates/openengine-cluster-server/src/lib.rs
+++ b/crates/openengine-cluster-server/src/lib.rs
@@ -15,7 +15,6 @@ mod dispatch;
 mod subscription_stream;
 mod wire;
 pub(crate) use wire::{serialize_backend_error, serialize_error, serialize_success};
-pub(crate) use stdio::classify_ndjson_line;
 
 use std::sync::Arc;
 

--- a/crates/openengine-cluster-server/src/stdio.rs
+++ b/crates/openengine-cluster-server/src/stdio.rs
@@ -2,10 +2,7 @@
 
 use std::io;
 
-use openengine_cluster_protocol::{
-    JsonRpcNotification, JsonRpcRequest, RequestId, SubscriptionCancelParams, PARSE_ERROR,
-};
-use serde_json::Value;
+use openengine_cluster_protocol::{RequestId, PARSE_ERROR};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -13,7 +10,8 @@ use tokio_util::codec::{Framed, LinesCodec, LinesCodecError};
 
 use crate::connection::{
     dispatch_classified_request, new_connection_setup, shutdown_connection, ConnectionSetup,
-    ConnectionState, DispatchCtx, RequestDispatch, RequestKind, ShutdownArgs,
+    ConnectionState, DecodedFrame, DecodedOutcome, DecodedRequest, DispatchCtx, RequestDispatch,
+    RequestKind, ShutdownArgs,
 };
 use crate::{serialize_error, ClusterBackend, Dispatcher};
 
@@ -121,37 +119,51 @@ where
     Ok(())
 }
 
-/// Classifies and dispatches one decoded NDJSON line, spawning passthrough work after the shared
-/// connection core applies duplicate-id rejection and task admission.
+/// Decodes and dispatches one NDJSON line, spawning every passthrough outcome after the shared
+/// connection core applies the legacy duplicate-id and task-slot admission boundary.
 async fn dispatch_ndjson_line<B>(line: String, ctx: &mut DispatchCtx<'_, B>)
 where
     B: ClusterBackend,
 {
-    let kind = classify_ndjson_line(&line);
-    if let RequestDispatch::Passthrough { id, permit } =
-        dispatch_classified_request(kind, ctx).await
+    let kind = match DecodedFrame::decode(&line) {
+        Ok(frame) => frame.into_request_kind(),
+        Err(response) => RequestKind::Passthrough {
+            admission_id: None,
+            outcome: DecodedOutcome::Response(response),
+        },
+    };
+    if let RequestDispatch::Passthrough {
+        admission_id,
+        outcome,
+        permit,
+    } = dispatch_classified_request(kind, ctx).await
     {
         let task_dispatcher = ctx.dispatcher.clone();
         let task_state = ctx.state.clone();
         ctx.tasks.spawn(async move {
             let _permit = permit;
-            run_passthrough_request(task_dispatcher, id, line, task_state).await;
+            run_passthrough_request(task_dispatcher, admission_id, outcome, task_state).await;
         });
     }
 }
 
-/// Dispatches a non-`watch` request or notification line, releasing its in-flight id (if any)
-/// once the backend call returns and before the response is enqueued.
+/// Resolves one admitted decoded outcome and releases its legacy classification id before the
+/// response is enqueued.
 async fn run_passthrough_request<B>(
     dispatcher: Dispatcher<B>,
-    id: Option<RequestId>,
-    line: String,
+    admission_id: Option<RequestId>,
+    outcome: DecodedOutcome,
     state: ConnectionState,
 ) where
     B: ClusterBackend,
 {
-    let response = dispatcher.dispatch(&line).await;
-    if let Some(id) = id {
+    let response = match outcome {
+        DecodedOutcome::Request(DecodedRequest { id, method, params }) => {
+            dispatcher.dispatch_decoded(id, &method, params).await
+        }
+        DecodedOutcome::Response(response) => response,
+    };
+    if let Some(id) = admission_id {
         state.in_flight_ids.lock().remove(&id);
     }
     let _ = state.outbound_tx.send(response).await;
@@ -168,42 +180,4 @@ where
         tokio::io::stderr(),
     )
     .await
-}
-
-/// Classifies a decoded NDJSON line without fully deserializing its params: a `watch`/`logs`/
-/// `agent/attach` request is pulled out for subscription handling, a `subscription/cancel`
-/// notification is pulled out for inline cancellation, and everything else (including malformed
-/// JSON) passes through to [`Dispatcher::dispatch`] unchanged.
-pub(crate) fn classify_ndjson_line(line: &str) -> RequestKind {
-    if let Ok(request) = serde_json::from_str::<JsonRpcRequest<Value>>(line) {
-        if request.method == "watch" {
-            return RequestKind::Watch {
-                id: request.id,
-                params: request.params,
-            };
-        }
-        if request.method == "logs" {
-            return RequestKind::Logs {
-                id: request.id,
-                params: request.params,
-            };
-        }
-        if request.method == "agent/attach" {
-            return RequestKind::AgentAttach {
-                id: request.id,
-                params: request.params,
-            };
-        }
-        return RequestKind::Passthrough {
-            id: Some(request.id),
-        };
-    }
-    if let Ok(notification) =
-        serde_json::from_str::<JsonRpcNotification<SubscriptionCancelParams>>(line)
-    {
-        if notification.method == "subscription/cancel" {
-            return RequestKind::Cancel(notification.params.subscription_id);
-        }
-    }
-    RequestKind::Passthrough { id: None }
 }

--- a/crates/openengine-cluster-server/src/websocket.rs
+++ b/crates/openengine-cluster-server/src/websocket.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use futures_util::stream::SplitStream;
 use futures_util::{Sink, SinkExt, StreamExt};
-use openengine_cluster_protocol::{CancelRequestParams, JsonRpcNotification, RequestId};
+use openengine_cluster_protocol::RequestId;
 use parking_lot::Mutex;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, oneshot, Notify, OwnedSemaphorePermit};
@@ -23,9 +23,10 @@ use tokio_tungstenite::WebSocketStream;
 
 use crate::connection::{
     dispatch_classified_request, new_connection_setup, race_cancel_or_next, shutdown_connection,
-    ConnectionSetup, ConnectionState, DispatchCtx, RequestDispatch, ShutdownArgs,
+    ConnectionSetup, ConnectionState, DecodedFrame, DecodedOutcome, DecodedRequest, DispatchCtx,
+    RequestDispatch, RequestKind, ShutdownArgs,
 };
-use crate::{classify_ndjson_line, ClusterBackend, Dispatcher};
+use crate::{ClusterBackend, Dispatcher};
 
 /// Bounded WebSocket text-frame length: a text message whose UTF-8 byte length exceeds this
 /// closes the connection with code 1009 (message too big), matching `stdio::serve_ndjson`'s
@@ -179,10 +180,8 @@ where
     }
 }
 
-/// Handles one `Message::Text` frame: enforces [`MAX_FRAME_BYTES`], routes a `$/cancelRequest`
-/// notification inline, and otherwise classifies and dispatches the request through
-/// [`dispatch_classified_request`] -- spawning this binding's own passthrough task (with
-/// `cancel_registry` tracking) for a [`RequestDispatch::Passthrough`] result.
+/// Handles one `Message::Text` frame: enforces [`MAX_FRAME_BYTES`], decodes exactly once, routes a
+/// valid `$/cancelRequest` notification inline, and otherwise admits the decoded outcome.
 async fn handle_text_frame<B>(text: Utf8Bytes, ctx: &mut WsCtx<'_, B>) -> FrameOutcome
 where
     B: ClusterBackend,
@@ -191,40 +190,41 @@ where
         signal_close(ctx.close_tx, CloseCode::Size, "message too big");
         return FrameOutcome::Break;
     }
-    if let Some(cancel_id) = parse_cancel_request(&text) {
-        // Notify only -- never remove here. Removal happens exactly once, in the owning task's
-        // own ownership-checked cleanup (`run_passthrough_request`), so the map always has a
-        // single source of truth for "who owns this entry". This intentionally diverges from
-        // `dispatch_classified_request`'s `subscription/cancel` handling (which does remove-then-
-        // notify): subscription ids are minted once and never reused, so eager removal is safe
-        // there, whereas JSON-RPC `RequestId`s are explicitly retryable/reusable by clients, which
-        // is exactly what makes eager removal here unsafe (a same-id retry could register between
-        // an eager remove and the owning task's own cleanup).
-        if let Some(notify) = ctx.cancel_registry.lock().get(&cancel_id) {
-            notify.notify_one();
+    let kind = match DecodedFrame::decode(&text) {
+        Ok(frame) => {
+            if let Some(cancel_id) = frame.cancel_request_id() {
+                // Notify only -- never remove here. Removal happens exactly once, in the owning
+                // task's ownership-checked cleanup.
+                if let Some(notify) = ctx.cancel_registry.lock().get(&cancel_id) {
+                    notify.notify_one();
+                }
+                return FrameOutcome::Continue;
+            }
+            frame.into_request_kind()
         }
-        return FrameOutcome::Continue;
-    }
-    let kind = classify_ndjson_line(&text);
-    if let RequestDispatch::Passthrough { id, permit } =
-        dispatch_classified_request(kind, &mut ctx.dispatch).await
+        Err(response) => RequestKind::Passthrough {
+            admission_id: None,
+            outcome: DecodedOutcome::Response(response),
+        },
+    };
+    if let RequestDispatch::Passthrough {
+        admission_id,
+        outcome,
+        permit,
+    } = dispatch_classified_request(kind, &mut ctx.dispatch).await
     {
-        spawn_passthrough(ctx, id, permit, text.as_str().to_owned());
+        spawn_passthrough(ctx, admission_id, outcome, permit);
     }
     FrameOutcome::Continue
 }
 
-/// Spawns the passthrough (non-subscription) request task for an admission-approved line,
-/// registering its cooperative cancellation signal under `id` in `cancel_registry` *synchronously,
-/// before* spawning the task -- registration happens-before the task can possibly run or complete
-/// (ordinary sequential program order on the calling task, not a scheduling race), so
-/// `$/cancelRequest` can never observe a not-yet-registered id for a request that has already been
-/// admitted.
+/// Spawns an admitted passthrough outcome, registering cooperative cancellation under the legacy
+/// classification id synchronously before the task can run.
 fn spawn_passthrough<B>(
     ctx: &mut WsCtx<'_, B>,
-    id: Option<RequestId>,
+    admission_id: Option<RequestId>,
+    outcome: DecodedOutcome,
     permit: OwnedSemaphorePermit,
-    line: String,
 ) where
     B: ClusterBackend,
 {
@@ -232,7 +232,7 @@ fn spawn_passthrough<B>(
     let task_state = ctx.dispatch.state.clone();
     let task_cancel_registry = Arc::clone(ctx.cancel_registry);
     let cancel_notify = Arc::new(Notify::new());
-    if let Some(id) = &id {
+    if let Some(id) = &admission_id {
         ctx.cancel_registry
             .lock()
             .insert(id.clone(), Arc::clone(&cancel_notify));
@@ -241,8 +241,8 @@ fn spawn_passthrough<B>(
         let _permit = permit;
         run_passthrough_request(PassthroughRequest {
             dispatcher: task_dispatcher,
-            id,
-            line,
+            admission_id,
+            outcome,
             state: task_state,
             cancel_registry: task_cancel_registry,
             cancel_notify,
@@ -251,60 +251,49 @@ fn spawn_passthrough<B>(
     });
 }
 
-/// Grouped arguments for [`run_passthrough_request`], keeping that function's argument count
-/// reasonable.
+/// Grouped arguments for [`run_passthrough_request`].
 struct PassthroughRequest<B> {
     dispatcher: Dispatcher<B>,
-    id: Option<RequestId>,
-    line: String,
+    admission_id: Option<RequestId>,
+    outcome: DecodedOutcome,
     state: ConnectionState,
     cancel_registry: CancelRegistry,
     cancel_notify: Arc<Notify>,
 }
 
-/// Dispatches a non-subscription request or notification frame, racing its completion against a
-/// cooperative `$/cancelRequest` signal via [`race_cancel_or_next`] -- the same idiom the
-/// connection core uses for subscription cancellation -- so cancellation and normal completion
-/// resume into the exact same cleanup code below regardless of which side wins; no exit path can
-/// skip it, unlike external task abortion. Once the race settles, unconditionally releases the
-/// request's in-flight id and -- only if this task's own cancellation entry is still the one
-/// registered under `id`, checked via `Arc::ptr_eq` -- its cancel-registry entry, so a same-id
-/// retry's fresh registration (inserted by its own [`spawn_passthrough`] call) is never disturbed
-/// by this task's cleanup. A response is enqueued only when the race resolved to completion; a
-/// cancelled request produces no response, preserving the no-rollback/at-most-one-terminal-
-/// response contract. Mirrors the NDJSON passthrough runner, plus the `cancel_registry` cleanup
-/// that binding has no notion of.
+/// Resolves one admitted outcome, racing it against cooperative `$/cancelRequest` and applying
+/// ownership-checked cleanup.
 async fn run_passthrough_request<B>(request: PassthroughRequest<B>)
 where
     B: ClusterBackend,
 {
     let PassthroughRequest {
         dispatcher,
-        id,
-        line,
+        admission_id,
+        outcome,
         state,
         cancel_registry,
         cancel_notify,
     } = request;
-    let outcome = race_cancel_or_next(&cancel_notify, async {
-        Some(dispatcher.dispatch(&line).await)
+    let response = race_cancel_or_next(&cancel_notify, async {
+        Some(match outcome {
+            DecodedOutcome::Request(DecodedRequest { id, method, params }) => {
+                dispatcher.dispatch_decoded(id, &method, params).await
+            }
+            DecodedOutcome::Response(response) => response,
+        })
     })
     .await;
-    if let Some(id) = &id {
+    if let Some(id) = &admission_id {
         state.in_flight_ids.lock().remove(id);
         release_owned_cancel_entry(&cancel_registry, id, &cancel_notify);
     }
-    if let Some(response) = outcome {
+    if let Some(response) = response {
         let _ = state.outbound_tx.send(response).await;
     }
 }
 
-/// Removes `cancel_registry`'s entry for `id` only if it is still `notify` itself (via
-/// `Arc::ptr_eq`), so a task can only ever remove its own registration. If a same-id retry has
-/// already overwritten the entry with its own fresh [`Notify`] by the time this runs, the pointer
-/// comparison fails and the newer registration is left untouched -- correct under every possible
-/// interleaving of an old request's cleanup and a new same-id request's registration, not just the
-/// common ordering.
+/// Removes `cancel_registry`'s entry for `id` only if it is still owned by `notify`.
 fn release_owned_cancel_entry(
     cancel_registry: &CancelRegistry,
     id: &RequestId,
@@ -317,14 +306,6 @@ fn release_owned_cancel_entry(
     {
         registry.remove(id);
     }
-}
-
-/// Parses `text` as a `$/cancelRequest` notification, returning the target `RequestId` only when
-/// both the JSON-RPC method matches and the body deserializes -- anything else (including every
-/// other recognized or unrecognized method) is left for `classify_ndjson_line` to route.
-fn parse_cancel_request(text: &str) -> Option<RequestId> {
-    let notification: JsonRpcNotification<CancelRequestParams> = serde_json::from_str(text).ok()?;
-    (notification.method == "$/cancelRequest").then_some(notification.params.id)
 }
 
 /// Sends `code`/`reason` on `close_tx` exactly once -- a no-op if a close was already signalled --

--- a/crates/openengine-cluster-server/src/websocket/tests.rs
+++ b/crates/openengine-cluster-server/src/websocket/tests.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use openengine_cluster_protocol::{
     GetParams, GetResult, InitializeParams, InitializeResult, RequestId, RunId,
 };
+use serde_json::Value;
 use tokio::sync::{Notify, Semaphore};
 
 use super::*;
@@ -47,8 +48,12 @@ fn fixture_backend() -> FixtureBackend {
     FixtureBackend::new(store)
 }
 
-fn get_request_line(id: i64) -> String {
-    format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"get","params":{{}}}}"#)
+fn get_request(id: i64) -> DecodedRequest {
+    DecodedRequest {
+        id: RequestId::Integer(id),
+        method: "get".to_owned(),
+        params: Value::Object(serde_json::Map::new()),
+    }
 }
 
 fn test_permit(task_slots: &Arc<Semaphore>) -> OwnedSemaphorePermit {
@@ -95,7 +100,12 @@ async fn spawn_passthrough_registers_cancellation_before_the_task_can_run() {
             cancel_registry: &cancel_registry,
             close_tx: &mut close_tx,
         };
-        spawn_passthrough(&mut ctx, Some(id.clone()), permit, get_request_line(1));
+        spawn_passthrough(
+            &mut ctx,
+            Some(id.clone()),
+            DecodedOutcome::Request(get_request(1)),
+            permit,
+        );
     }
 
     // `spawn_passthrough` has no `.await` of its own, so returning here happens strictly after the
@@ -128,8 +138,8 @@ async fn run_passthrough_request_on_instant_completion_leaves_registry_empty() {
 
     run_passthrough_request(PassthroughRequest {
         dispatcher,
-        id: Some(id.clone()),
-        line: get_request_line(7),
+        admission_id: Some(id.clone()),
+        outcome: DecodedOutcome::Request(get_request(7)),
         state: state.clone(),
         cancel_registry: Arc::clone(&cancel_registry),
         cancel_notify,

--- a/crates/openengine-cluster-server/tests/admission_bound_support/mod.rs
+++ b/crates/openengine-cluster-server/tests/admission_bound_support/mod.rs
@@ -3,21 +3,31 @@
 //! both drive the exact same admission/dedup behavior against the shared `Dispatcher`/
 //! connection-task machinery, independent of wire framing.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use openengine_cluster_protocol::RunId;
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    AgentAttachParams, AgentAttachResult, ClusterStatus, GetParams, GetResult, InitializeParams,
+    InitializeResult, LogsParams, LogsResult, RunId, ServerCapabilities, WatchParams, WatchResult,
+};
+use openengine_cluster_server::agent_attach::{AgentAttachEventStream, AgentAttachHandle};
+use openengine_cluster_server::logs::{LogEventStream, LogsHandle};
 use openengine_cluster_server::watch::fixtures::{FixtureBackend, FixtureStore};
+use openengine_cluster_server::watch::{WatchEventStream, WatchHandle};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
 use serde_json::Value;
 use tokio::sync::Notify;
 
 use crate::gated_backend_support::GatedBackend;
 
-/// Minimal capability both wire harnesses share: writing a `get` request with a given id and
-/// reading the next decoded JSON-RPC frame, regardless of wire framing (NDJSON lines vs WebSocket
-/// text frames).
+/// Minimal capability both wire harnesses share: writing framed requests and reading the next
+/// decoded JSON-RPC frame, regardless of wire framing (NDJSON lines vs WebSocket text frames).
 pub trait RequestChannel {
     async fn send_get(&mut self, id: i64);
+    async fn send_raw(&mut self, text: &str);
+    async fn recv_raw(&mut self) -> String;
     async fn recv_value(&mut self) -> Value;
 }
 
@@ -25,6 +35,12 @@ pub trait RequestChannel {
 /// gated backend without each binding needing its own copy of that setup.
 pub trait GatedHarnessSpawn: Sized {
     async fn spawn_gated(backend: GatedBackend) -> Self;
+    async fn shut_down(self);
+}
+
+/// Spawn glue for exact subscription-envelope validation against an instrumented backend.
+pub trait SubscriptionValidationHarness: GatedHarnessSpawn + RequestChannel {
+    async fn spawn_subscription_validation(backend: SubscriptionCountingBackend) -> Self;
 }
 
 /// Constructs a fresh `FixtureStore`/[`GatedBackend`] pair (gating only `get`) and spawns `H`
@@ -41,6 +57,122 @@ pub async fn spawn_gated_harness<H: GatedHarnessSpawn>() -> (H, Arc<Notify>) {
     (harness, gate)
 }
 
+#[derive(Default)]
+pub struct SubscriptionCallCounters {
+    watch: AtomicUsize,
+    logs: AtomicUsize,
+    agent_attach: AtomicUsize,
+}
+
+impl SubscriptionCallCounters {
+    fn assert_zero(&self) {
+        assert_eq!(self.watch.load(Ordering::SeqCst), 0, "watch backend calls");
+        assert_eq!(self.logs.load(Ordering::SeqCst), 0, "logs backend calls");
+        assert_eq!(
+            self.agent_attach.load(Ordering::SeqCst),
+            0,
+            "agent/attach backend calls"
+        );
+    }
+
+    fn assert_one_each(&self) {
+        assert_eq!(self.watch.load(Ordering::SeqCst), 1, "watch backend calls");
+        assert_eq!(self.logs.load(Ordering::SeqCst), 1, "logs backend calls");
+        assert_eq!(
+            self.agent_attach.load(Ordering::SeqCst),
+            1,
+            "agent/attach backend calls"
+        );
+    }
+}
+
+pub struct SubscriptionCountingBackend {
+    counters: Arc<SubscriptionCallCounters>,
+}
+
+#[async_trait]
+impl ClusterBackend for SubscriptionCountingBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        Ok(InitializeResult::new(
+            ServerCapabilities::default(),
+            ClusterStatus::empty(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult::empty())
+    }
+
+    async fn watch(
+        &self,
+        _context: &ConnectionContext,
+        _params: WatchParams,
+        _queue_capacity: usize,
+    ) -> Result<(WatchResult, WatchEventStream, WatchHandle), BackendError> {
+        self.counters.watch.fetch_add(1, Ordering::SeqCst);
+        Err(BackendError::application("TEST", "unexpected watch", None))
+    }
+
+    async fn logs(
+        &self,
+        _context: &ConnectionContext,
+        _params: LogsParams,
+        _queue_capacity: usize,
+    ) -> Result<(LogsResult, LogEventStream, LogsHandle), BackendError> {
+        self.counters.logs.fetch_add(1, Ordering::SeqCst);
+        Err(BackendError::application("TEST", "unexpected logs", None))
+    }
+
+    async fn agent_attach(
+        &self,
+        _context: &ConnectionContext,
+        _params: AgentAttachParams,
+        _queue_capacity: usize,
+    ) -> Result<(AgentAttachResult, AgentAttachEventStream, AgentAttachHandle), BackendError> {
+        self.counters.agent_attach.fetch_add(1, Ordering::SeqCst);
+        Err(BackendError::application(
+            "TEST",
+            "unexpected agent attach",
+            None,
+        ))
+    }
+}
+
+fn assert_duplicate_response(response: &Value, id: i64) {
+    assert_eq!(response["id"], id);
+    assert_eq!(response["error"]["code"], -32600);
+    assert_eq!(response["error"]["data"]["code"], "DUPLICATE_REQUEST_ID");
+}
+
+fn assert_get_success(response: &Value, id: i64) {
+    assert_eq!(response["id"], id);
+    assert!(response.get("result").is_some(), "{response}");
+}
+
+async fn fill_task_slots<H: RequestChannel>(harness: &mut H, max_connection_tasks: i64) -> Value {
+    for id in 0..max_connection_tasks {
+        harness.send_get(id).await;
+    }
+    harness.send_get(max_connection_tasks).await;
+    tokio::time::timeout(Duration::from_secs(1), harness.recv_value())
+        .await
+        .expect("the bounded admission rejection must not wait for blocked backend calls")
+}
+
+fn assert_server_busy(response: &Value, id: i64) {
+    assert_eq!(response["id"], id);
+    assert_eq!(response["error"]["code"], -32000);
+    assert_eq!(response["error"]["data"]["code"], "SERVER_BUSY");
+}
+
 /// Sends two `get` requests sharing request id `1` while `gate` blocks the first from completing,
 /// asserts the second is rejected as a synchronous `DUPLICATE_REQUEST_ID` error (the first request
 /// is still blocked on the gate, so the only frame that can possibly exist yet is the duplicate
@@ -54,14 +186,11 @@ pub async fn assert_duplicate_in_flight_ids_are_rejected<H: RequestChannel>(
     harness.send_get(1).await;
 
     let duplicate = harness.recv_value().await;
-    assert_eq!(duplicate["id"], 1);
-    assert_eq!(duplicate["error"]["code"], -32600);
-    assert_eq!(duplicate["error"]["data"]["code"], "DUPLICATE_REQUEST_ID");
+    assert_duplicate_response(&duplicate, 1);
 
     gate.notify_one();
     let first = harness.recv_value().await;
-    assert_eq!(first["id"], 1);
-    assert!(first.get("result").is_some(), "{first}");
+    assert_get_success(&first, 1);
 }
 
 /// Sends `max_connection_tasks + 1` distinct-id `get` requests, all blocked on `harness`'s gated
@@ -71,14 +200,154 @@ pub async fn assert_excess_requests_are_rejected_with_server_busy<H: RequestChan
     harness: &mut H,
     max_connection_tasks: i64,
 ) {
-    for id in 1..=max_connection_tasks + 1 {
-        harness.send_get(id).await;
-    }
+    let rejected = fill_task_slots(harness, max_connection_tasks).await;
+    assert_server_busy(&rejected, max_connection_tasks);
+}
 
-    let rejected = tokio::time::timeout(Duration::from_secs(1), harness.recv_value())
-        .await
-        .expect("the bounded admission rejection must not wait for blocked backend calls");
-    assert_eq!(rejected["id"], max_connection_tasks + 1);
-    assert_eq!(rejected["error"]["code"], -32000);
-    assert_eq!(rejected["error"]["data"]["code"], "SERVER_BUSY");
+/// Proves an envelope with a legacy typed-request id still reaches duplicate detection before its
+/// pre-encoded strict-version error.
+pub async fn assert_wrong_version_envelope_retains_duplicate_precedence<H: RequestChannel>(
+    harness: &mut H,
+    gate: &Notify,
+) {
+    harness.send_get(1).await;
+    harness
+        .send_raw(r#"{"jsonrpc":"1.0","id":1,"method":"watch","params":{}}"#)
+        .await;
+
+    let duplicate = harness.recv_value().await;
+    assert_duplicate_response(&duplicate, 1);
+    gate.notify_one();
+    let completed = harness.recv_value().await;
+    assert_get_success(&completed, 1);
+}
+
+fn duplicate_subscription_frames(id: i64, method: &str) -> [String; 4] {
+    [
+        format!(
+            r#"{{"jsonrpc":"2.0","jsonrpc":"2.0","id":{id},"method":"{method}","params":{{}}}}"#
+        ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{},"id":{id},"method":"{method}","params":{{}}}}"#,
+            id - 1
+        ),
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"method":"get","method":"{method}","params":{{}}}}"#
+        ),
+        format!(r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":[],"params":{{}}}}"#),
+    ]
+}
+
+async fn assert_subscription_envelopes_are_not_classified<H: RequestChannel>(harness: &mut H) {
+    for (id, method) in [(41, "watch"), (42, "logs"), (43, "agent/attach")] {
+        harness
+            .send_raw(&format!(
+                r#"{{"jsonrpc":"1.0","id":{id},"method":"{method}","params":{{}}}}"#
+            ))
+            .await;
+        assert_eq!(
+            harness.recv_raw().await,
+            r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+            "{method}"
+        );
+
+        for frame in duplicate_subscription_frames(id + 100, method) {
+            harness.send_raw(&frame).await;
+            assert_eq!(
+                harness.recv_raw().await,
+                format!(
+                    r#"{{"jsonrpc":"2.0","id":{},"error":{{"code":-32601,"message":"Method not found"}}}}"#,
+                    id + 100
+                ),
+                "{method}: {frame}"
+            );
+        }
+    }
+}
+
+async fn assert_unknown_subscription_members_are_accepted<H: RequestChannel>(harness: &mut H) {
+    for (id, method, params, message) in [
+        (201, "watch", "{}", "unexpected watch"),
+        (202, "logs", "{}", "unexpected logs"),
+        (
+            203,
+            "agent/attach",
+            r#"{"execution":"exec-1"}"#,
+            "unexpected agent attach",
+        ),
+    ] {
+        harness
+            .send_raw(&format!(
+                r#"{{"jsonrpc":"2.0","id":{id},"method":"{method}","params":{params},"extension":true}}"#
+            ))
+            .await;
+        assert_eq!(
+            harness.recv_raw().await,
+            format!(
+                r#"{{"jsonrpc":"2.0","id":{id},"error":{{"code":-32000,"message":"{message}","data":{{"code":"TEST"}}}}}}"#
+            ),
+            "{method}"
+        );
+    }
+}
+
+/// Runs strict and duplicate-field subscription-envelope scenarios against an instrumented
+/// backend, asserting exact response bytes and zero subscription backend calls.
+pub async fn assert_subscription_envelope_validation_for_binding<H>()
+where
+    H: SubscriptionValidationHarness,
+{
+    let counters = Arc::new(SubscriptionCallCounters::default());
+    let mut harness = H::spawn_subscription_validation(SubscriptionCountingBackend {
+        counters: Arc::clone(&counters),
+    })
+    .await;
+    assert_subscription_envelopes_are_not_classified(&mut harness).await;
+    counters.assert_zero();
+    assert_unknown_subscription_members_are_accepted(&mut harness).await;
+    counters.assert_one_each();
+    harness.shut_down().await;
+}
+
+/// Proves id-less malformed input remains subject to the legacy task-slot boundary.
+pub async fn assert_malformed_frame_is_dropped_at_task_saturation<H: RequestChannel>(
+    harness: &mut H,
+    max_connection_tasks: i64,
+) {
+    let saturated = fill_task_slots(harness, max_connection_tasks).await;
+    assert_server_busy(&saturated, max_connection_tasks);
+
+    harness.send_raw("{").await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), harness.recv_value())
+            .await
+            .is_err(),
+        "an id-less malformed frame must be dropped when every task slot is occupied"
+    );
+}
+
+/// Binding-specific setup and liveness proofs for duplicate-key and unknown-member cancellation.
+pub trait DuplicateCancellationChannel {
+    async fn arrange_targets(&mut self);
+    async fn send_duplicate_cancellation(&mut self);
+    async fn recv_raw(&mut self) -> String;
+    async fn assert_targets_remain_active(&mut self);
+    async fn assert_unknown_member_cancellation_is_accepted(&mut self);
+}
+
+/// Proves duplicate cancellation keys retain typed-deserialization failure semantics and cancel
+/// none of the binding's arranged targets, while unknown top-level members remain accepted.
+pub async fn assert_duplicate_cancellation_is_malformed<C: DuplicateCancellationChannel>(
+    channel: &mut C,
+) {
+    channel.arrange_targets().await;
+    channel.send_duplicate_cancellation().await;
+    assert_eq!(
+        channel.recv_raw().await,
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#
+    );
+    channel.assert_targets_remain_active().await;
+    channel
+        .assert_unknown_member_cancellation_is_accepted()
+        .await;
 }

--- a/crates/openengine-cluster-server/tests/decoded_dispatch.rs
+++ b/crates/openengine-cluster-server/tests/decoded_dispatch.rs
@@ -1,0 +1,163 @@
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, RequestId,
+    ServerCapabilities,
+};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
+use serde_json::{Map, Value};
+
+struct EmptyBackend;
+
+#[async_trait]
+impl ClusterBackend for EmptyBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        Ok(InitializeResult::new(
+            ServerCapabilities::default(),
+            ClusterStatus::empty(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult {
+            spec: None,
+            status: ClusterStatus::empty(),
+            at_cursor: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn decoded_routing_accepts_rust_values_and_matches_envelope_dispatch_byte_for_byte() {
+    let dispatcher = Dispatcher::new(EmptyBackend, ConnectionContext::default());
+
+    let decoded_response = dispatcher
+        .dispatch_decoded(RequestId::Integer(1), "get", Value::Object(Map::new()))
+        .await;
+    assert_eq!(
+        decoded_response,
+        r#"{"jsonrpc":"2.0","id":1,"result":{"spec":null,"status":{"phase":"empty","observedGeneration":null,"currentRunId":null,"atCursor":null},"atCursor":null}}"#
+    );
+
+    let envelope_response = dispatcher
+        .dispatch(r#"{"jsonrpc":"2.0","id":1,"method":"get","params":{}}"#)
+        .await;
+    assert_eq!(decoded_response, envelope_response);
+}
+
+#[tokio::test]
+async fn decoded_unknown_method_precedes_parameter_shape_validation() {
+    let dispatcher = Dispatcher::new(EmptyBackend, ConnectionContext::default());
+
+    let response = dispatcher
+        .dispatch_decoded(
+            RequestId::String("decoded".to_owned()),
+            "missing",
+            Value::Array(Vec::new()),
+        )
+        .await;
+
+    assert_eq!(
+        response,
+        r#"{"jsonrpc":"2.0","id":"decoded","error":{"code":-32601,"message":"Method not found"}}"#
+    );
+}
+
+const ENVELOPE_ERROR_CASES: &[(&str, &str, &str)] = &[
+    (
+        "non-JSON input",
+        "{",
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}}"#,
+    ),
+    (
+        "JSON array",
+        "[]",
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "JSON scalar",
+        "42",
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "missing jsonrpc",
+        r#"{"id":1,"method":"get","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "wrong jsonrpc",
+        r#"{"jsonrpc":"1.0","id":1,"method":"get","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "missing id",
+        r#"{"jsonrpc":"2.0","method":"get","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "non-scalar id",
+        r#"{"jsonrpc":"2.0","id":{},"method":"get","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid Request"}}"#,
+    ),
+    (
+        "unknown method with object params",
+        r#"{"jsonrpc":"2.0","id":10,"method":"missing","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":10,"error":{"code":-32601,"message":"Method not found"}}"#,
+    ),
+    (
+        "unknown method with array params",
+        r#"{"jsonrpc":"2.0","id":10,"method":"missing","params":[]}"#,
+        r#"{"jsonrpc":"2.0","id":10,"error":{"code":-32601,"message":"Method not found"}}"#,
+    ),
+    (
+        "unknown method with null params",
+        r#"{"jsonrpc":"2.0","id":10,"method":"missing","params":null}"#,
+        r#"{"jsonrpc":"2.0","id":10,"error":{"code":-32601,"message":"Method not found"}}"#,
+    ),
+    (
+        "unknown method with string params",
+        r#"{"jsonrpc":"2.0","id":10,"method":"missing","params":"scalar"}"#,
+        r#"{"jsonrpc":"2.0","id":10,"error":{"code":-32601,"message":"Method not found"}}"#,
+    ),
+    (
+        "unknown method with absent params",
+        r#"{"jsonrpc":"2.0","id":10,"method":"missing"}"#,
+        r#"{"jsonrpc":"2.0","id":10,"error":{"code":-32601,"message":"Method not found"}}"#,
+    ),
+    (
+        "known method with absent params",
+        r#"{"jsonrpc":"2.0","id":"absent","method":"get"}"#,
+        r#"{"jsonrpc":"2.0","id":"absent","error":{"code":-32602,"message":"Invalid params"}}"#,
+    ),
+    (
+        "known method with array params",
+        r#"{"jsonrpc":"2.0","id":"array","method":"get","params":[]}"#,
+        r#"{"jsonrpc":"2.0","id":"array","error":{"code":-32602,"message":"Invalid params"}}"#,
+    ),
+    (
+        "known method with null params",
+        r#"{"jsonrpc":"2.0","id":"null","method":"get","params":null}"#,
+        r#"{"jsonrpc":"2.0","id":"null","error":{"code":-32602,"message":"Invalid params"}}"#,
+    ),
+    (
+        "known method with string params",
+        r#"{"jsonrpc":"2.0","id":"string","method":"get","params":"scalar"}"#,
+        r#"{"jsonrpc":"2.0","id":"string","error":{"code":-32602,"message":"Invalid params"}}"#,
+    ),
+];
+
+#[tokio::test]
+async fn envelope_errors_retain_exact_frames_and_observable_validation_order() {
+    let dispatcher = Dispatcher::new(EmptyBackend, ConnectionContext::default());
+
+    for &(name, request, expected) in ENVELOPE_ERROR_CASES {
+        assert_eq!(dispatcher.dispatch(request).await, expected, "{name}");
+    }
+}

--- a/crates/openengine-cluster-server/tests/subscription_ndjson.rs
+++ b/crates/openengine-cluster-server/tests/subscription_ndjson.rs
@@ -28,9 +28,13 @@ use gated_backend_support::GatedBackend;
 #[path = "admission_bound_support/mod.rs"]
 mod admission_bound_support;
 use admission_bound_support::{
-    assert_duplicate_in_flight_ids_are_rejected,
-    assert_excess_requests_are_rejected_with_server_busy, spawn_gated_harness, GatedHarnessSpawn,
-    RequestChannel,
+    assert_duplicate_cancellation_is_malformed, assert_duplicate_in_flight_ids_are_rejected,
+    assert_excess_requests_are_rejected_with_server_busy,
+    assert_malformed_frame_is_dropped_at_task_saturation,
+    assert_subscription_envelope_validation_for_binding,
+    assert_wrong_version_envelope_retains_duplicate_precedence, spawn_gated_harness,
+    DuplicateCancellationChannel, GatedHarnessSpawn, RequestChannel, SubscriptionCountingBackend,
+    SubscriptionValidationHarness,
 };
 
 /// Matches the issue's documented "> 1 MiB" oversized-frame threshold; the exact bound is an
@@ -60,6 +64,14 @@ impl RequestChannel for Harness {
         write_line(&mut self.write, &request_line(id, "get", json!({}))).await;
     }
 
+    async fn send_raw(&mut self, text: &str) {
+        write_line(&mut self.write, text).await;
+    }
+
+    async fn recv_raw(&mut self) -> String {
+        read_line(&mut self.read).await
+    }
+
     async fn recv_value(&mut self) -> Value {
         read_value(&mut self.read).await
     }
@@ -68,6 +80,81 @@ impl RequestChannel for Harness {
 impl GatedHarnessSpawn for Harness {
     async fn spawn_gated(backend: GatedBackend) -> Self {
         spawn_server(backend)
+    }
+
+    async fn shut_down(self) {
+        shut_down(self).await;
+    }
+}
+
+impl SubscriptionValidationHarness for Harness {
+    async fn spawn_subscription_validation(backend: SubscriptionCountingBackend) -> Self {
+        spawn_server(backend)
+    }
+}
+
+struct NdjsonDuplicateCancellation<'a> {
+    harness: &'a mut Harness,
+    store: Arc<FixtureStore>,
+    subscription_id: Option<String>,
+}
+
+impl DuplicateCancellationChannel for NdjsonDuplicateCancellation<'_> {
+    async fn arrange_targets(&mut self) {
+        self.harness
+            .send_raw(&request_line(1, "watch", json!({})))
+            .await;
+        let established = self.harness.recv_value().await;
+        self.subscription_id = Some(
+            established["result"]["subscriptionId"]
+                .as_str()
+                .unwrap()
+                .to_owned(),
+        );
+    }
+
+    async fn send_duplicate_cancellation(&mut self) {
+        let subscription_id = self.subscription_id.as_deref().unwrap();
+        self.harness
+            .send_raw(&format!(
+                r#"{{"jsonrpc":"2.0","method":"subscription/cancel","params":{{"subscriptionId":"other","subscriptionId":"{subscription_id}"}}}}"#
+            ))
+            .await;
+    }
+
+    async fn recv_raw(&mut self) -> String {
+        self.harness.recv_raw().await
+    }
+
+    async fn assert_targets_remain_active(&mut self) {
+        self.store.publish(WatchEvent::Bookmark).await;
+        let event = self.harness.recv_value().await;
+        assert_eq!(event["method"], "event");
+        assert_eq!(
+            event["params"]["subscriptionId"],
+            self.subscription_id.as_deref().unwrap()
+        );
+    }
+
+    async fn assert_unknown_member_cancellation_is_accepted(&mut self) {
+        let subscription_id = self.subscription_id.as_deref().unwrap();
+        self.harness
+            .send_raw(&format!(
+                r#"{{"jsonrpc":"2.0","method":"subscription/cancel","params":{{"subscriptionId":"{subscription_id}"}},"extension":true}}"#
+            ))
+            .await;
+        self.harness.send_get(99).await;
+        let sync = self.harness.recv_value().await;
+        assert_eq!(sync["id"], 99);
+        assert!(sync.get("result").is_some(), "{sync}");
+
+        self.store.publish(WatchEvent::Bookmark).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), self.harness.recv_raw())
+                .await
+                .is_err(),
+            "subscription/cancel with an unknown top-level member must cancel the subscription"
+        );
     }
 }
 
@@ -158,6 +245,40 @@ async fn duplicate_request_ids_are_rejected() {
 
     assert_duplicate_in_flight_ids_are_rejected(&mut harness, &gate).await;
 
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn wrong_version_envelope_retains_duplicate_id_precedence() {
+    let (mut harness, gate) = spawn_gated_harness::<Harness>().await;
+    assert_wrong_version_envelope_retains_duplicate_precedence(&mut harness, &gate).await;
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn wrong_version_subscription_methods_are_invalid_requests() {
+    assert_subscription_envelope_validation_for_binding::<Harness>().await;
+}
+
+#[tokio::test]
+async fn malformed_frame_remains_subject_to_task_slot_saturation() {
+    let (mut harness, _gate) = spawn_gated_harness::<Harness>().await;
+    assert_malformed_frame_is_dropped_at_task_saturation(&mut harness, 256).await;
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn duplicate_subscription_cancel_keys_are_malformed_and_cancel_nothing() {
+    let store = Arc::new(FixtureStore::new(RunId::new("run-1"), Vec::new(), 8));
+    let mut harness = spawn_server(FixtureBackend::new(Arc::clone(&store)));
+    {
+        let mut channel = NdjsonDuplicateCancellation {
+            harness: &mut harness,
+            store,
+            subscription_id: None,
+        };
+        assert_duplicate_cancellation_is_malformed(&mut channel).await;
+    }
     shut_down(harness).await;
 }
 

--- a/crates/openengine-cluster-server/tests/websocket.rs
+++ b/crates/openengine-cluster-server/tests/websocket.rs
@@ -28,9 +28,13 @@ use gated_backend_support::GatedBackend;
 #[path = "admission_bound_support/mod.rs"]
 mod admission_bound_support;
 use admission_bound_support::{
-    assert_duplicate_in_flight_ids_are_rejected,
-    assert_excess_requests_are_rejected_with_server_busy, spawn_gated_harness, GatedHarnessSpawn,
-    RequestChannel,
+    assert_duplicate_cancellation_is_malformed, assert_duplicate_in_flight_ids_are_rejected,
+    assert_excess_requests_are_rejected_with_server_busy,
+    assert_malformed_frame_is_dropped_at_task_saturation,
+    assert_subscription_envelope_validation_for_binding,
+    assert_wrong_version_envelope_retains_duplicate_precedence, spawn_gated_harness,
+    DuplicateCancellationChannel, GatedHarnessSpawn, RequestChannel, SubscriptionCountingBackend,
+    SubscriptionValidationHarness,
 };
 
 /// Matches `serve_websocket`'s documented `MAX_FRAME_BYTES` bound; hardcoded rather than imported
@@ -56,16 +60,20 @@ async fn send_text(client: &mut WebSocketStream<DuplexStream>, text: impl Into<S
     client.send(Message::text(text.into())).await.unwrap();
 }
 
-async fn recv_json(client: &mut WebSocketStream<DuplexStream>) -> Value {
+async fn recv_text(client: &mut WebSocketStream<DuplexStream>) -> String {
     match client
         .next()
         .await
         .expect("connection closed unexpectedly while awaiting a frame")
     {
-        Ok(Message::Text(text)) => serde_json::from_str(&text).unwrap(),
+        Ok(Message::Text(text)) => text.to_string(),
         Ok(other) => panic!("expected a text frame, got {other:?}"),
         Err(error) => panic!("websocket read failed: {error}"),
     }
+}
+
+async fn recv_json(client: &mut WebSocketStream<DuplexStream>) -> Value {
+    serde_json::from_str(&recv_text(client).await).unwrap()
 }
 
 fn request_text(id: i64, method: &str, params: Value) -> String {
@@ -205,6 +213,14 @@ impl RequestChannel for Harness {
         send_text(&mut self.client, request_text(id, "get", json!({}))).await;
     }
 
+    async fn send_raw(&mut self, text: &str) {
+        send_text(&mut self.client, text).await;
+    }
+
+    async fn recv_raw(&mut self) -> String {
+        recv_text(&mut self.client).await
+    }
+
     async fn recv_value(&mut self) -> Value {
         recv_json(&mut self.client).await
     }
@@ -213,6 +229,71 @@ impl RequestChannel for Harness {
 impl GatedHarnessSpawn for Harness {
     async fn spawn_gated(backend: GatedBackend) -> Self {
         spawn_server(backend).await
+    }
+
+    async fn shut_down(self) {
+        shut_down(self).await;
+    }
+}
+
+impl SubscriptionValidationHarness for Harness {
+    async fn spawn_subscription_validation(backend: SubscriptionCountingBackend) -> Self {
+        spawn_server(backend).await
+    }
+}
+
+struct WebsocketDuplicateCancellation<'a> {
+    harness: &'a mut Harness,
+    gate: Arc<tokio::sync::Notify>,
+}
+
+impl DuplicateCancellationChannel for WebsocketDuplicateCancellation<'_> {
+    async fn arrange_targets(&mut self) {
+        self.harness.send_get(1).await;
+        self.harness.send_get(2).await;
+    }
+
+    async fn send_duplicate_cancellation(&mut self) {
+        self.harness
+            .send_raw(r#"{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":1,"id":2}}"#)
+            .await;
+    }
+
+    async fn recv_raw(&mut self) -> String {
+        self.harness.recv_raw().await
+    }
+
+    async fn assert_targets_remain_active(&mut self) {
+        let mut completed_ids = Vec::new();
+        for _ in 0..2 {
+            self.gate.notify_one();
+            completed_ids.push(self.harness.recv_value().await["id"].as_i64().unwrap());
+        }
+        completed_ids.sort_unstable();
+        assert_eq!(completed_ids, [1, 2]);
+    }
+
+    async fn assert_unknown_member_cancellation_is_accepted(&mut self) {
+        self.harness.send_get(3).await;
+        self.harness
+            .send_raw(
+                r#"{"jsonrpc":"2.0","method":"$/cancelRequest","params":{"id":3},"extension":true}"#,
+            )
+            .await;
+        self.harness
+            .send_raw(
+                r#"{"jsonrpc":"2.0","id":99,"method":"initialize","params":{"protocolVersion":"openengine.cluster/v1"}}"#,
+            )
+            .await;
+        let sync = self.harness.recv_value().await;
+        assert_eq!(sync["id"], 99);
+        assert!(sync.get("result").is_some(), "{sync}");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), self.harness.recv_raw())
+                .await
+                .is_err(),
+            "$/cancelRequest with an unknown top-level member must cancel the request"
+        );
     }
 }
 
@@ -231,6 +312,38 @@ async fn excess_requests_are_rejected_with_server_busy() {
 
     assert_excess_requests_are_rejected_with_server_busy(&mut harness, MAX_CONNECTION_TASKS).await;
 
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn wrong_version_envelope_retains_duplicate_id_precedence() {
+    let (mut harness, gate) = spawn_gated_harness::<Harness>().await;
+    assert_wrong_version_envelope_retains_duplicate_precedence(&mut harness, &gate).await;
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn wrong_version_subscription_methods_are_invalid_requests() {
+    assert_subscription_envelope_validation_for_binding::<Harness>().await;
+}
+
+#[tokio::test]
+async fn malformed_frame_remains_subject_to_task_slot_saturation() {
+    let (mut harness, _gate) = spawn_gated_harness::<Harness>().await;
+    assert_malformed_frame_is_dropped_at_task_saturation(&mut harness, MAX_CONNECTION_TASKS).await;
+    shut_down(harness).await;
+}
+
+#[tokio::test]
+async fn duplicate_cancel_request_keys_are_malformed_and_cancel_nothing() {
+    let (mut harness, gate) = spawn_gated_harness::<Harness>().await;
+    {
+        let mut channel = WebsocketDuplicateCancellation {
+            harness: &mut harness,
+            gate,
+        };
+        assert_duplicate_cancellation_is_malformed(&mut channel).await;
+    }
     shut_down(harness).await;
 }
 


### PR DESCRIPTION
Closes #827

## Decision
Bindings parse each inbound JSON frame once into a transport-neutral, duplicate-preserving decoded frame. `Dispatcher::dispatch_decoded` owns method lookup and typed method routing; `Dispatcher::dispatch` is now the envelope-decoding compatibility entry point. Response encoding remains unchanged.

A plain `serde_json::Value` decode was insufficient: it collapses duplicate keys and would change malformed cancellation behavior. The private `connection/frame.rs` parser therefore preserves object members through legacy request/cancellation classification, then projects the same last-key-wins value used by the existing dispatcher.

## Changes
- adds `Dispatcher::dispatch_decoded(id, method, params)` and delegates `dispatch(&str)` to it
- adds crate-private `DecodedRequest` / single-pass decoded-frame machinery
- passes decoded requests/outcomes through NDJSON and WebSocket instead of reparsing raw frames
- preserves method-not-found-before-params ordering and exact envelope frames
- preserves legacy duplicate-ID/task-slot admission for malformed and wrong-version envelopes
- requires both strict and legacy classification before special watch/logs/agent-attach routing
- preserves duplicate-key cancellation rejection and unknown-field acceptance
- adds exact decoded/envelope parity plus cross-binding admission/cancellation/subscription regressions
- records the decode/routing and admission boundary in AGENTS.md

## Review loop
Independent reviewers found and closed concrete regressions before merge: inline malformed replies initially bypassed admission; `Value` decoding collapsed duplicate cancellation keys; wrong-version and duplicate-field subscription envelopes could reach special routing; and initial tests lacked raw-byte/backend-call/unknown-field mutation sensitivity. The final implementation carries pre-encoded outcomes through admission, retains duplicate members, gates special routing on strict + legacy classification, and uses raw cross-binding scenarios with per-method counters. Five rounds ended with two independent zero-finding passes.

## Verification
- `cargo test -p openengine-cluster-server --test decoded_dispatch` — 3 passed
- `cargo test -p openengine-cluster-server --test subscription_ndjson` — 12 passed
- `cargo test -p openengine-cluster-server --test websocket` — 13 passed
- `npm run rust:check` — passed (fmt, clippy `-D warnings`, workspace tests)
- `npm run protocol:check` — passed, zero byte drift
- `npm run typecheck` — passed
- `npm run lint` — passed (0 errors; existing warnings only)
- `npm run test:unit` — 2,056 passed, 18 pending
- `opcore check --changed` — 25 checks passed, 0 findings