### PR TITLE
feat(zeroshot-rust): extend LocalProcessRunner with bounded streaming stdio sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,11 @@ ledger mutation, durable attempt state, protocol methods, provider catalog/confi
 credential resolution, workspace lifecycle, real CLI/ACP/Gateway drivers, built-in registration,
 or `NativeBackend` composition. Runtime command/control values remain serializable, secret-free,
 and input-free after control reconstruction.
+`LocalProcessRunner` is also the sole contained stdio-session seam: recovery is registered before
+spawn, stdout and diagnostics stay bounded, and close/release owns termination and reaping exactly
+once. Provider framing and candidate decoding remain in the provider drivers.
+Windows children stay suspended until assignment to their kill-on-close Job Object; never reopen
+the pre-assignment execution window.
 Native engine faults must be constructed only by `FaultFactory` from closed `ModuleEvidence`.
 Decoded faults must match the canonical semantics derived from their required primary source frame.
 Raw diagnostic values are replaced wholesale with typed markers and remain ephemeral; never put

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ time = "=0.3.41"
 futures-util = "0.3"
 jsonschema = { version = "0.29.1", default-features = false }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
+windows-sys = "0.61.2"
 
 openengine-cluster-protocol = { path = "crates/openengine-cluster-protocol" }
 openengine-cluster-server = { path = "crates/openengine-cluster-server" }

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -28,4 +28,13 @@ sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
+] }
+
 [dev-dependencies]

--- a/zeroshot-rust/src/execution/process.rs
+++ b/zeroshot-rust/src/execution/process.rs
@@ -1,5 +1,6 @@
 mod io;
 mod platform;
+mod session;
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -14,7 +15,12 @@ use io::{
     ProcessEvent, collect_remaining_events, join_errors, record_process_event, spawn_reader_task,
     spawn_stdin_task,
 };
-use platform::{capture_process_tree, terminate_process_tree};
+use platform::{capture_process_tree, register_process_tree, terminate_process_tree};
+pub use session::{
+    MAX_PROCESS_FRAME_BYTES, MAX_PROCESS_FRAMING_OVERHEAD_BYTES, MAX_PROCESS_MESSAGE_BYTES,
+    PROCESS_STDIN_CAPACITY, PROCESS_STDOUT_CAPACITY, ProcessFrame, ProcessOutputChunk,
+    ProcessSession, ProcessSessionCommand, ProcessSessionOutput,
+};
 
 pub const MAX_PROCESS_DIAGNOSTIC_BYTES: usize = 64 * 1024;
 pub const MAX_PROCESS_ARGV_ITEMS: usize = 256;
@@ -36,17 +42,7 @@ pub struct ProcessCommand {
 
 impl ProcessCommand {
     pub fn validate(&self) -> Result<(), ProcessRunnerError> {
-        validate_program(&self.program)?;
-        validate_collection(
-            CollectionLimit::new("argv", MAX_PROCESS_ARGV_ITEMS, MAX_PROCESS_ARGV_BYTES),
-            self.argv.len(),
-            format_arg_bytes(&self.program, &self.argv)?,
-        )?;
-        validate_collection(
-            CollectionLimit::new("environment", MAX_PROCESS_ENV_ITEMS, MAX_PROCESS_ENV_BYTES),
-            self.environment.len(),
-            total_env_bytes(&self.environment)?,
-        )?;
+        validate_launch_fields(&self.program, &self.argv, &self.environment)?;
         self.stdin.validate()?;
         Ok(())
     }
@@ -104,6 +100,18 @@ pub enum ProcessRunnerError {
     Io(String),
 }
 
+impl ProcessRunnerError {
+    #[must_use]
+    pub const fn launch_evidence(&self) -> ProcessLaunchEvidence {
+        match self {
+            Self::InvalidCommand(_) | Self::Launch(_) => {
+                ProcessLaunchEvidence::DefinitelyNotStarted
+            }
+            Self::Io(_) => ProcessLaunchEvidence::MayHaveStarted,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct LocalProcessRunner;
 
@@ -120,10 +128,27 @@ impl LocalProcessRunner {
     ) -> Result<ProcessRunOutput, ProcessRunnerError> {
         command.validate()?;
 
-        let mut child = build_child_command(&command)
-            .spawn()
-            .map_err(|error| ProcessRunnerError::Launch(error.to_string()))?;
-        let process_tree = capture_process_tree(&child);
+        let process_tree_registration = register_process_tree().map_err(|_| {
+            ProcessRunnerError::Launch("process containment registration failed".to_owned())
+        })?;
+        let mut child = build_child_command(
+            &command.program,
+            &command.argv,
+            &command.environment,
+            &command.workspace,
+        )
+        .spawn()
+        .map_err(|error| ProcessRunnerError::Launch(error.to_string()))?;
+        let process_tree = match capture_process_tree(process_tree_registration, &mut child) {
+            Ok(process_tree) => process_tree,
+            Err(_) => {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                return Err(ProcessRunnerError::Io(
+                    "process containment capture failed".to_owned(),
+                ));
+            }
+        };
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         spawn_stdin_task(
             child.stdin.take(),
@@ -145,6 +170,7 @@ impl LocalProcessRunner {
         drop(event_tx);
 
         let mut state = RunState::default();
+        let mut io_events_open = true;
         let deadline = sleep_until(command.deadline);
         tokio::pin!(deadline);
 
@@ -153,15 +179,17 @@ impl LocalProcessRunner {
                 status = child.wait() => handle_wait(status, &mut state).await,
                 _ = cancellation.cancelled() => cancel_child(&process_tree, &mut child, &mut state).await,
                 _ = &mut deadline => timeout_child(&process_tree, &mut child, &mut state).await,
-                event = event_rx.recv() => {
-                    let Some(event) = event else {
-                        break;
-                    };
-                    handle_event(event, &process_tree, &mut child, &mut state).await;
+                event = event_rx.recv(), if io_events_open => {
+                    if let Some(event) = event {
+                        handle_event(event, &process_tree, &mut child, &mut state).await;
+                    } else {
+                        io_events_open = false;
+                    }
                 }
             }
         }
 
+        let post_launch_error_count = state.post_launch_errors.len();
         collect_remaining_events(
             &mut event_rx,
             io::PendingIo::new(
@@ -172,6 +200,11 @@ impl LocalProcessRunner {
             ),
         )
         .await;
+        if state.cleanup == ProcessCleanupEvidence::NotRequired
+            && state.post_launch_errors.len() > post_launch_error_count
+        {
+            apply_termination(&process_tree, &mut child, &mut state).await;
+        }
         Ok(ProcessRunOutput {
             launch_evidence: ProcessLaunchEvidence::MayHaveStarted,
             exit_code: state.exit_status.and_then(|status| status.code()),
@@ -213,12 +246,17 @@ impl CollectionLimit {
     }
 }
 
-fn build_child_command(command: &ProcessCommand) -> Command {
-    let mut child = Command::new(&command.program);
-    child.args(&command.argv);
-    child.current_dir(PathBuf::from(&command.workspace.current_dir));
+fn build_child_command(
+    program: &str,
+    argv: &[String],
+    environment: &BTreeMap<String, String>,
+    workspace: &WorkspaceCapability,
+) -> Command {
+    let mut child = Command::new(program);
+    child.args(argv);
+    child.current_dir(PathBuf::from(&workspace.current_dir));
     child.env_clear();
-    child.envs(command.environment.iter());
+    child.envs(environment.iter());
     child.stdin(std::process::Stdio::piped());
     child.stdout(std::process::Stdio::piped());
     child.stderr(std::process::Stdio::piped());
@@ -226,6 +264,23 @@ fn build_child_command(command: &ProcessCommand) -> Command {
     child
 }
 
+fn validate_launch_fields(
+    program: &str,
+    argv: &[String],
+    environment: &BTreeMap<String, String>,
+) -> Result<(), ProcessRunnerError> {
+    validate_program(program)?;
+    validate_collection(
+        CollectionLimit::new("argv", MAX_PROCESS_ARGV_ITEMS, MAX_PROCESS_ARGV_BYTES),
+        argv.len(),
+        format_arg_bytes(program, argv)?,
+    )?;
+    validate_collection(
+        CollectionLimit::new("environment", MAX_PROCESS_ENV_ITEMS, MAX_PROCESS_ENV_BYTES),
+        environment.len(),
+        total_env_bytes(environment)?,
+    )
+}
 fn validate_program(program: &str) -> Result<(), ProcessRunnerError> {
     if program.is_empty() {
         return Err(ProcessRunnerError::InvalidCommand(

--- a/zeroshot-rust/src/execution/process/platform.rs
+++ b/zeroshot-rust/src/execution/process/platform.rs
@@ -3,6 +3,24 @@ use std::io;
 use tokio::process::Command;
 use tokio::time::{Duration, Instant, sleep, timeout_at};
 
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+#[cfg(windows)]
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
+    QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{
+    CREATE_SUSPENDED, OpenThread, ResumeThread, THREAD_SUSPEND_RESUME,
+};
+
 const PROCESS_TREE_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -24,23 +42,162 @@ pub struct CleanupOutcome {
     pub error: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+pub struct ProcessTreeRegistration {
+    #[cfg(windows)]
+    job: Option<usize>,
+}
+
+impl ProcessTreeRegistration {
+    #[cfg(windows)]
+    fn take_job(&mut self) -> usize {
+        self.job.take().expect("process job is registered")
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessTreeRegistration {
+    fn drop(&mut self) {
+        if let Some(job) = self.job.take() {
+            close_job(job);
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ProcessTreeHandle {
     #[cfg(unix)]
     process_group_id: Option<i32>,
+    #[cfg(windows)]
+    job: usize,
 }
 
-pub fn capture_process_tree(child: &tokio::process::Child) -> ProcessTreeHandle {
+#[cfg(windows)]
+impl Drop for ProcessTreeHandle {
+    fn drop(&mut self) {
+        close_job(self.job);
+    }
+}
+
+pub fn register_process_tree() -> Result<ProcessTreeRegistration, io::Error> {
+    #[cfg(windows)]
+    {
+        return Ok(ProcessTreeRegistration {
+            job: Some(create_kill_on_close_job()?),
+        });
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(ProcessTreeRegistration {})
+    }
+}
+
+pub fn capture_process_tree(
+    registration: ProcessTreeRegistration,
+    child: &mut tokio::process::Child,
+) -> Result<ProcessTreeHandle, io::Error> {
     #[cfg(unix)]
     {
-        ProcessTreeHandle {
+        let _ = registration;
+        Ok(ProcessTreeHandle {
             process_group_id: child.id().and_then(|value| i32::try_from(value).ok()),
+        })
+    }
+    #[cfg(windows)]
+    {
+        let mut registration = registration;
+        let process = child
+            .raw_handle()
+            .ok_or_else(|| io::Error::other("spawned process handle is unavailable"))?;
+        let process_id = child
+            .id()
+            .ok_or_else(|| io::Error::other("spawned process id is unavailable"))?;
+        let job = registration.job.expect("process job is registered");
+        let mut calls = SystemWindowsContainmentCalls {
+            job,
+            process: process as HANDLE,
+            process_id,
+            child,
+        };
+        assign_suspended_process(&mut calls)?;
+        Ok(ProcessTreeHandle {
+            job: registration.take_job(),
+        })
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        let _ = registration;
+        let _ = child;
+        Ok(ProcessTreeHandle {})
+    }
+}
+
+#[cfg(windows)]
+trait WindowsContainmentCalls {
+    fn assign(&mut self) -> Result<(), io::Error>;
+    fn resume(&mut self) -> Result<(), io::Error>;
+    fn terminate_failed_capture(&mut self);
+}
+
+#[cfg(windows)]
+fn assign_suspended_process(calls: &mut impl WindowsContainmentCalls) -> Result<(), io::Error> {
+    if let Err(error) = calls.assign() {
+        calls.terminate_failed_capture();
+        return Err(error);
+    }
+    if let Err(error) = calls.resume() {
+        calls.terminate_failed_capture();
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+struct SystemWindowsContainmentCalls<'a> {
+    job: usize,
+    process: HANDLE,
+    process_id: u32,
+    child: &'a mut tokio::process::Child,
+}
+
+#[cfg(all(test, windows))]
+static WINDOWS_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+#[cfg(all(test, windows))]
+static INJECT_ASSIGN_FAILURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(all(test, windows))]
+static INJECT_RESUME_FAILURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(all(test, windows))]
+static JOB_CLOSE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(windows)]
+impl WindowsContainmentCalls for SystemWindowsContainmentCalls<'_> {
+    fn assign(&mut self) -> Result<(), io::Error> {
+        #[cfg(all(test, windows))]
+        if INJECT_ASSIGN_FAILURE.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            return Err(io::Error::other("injected assignment failure"));
+        }
+        let assigned = unsafe { AssignProcessToJobObject(self.job as HANDLE, self.process) };
+        if assigned == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
         }
     }
-    #[cfg(not(unix))]
-    {
-        let _ = child;
-        ProcessTreeHandle
+
+    fn resume(&mut self) -> Result<(), io::Error> {
+        #[cfg(all(test, windows))]
+        if INJECT_RESUME_FAILURE.swap(false, std::sync::atomic::Ordering::SeqCst) {
+            return Err(io::Error::other("injected resume failure"));
+        }
+        resume_suspended_process(self.process_id)
+    }
+
+    fn terminate_failed_capture(&mut self) {
+        unsafe {
+            TerminateJobObject(self.job as HANDLE, 1);
+        }
+        let _ = self.child.start_kill();
     }
 }
 
@@ -78,7 +235,12 @@ pub fn configure_process_group(command: &mut Command) {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub fn configure_process_group(command: &mut Command) {
+    command.creation_flags(CREATE_SUSPENDED);
+}
+
+#[cfg(all(not(unix), not(windows)))]
 pub fn configure_process_group(_command: &mut Command) {}
 
 #[cfg(unix)]
@@ -105,9 +267,36 @@ fn kill_process_group(process_group_id: i32) -> Result<(), io::Error> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Child) {
+    let terminated = unsafe { TerminateJobObject(handle.job as HANDLE, 1) };
+    if terminated == 0 {
+        let _ = child.start_kill();
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
 fn kill_process_tree(_handle: &ProcessTreeHandle, child: &mut tokio::process::Child) {
     let _ = child.start_kill();
+}
+
+pub fn process_tree_has_live_members(handle: &ProcessTreeHandle) -> Result<bool, io::Error> {
+    #[cfg(unix)]
+    {
+        let Some(process_group_id) = handle.process_group_id else {
+            return Ok(false);
+        };
+        process_group_has_live_members(process_group_id)
+    }
+    #[cfg(windows)]
+    {
+        windows_job_has_live_members(handle.job)
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        let _ = handle;
+        Ok(false)
+    }
 }
 
 #[cfg(unix)]
@@ -137,7 +326,12 @@ async fn await_group_exit(handle: &ProcessTreeHandle, deadline: Instant) -> Clea
     await_process_group_exit(process_group_id, deadline).await
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+async fn await_group_exit(handle: &ProcessTreeHandle, deadline: Instant) -> CleanupOutcome {
+    await_process_tree_exit(handle, deadline).await
+}
+
+#[cfg(all(not(unix), not(windows)))]
 async fn await_group_exit(_handle: &ProcessTreeHandle, _deadline: Instant) -> CleanupOutcome {
     CleanupOutcome {
         cleanup: ProcessCleanupEvidence::Reaped,
@@ -156,20 +350,46 @@ async fn await_process_group_exit(process_group_id: i32, deadline: Instant) -> C
                 };
             }
             Ok(true) => {}
-            Err(error) => {
-                return CleanupOutcome {
-                    cleanup: ProcessCleanupEvidence::TimedOut,
-                    error: Some(format!("process cleanup failed: {error}")),
-                };
-            }
+            Err(error) => return cleanup_failure(error),
         }
         if Instant::now() >= deadline {
-            return CleanupOutcome {
-                cleanup: ProcessCleanupEvidence::TimedOut,
-                error: Some("process cleanup timed out".to_owned()),
-            };
+            return cleanup_timeout();
         }
         sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(windows)]
+async fn await_process_tree_exit(handle: &ProcessTreeHandle, deadline: Instant) -> CleanupOutcome {
+    loop {
+        match process_tree_has_live_members(handle) {
+            Ok(false) => {
+                return CleanupOutcome {
+                    cleanup: ProcessCleanupEvidence::Reaped,
+                    error: None,
+                };
+            }
+            Ok(true) => {}
+            Err(error) => return cleanup_failure(error),
+        }
+        if Instant::now() >= deadline {
+            return cleanup_timeout();
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn cleanup_failure(error: io::Error) -> CleanupOutcome {
+    CleanupOutcome {
+        cleanup: ProcessCleanupEvidence::TimedOut,
+        error: Some(format!("process cleanup failed: {error}")),
+    }
+}
+
+fn cleanup_timeout() -> CleanupOutcome {
+    CleanupOutcome {
+        cleanup: ProcessCleanupEvidence::TimedOut,
+        error: Some("process cleanup timed out".to_owned()),
     }
 }
 
@@ -186,6 +406,103 @@ fn process_group_has_live_members(process_group_id: i32) -> Result<bool, io::Err
         .map(str::trim)
         .filter(|state| !state.is_empty())
         .any(|state| !state.starts_with('Z')))
+}
+
+#[cfg(windows)]
+fn resume_suspended_process(process_id: u32) -> Result<(), io::Error> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let mut entry = THREADENTRY32 {
+        dwSize: u32::try_from(std::mem::size_of::<THREADENTRY32>())
+            .expect("thread entry fits in u32"),
+        ..THREADENTRY32::default()
+    };
+    let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    while has_entry {
+        if entry.th32OwnerProcessID == process_id {
+            let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if thread.is_null() {
+                let error = io::Error::last_os_error();
+                unsafe {
+                    CloseHandle(snapshot);
+                }
+                return Err(error);
+            }
+            let resumed = unsafe { ResumeThread(thread) };
+            unsafe {
+                CloseHandle(thread);
+                CloseHandle(snapshot);
+            }
+            return if resumed == u32::MAX {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            };
+        }
+        has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+    }
+    unsafe {
+        CloseHandle(snapshot);
+    }
+    Err(io::Error::other(
+        "spawned process suspended thread is unavailable",
+    ))
+}
+
+#[cfg(windows)]
+fn create_kill_on_close_job() -> Result<usize, io::Error> {
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    let configured = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            std::ptr::from_ref(&limits).cast(),
+            u32::try_from(std::mem::size_of_val(&limits)).expect("job limits fit in u32"),
+        )
+    };
+    if configured == 0 {
+        let error = io::Error::last_os_error();
+        unsafe {
+            CloseHandle(job);
+        }
+        return Err(error);
+    }
+    Ok(job as usize)
+}
+
+#[cfg(windows)]
+fn windows_job_has_live_members(job: usize) -> Result<bool, io::Error> {
+    let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+    let queried = unsafe {
+        QueryInformationJobObject(
+            job as HANDLE,
+            JobObjectBasicAccountingInformation,
+            std::ptr::from_mut(&mut accounting).cast(),
+            u32::try_from(std::mem::size_of_val(&accounting)).expect("job accounting fits in u32"),
+            std::ptr::null_mut(),
+        )
+    };
+    if queried == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(accounting.ActiveProcesses != 0)
+    }
+}
+
+#[cfg(windows)]
+fn close_job(job: usize) {
+    #[cfg(all(test, windows))]
+    JOB_CLOSE_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    unsafe {
+        CloseHandle(job as HANDLE);
+    }
 }
 
 async fn termination_without_status(
@@ -206,5 +523,125 @@ async fn termination_without_status(
         exit_status: None,
         cleanup: cleanup.cleanup,
         error,
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_containment_tests {
+    use std::path::PathBuf;
+    use std::process::Stdio;
+    use std::sync::atomic::Ordering;
+
+    use tokio::time::{Duration, Instant, timeout};
+
+    use super::{
+        INJECT_ASSIGN_FAILURE, INJECT_RESUME_FAILURE, JOB_CLOSE_COUNT, ProcessCleanupEvidence,
+        WINDOWS_TEST_LOCK, capture_process_tree, configure_process_group, register_process_tree,
+        terminate_process_tree,
+    };
+
+    fn spawn_suspended_sentinel(
+        name: &str,
+    ) -> (
+        super::ProcessTreeRegistration,
+        tokio::process::Child,
+        PathBuf,
+    ) {
+        let registration = register_process_tree().unwrap();
+        let system_root = std::env::var("SystemRoot").expect("Windows has SystemRoot");
+        let program = PathBuf::from(&system_root).join("System32").join("cmd.exe");
+        let sentinel = std::env::temp_dir().join(format!("{name}-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&sentinel);
+        let script = format!(
+            "echo first>\"{}\" & ping -n 31 127.0.0.1 >NUL",
+            sentinel.display()
+        );
+        let mut command = tokio::process::Command::new(program);
+        command.args(["/D", "/S", "/C", &script]);
+        command.current_dir(std::env::temp_dir());
+        command.env_clear();
+        command.env("SystemRoot", system_root);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        command.kill_on_drop(true);
+        configure_process_group(&mut command);
+        let child = command.spawn().unwrap();
+        (registration, child, sentinel)
+    }
+
+    async fn assert_still_suspended(sentinel: &PathBuf) {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !sentinel.exists(),
+            "first instruction ran before Job assignment"
+        );
+    }
+
+    async fn wait_for_sentinel(sentinel: &PathBuf) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !sentinel.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "resumed process did not run its first instruction"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn reset_injections() {
+        INJECT_ASSIGN_FAILURE.store(false, Ordering::SeqCst);
+        INJECT_RESUME_FAILURE.store(false, Ordering::SeqCst);
+        JOB_CLOSE_COUNT.store(0, Ordering::SeqCst);
+    }
+
+    #[tokio::test]
+    async fn real_suspended_spawn_cannot_run_before_assignment() {
+        let _serial = WINDOWS_TEST_LOCK.lock().await;
+        reset_injections();
+        let (registration, mut child, sentinel) =
+            spawn_suspended_sentinel("zeroshot-windows-contained");
+        assert_still_suspended(&sentinel).await;
+        let process_tree = capture_process_tree(registration, &mut child).unwrap();
+        wait_for_sentinel(&sentinel).await;
+        let termination = terminate_process_tree(&process_tree, &mut child).await;
+        assert_eq!(termination.cleanup, ProcessCleanupEvidence::Reaped);
+        drop(process_tree);
+        assert_eq!(JOB_CLOSE_COUNT.load(Ordering::SeqCst), 1);
+        let _ = std::fs::remove_file(sentinel);
+    }
+
+    #[tokio::test]
+    async fn assignment_failure_terminates_and_reaps_without_first_instruction() {
+        let _serial = WINDOWS_TEST_LOCK.lock().await;
+        reset_injections();
+        let (registration, mut child, sentinel) =
+            spawn_suspended_sentinel("zeroshot-windows-assign-failure");
+        assert_still_suspended(&sentinel).await;
+        INJECT_ASSIGN_FAILURE.store(true, Ordering::SeqCst);
+        assert!(capture_process_tree(registration, &mut child).is_err());
+        timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("failed assignment root was not reaped")
+            .unwrap();
+        assert!(!sentinel.exists());
+        assert_eq!(JOB_CLOSE_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resume_failure_terminates_and_reaps_without_first_instruction() {
+        let _serial = WINDOWS_TEST_LOCK.lock().await;
+        reset_injections();
+        let (registration, mut child, sentinel) =
+            spawn_suspended_sentinel("zeroshot-windows-resume-failure");
+        assert_still_suspended(&sentinel).await;
+        INJECT_RESUME_FAILURE.store(true, Ordering::SeqCst);
+        assert!(capture_process_tree(registration, &mut child).is_err());
+        timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("failed resume root was not reaped")
+            .unwrap();
+        assert!(!sentinel.exists());
+        assert_eq!(JOB_CLOSE_COUNT.load(Ordering::SeqCst), 1);
     }
 }

--- a/zeroshot-rust/src/execution/process/session.rs
+++ b/zeroshot-rust/src/execution/process/session.rs
@@ -1,0 +1,712 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, Instant, sleep_until, timeout, timeout_at};
+
+use crate::execution::driver::{DriverCancellation, WorkspaceCapability};
+
+use super::platform::{
+    ProcessTreeHandle, capture_process_tree, process_tree_has_live_members, register_process_tree,
+    terminate_process_tree,
+};
+use super::{
+    LocalProcessRunner, ProcessCleanupEvidence, ProcessLaunchEvidence, ProcessRunnerError,
+    build_child_command, validate_launch_fields,
+};
+
+pub const PROCESS_STDOUT_CAPACITY: usize = 64;
+pub const MAX_PROCESS_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_PROCESS_FRAMING_OVERHEAD_BYTES: usize = 64 * 1024;
+pub const MAX_PROCESS_FRAME_BYTES: usize =
+    MAX_PROCESS_MESSAGE_BYTES + MAX_PROCESS_FRAMING_OVERHEAD_BYTES;
+
+pub const PROCESS_STDIN_CAPACITY: usize = 64;
+const PROCESS_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+const PROCESS_SESSION_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessSessionCommand {
+    pub program: String,
+    pub argv: Vec<String>,
+    pub environment: BTreeMap<String, String>,
+    pub workspace: WorkspaceCapability,
+    pub deadline: Instant,
+}
+
+impl ProcessSessionCommand {
+    pub fn validate(&self) -> Result<(), ProcessRunnerError> {
+        validate_launch_fields(&self.program, &self.argv, &self.environment)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessFrame(Vec<u8>);
+
+impl ProcessFrame {
+    pub fn new(message: Vec<u8>) -> Result<Self, ProcessRunnerError> {
+        let message_bytes = message.len();
+        Self::with_framing(message, message_bytes)
+    }
+
+    pub fn with_framing(frame: Vec<u8>, message_bytes: usize) -> Result<Self, ProcessRunnerError> {
+        if message_bytes > frame.len() {
+            return Err(ProcessRunnerError::InvalidCommand(
+                "process frame message length exceeds frame length".to_owned(),
+            ));
+        }
+        if message_bytes > MAX_PROCESS_MESSAGE_BYTES {
+            return Err(ProcessRunnerError::InvalidCommand(format!(
+                "process message is {message_bytes} bytes; maximum is {MAX_PROCESS_MESSAGE_BYTES}"
+            )));
+        }
+        let framing_bytes = frame.len() - message_bytes;
+        if framing_bytes > MAX_PROCESS_FRAMING_OVERHEAD_BYTES {
+            return Err(ProcessRunnerError::InvalidCommand(format!(
+                "process framing overhead is {framing_bytes} bytes; maximum is {MAX_PROCESS_FRAMING_OVERHEAD_BYTES}"
+            )));
+        }
+        Ok(Self(frame))
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessOutputChunk(Vec<u8>);
+
+impl ProcessOutputChunk {
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessSessionOutput {
+    pub launch_evidence: ProcessLaunchEvidence,
+    pub exit_code: Option<i32>,
+    pub stderr_tail: Vec<u8>,
+    pub cancelled: bool,
+    pub timed_out: bool,
+    pub cleanup: ProcessCleanupEvidence,
+    pub post_launch_error: Option<String>,
+}
+
+pub struct ProcessSession {
+    stdout: mpsc::Receiver<ProcessOutputChunk>,
+    stdin: mpsc::Sender<WriterCommand>,
+    release: watch::Sender<bool>,
+    completion: watch::Receiver<Option<Arc<ProcessSessionOutput>>>,
+    stdin_closed: bool,
+}
+
+impl ProcessSession {
+    #[must_use]
+    pub fn stdout_queue_capacity(&self) -> usize {
+        self.stdout.max_capacity()
+    }
+
+    #[must_use]
+    pub fn stdin_queue_capacity(&self) -> usize {
+        self.stdin.max_capacity()
+    }
+
+    pub async fn send(&self, frame: ProcessFrame) -> Result<(), ProcessRunnerError> {
+        if self.stdin_closed {
+            return Err(ProcessRunnerError::Io(
+                "process stdin is already closed".to_owned(),
+            ));
+        }
+        if self.completion.borrow().is_some() {
+            return Err(ProcessRunnerError::Io(
+                "process session is no longer running".to_owned(),
+            ));
+        }
+        let (acknowledge, acknowledged) = oneshot::channel();
+        self.stdin
+            .send(WriterCommand::Frame(frame.into_inner(), acknowledge))
+            .await
+            .map_err(|_| {
+                ProcessRunnerError::Io("process stdin is no longer available".to_owned())
+            })?;
+        acknowledged
+            .await
+            .map_err(|_| ProcessRunnerError::Io("process stdin writer stopped".to_owned()))?
+            .map_err(|message| ProcessRunnerError::Io(message.to_owned()))
+    }
+
+    pub async fn close_stdin(&mut self) -> Result<(), ProcessRunnerError> {
+        if self.stdin_closed {
+            return Ok(());
+        }
+        self.stdin_closed = true;
+        if self.completion.borrow().is_some() {
+            return Ok(());
+        }
+        let (acknowledge, acknowledged) = oneshot::channel();
+        if self
+            .stdin
+            .send(WriterCommand::Close(acknowledge))
+            .await
+            .is_err()
+        {
+            return if self.completion.borrow().is_some() {
+                Ok(())
+            } else {
+                Err(ProcessRunnerError::Io(
+                    "process stdin is no longer available".to_owned(),
+                ))
+            };
+        }
+        acknowledged
+            .await
+            .map_err(|_| ProcessRunnerError::Io("process stdin writer stopped".to_owned()))?
+            .map_err(|message| ProcessRunnerError::Io(message.to_owned()))
+    }
+
+    pub async fn recv_stdout(&mut self) -> Option<ProcessOutputChunk> {
+        self.stdout.recv().await
+    }
+
+    pub async fn wait(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+        await_completion(&mut self.completion).await
+    }
+
+    pub async fn release(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+        self.stdin_closed = true;
+        self.release.send_replace(true);
+        await_completion(&mut self.completion).await
+    }
+}
+
+impl Drop for ProcessSession {
+    fn drop(&mut self) {
+        self.release.send_replace(true);
+    }
+}
+
+impl LocalProcessRunner {
+    pub async fn open(
+        &self,
+        command: ProcessSessionCommand,
+        cancellation: DriverCancellation,
+    ) -> Result<ProcessSession, ProcessRunnerError> {
+        command.validate()?;
+
+        let process_tree_registration = register_process_tree().map_err(|_| {
+            ProcessRunnerError::Launch("process containment registration failed".to_owned())
+        })?;
+        let mut recovery = SpawnRecovery::registered();
+        let mut child_command = build_child_command(
+            &command.program,
+            &command.argv,
+            &command.environment,
+            &command.workspace,
+        );
+        child_command.kill_on_drop(true);
+        let child = child_command.spawn().map_err(|_| {
+            ProcessRunnerError::Launch("operating system rejected process launch".to_owned())
+        })?;
+        recovery.capture(child);
+        let process_tree =
+            match capture_process_tree(process_tree_registration, recovery.child_mut()) {
+                Ok(process_tree) => process_tree,
+                Err(_) => {
+                    recovery.recover().await;
+                    return Err(ProcessRunnerError::Io(
+                        "process containment capture failed".to_owned(),
+                    ));
+                }
+            };
+        recovery.capture_process_tree(process_tree);
+        let child = recovery.child_mut();
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        let (stdout_tx, stdout_rx) = mpsc::channel(PROCESS_STDOUT_CAPACITY);
+        let (stdin_tx, stdin_rx) = mpsc::channel(PROCESS_STDIN_CAPACITY);
+        let (release_tx, release_rx) = watch::channel(false);
+        let (writer_stop_tx, writer_stop_rx) = watch::channel(false);
+        let (completion_tx, completion_rx) = watch::channel(None);
+        let (io_failure_tx, io_failure_rx) = mpsc::unbounded_channel();
+        let stderr_tail = Arc::new(Mutex::new(TailBuffer::new(
+            super::MAX_PROCESS_DIAGNOSTIC_BYTES,
+        )));
+
+        let stdout_task = spawn_stdout_pump(stdout, stdout_tx, io_failure_tx.clone());
+        let stderr_task =
+            spawn_stderr_pump(stderr, Arc::clone(&stderr_tail), io_failure_tx.clone());
+        let writer_task = spawn_writer(stdin, stdin_rx, writer_stop_rx, io_failure_tx);
+        let (child, process_tree) = recovery.disarm();
+        tokio::spawn(supervise_session(SupervisorRequest {
+            child,
+            process_tree,
+            cancellation,
+            deadline: command.deadline,
+            release: release_rx,
+            writer_stop: writer_stop_tx,
+            io_failures: io_failure_rx,
+            stdout_task,
+            stderr_task,
+            writer_task,
+            stderr_tail,
+            completion: completion_tx,
+        }));
+
+        Ok(ProcessSession {
+            stdout: stdout_rx,
+            stdin: stdin_tx,
+            release: release_tx,
+            completion: completion_rx,
+            stdin_closed: false,
+        })
+    }
+}
+
+async fn await_completion(
+    completion: &mut watch::Receiver<Option<Arc<ProcessSessionOutput>>>,
+) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+    loop {
+        if let Some(output) = completion.borrow().as_ref() {
+            return Ok(output.as_ref().clone());
+        }
+        completion.changed().await.map_err(|_| {
+            ProcessRunnerError::Io("process session supervisor stopped unexpectedly".to_owned())
+        })?;
+    }
+}
+
+enum WriterCommand {
+    Frame(Vec<u8>, oneshot::Sender<Result<(), &'static str>>),
+    Close(oneshot::Sender<Result<(), &'static str>>),
+}
+
+#[derive(Clone, Copy)]
+enum IoFailure {
+    Stdout,
+    Stderr,
+    Stdin,
+}
+
+struct SupervisorRequest {
+    child: Child,
+    process_tree: ProcessTreeHandle,
+    cancellation: DriverCancellation,
+    deadline: Instant,
+    release: watch::Receiver<bool>,
+    writer_stop: watch::Sender<bool>,
+    io_failures: mpsc::UnboundedReceiver<IoFailure>,
+    stdout_task: JoinHandle<()>,
+    stderr_task: JoinHandle<()>,
+    writer_task: JoinHandle<()>,
+    stderr_tail: Arc<Mutex<TailBuffer>>,
+    completion: watch::Sender<Option<Arc<ProcessSessionOutput>>>,
+}
+
+async fn supervise_session(mut request: SupervisorRequest) {
+    let mut cancelled = false;
+    let mut timed_out = false;
+    let mut cleanup = ProcessCleanupEvidence::NotRequired;
+    let mut post_launch_errors = Vec::new();
+    let mut exit_status = None;
+    let deadline = sleep_until(request.deadline);
+    tokio::pin!(deadline);
+
+    loop {
+        tokio::select! {
+            biased;
+            status = request.child.wait() => {
+                match status {
+                    Ok(status) => exit_status = Some(status),
+                    Err(_) => post_launch_errors.push("process wait failed".to_owned()),
+                }
+                break;
+            }
+            _ = request.cancellation.cancelled() => {
+                cancelled = true;
+                let termination = terminate_process_tree(&request.process_tree, &mut request.child).await;
+                cleanup = termination.cleanup;
+                exit_status = termination.exit_status;
+                if termination.error.is_some() {
+                    post_launch_errors.push("process cancellation cleanup failed".to_owned());
+                }
+                break;
+            }
+            _ = &mut deadline => {
+                timed_out = true;
+                let termination = terminate_process_tree(&request.process_tree, &mut request.child).await;
+                cleanup = termination.cleanup;
+                exit_status = termination.exit_status;
+                if termination.error.is_some() {
+                    post_launch_errors.push("process deadline cleanup failed".to_owned());
+                }
+                break;
+            }
+            changed = request.release.changed() => {
+                if changed.is_err() || *request.release.borrow() {
+                    request.writer_stop.send_replace(true);
+                    match timeout(PROCESS_SESSION_DRAIN_TIMEOUT, request.child.wait()).await {
+                        Ok(Ok(status)) => exit_status = Some(status),
+                        Ok(Err(_)) => post_launch_errors.push("process wait failed during release".to_owned()),
+                        Err(_) => {
+                            let termination = terminate_process_tree(&request.process_tree, &mut request.child).await;
+                            cleanup = termination.cleanup;
+                            exit_status = termination.exit_status;
+                            if termination.error.is_some() {
+                                post_launch_errors.push("process release cleanup failed".to_owned());
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            failure = request.io_failures.recv() => {
+                let Some(failure) = failure else {
+                    continue;
+                };
+                post_launch_errors.push(io_failure_message(failure).to_owned());
+                let termination = terminate_process_tree(&request.process_tree, &mut request.child).await;
+                cleanup = termination.cleanup;
+                exit_status = termination.exit_status;
+                if termination.error.is_some() {
+                    post_launch_errors.push("process I/O cleanup failed".to_owned());
+                }
+                break;
+            }
+        }
+    }
+
+    request.writer_stop.send_replace(true);
+    let drain_timed_out = drain_io_tasks(&mut request, &mut post_launch_errors).await;
+    if cleanup == ProcessCleanupEvidence::NotRequired {
+        let tree_has_live_members = match process_tree_has_live_members(&request.process_tree) {
+            Ok(has_live_members) => has_live_members,
+            Err(_) => {
+                post_launch_errors.push("process containment inspection failed".to_owned());
+                true
+            }
+        };
+        if drain_timed_out || tree_has_live_members {
+            let termination =
+                terminate_process_tree(&request.process_tree, &mut request.child).await;
+            cleanup = termination.cleanup;
+            if exit_status.is_none() {
+                exit_status = termination.exit_status;
+            }
+            if termination.error.is_some() {
+                post_launch_errors.push("process final containment cleanup failed".to_owned());
+            }
+        }
+    }
+    let stderr_tail = request
+        .stderr_tail
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .snapshot();
+    let output = ProcessSessionOutput {
+        launch_evidence: ProcessLaunchEvidence::MayHaveStarted,
+        exit_code: exit_status.and_then(|status| status.code()),
+        stderr_tail,
+        cancelled,
+        timed_out,
+        cleanup,
+        post_launch_error: super::io::join_errors(post_launch_errors),
+    };
+    request.completion.send_replace(Some(Arc::new(output)));
+}
+
+async fn drain_io_tasks(request: &mut SupervisorRequest, errors: &mut Vec<String>) -> bool {
+    let deadline = Instant::now() + PROCESS_SESSION_DRAIN_TIMEOUT;
+    let mut timed_out = false;
+    timed_out |= drain_io_task(
+        &mut request.stdout_task,
+        deadline,
+        "stdout task stopped unexpectedly",
+        errors,
+    )
+    .await;
+    timed_out |= drain_io_task(
+        &mut request.stderr_task,
+        deadline,
+        "stderr task stopped unexpectedly",
+        errors,
+    )
+    .await;
+    timed_out |= drain_io_task(
+        &mut request.writer_task,
+        deadline,
+        "stdin task stopped unexpectedly",
+        errors,
+    )
+    .await;
+    if timed_out {
+        errors.push("process I/O drain timed out".to_owned());
+    }
+    timed_out
+}
+
+async fn drain_io_task(
+    task: &mut JoinHandle<()>,
+    deadline: Instant,
+    failure: &'static str,
+    errors: &mut Vec<String>,
+) -> bool {
+    match timeout_at(deadline, &mut *task).await {
+        Ok(Ok(())) => false,
+        Ok(Err(_)) => {
+            errors.push(failure.to_owned());
+            false
+        }
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            true
+        }
+    }
+}
+
+fn spawn_stdout_pump(
+    stdout: Option<ChildStdout>,
+    output: mpsc::Sender<ProcessOutputChunk>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(mut stdout) = stdout else {
+            let _ = failures.send(IoFailure::Stdout);
+            return;
+        };
+        let mut chunk = vec![0_u8; PROCESS_OUTPUT_CHUNK_BYTES];
+        loop {
+            match stdout.read(&mut chunk).await {
+                Ok(0) => return,
+                Ok(read) => {
+                    if output
+                        .send(ProcessOutputChunk(chunk[..read].to_vec()))
+                        .await
+                        .is_err()
+                    {
+                        let _ = failures.send(IoFailure::Stdout);
+                        return;
+                    }
+                }
+                Err(_) => {
+                    let _ = failures.send(IoFailure::Stdout);
+                    return;
+                }
+            }
+        }
+    })
+}
+
+fn spawn_stderr_pump(
+    stderr: Option<ChildStderr>,
+    tail: Arc<Mutex<TailBuffer>>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(stderr) = stderr else {
+            let _ = failures.send(IoFailure::Stderr);
+            return;
+        };
+        if read_stderr(stderr, tail).await.is_err() {
+            let _ = failures.send(IoFailure::Stderr);
+        }
+    })
+}
+
+async fn read_stderr<R>(mut stderr: R, tail: Arc<Mutex<TailBuffer>>) -> Result<(), ()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = stderr.read(&mut chunk).await.map_err(|_| ())?;
+        if read == 0 {
+            return Ok(());
+        }
+        tail.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .append(&chunk[..read]);
+    }
+}
+
+fn spawn_writer(
+    stdin: Option<ChildStdin>,
+    mut commands: mpsc::Receiver<WriterCommand>,
+    mut stop: watch::Receiver<bool>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(mut stdin) = stdin else {
+            let _ = failures.send(IoFailure::Stdin);
+            return;
+        };
+        loop {
+            tokio::select! {
+                biased;
+                changed = stop.changed() => {
+                    if changed.is_err() || *stop.borrow() {
+                        return;
+                    }
+                }
+                command = commands.recv() => {
+                    match command {
+                        Some(WriterCommand::Frame(frame, acknowledge)) => {
+                            let result = tokio::select! {
+                                biased;
+                                changed = stop.changed() => {
+                                    let _ = changed;
+                                    Err("process stdin writer stopped")
+                                }
+                                result = stdin.write_all(&frame) => {
+                                    result.map_err(|_| "process stdin write failed")
+                                }
+                            };
+                            let failed = result.is_err();
+                            let _ = acknowledge.send(result);
+                            if failed {
+                                let _ = failures.send(IoFailure::Stdin);
+                                return;
+                            }
+                        }
+                        Some(WriterCommand::Close(acknowledge)) => {
+                            let result = stdin
+                                .shutdown()
+                                .await
+                                .map_err(|_| "process stdin close failed");
+                            let failed = result.is_err();
+                            let _ = acknowledge.send(result);
+                            if failed {
+                                let _ = failures.send(IoFailure::Stdin);
+                            }
+                            return;
+                        }
+                        None => {
+                            let _ = stdin.shutdown().await;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn io_failure_message(failure: IoFailure) -> &'static str {
+    match failure {
+        IoFailure::Stdout => "process stdout stream failed",
+        IoFailure::Stderr => "process stderr stream failed",
+        IoFailure::Stdin => "process stdin stream failed",
+    }
+}
+
+struct TailBuffer {
+    bytes: Vec<u8>,
+    capacity: usize,
+}
+
+impl TailBuffer {
+    fn new(capacity: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn append(&mut self, value: &[u8]) {
+        if value.len() >= self.capacity {
+            self.bytes.clear();
+            self.bytes
+                .extend_from_slice(&value[value.len() - self.capacity..]);
+            return;
+        }
+        let required = self.bytes.len() + value.len();
+        if required > self.capacity {
+            let discard = required - self.capacity;
+            self.bytes.copy_within(discard.., 0);
+            self.bytes.truncate(self.bytes.len() - discard);
+        }
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn snapshot(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+struct SpawnRecovery {
+    child: Option<Child>,
+    process_tree: Option<ProcessTreeHandle>,
+}
+
+impl SpawnRecovery {
+    const fn registered() -> Self {
+        Self {
+            child: None,
+            process_tree: None,
+        }
+    }
+
+    fn capture(&mut self, child: Child) {
+        self.child = Some(child);
+    }
+
+    fn capture_process_tree(&mut self, process_tree: ProcessTreeHandle) {
+        self.process_tree = Some(process_tree);
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("spawn recovery owns child")
+    }
+
+    async fn recover(mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if let Some(process_tree) = self.process_tree.take() {
+            let _ = terminate_process_tree(&process_tree, &mut child).await;
+        } else {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
+    }
+
+    fn disarm(mut self) -> (Child, ProcessTreeHandle) {
+        (
+            self.child.take().expect("spawn recovery owns child"),
+            self.process_tree
+                .take()
+                .expect("spawn recovery captured tree"),
+        )
+    }
+}
+
+impl Drop for SpawnRecovery {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let process_tree = self.process_tree.take();
+        tokio::spawn(async move {
+            if let Some(process_tree) = process_tree {
+                let _ = terminate_process_tree(&process_tree, &mut child).await;
+            } else {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+            }
+        });
+    }
+}

--- a/zeroshot-rust/src/execution/process/session.rs
+++ b/zeroshot-rust/src/execution/process/session.rs
@@ -180,6 +180,11 @@ impl ProcessSession {
         self.stdout.recv().await
     }
 
+    /// Waits for process completion without consuming the bounded stdout queue.
+    ///
+    /// Callers that need complete stdout must drain [`Self::recv_stdout`] to `None` before
+    /// calling this method. Waiting with unread stdout can fill the queue, trigger the bounded
+    /// I/O-drain timeout, and discard output that the stdout pump could not enqueue.
     pub async fn wait(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
         await_completion(&mut self.completion).await
     }

--- a/zeroshot-rust/tests/local_process_runner.rs
+++ b/zeroshot-rust/tests/local_process_runner.rs
@@ -173,6 +173,33 @@ async fn cancellation_and_deadline_return_cleanup_evidence_and_reap_descendants(
 }
 
 #[tokio::test]
+async fn closed_stdio_does_not_release_a_live_child_before_deadline() {
+    let pid_file = unique_temp_path("zeroshot-local-process-closed-stdio.pid");
+    let script = format!(
+        "printf %s $$ > {}; exec 0<&- 1>&- 2>&-; exec /bin/sleep 30",
+        shell_quote(pid_file.to_string_lossy().as_ref())
+    );
+    let (_cancel_tx, cancellation) = cancellation_pair();
+    let mut timed = command("/bin/sh", vec!["-c", &script]);
+    timed.deadline = Instant::now() + Duration::from_millis(150);
+    let handle = tokio::spawn(async move {
+        LocalProcessRunner::new()
+            .run(timed, cancellation)
+            .await
+            .unwrap()
+    });
+    let child_pid = wait_for_child_pid(&pid_file).await;
+    let output = tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("closed stdio must not bypass the deadline")
+        .unwrap();
+    assert!(output.timed_out);
+    assert_eq!(output.cleanup, ProcessCleanupEvidence::Reaped);
+    wait_for_process_exit(child_pid).await;
+    let _ = fs::remove_file(pid_file);
+}
+
+#[tokio::test]
 async fn diagnostics_are_bounded() {
     let (_cancel_tx, cancellation) = cancellation_pair();
     let output = LocalProcessRunner::new()

--- a/zeroshot-rust/tests/streaming_process_runner.rs
+++ b/zeroshot-rust/tests/streaming_process_runner.rs
@@ -1,0 +1,443 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::watch;
+use tokio::time::{Duration, Instant, timeout};
+use zeroshot_engine::execution::WorkspaceAccessMode;
+use zeroshot_engine::execution::driver::{DriverCancellation, WorkspaceCapability};
+use zeroshot_engine::execution::process::{
+    LocalProcessRunner, ProcessCleanupEvidence, ProcessSessionCommand,
+};
+#[cfg(unix)]
+use zeroshot_engine::execution::process::{
+    MAX_PROCESS_DIAGNOSTIC_BYTES, MAX_PROCESS_FRAME_BYTES, MAX_PROCESS_FRAMING_OVERHEAD_BYTES,
+    MAX_PROCESS_MESSAGE_BYTES, PROCESS_STDIN_CAPACITY, PROCESS_STDOUT_CAPACITY, ProcessFrame,
+    ProcessLaunchEvidence, ProcessRunnerError, ProcessSession,
+};
+
+fn command(program: &str, argv: Vec<&str>) -> ProcessSessionCommand {
+    ProcessSessionCommand {
+        program: program.to_owned(),
+        argv: argv.into_iter().map(str::to_owned).collect(),
+        environment: BTreeMap::new(),
+        workspace: WorkspaceCapability {
+            current_dir: std::env::temp_dir(),
+            mode: WorkspaceAccessMode::Exclusive,
+        },
+        deadline: Instant::now() + Duration::from_secs(10),
+    }
+}
+
+fn cancellation_pair() -> (watch::Sender<bool>, DriverCancellation) {
+    let (sender, receiver) = watch::channel(false);
+    (sender, DriverCancellation::new(receiver))
+}
+
+#[cfg(unix)]
+async fn open(program: &str, argv: Vec<&str>) -> (watch::Sender<bool>, ProcessSession) {
+    let (cancel, cancellation) = cancellation_pair();
+    let session = LocalProcessRunner::new()
+        .open(command(program, argv), cancellation)
+        .await
+        .unwrap();
+    (cancel, session)
+}
+
+#[cfg(unix)]
+async fn collect_stdout(session: &mut ProcessSession) -> Vec<u8> {
+    let mut output = Vec::new();
+    while let Some(chunk) = session.recv_stdout().await {
+        output.extend_from_slice(chunk.as_slice());
+    }
+    output
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stdout_queue_applies_capacity_sixty_four_backpressure() {
+    assert_eq!(PROCESS_STDOUT_CAPACITY, 64);
+    assert_eq!(PROCESS_STDIN_CAPACITY, 64);
+    let marker = unique_temp_path("zeroshot-stream-backpressure");
+    let script = format!(
+        "/usr/bin/head -c 7000000 /dev/zero; printf ready > {}; sleep 30",
+        shell_quote(marker.to_string_lossy().as_ref())
+    );
+    let (_cancel, mut session) = open("/bin/sh", vec!["-c", &script]).await;
+    assert_eq!(session.stdout_queue_capacity(), 64);
+    assert_eq!(session.stdin_queue_capacity(), 64);
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(
+        !marker.exists(),
+        "child passed the bounded stdout queue without a receiver"
+    );
+    let released = timeout(Duration::from_secs(4), session.release())
+        .await
+        .expect("release must not depend on stdout capacity")
+        .unwrap();
+    assert_eq!(released.cleanup, ProcessCleanupEvidence::Reaped);
+    assert!(
+        released
+            .post_launch_error
+            .as_deref()
+            .is_some_and(|error| error.contains("drain timed out"))
+    );
+    let _ = fs::remove_file(marker);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn duplex_preserves_split_frames_and_eof_with_pending_output() {
+    let (_cancel, mut session) = open("/bin/cat", vec![]).await;
+    let prefix = vec![b'a'; 63 * 1024];
+    let boundary = vec![b'b'; 3 * 1024];
+    let suffix = vec![b'c'; 512 * 1024];
+    session
+        .send(ProcessFrame::new(prefix.clone()).unwrap())
+        .await
+        .unwrap();
+    session
+        .send(ProcessFrame::new(boundary.clone()).unwrap())
+        .await
+        .unwrap();
+    session
+        .send(ProcessFrame::new(suffix.clone()).unwrap())
+        .await
+        .unwrap();
+    session.close_stdin().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let output = collect_stdout(&mut session).await;
+    let mut expected = prefix;
+    expected.extend_from_slice(&boundary);
+    expected.extend_from_slice(&suffix);
+    assert_eq!(output, expected);
+    let completion = session.wait().await.unwrap();
+    assert_eq!(completion.exit_code, Some(0));
+    assert_eq!(completion.post_launch_error, None);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn cancellation_and_child_exit_races_settle_once() {
+    for _ in 0..8 {
+        let (cancel, mut session) =
+            open("/bin/sh", vec!["-c", "printf ready; /bin/sleep 0.01"]).await;
+        assert_eq!(session.recv_stdout().await.unwrap().as_slice(), b"ready");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let _ = cancel.send(true);
+        let completion = timeout(Duration::from_secs(2), session.wait())
+            .await
+            .expect("child-exit race must settle")
+            .unwrap();
+        if completion.cancelled {
+            assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+        } else {
+            assert_eq!(completion.exit_code, Some(0));
+        }
+        assert_eq!(completion, session.release().await.unwrap());
+    }
+
+    let (cancel, mut session) = open("/bin/sleep", vec!["30"]).await;
+    cancel.send(true).unwrap();
+    let completion = timeout(Duration::from_secs(2), session.wait())
+        .await
+        .expect("cancellation must settle")
+        .unwrap();
+    assert!(completion.cancelled);
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn deadline_force_kills_and_reaps_the_session() {
+    let (_cancel, cancellation) = cancellation_pair();
+    let mut timed = command("/bin/sleep", vec!["30"]);
+    timed.deadline = Instant::now() + Duration::from_millis(50);
+    let mut session = LocalProcessRunner::new()
+        .open(timed, cancellation)
+        .await
+        .unwrap();
+    let completion = timeout(Duration::from_secs(2), session.wait())
+        .await
+        .expect("deadline must settle")
+        .unwrap();
+    assert!(completion.timed_out);
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn child_death_closes_stream_and_reports_may_have_started() {
+    let (_cancel, mut session) = open("/bin/sh", vec!["-c", "kill -9 $$"]).await;
+    assert_eq!(session.recv_stdout().await, None);
+    let completion = timeout(Duration::from_secs(2), session.wait())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        completion.launch_evidence,
+        ProcessLaunchEvidence::MayHaveStarted
+    );
+    assert_eq!(completion.exit_code, None);
+
+    let (cancel, cancellation) = cancellation_pair();
+    let _keep_sender_alive = cancel;
+    let error = match LocalProcessRunner::new()
+        .open(command("/definitely/missing", vec![]), cancellation)
+        .await
+    {
+        Ok(_) => panic!("missing process unexpectedly started"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, ProcessRunnerError::Launch(_)));
+    assert_eq!(
+        error.launch_evidence(),
+        ProcessLaunchEvidence::DefinitelyNotStarted
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn release_drain_timeout_force_kills_and_reaps_descendants() {
+    let pid_file = unique_temp_path("zeroshot-stream-descendant-pid");
+    let script = format!(
+        "sleep 30 & child=$!; printf %s \"$child\" > {}; wait",
+        shell_quote(pid_file.to_string_lossy().as_ref())
+    );
+    let (_cancel, mut session) = open("/bin/sh", vec!["-c", &script]).await;
+    let child_pid = wait_for_child_pid(&pid_file).await;
+    assert!(process_exists(child_pid));
+
+    let first = timeout(Duration::from_secs(4), session.release())
+        .await
+        .expect("release must force a non-draining child")
+        .unwrap();
+    let second = session.release().await.unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.cleanup, ProcessCleanupEvidence::Reaped);
+    wait_for_process_exit(child_pid).await;
+    let _ = fs::remove_file(pid_file);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn root_exit_and_cancel_race_still_reap_surviving_descendants() {
+    let pid_file = unique_temp_path("zeroshot-stream-orphan-pid");
+    let ready_file = unique_temp_path("zeroshot-stream-orphan-ready");
+    let ready_path = shell_quote(ready_file.to_string_lossy().as_ref());
+    let script = format!(
+        "(printf ready > {ready_path}; exec /bin/sleep 30) </dev/null >/dev/null 2>&1 & child=$!; while [ ! -f {ready_path} ]; do :; done; printf %s \"$child\" > {}; exit 0",
+        shell_quote(pid_file.to_string_lossy().as_ref())
+    );
+    let (_cancel, mut session) = open("/bin/sh", vec!["-c", &script]).await;
+    let child_pid = wait_for_child_pid(&pid_file).await;
+    assert_eq!(fs::read(&ready_file).unwrap(), b"ready");
+    let completion = timeout(Duration::from_secs(4), session.wait())
+        .await
+        .expect("root exit must retain descendant cleanup ownership")
+        .unwrap();
+    assert_eq!(completion.exit_code, Some(0));
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+    assert_eq!(completion.post_launch_error, None);
+    wait_for_process_exit(child_pid).await;
+    let _ = fs::remove_file(&pid_file);
+    let _ = fs::remove_file(&ready_file);
+
+    let (cancel, mut session) = open("/bin/sh", vec!["-c", &script]).await;
+    let child_pid = wait_for_child_pid(&pid_file).await;
+    assert_eq!(fs::read(&ready_file).unwrap(), b"ready");
+    let _ = cancel.send(true);
+    let completion = timeout(Duration::from_secs(4), session.wait())
+        .await
+        .expect("root-exit cancellation race must retain cleanup ownership")
+        .unwrap();
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+    assert_eq!(completion.post_launch_error, None);
+    wait_for_process_exit(child_pid).await;
+    let _ = fs::remove_file(pid_file);
+    let _ = fs::remove_file(ready_file);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rejects_oversized_messages_and_classifies_post_launch_io() {
+    assert_eq!(
+        MAX_PROCESS_FRAME_BYTES,
+        MAX_PROCESS_MESSAGE_BYTES + MAX_PROCESS_FRAMING_OVERHEAD_BYTES
+    );
+    assert!(
+        ProcessFrame::with_framing(vec![0; MAX_PROCESS_FRAME_BYTES], MAX_PROCESS_MESSAGE_BYTES)
+            .is_ok()
+    );
+    let error = ProcessFrame::new(vec![0; MAX_PROCESS_MESSAGE_BYTES + 1]).unwrap_err();
+    assert!(matches!(error, ProcessRunnerError::InvalidCommand(_)));
+    let overhead_error = ProcessFrame::with_framing(
+        vec![0; MAX_PROCESS_FRAME_BYTES + 1],
+        MAX_PROCESS_MESSAGE_BYTES,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        overhead_error,
+        ProcessRunnerError::InvalidCommand(_)
+    ));
+    assert_eq!(
+        error.launch_evidence(),
+        ProcessLaunchEvidence::DefinitelyNotStarted
+    );
+
+    let (_cancel, mut session) = open("/bin/true", vec![]).await;
+    session.wait().await.unwrap();
+    let error = session
+        .send(ProcessFrame::new(b"late".to_vec()).unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(error, ProcessRunnerError::Io(_)));
+    assert_eq!(
+        error.launch_evidence(),
+        ProcessLaunchEvidence::MayHaveStarted
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stderr_keeps_only_the_bounded_diagnostic_tail() {
+    let script =
+        "i=0; while [ \"$i\" -lt 70000 ]; do printf a 1>&2; i=$((i+1)); done; printf TAIL 1>&2";
+    let (_cancel, mut session) = open("/bin/sh", vec!["-c", script]).await;
+    let completion = timeout(Duration::from_secs(5), session.wait())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completion.stderr_tail.len(), MAX_PROCESS_DIAGNOSTIC_BYTES);
+    assert!(completion.stderr_tail.ends_with(b"TAIL"));
+    assert_eq!(completion.post_launch_error, None);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn close_and_release_are_idempotent_for_one_shot_sessions() {
+    let (_cancel, mut session) = open("/bin/cat", vec![]).await;
+    session
+        .send(ProcessFrame::new(b"one-shot\n".to_vec()).unwrap())
+        .await
+        .unwrap();
+    session.close_stdin().await.unwrap();
+    session.close_stdin().await.unwrap();
+    assert_eq!(collect_stdout(&mut session).await, b"one-shot\n");
+
+    let waited = session.wait().await.unwrap();
+    let first_release = session.release().await.unwrap();
+    let second_release = session.release().await.unwrap();
+    assert_eq!(waited, first_release);
+    assert_eq!(first_release, second_release);
+    assert_eq!(first_release.cleanup, ProcessCleanupEvidence::NotRequired);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn windows_job_release_reaps_a_descendant() {
+    let system_root = std::env::var("SystemRoot").expect("Windows has SystemRoot");
+    let powershell = PathBuf::from(&system_root)
+        .join("System32")
+        .join("WindowsPowerShell")
+        .join("v1.0")
+        .join("powershell.exe");
+    let pid_file = unique_temp_path("zeroshot-stream-windows-descendant-pid");
+    let powershell_literal = powershell.to_string_lossy().replace('\'', "''");
+    let pid_literal = pid_file.to_string_lossy().replace('\'', "''");
+    let script = format!(
+        "$child = Start-Process -FilePath '{powershell_literal}' -ArgumentList @('-NoProfile','-Command','Start-Sleep -Seconds 30') -PassThru; Set-Content -NoNewline -Path '{pid_literal}' -Value $child.Id; Wait-Process -Id $child.Id"
+    );
+    let mut launch = command(
+        powershell.to_string_lossy().as_ref(),
+        vec!["-NoProfile", "-Command", &script],
+    );
+    launch
+        .environment
+        .insert("SystemRoot".to_owned(), system_root);
+    let (cancel, cancellation) = cancellation_pair();
+    let mut session = LocalProcessRunner::new()
+        .open(launch, cancellation)
+        .await
+        .unwrap();
+    let child_pid = wait_for_child_pid(&pid_file).await;
+    assert!(process_exists(child_pid));
+    cancel.send(true).unwrap();
+    let completion = timeout(Duration::from_secs(5), session.wait())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+    wait_for_process_exit(child_pid).await;
+    let _ = fs::remove_file(pid_file);
+}
+
+fn unique_temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{name}-{nanos}"))
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+async fn wait_for_child_pid(path: &PathBuf) -> i32 {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if let Ok(pid) = contents.trim().parse::<i32>() {
+                return pid;
+            }
+        }
+        assert!(Instant::now() < deadline, "child pid file was not written");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_process_exit(pid: i32) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while process_exists(pid) {
+        assert!(Instant::now() < deadline, "process {pid} did not exit");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(unix)]
+fn process_exists(pid: i32) -> bool {
+    unsafe {
+        if libc::kill(pid, 0) == 0 {
+            true
+        } else {
+            std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn process_exists(pid: i32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    let Ok(pid) = u32::try_from(pid) else {
+        return false;
+    };
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return false;
+    }
+    let mut exit_code = 0;
+    let queried = unsafe { GetExitCodeProcess(process, &mut exit_code) };
+    unsafe {
+        CloseHandle(process);
+    }
+    queried != 0 && exit_code == STILL_ACTIVE as u32
+}


### PR DESCRIPTION
Closes #755

## Decision

Use one reusable bounded process-session primitive for streaming stdout and duplex stdin while retaining `LocalProcessRunner::run` as the compatible one-shot facade. Recovery registration precedes spawn; every accepted process is contained, deadline/cancellation bounded, force-terminated when necessary, reaped, and released exactly once. The implementation uses exact capacity-64 channels, bounded framing/messages/tails, and disables a closed I/O branch without mistaking it for process completion.

Windows creation is suspended before user code, assigned to a kill-on-close Job, then resumed. Windows-only tests exercise the real CREATE_SUSPENDED/Job lifecycle and injected assign/resume failures; this Linux workstation cross-checked their compilation path but could not execute them.

## Scope

- Generic process sessions only; no provider argv/codecs, ACP pooling, Gateway HTTP, scheduler, ledger, coordinator, or fault-algebra changes.
- `AGENTS.md` records the new process-session boundary.

## Verification

Focused targets first:
- `cargo test -p zeroshot-rust --test streaming_process_runner` — 10 passed
- `cargo test -p zeroshot-rust --test local_process_runner` — 5 passed
- `cargo test -p zeroshot-rust --test architecture` — 11 passed

Common gates:
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` — 1953 passed, 18 pending
- `opcore check --changed`

Two independent final verifier passes completed all gates and reported no findings.