### PR TITLE
feat(zeroshot-rust): bind source operations to workspace authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ locks, and manifests remain product-private; only verified protocol `ArtifactRef
 the engine boundary. `LocalCasArtifactStore` takes an explicit root, is a single-writer local
 filesystem store, and must preserve ref-first release plus synchronized blob-then-ref publication.
 Issue and source registries and identifiers remain independent; neither is a worker/model provider.
+Mutating source calls carry an exclusively borrowed, non-serializable verified-workspace capability;
+their serializable intent and closed operation-specific receipts contain only canonical workspace,
+pre-effect, branch/revision, review, policy/conclusion, and idempotency identities. Successful or
+uncertain effects reconcile only through exact authoritative post-effect inspection.
 Keep protocol, transport, daemon, compatibility, adapter, credential resolution, ledger, and
 workspace behavior outside it.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair

--- a/zeroshot-rust/src/provider_value/macros.rs
+++ b/zeroshot-rust/src/provider_value/macros.rs
@@ -123,7 +123,7 @@ macro_rules! contract_error_type {
 macro_rules! provider_ref_type {
     ($name:ident, $id:ident, $error:ident, $field:expr) => {
         #[derive(Clone, Debug, serde::Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize)]
-        #[serde(rename_all = "camelCase")]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
         pub struct $name { id: $id, version: std::num::NonZeroU32 }
         impl $name {
             pub fn new(id: $id, version: u32) -> Result<Self, $error> {
@@ -153,7 +153,7 @@ macro_rules! profile_descriptor_type {
             provider_native_idempotency: $crate::provider_value::BoundedSet<$capability>,
         }
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
         struct $wire {
             capabilities: $crate::provider_value::BoundedSet<$capability>,
             provider_native_idempotency: $crate::provider_value::BoundedSet<$capability>,
@@ -273,7 +273,7 @@ macro_rules! provider_descriptor_type {
             profiles: $crate::provider_value::BoundedMap<$profile_id, $profile>,
         }
         #[derive(serde::Deserialize)]
-        #[serde(rename_all = "camelCase")]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
         struct $wire {
             provider: $provider_ref,
             profiles: $crate::provider_value::BoundedMap<$profile_id, $profile>,

--- a/zeroshot-rust/src/source_code_provider.rs
+++ b/zeroshot-rust/src/source_code_provider.rs
@@ -63,17 +63,30 @@
 //! let destination = SourceMaterializationDestination::new(&mut destination);
 //! serde_json::to_string(&destination).unwrap();
 //! ```
+//!
+//! A verified workspace capability cannot be minted, serialized, or cloned by safe downstream
+//! code:
+//!
+//! ```compile_fail
+//! use zeroshot_engine::source_code_provider::{SourceWorkspaceCapability, SourceWorkspaceId};
+//!
+//! let id = SourceWorkspaceId::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+//! let mut runtime = ();
+//! let capability = SourceWorkspaceCapability::from_verified(id, &mut runtime);
+//! serde_json::to_string(&capability).unwrap();
+//! let _replay = capability.clone();
+//! ```
 
 use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use serde::{ser, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::provider_value::{
     bounded_bytes_type, bounded_text_type, digest_type, profile_descriptor_type,
-    provider_contract_types, provider_descriptor_type, validate_serialized, BoundedVec, ValueError,
+    provider_contract_types, provider_descriptor_type, BoundedMap, BoundedVec, ValueError,
 };
 
 const PROFILE_ID_MAX: usize = 128;
@@ -116,6 +129,24 @@ bounded_text_type!(
     SourceContractError,
     "branch id"
 );
+bounded_text_type!(
+    SourceReviewId,
+    EXTERNAL_ID_MAX,
+    SourceContractError,
+    "review id"
+);
+bounded_text_type!(
+    SourceRemoteId,
+    EXTERNAL_ID_MAX,
+    SourceContractError,
+    "remote id"
+);
+bounded_text_type!(
+    SourceCheckId,
+    EXTERNAL_ID_MAX,
+    SourceContractError,
+    "check id"
+);
 bounded_bytes_type!(
     SourcePublicUrl,
     PUBLIC_URL_MAX,
@@ -129,6 +160,22 @@ bounded_text_type!(
     "failure message"
 );
 digest_type!(SourceContentDigest, SourceContractError, "content digest");
+digest_type!(SourceWorkspaceId, SourceContractError, "workspace id");
+digest_type!(
+    SourceStateDigest,
+    SourceContractError,
+    "pre-effect state digest"
+);
+digest_type!(
+    SourceMessageDigest,
+    SourceContractError,
+    "commit message digest"
+);
+digest_type!(
+    SourcePolicyDigest,
+    SourceContractError,
+    "required policy digest"
+);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -165,7 +212,7 @@ provider_descriptor_type!(
 );
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CanonicalRepository {
     provider: SourceProviderRef,
     profile: SourceProfileId,

--- a/zeroshot-rust/src/source_code_provider/evidence.rs
+++ b/zeroshot-rust/src/source_code_provider/evidence.rs
@@ -1,17 +1,29 @@
 use super::*;
+use serde::{ser, Serializer};
+use crate::provider_value::validate_serialized;
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-#[serde(try_from = "SourceOperationReceiptWire")]
-#[serde(rename_all = "snake_case", tag = "kind", content = "receipt")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SourceOperationReceipt {
-    Applied(SourceAppliedReceipt),
+    Branch(SourceBranchReceipt),
+    Commit(SourceCommitReceipt),
+    Push(SourcePushReceipt),
+    PullRequest(SourcePullRequestReceipt),
+    Checks(SourceChecksReceipt),
+    AutoMerge(SourceAutoMergeReceipt),
+    MergeQueue(SourceMergeQueueReceipt),
     Merge(SourceMergeReceipt),
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "receipt")]
 enum SourceOperationReceiptRef<'a> {
-    Applied(&'a SourceAppliedReceipt),
+    Branch(&'a SourceBranchReceipt),
+    Commit(&'a SourceCommitReceipt),
+    Push(&'a SourcePushReceipt),
+    PullRequest(&'a SourcePullRequestReceipt),
+    Checks(&'a SourceChecksReceipt),
+    AutoMerge(&'a SourceAutoMergeReceipt),
+    MergeQueue(&'a SourceMergeQueueReceipt),
     Merge(&'a SourceMergeReceipt),
 }
 
@@ -21,7 +33,13 @@ impl Serialize for SourceOperationReceipt {
         S: Serializer,
     {
         let wire = match self {
-            Self::Applied(receipt) => SourceOperationReceiptRef::Applied(receipt),
+            Self::Branch(receipt) => SourceOperationReceiptRef::Branch(receipt),
+            Self::Commit(receipt) => SourceOperationReceiptRef::Commit(receipt),
+            Self::Push(receipt) => SourceOperationReceiptRef::Push(receipt),
+            Self::PullRequest(receipt) => SourceOperationReceiptRef::PullRequest(receipt),
+            Self::Checks(receipt) => SourceOperationReceiptRef::Checks(receipt),
+            Self::AutoMerge(receipt) => SourceOperationReceiptRef::AutoMerge(receipt),
+            Self::MergeQueue(receipt) => SourceOperationReceiptRef::MergeQueue(receipt),
             Self::Merge(receipt) => SourceOperationReceiptRef::Merge(receipt),
         };
         validate_serialized(&wire).map_err(ser::Error::custom)?;
@@ -30,9 +48,20 @@ impl Serialize for SourceOperationReceipt {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "snake_case", tag = "kind", content = "receipt")]
+#[serde(
+    rename_all = "snake_case",
+    tag = "kind",
+    content = "receipt",
+    deny_unknown_fields
+)]
 enum SourceOperationReceiptWire {
-    Applied(SourceAppliedReceipt),
+    Branch(SourceBranchReceipt),
+    Commit(SourceCommitReceipt),
+    Push(SourcePushReceipt),
+    PullRequest(SourcePullRequestReceipt),
+    Checks(SourceChecksReceipt),
+    AutoMerge(SourceAutoMergeReceipt),
+    MergeQueue(SourceMergeQueueReceipt),
     Merge(SourceMergeReceipt),
 }
 
@@ -41,9 +70,26 @@ impl TryFrom<SourceOperationReceiptWire> for SourceOperationReceipt {
 
     fn try_from(wire: SourceOperationReceiptWire) -> Result<Self, Self::Error> {
         SourceContractError::checked(match wire {
-            SourceOperationReceiptWire::Applied(receipt) => Self::Applied(receipt),
+            SourceOperationReceiptWire::Branch(receipt) => Self::Branch(receipt),
+            SourceOperationReceiptWire::Commit(receipt) => Self::Commit(receipt),
+            SourceOperationReceiptWire::Push(receipt) => Self::Push(receipt),
+            SourceOperationReceiptWire::PullRequest(receipt) => Self::PullRequest(receipt),
+            SourceOperationReceiptWire::Checks(receipt) => Self::Checks(receipt),
+            SourceOperationReceiptWire::AutoMerge(receipt) => Self::AutoMerge(receipt),
+            SourceOperationReceiptWire::MergeQueue(receipt) => Self::MergeQueue(receipt),
             SourceOperationReceiptWire::Merge(receipt) => Self::Merge(receipt),
         })
+    }
+}
+
+impl<'de> Deserialize<'de> for SourceOperationReceipt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        SourceOperationReceiptWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -51,60 +97,75 @@ impl SourceOperationReceipt {
     #[must_use]
     pub fn capability(&self) -> SourceCapability {
         match self {
-            Self::Applied(receipt) => receipt.capability(),
+            Self::Branch(_) => SourceCapability::Branch,
+            Self::Commit(_) => SourceCapability::Commit,
+            Self::Push(_) => SourceCapability::Push,
+            Self::PullRequest(_) => SourceCapability::PullRequest,
+            Self::Checks(_) => SourceCapability::Checks,
+            Self::AutoMerge(_) => SourceCapability::AutoMerge,
+            Self::MergeQueue(_) => SourceCapability::MergeQueue,
             Self::Merge(_) => SourceCapability::Merge,
         }
     }
 
-    fn operation_identity(
-        &self,
-    ) -> (
-        &CanonicalRepository,
-        &SourceOperationId,
-        &SourceOperationFingerprint,
-    ) {
+    #[must_use]
+    pub fn request(&self) -> &SourceOperationRequest {
         match self {
-            Self::Applied(receipt) => (
-                receipt.repository(),
-                receipt.operation_id(),
-                receipt.fingerprint(),
-            ),
-            Self::Merge(receipt) => (
-                receipt.repository(),
-                receipt.operation_id(),
-                receipt.fingerprint(),
-            ),
+            Self::Branch(receipt) => receipt.request(),
+            Self::Commit(receipt) => receipt.request(),
+            Self::Push(receipt) => receipt.request(),
+            Self::PullRequest(receipt) => receipt.request(),
+            Self::Checks(receipt) => receipt.request(),
+            Self::AutoMerge(receipt) => receipt.request(),
+            Self::MergeQueue(receipt) => receipt.request(),
+            Self::Merge(receipt) => receipt.request(),
         }
     }
 
-    fn matches_operation(&self, operation: &SourceOperation) -> bool {
-        match (self, operation) {
+    fn evidence_matches_operation(&self) -> bool {
+        match (self, self.request().operation()) {
+            (
+                Self::Branch(receipt),
+                SourceOperation::Branch {
+                    expected_parent, ..
+                },
+            ) => receipt.resulting_head() == expected_parent,
+            (Self::Commit(_), SourceOperation::Commit { .. }) => true,
+            (Self::Push(receipt), SourceOperation::Push { revision, .. }) => {
+                receipt.pushed_revision() == revision
+            }
+            (Self::PullRequest(receipt), SourceOperation::PullRequest { review, .. }) => {
+                receipt.review() == review
+            }
+            (Self::AutoMerge(receipt), SourceOperation::AutoMerge { review, policy, .. }) => {
+                receipt.review() == review && policy.is_satisfied()
+            }
+            (Self::MergeQueue(receipt), SourceOperation::MergeQueue { review, policy, .. }) => {
+                receipt.review() == review && policy.is_satisfied()
+            }
+            (Self::Checks(receipt), SourceOperation::Checks { policy, .. }) => {
+                receipt.policy() == policy && receipt.policy().is_satisfied()
+            }
             (
                 Self::Merge(receipt),
                 SourceOperation::Merge {
-                    expected_base,
-                    expected_head,
+                    integrated_revision,
+                    policy,
+                    ..
                 },
-            ) => {
-                receipt.expected_base() == expected_base && receipt.expected_head() == expected_head
-            }
-            (Self::Applied(receipt), _) => receipt.capability() == operation.capability(),
-            (Self::Merge(_), _) => false,
+            ) => receipt.integrated_revision() == integrated_revision && policy.is_satisfied(),
+            _ => false,
         }
     }
 
-    pub(super) fn matches_request(&self, request: &SourceOperationRequest) -> bool {
-        let (repository, operation_id, fingerprint) = self.operation_identity();
-        repository == request.repository()
-            && operation_id == request.operation_id()
-            && fingerprint == request.fingerprint()
-            && self.matches_operation(request.operation())
+    pub fn matches_request(&self, request: &SourceOperationRequest) -> bool {
+        self.request() == request
+            && self.evidence_matches_operation()
+            && validate_serialized(self).is_ok()
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-#[serde(try_from = "SourceOperationInspectionWire")]
-#[serde(rename_all = "snake_case", tag = "state", content = "evidence")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SourceOperationInspection {
     Unobserved,
     Pending,
@@ -155,7 +216,12 @@ impl Serialize for SourceOperationInspection {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "snake_case", tag = "state", content = "evidence")]
+#[serde(
+    rename_all = "snake_case",
+    tag = "state",
+    content = "evidence",
+    deny_unknown_fields
+)]
 enum SourceOperationInspectionWire {
     Unobserved,
     Pending,
@@ -188,12 +254,21 @@ impl TryFrom<SourceOperationInspectionWire> for SourceOperationInspection {
     }
 }
 
+impl<'de> Deserialize<'de> for SourceOperationInspection {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        SourceOperationInspectionWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 impl SourceOperationInspection {
     #[must_use]
-    pub fn permits_invocation(&self, provider_native_idempotency: bool) -> bool {
+    pub fn permits_invocation(&self, _provider_native_idempotency: bool) -> bool {
         matches!(self, Self::Unobserved)
-            || (provider_native_idempotency
-                && matches!(self, Self::Pending | Self::Indeterminate { .. }))
     }
 }
 
@@ -209,7 +284,7 @@ pub enum SourceProviderFailureCode {
 
 #[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]
 #[error("source provider {code:?}: {message}")]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SourceProviderFailure {
     code: SourceProviderFailureCode,
     message: SourceFailureMessage,
@@ -262,5 +337,6 @@ pub trait SourceCodeProvider: Send + Sync {
     async fn operate(
         &self,
         request: &SourceOperationRequest,
+        workspace: SourceWorkspaceCapability<'_>,
     ) -> Result<SourceOperationReceipt, SourceProviderFailure>;
 }

--- a/zeroshot-rust/src/source_code_provider/operation.rs
+++ b/zeroshot-rust/src/source_code_provider/operation.rs
@@ -1,50 +1,175 @@
+use std::collections::BTreeMap;
+
+use sha2::{Digest, Sha256};
+
 use super::*;
 
-/// Caller-owned stable operation identifier and canonical fingerprint.
-pub type SourceOperationIdentity = (SourceOperationId, SourceOperationFingerprint);
-
-/// Optional revision and bounded public URL evidence for a source operation.
-pub type SourceRevisionEvidence = (Option<SourceRevisionId>, Vec<SourcePublicUrl>);
-
-/// Expected base and head revisions for a merge.
-pub type SourceMergeExpectation = (SourceRevisionId, SourceRevisionId);
-
-/// Integrated revision and bounded public URL evidence for a merge.
-pub type SourceMergeEvidence = (SourceRevisionId, Vec<SourcePublicUrl>);
-
+/// Canonical, provider-independent identity of one code review.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case", tag = "kind")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceReviewIdentity {
+    review: SourceReviewId,
+    base_branch: SourceBranchId,
+    head_branch: SourceBranchId,
+}
+
+impl SourceReviewIdentity {
+    pub fn new(
+        review: SourceReviewId,
+        base_branch: SourceBranchId,
+        head_branch: SourceBranchId,
+    ) -> Result<Self, SourceContractError> {
+        SourceContractError::checked(Self {
+            review,
+            base_branch,
+            head_branch,
+        })
+    }
+
+    #[must_use]
+    pub fn review(&self) -> &SourceReviewId {
+        &self.review
+    }
+
+    #[must_use]
+    pub fn base_branch(&self) -> &SourceBranchId {
+        &self.base_branch
+    }
+
+    #[must_use]
+    pub fn head_branch(&self) -> &SourceBranchId {
+        &self.head_branch
+    }
+}
+
+/// Closed conclusion vocabulary used as authoritative check evidence.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceCheckConclusion {
+    Pending,
+    Satisfied,
+    Failed,
+    Cancelled,
+    Skipped,
+}
+
+/// Exact required-policy identity and its canonical, sorted conclusions.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "SourceRequiredPolicyWire", rename_all = "camelCase")]
+pub struct SourceRequiredPolicy {
+    digest: SourcePolicyDigest,
+    conclusions: BoundedMap<SourceCheckId, SourceCheckConclusion>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceRequiredPolicyWire {
+    digest: SourcePolicyDigest,
+    conclusions: BoundedMap<SourceCheckId, SourceCheckConclusion>,
+}
+
+impl TryFrom<SourceRequiredPolicyWire> for SourceRequiredPolicy {
+    type Error = SourceContractError;
+
+    fn try_from(wire: SourceRequiredPolicyWire) -> Result<Self, Self::Error> {
+        SourceContractError::checked(Self {
+            digest: wire.digest,
+            conclusions: wire.conclusions,
+        })
+    }
+}
+
+impl SourceRequiredPolicy {
+    pub fn new(
+        digest: SourcePolicyDigest,
+        conclusions: BTreeMap<SourceCheckId, SourceCheckConclusion>,
+    ) -> Result<Self, SourceContractError> {
+        SourceContractError::checked(Self {
+            digest,
+            conclusions: BoundedMap::new(conclusions)
+                .map_err(|error| SourceContractError::new("required check conclusions", error))?,
+        })
+    }
+
+    #[must_use]
+    pub fn digest(&self) -> &SourcePolicyDigest {
+        &self.digest
+    }
+
+    #[must_use]
+    pub fn conclusions(&self) -> &BTreeMap<SourceCheckId, SourceCheckConclusion> {
+        self.conclusions.as_map()
+    }
+
+    #[must_use]
+    pub fn is_satisfied(&self) -> bool {
+        !self.conclusions().is_empty()
+            && self
+                .conclusions()
+                .values()
+                .all(|conclusion| *conclusion == SourceCheckConclusion::Satisfied)
+    }
+}
+
+/// Closed source mutation intent. Every field is stable, bounded, and secret-free.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
 pub enum SourceOperation {
     Branch {
-        expected_base: SourceRevisionId,
+        expected_parent: SourceRevisionId,
         branch: SourceBranchId,
+        pre_effect: SourceStateDigest,
     },
     Commit {
         expected_head: SourceRevisionId,
+        branch: SourceBranchId,
+        message_digest: SourceMessageDigest,
         change_digest: SourceContentDigest,
+        pre_effect: SourceStateDigest,
     },
     Push {
         expected_head: SourceRevisionId,
+        branch: SourceBranchId,
+        remote: SourceRemoteId,
+        expected_remote_head: Option<SourceRevisionId>,
         revision: SourceRevisionId,
+        pre_effect: SourceStateDigest,
     },
     PullRequest {
+        review: SourceReviewIdentity,
         expected_base: SourceRevisionId,
         expected_head: SourceRevisionId,
+        checked_revision: SourceRevisionId,
+        policy: SourceRequiredPolicy,
     },
     Checks {
-        revision: SourceRevisionId,
+        review: SourceReviewIdentity,
+        expected_base: SourceRevisionId,
+        expected_head: SourceRevisionId,
+        checked_revision: SourceRevisionId,
+        policy: SourceRequiredPolicy,
     },
     AutoMerge {
+        review: SourceReviewIdentity,
         expected_base: SourceRevisionId,
         expected_head: SourceRevisionId,
+        checked_revision: SourceRevisionId,
+        policy: SourceRequiredPolicy,
     },
     MergeQueue {
+        review: SourceReviewIdentity,
         expected_base: SourceRevisionId,
         expected_head: SourceRevisionId,
+        checked_revision: SourceRevisionId,
+        policy: SourceRequiredPolicy,
     },
     Merge {
+        review: SourceReviewIdentity,
         expected_base: SourceRevisionId,
         expected_head: SourceRevisionId,
+        checked_revision: SourceRevisionId,
+        policy: SourceRequiredPolicy,
+        integrated_revision: SourceRevisionId,
     },
 }
 
@@ -64,27 +189,114 @@ impl SourceOperation {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceOperationRequest {
     repository: CanonicalRepository,
     credential_handle: SourceCredentialHandleId,
+    workspace: SourceWorkspaceId,
     operation_id: SourceOperationId,
     fingerprint: SourceOperationFingerprint,
     operation: SourceOperation,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SourceOperationRequestWire {
+    repository: CanonicalRepository,
+    credential_handle: SourceCredentialHandleId,
+    workspace: SourceWorkspaceId,
+    operation_id: SourceOperationId,
+    fingerprint: SourceOperationFingerprint,
+    operation: SourceOperation,
+}
+
+struct SourceOperationRequestInput {
+    repository: CanonicalRepository,
+    credential_handle: SourceCredentialHandleId,
+    workspace: SourceWorkspaceId,
+    operation_id: SourceOperationId,
+    operation: SourceOperation,
+}
+
+impl<'de> Deserialize<'de> for SourceOperationRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let SourceOperationRequestWire {
+            repository,
+            credential_handle,
+            workspace,
+            operation_id,
+            fingerprint,
+            operation,
+        } = SourceOperationRequestWire::deserialize(deserializer)?;
+        let request = Self::build(SourceOperationRequestInput {
+            repository,
+            credential_handle,
+            workspace,
+            operation_id,
+            operation,
+        })
+        .map_err(serde::de::Error::custom)?;
+        if request.fingerprint != fingerprint {
+            return Err(serde::de::Error::custom(
+                "source operation fingerprint does not match canonical intent",
+            ));
+        }
+        Ok(request)
+    }
 }
 
 impl SourceOperationRequest {
     pub fn new(
         repository: CanonicalRepository,
         credential_handle: SourceCredentialHandleId,
-        identity: SourceOperationIdentity,
+        identity: (SourceWorkspaceId, SourceOperationId),
         operation: SourceOperation,
     ) -> Result<Self, SourceContractError> {
-        let (operation_id, fingerprint) = identity;
+        let (workspace, operation_id) = identity;
+        Self::build(SourceOperationRequestInput {
+            repository,
+            credential_handle,
+            workspace,
+            operation_id,
+            operation,
+        })
+    }
+
+    fn build(input: SourceOperationRequestInput) -> Result<Self, SourceContractError> {
+        let SourceOperationRequestInput {
+            repository,
+            credential_handle,
+            workspace,
+            operation_id,
+            operation,
+        } = input;
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct CanonicalIntent<'a> {
+            repository: &'a CanonicalRepository,
+            credential_handle: &'a SourceCredentialHandleId,
+            workspace: &'a SourceWorkspaceId,
+            operation_id: &'a SourceOperationId,
+            operation: &'a SourceOperation,
+        }
+
+        let bytes = serde_json::to_vec(&CanonicalIntent {
+            repository: &repository,
+            credential_handle: &credential_handle,
+            workspace: &workspace,
+            operation_id: &operation_id,
+            operation: &operation,
+        })
+        .map_err(|error| SourceContractError::new("canonical source intent", error))?;
+        let fingerprint = SourceOperationFingerprint::new(format!("{:x}", Sha256::digest(bytes)))?;
         SourceContractError::checked(Self {
             repository,
             credential_handle,
+            workspace,
             operation_id,
             fingerprint,
             operation,
@@ -99,6 +311,11 @@ impl SourceOperationRequest {
     #[must_use]
     pub fn credential_handle(&self) -> &SourceCredentialHandleId {
         &self.credential_handle
+    }
+
+    #[must_use]
+    pub fn workspace(&self) -> &SourceWorkspaceId {
+        &self.workspace
     }
 
     #[must_use]
@@ -117,217 +334,154 @@ impl SourceOperationRequest {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(try_from = "SourceAppliedReceiptWire")]
-#[serde(rename_all = "camelCase")]
-pub struct SourceAppliedReceipt {
-    repository: CanonicalRepository,
-    operation_id: SourceOperationId,
-    fingerprint: SourceOperationFingerprint,
-    capability: SourceCapability,
-    revision: Option<SourceRevisionId>,
-    public_urls: BoundedVec<SourcePublicUrl>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SourceAppliedReceiptWire {
-    repository: CanonicalRepository,
-    operation_id: SourceOperationId,
-    fingerprint: SourceOperationFingerprint,
-    capability: SourceCapability,
-    revision: Option<SourceRevisionId>,
-    public_urls: BoundedVec<SourcePublicUrl>,
-}
-
-impl TryFrom<SourceAppliedReceiptWire> for SourceAppliedReceipt {
-    type Error = SourceContractError;
-
-    fn try_from(wire: SourceAppliedReceiptWire) -> Result<Self, Self::Error> {
-        if wire.capability == SourceCapability::Merge {
-            return Err(SourceContractError {
-                field: "source applied receipt capability",
-                reason: "merge requires SourceMergeReceipt".to_owned(),
-            });
+macro_rules! source_receipt {
+    ($name:ident, $variant:ident, $capability:ident, $field:ident : $field_ty:ty, $valid:expr) => {
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct $name {
+            request: SourceOperationRequest,
+            $field: $field_ty,
         }
-        SourceContractError::checked(Self {
-            repository: wire.repository,
-            operation_id: wire.operation_id,
-            fingerprint: wire.fingerprint,
-            capability: wire.capability,
-            revision: wire.revision,
-            public_urls: wire.public_urls,
-        })
-    }
-}
 
-impl SourceAppliedReceipt {
-    pub fn new(
-        repository: CanonicalRepository,
-        identity: SourceOperationIdentity,
-        capability: SourceCapability,
-        evidence: SourceRevisionEvidence,
-    ) -> Result<Self, SourceContractError> {
-        let (operation_id, fingerprint) = identity;
-        let (revision, public_urls) = evidence;
-        if capability == SourceCapability::Merge {
-            return Err(SourceContractError {
-                field: "source applied receipt capability",
-                reason: "merge requires SourceMergeReceipt".to_owned(),
-            });
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct $variant {
+            request: SourceOperationRequest,
+            $field: $field_ty,
         }
-        SourceContractError::checked(Self {
-            repository,
-            operation_id,
-            fingerprint,
-            capability,
-            revision,
-            public_urls: BoundedVec::new(public_urls)
-                .map_err(|error| SourceContractError::new("public URLs", error))?,
-        })
-    }
 
-    #[must_use]
-    pub fn repository(&self) -> &CanonicalRepository {
-        &self.repository
-    }
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let wire = $variant::deserialize(deserializer)?;
+                Self::new(wire.request, wire.$field).map_err(serde::de::Error::custom)
+            }
+        }
 
-    #[must_use]
-    pub fn operation_id(&self) -> &SourceOperationId {
-        &self.operation_id
-    }
+        impl $name {
+            pub fn new(
+                request: SourceOperationRequest,
+                $field: $field_ty,
+            ) -> Result<Self, SourceContractError> {
+                if request.operation().capability() != SourceCapability::$capability {
+                    return Err(SourceContractError::new(
+                        "source operation receipt",
+                        concat!(
+                            stringify!($name),
+                            " requires a ",
+                            stringify!($capability),
+                            " request"
+                        ),
+                    ));
+                }
+                if !($valid)(&request, &$field) {
+                    return Err(SourceContractError::new(
+                        "source operation receipt evidence",
+                        concat!(stringify!($name), " contradicts its request"),
+                    ));
+                }
+                SourceContractError::checked(Self { request, $field })
+            }
 
-    #[must_use]
-    pub fn fingerprint(&self) -> &SourceOperationFingerprint {
-        &self.fingerprint
-    }
+            #[must_use]
+            pub fn request(&self) -> &SourceOperationRequest {
+                &self.request
+            }
 
-    #[must_use]
-    pub fn capability(&self) -> SourceCapability {
-        self.capability
-    }
-
-    #[must_use]
-    pub fn revision(&self) -> Option<&SourceRevisionId> {
-        self.revision.as_ref()
-    }
-
-    #[must_use]
-    pub fn public_urls(&self) -> &[SourcePublicUrl] {
-        self.public_urls.as_slice()
-    }
+            #[must_use]
+            pub fn $field(&self) -> &$field_ty {
+                &self.$field
+            }
+        }
+    };
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SourceMergedState {
-    Merged,
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(try_from = "SourceMergeReceiptWire")]
-#[serde(rename_all = "camelCase")]
-pub struct SourceMergeReceipt {
-    repository: CanonicalRepository,
-    operation_id: SourceOperationId,
-    fingerprint: SourceOperationFingerprint,
-    expected_base: SourceRevisionId,
-    expected_head: SourceRevisionId,
+source_receipt!(
+    SourceBranchReceipt,
+    SourceBranchReceiptWire,
+    Branch,
+    resulting_head: SourceRevisionId,
+    |request: &SourceOperationRequest, evidence: &SourceRevisionId| matches!(
+        request.operation(),
+        SourceOperation::Branch {
+            expected_parent,
+            ..
+        } if evidence == expected_parent
+    )
+);
+source_receipt!(
+    SourceCommitReceipt,
+    SourceCommitReceiptWire,
+    Commit,
+    committed_revision: SourceRevisionId,
+    |_request: &SourceOperationRequest, _evidence: &SourceRevisionId| true
+);
+source_receipt!(
+    SourcePushReceipt,
+    SourcePushReceiptWire,
+    Push,
+    pushed_revision: SourceRevisionId,
+    |request: &SourceOperationRequest, evidence: &SourceRevisionId| matches!(
+        request.operation(),
+        SourceOperation::Push { revision, .. } if evidence == revision
+    )
+);
+source_receipt!(
+    SourcePullRequestReceipt,
+    SourcePullRequestReceiptWire,
+    PullRequest,
+    review: SourceReviewIdentity,
+    |request: &SourceOperationRequest, evidence: &SourceReviewIdentity| matches!(
+        request.operation(),
+        SourceOperation::PullRequest { review, .. } if evidence == review
+    )
+);
+source_receipt!(
+    SourceChecksReceipt,
+    SourceChecksReceiptWire,
+    Checks,
+    policy: SourceRequiredPolicy,
+    |request: &SourceOperationRequest, evidence: &SourceRequiredPolicy| matches!(
+        request.operation(),
+        SourceOperation::Checks { policy, .. }
+            if evidence == policy && policy.is_satisfied()
+    )
+);
+source_receipt!(
+    SourceAutoMergeReceipt,
+    SourceAutoMergeReceiptWire,
+    AutoMerge,
+    review: SourceReviewIdentity,
+    |request: &SourceOperationRequest, evidence: &SourceReviewIdentity| matches!(
+        request.operation(),
+        SourceOperation::AutoMerge { review, policy, .. }
+            if evidence == review && policy.is_satisfied()
+    )
+);
+source_receipt!(
+    SourceMergeQueueReceipt,
+    SourceMergeQueueReceiptWire,
+    MergeQueue,
+    review: SourceReviewIdentity,
+    |request: &SourceOperationRequest, evidence: &SourceReviewIdentity| matches!(
+        request.operation(),
+        SourceOperation::MergeQueue { review, policy, .. }
+            if evidence == review && policy.is_satisfied()
+    )
+);
+source_receipt!(
+    SourceMergeReceipt,
+    SourceMergeReceiptWire,
+    Merge,
     integrated_revision: SourceRevisionId,
-    merged_state: SourceMergedState,
-    public_urls: BoundedVec<SourcePublicUrl>,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SourceMergeReceiptWire {
-    repository: CanonicalRepository,
-    operation_id: SourceOperationId,
-    fingerprint: SourceOperationFingerprint,
-    expected_base: SourceRevisionId,
-    expected_head: SourceRevisionId,
-    integrated_revision: SourceRevisionId,
-    merged_state: SourceMergedState,
-    public_urls: BoundedVec<SourcePublicUrl>,
-}
-
-impl TryFrom<SourceMergeReceiptWire> for SourceMergeReceipt {
-    type Error = SourceContractError;
-
-    fn try_from(wire: SourceMergeReceiptWire) -> Result<Self, Self::Error> {
-        SourceContractError::checked(Self {
-            repository: wire.repository,
-            operation_id: wire.operation_id,
-            fingerprint: wire.fingerprint,
-            expected_base: wire.expected_base,
-            expected_head: wire.expected_head,
-            integrated_revision: wire.integrated_revision,
-            merged_state: wire.merged_state,
-            public_urls: wire.public_urls,
-        })
-    }
-}
-
-impl SourceMergeReceipt {
-    pub fn new(
-        repository: CanonicalRepository,
-        identity: SourceOperationIdentity,
-        expectation: SourceMergeExpectation,
-        evidence: SourceMergeEvidence,
-    ) -> Result<Self, SourceContractError> {
-        let (operation_id, fingerprint) = identity;
-        let (expected_base, expected_head) = expectation;
-        let (integrated_revision, public_urls) = evidence;
-        SourceContractError::checked(Self {
-            repository,
-            operation_id,
-            fingerprint,
-            expected_base,
-            expected_head,
+    |request: &SourceOperationRequest, evidence: &SourceRevisionId| matches!(
+        request.operation(),
+        SourceOperation::Merge {
+            policy,
             integrated_revision,
-            merged_state: SourceMergedState::Merged,
-            public_urls: BoundedVec::new(public_urls)
-                .map_err(|error| SourceContractError::new("public URLs", error))?,
-        })
-    }
-
-    #[must_use]
-    pub fn repository(&self) -> &CanonicalRepository {
-        &self.repository
-    }
-
-    #[must_use]
-    pub fn operation_id(&self) -> &SourceOperationId {
-        &self.operation_id
-    }
-
-    #[must_use]
-    pub fn fingerprint(&self) -> &SourceOperationFingerprint {
-        &self.fingerprint
-    }
-
-    #[must_use]
-    pub fn expected_base(&self) -> &SourceRevisionId {
-        &self.expected_base
-    }
-
-    #[must_use]
-    pub fn expected_head(&self) -> &SourceRevisionId {
-        &self.expected_head
-    }
-
-    #[must_use]
-    pub fn integrated_revision(&self) -> &SourceRevisionId {
-        &self.integrated_revision
-    }
-
-    #[must_use]
-    pub fn merged_state(&self) -> SourceMergedState {
-        self.merged_state
-    }
-
-    #[must_use]
-    pub fn public_urls(&self) -> &[SourcePublicUrl] {
-        self.public_urls.as_slice()
-    }
-}
+            ..
+        } if evidence == integrated_revision && policy.is_satisfied()
+    )
+);

--- a/zeroshot-rust/src/source_code_provider/registry.rs
+++ b/zeroshot-rust/src/source_code_provider/registry.rs
@@ -1,14 +1,20 @@
 use super::*;
 use std::collections::BTreeMap;
+use crate::provider_value::validate_serialized;
 
 fn validate_operation_inspection(
     request: &SourceOperationRequest,
     inspection: SourceOperationInspection,
 ) -> Result<SourceOperationInspection, SourceCallError> {
+    if validate_serialized(&inspection).is_err() {
+        return Err(SourceCallError::InvalidEvidence {
+            reason: "operation inspection exceeded the canonical serialized bound",
+        });
+    }
     if let SourceOperationInspection::Applied(receipt) = &inspection {
         if !receipt.matches_request(request) {
             return Err(SourceCallError::InvalidEvidence {
-                reason: "applied inspection changed repository, operation, fingerprint, or merge expectation identity",
+                reason: "applied inspection changed exact source operation authority",
             });
         }
     }
@@ -36,6 +42,12 @@ pub enum SourceRegistryError {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceInvocationOutcome {
+    ReturnedReceipt,
+    Indeterminate,
+}
+
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum SourceCallError {
     #[error(transparent)]
@@ -45,6 +57,25 @@ pub enum SourceCallError {
     #[error("source operation cannot be invoked from inspection state {inspection:?}")]
     UnsafeToInvoke {
         inspection: SourceOperationInspection,
+    },
+    #[error("source workspace capability does not match operation workspace")]
+    WorkspaceMismatch,
+    #[error(
+        "source operation remains uncertain after {outcome:?} and authoritative inspection: {inspection:?}"
+    )]
+    UnreconciledUncertainty {
+        outcome: SourceInvocationOutcome,
+        inspection: SourceOperationInspection,
+    },
+    #[error("source operation authoritative inspection failed after {outcome:?}: {failure}")]
+    PostEffectInspectionFailed {
+        outcome: SourceInvocationOutcome,
+        failure: SourceProviderFailure,
+    },
+    #[error("source operation evidence is invalid after {outcome:?}: {reason}")]
+    PostEffectInvalidEvidence {
+        outcome: SourceInvocationOutcome,
+        reason: &'static str,
     },
     #[error("source provider returned evidence that does not match the request: {reason}")]
     InvalidEvidence { reason: &'static str },
@@ -219,7 +250,11 @@ impl SourceCodeProviderRegistry {
     pub async fn operate(
         &self,
         request: &SourceOperationRequest,
+        workspace: SourceWorkspaceCapability<'_>,
     ) -> Result<SourceOperationReceipt, SourceCallError> {
+        if workspace.workspace() != request.workspace() {
+            return Err(SourceCallError::WorkspaceMismatch);
+        }
         let repository = request.repository();
         let capability = request.operation().capability();
         let profile_descriptor =
@@ -235,13 +270,68 @@ impl SourceCodeProviderRegistry {
         if !inspection.permits_invocation(native_idempotency) {
             return Err(SourceCallError::UnsafeToInvoke { inspection });
         }
-        let receipt = provider.operate(request).await?;
-        if !receipt.matches_request(request) {
-            return Err(SourceCallError::InvalidEvidence {
-                reason: "operation receipt changed repository, operation, fingerprint, or merge expectation identity",
-            });
+
+        let performed = provider.operate(request, workspace).await;
+        match performed {
+            Ok(receipt) => {
+                let outcome = SourceInvocationOutcome::ReturnedReceipt;
+                let observed = provider
+                    .inspect_operation(request)
+                    .await
+                    .map_err(|failure| SourceCallError::PostEffectInspectionFailed {
+                        outcome,
+                        failure,
+                    })?;
+                let authoritative = validate_operation_inspection(request, observed).map_err(
+                    |_| SourceCallError::PostEffectInvalidEvidence {
+                        outcome,
+                        reason: "post-effect inspection changed exact source operation authority",
+                    },
+                )?;
+                match authoritative {
+                    SourceOperationInspection::Applied(observed)
+                        if receipt.matches_request(request) && *observed == receipt =>
+                    {
+                        Ok(receipt)
+                    }
+                    SourceOperationInspection::Applied(_) => {
+                        Err(SourceCallError::PostEffectInvalidEvidence {
+                            outcome,
+                            reason: "direct and inspected receipts did not prove the same exact authority",
+                        })
+                    }
+                    inspection => Err(SourceCallError::UnreconciledUncertainty {
+                        outcome,
+                        inspection,
+                    }),
+                }
+            }
+            Err(failure) if failure.code() == SourceProviderFailureCode::Indeterminate => {
+                let outcome = SourceInvocationOutcome::Indeterminate;
+                let observed = provider
+                    .inspect_operation(request)
+                    .await
+                    .map_err(|failure| SourceCallError::PostEffectInspectionFailed {
+                        outcome,
+                        failure,
+                    })?;
+                let authoritative =
+                    validate_operation_inspection(request, observed).map_err(|_| {
+                        SourceCallError::PostEffectInvalidEvidence {
+                            outcome,
+                            reason: "post-uncertainty inspection changed exact source operation authority",
+                        }
+                    })?;
+                match authoritative {
+                    SourceOperationInspection::Applied(receipt) => Ok(*receipt),
+                    inspection => Err(SourceCallError::UnreconciledUncertainty {
+                        outcome,
+                        inspection,
+                    }),
+                }
+            }
+            Err(failure) => Err(SourceCallError::Provider(failure)),
         }
-        Ok(receipt)
     }
 }
 

--- a/zeroshot-rust/src/source_code_provider/repository.rs
+++ b/zeroshot-rust/src/source_code_provider/repository.rs
@@ -194,6 +194,47 @@ impl<'a> SourceMaterializationDestination<'a> {
         self.handle.downcast_mut::<T>()
     }
 }
+/// Ephemeral proof that a previously verified workspace is the mutation target.
+///
+/// The capability is neither cloneable nor serializable, and its exclusive runtime handle makes
+/// one capability single-use. Normal safe callers cannot mint one; serializable requests carry
+/// only the stable, secret-free workspace identity.
+pub struct SourceWorkspaceCapability<'a> {
+    workspace: SourceWorkspaceId,
+    handle: &'a mut (dyn Any + Send),
+}
+
+impl<'a> SourceWorkspaceCapability<'a> {
+    pub(crate) fn from_verified<T: Any + Send>(
+        workspace: SourceWorkspaceId,
+        handle: &'a mut T,
+    ) -> Self {
+        Self { workspace, handle }
+    }
+
+    /// Test-support escape hatch for contract tests that have no product workspace authority.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `workspace` is the verified identity of `handle`. Production code
+    /// must use the crate-private verified-workspace authority instead.
+    #[doc(hidden)]
+    pub unsafe fn from_verified_contract_test<T: Any + Send>(
+        workspace: SourceWorkspaceId,
+        handle: &'a mut T,
+    ) -> Self {
+        Self::from_verified(workspace, handle)
+    }
+
+    #[must_use]
+    pub fn workspace(&self) -> &SourceWorkspaceId {
+        &self.workspace
+    }
+
+    pub fn downcast_mut<T: Any + Send>(&mut self) -> Option<&mut T> {
+        self.handle.downcast_mut::<T>()
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -53,6 +53,7 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         "tests/observability_contract.rs",
         "tests/provider_contracts.rs",
         "tests/provider_bounds.rs",
+        "tests/source_authority_contract.rs",
         "tests/scheduler_contract.rs",
     ] {
         assert!(files.contains(required), "missing product file: {required}");
@@ -93,6 +94,7 @@ fn workspace_metadata_preserves_package_lib_and_bin_identity() {
         ("local_execution_runtime".to_owned(), "test".to_owned()),
         ("local_process_runner".to_owned(), "test".to_owned()),
         ("observability_contract".to_owned(), "test".to_owned()),
+        ("source_authority_contract".to_owned(), "test".to_owned()),
         ("scheduler_contract".to_owned(), "test".to_owned()),
     ] {
         assert!(
@@ -377,6 +379,13 @@ fn provider_contracts_add_no_ledger_workspace_worker_protocol_adapter_or_fault_b
         read(&product.join("src/lib.rs")).contains("mod provider_value;"),
         "bounded provider helpers must remain product-private"
     );
+    assert!(
+        contracts.contains("pub struct SourceWorkspaceCapability<'a>")
+            && contracts.contains("pub(crate) fn from_verified")
+            && contracts.contains("pub unsafe fn from_verified_contract_test")
+            && !contracts.contains("pub mod fake"),
+        "safe callers must receive workspace capabilities only from verified product state"
+    );
     for forbidden in [
         "pub trait Provider",
         "PlatformProfile",
@@ -398,6 +407,8 @@ fn provider_contracts_add_no_ledger_workspace_worker_protocol_adapter_or_fault_b
         "openengine_cluster_protocol",
         "openengine_cluster_server",
         "Adapter",
+        "std::process",
+        "reqwest",
     ] {
         assert!(
             !contracts.contains(forbidden),

--- a/zeroshot-rust/tests/provider_bounds.rs
+++ b/zeroshot-rust/tests/provider_bounds.rs
@@ -53,24 +53,48 @@ fn repository() -> CanonicalRepository {
     )
     .unwrap()
 }
-
-fn merge_receipt() -> SourceMergeReceipt {
-    SourceMergeReceipt::new(
-        repository(),
-        (
-            SourceOperationId::new("merge-1").unwrap(),
-            SourceOperationFingerprint::new(digest('a')).unwrap(),
-        ),
-        (
-            SourceRevisionId::new("base-sha").unwrap(),
-            SourceRevisionId::new("head-sha").unwrap(),
-        ),
-        (
-            SourceRevisionId::new("merge-sha").unwrap(),
-            vec![SourcePublicUrl::new("https://github.com/pull/1").unwrap()],
-        ),
+fn source_review() -> SourceReviewIdentity {
+    SourceReviewIdentity::new(
+        SourceReviewId::new("review-1").unwrap(),
+        SourceBranchId::new("main").unwrap(),
+        SourceBranchId::new("feature").unwrap(),
     )
     .unwrap()
+}
+
+fn source_policy() -> SourceRequiredPolicy {
+    SourceRequiredPolicy::new(
+        SourcePolicyDigest::new(digest('9')).unwrap(),
+        BTreeMap::from([(
+            SourceCheckId::new("required/build").unwrap(),
+            SourceCheckConclusion::Satisfied,
+        )]),
+    )
+    .unwrap()
+}
+
+fn merge_request() -> SourceOperationRequest {
+    SourceOperationRequest::new(
+        repository(),
+        SourceCredentialHandleId::new("github-lease").unwrap(),
+        (
+            SourceWorkspaceId::new(digest('8')).unwrap(),
+            SourceOperationId::new("merge-1").unwrap(),
+        ),
+        SourceOperation::Merge {
+            review: source_review(),
+            expected_base: SourceRevisionId::new("base-sha").unwrap(),
+            expected_head: SourceRevisionId::new("head-sha").unwrap(),
+            checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+            policy: source_policy(),
+            integrated_revision: SourceRevisionId::new("merge-sha").unwrap(),
+        },
+    )
+    .unwrap()
+}
+
+fn merge_receipt() -> SourceMergeReceipt {
+    SourceMergeReceipt::new(merge_request(), SourceRevisionId::new("merge-sha").unwrap()).unwrap()
 }
 
 fn issue_reference() -> IssueProviderRef {
@@ -170,31 +194,30 @@ fn bounded_provider_failure_evidence_round_trips() {
 }
 
 #[test]
-fn applied_source_receipts_round_trip_and_cannot_claim_merge() {
-    let identity = (
-        SourceOperationId::new("branch-1").unwrap(),
-        SourceOperationFingerprint::new(digest('c')).unwrap(),
-    );
-    let receipt = SourceAppliedReceipt::new(
+fn operation_specific_source_receipts_round_trip_and_reject_cross_operation_use() {
+    let request = SourceOperationRequest::new(
         repository(),
-        identity.clone(),
-        SourceCapability::Branch,
+        SourceCredentialHandleId::new("github-lease").unwrap(),
         (
-            Some(SourceRevisionId::new("branch-sha").unwrap()),
-            vec![SourcePublicUrl::new("https://github.com/branch/1").unwrap()],
+            SourceWorkspaceId::new(digest('8')).unwrap(),
+            SourceOperationId::new("branch-1").unwrap(),
         ),
+        SourceOperation::Branch {
+            expected_parent: SourceRevisionId::new("branch-sha").unwrap(),
+            branch: SourceBranchId::new("feature").unwrap(),
+            pre_effect: SourceStateDigest::new(digest('c')).unwrap(),
+        },
+    )
+    .unwrap();
+    let receipt = SourceBranchReceipt::new(
+        request.clone(),
+        SourceRevisionId::new("branch-sha").unwrap(),
     )
     .unwrap();
     round_trip(&receipt);
-    round_trip(&SourceOperationReceipt::Applied(receipt));
+    round_trip(&SourceOperationReceipt::Branch(receipt));
     assert!(
-        SourceAppliedReceipt::new(
-            repository(),
-            identity,
-            SourceCapability::Merge,
-            (None, Vec::new()),
-        )
-        .is_err()
+        SourceMergeReceipt::new(request, SourceRevisionId::new("branch-sha").unwrap()).is_err()
     );
 }
 

--- a/zeroshot-rust/tests/provider_bounds/cases.rs
+++ b/zeroshot-rust/tests/provider_bounds/cases.rs
@@ -311,37 +311,64 @@ fn repository_requests_and_inspections_round_trip() {
 #[test]
 fn source_operations_inspections_and_receipts_round_trip() {
     let repository = repository();
+    let review = source_review();
+    let policy = source_policy();
     let operations = [
         SourceOperation::Branch {
-            expected_base: SourceRevisionId::new("base").unwrap(),
+            expected_parent: SourceRevisionId::new("base").unwrap(),
             branch: SourceBranchId::new("feature").unwrap(),
+            pre_effect: SourceStateDigest::new(digest('1')).unwrap(),
         },
         SourceOperation::Commit {
             expected_head: SourceRevisionId::new("head").unwrap(),
+            branch: SourceBranchId::new("feature").unwrap(),
+            message_digest: SourceMessageDigest::new(digest('2')).unwrap(),
             change_digest: SourceContentDigest::new(digest('d')).unwrap(),
+            pre_effect: SourceStateDigest::new(digest('3')).unwrap(),
         },
         SourceOperation::Push {
             expected_head: SourceRevisionId::new("head").unwrap(),
+            branch: SourceBranchId::new("feature").unwrap(),
+            remote: SourceRemoteId::new("origin").unwrap(),
+            expected_remote_head: Some(SourceRevisionId::new("base").unwrap()),
             revision: SourceRevisionId::new("next").unwrap(),
+            pre_effect: SourceStateDigest::new(digest('4')).unwrap(),
         },
         SourceOperation::PullRequest {
+            review: review.clone(),
             expected_base: SourceRevisionId::new("base").unwrap(),
             expected_head: SourceRevisionId::new("head").unwrap(),
+            checked_revision: SourceRevisionId::new("head").unwrap(),
+            policy: policy.clone(),
         },
         SourceOperation::Checks {
-            revision: SourceRevisionId::new("head").unwrap(),
+            review: review.clone(),
+            expected_base: SourceRevisionId::new("base").unwrap(),
+            expected_head: SourceRevisionId::new("head").unwrap(),
+            checked_revision: SourceRevisionId::new("head").unwrap(),
+            policy: policy.clone(),
         },
         SourceOperation::AutoMerge {
+            review: review.clone(),
             expected_base: SourceRevisionId::new("base").unwrap(),
             expected_head: SourceRevisionId::new("head").unwrap(),
+            checked_revision: SourceRevisionId::new("head").unwrap(),
+            policy: policy.clone(),
         },
         SourceOperation::MergeQueue {
+            review: review.clone(),
             expected_base: SourceRevisionId::new("base").unwrap(),
             expected_head: SourceRevisionId::new("head").unwrap(),
+            checked_revision: SourceRevisionId::new("head").unwrap(),
+            policy: policy.clone(),
         },
         SourceOperation::Merge {
+            review,
             expected_base: SourceRevisionId::new("base").unwrap(),
             expected_head: SourceRevisionId::new("head").unwrap(),
+            checked_revision: SourceRevisionId::new("head").unwrap(),
+            policy,
+            integrated_revision: SourceRevisionId::new("merge").unwrap(),
         },
     ];
     for (index, operation) in operations.into_iter().enumerate() {
@@ -350,8 +377,8 @@ fn source_operations_inspections_and_receipts_round_trip() {
                 repository.clone(),
                 SourceCredentialHandleId::new("github-lease").unwrap(),
                 (
+                    SourceWorkspaceId::new(digest('8')).unwrap(),
                     SourceOperationId::new(format!("operation-{index}")).unwrap(),
-                    SourceOperationFingerprint::new(digest('e')).unwrap(),
                 ),
                 operation,
             )

--- a/zeroshot-rust/tests/provider_contracts.rs
+++ b/zeroshot-rust/tests/provider_contracts.rs
@@ -9,6 +9,53 @@ use zeroshot_engine::source_code_provider::*;
 fn digest(character: char) -> String {
     std::iter::repeat_n(character, 64).collect()
 }
+fn source_workspace(character: char) -> SourceWorkspaceId {
+    SourceWorkspaceId::new(digest(character)).unwrap()
+}
+
+fn review() -> SourceReviewIdentity {
+    SourceReviewIdentity::new(
+        SourceReviewId::new("review-7").unwrap(),
+        SourceBranchId::new("main").unwrap(),
+        SourceBranchId::new("delivery/7").unwrap(),
+    )
+    .unwrap()
+}
+
+fn satisfied_policy() -> SourceRequiredPolicy {
+    SourceRequiredPolicy::new(
+        SourcePolicyDigest::new(digest('9')).unwrap(),
+        BTreeMap::from([(
+            SourceCheckId::new("required/build").unwrap(),
+            SourceCheckConclusion::Satisfied,
+        )]),
+    )
+    .unwrap()
+}
+
+struct ContractWorkspace {
+    identity: SourceWorkspaceId,
+    runtime_marker: (),
+}
+
+impl ContractWorkspace {
+    fn capability(&mut self) -> SourceWorkspaceCapability<'_> {
+        // SAFETY: this test-only marker is the runtime handle for exactly `identity`.
+        unsafe {
+            SourceWorkspaceCapability::from_verified_contract_test(
+                self.identity.clone(),
+                &mut self.runtime_marker,
+            )
+        }
+    }
+}
+
+fn verified_workspace(request: &SourceOperationRequest) -> ContractWorkspace {
+    ContractWorkspace {
+        identity: request.workspace().clone(),
+        runtime_marker: (),
+    }
+}
 
 fn source_ref(id: &str, version: u32) -> SourceProviderRef {
     SourceProviderRef::new(SourceProviderId::new(id).unwrap(), version).unwrap()
@@ -52,12 +99,16 @@ fn source_operation(repository: CanonicalRepository) -> SourceOperationRequest {
         repository,
         SourceCredentialHandleId::new("source-lease-7").unwrap(),
         (
+            source_workspace('7'),
             SourceOperationId::new("merge-7").unwrap(),
-            SourceOperationFingerprint::new(digest('a')).unwrap(),
         ),
         SourceOperation::Merge {
+            review: review(),
             expected_base: SourceRevisionId::new("base-sha").unwrap(),
             expected_head: SourceRevisionId::new("head-sha").unwrap(),
+            checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+            policy: satisfied_policy(),
+            integrated_revision: SourceRevisionId::new("integrated-sha").unwrap(),
         },
     )
     .unwrap()
@@ -94,25 +145,13 @@ impl FakeSourceProvider {
 
     fn merge_receipt(&self, request: &SourceOperationRequest) -> SourceMergeReceipt {
         let SourceOperation::Merge {
-            expected_base,
-            expected_head,
+            integrated_revision,
+            ..
         } = request.operation()
         else {
             panic!("fake expected merge request")
         };
-        SourceMergeReceipt::new(
-            request.repository().clone(),
-            (
-                request.operation_id().clone(),
-                request.fingerprint().clone(),
-            ),
-            (expected_base.clone(), expected_head.clone()),
-            (
-                SourceRevisionId::new("integrated-sha").unwrap(),
-                vec![SourcePublicUrl::new("https://github.com/pull/7").unwrap()],
-            ),
-        )
-        .unwrap()
+        SourceMergeReceipt::new(request.clone(), integrated_revision.clone()).unwrap()
     }
 }
 
@@ -175,12 +214,18 @@ impl SourceCodeProvider for FakeSourceProvider {
     async fn operate(
         &self,
         request: &SourceOperationRequest,
+        _workspace: SourceWorkspaceCapability<'_>,
     ) -> Result<SourceOperationReceipt, SourceProviderFailure> {
         self.operation_calls.fetch_add(1, Ordering::SeqCst);
-        if let Some(receipt) = self.operation_result.lock().unwrap().clone() {
-            return Ok(receipt);
-        }
-        Ok(SourceOperationReceipt::Merge(self.merge_receipt(request)))
+        let receipt = self
+            .operation_result
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| SourceOperationReceipt::Merge(self.merge_receipt(request)));
+        *self.inspection.lock().unwrap() =
+            SourceOperationInspection::Applied(Box::new(receipt.clone()));
+        Ok(receipt)
     }
 }
 
@@ -212,19 +257,8 @@ fn issue_descriptor(
 }
 
 fn merge_receipt_for_issue() -> SourceMergeReceipt {
-    SourceMergeReceipt::new(
-        canonical_repository(source_ref("source.github", 1)),
-        (
-            SourceOperationId::new("merge-for-close").unwrap(),
-            SourceOperationFingerprint::new(digest('e')).unwrap(),
-        ),
-        (
-            SourceRevisionId::new("base-sha").unwrap(),
-            SourceRevisionId::new("head-sha").unwrap(),
-        ),
-        (SourceRevisionId::new("integrated-sha").unwrap(), Vec::new()),
-    )
-    .unwrap()
+    let request = source_operation(canonical_repository(source_ref("source.github", 1)));
+    SourceMergeReceipt::new(request, SourceRevisionId::new("integrated-sha").unwrap()).unwrap()
 }
 
 fn resolved_linear_issue(reference: IssueProviderRef) -> ResolvedIssue {

--- a/zeroshot-rust/tests/provider_contracts/cases.rs
+++ b/zeroshot-rust/tests/provider_contracts/cases.rs
@@ -111,8 +111,10 @@ async fn unsupported_source_capability_is_rejected_before_fake_invocation() {
     ));
     let mut registry = SourceCodeProviderRegistry::new();
     registry.register(provider.clone()).unwrap();
+    let request = source_operation(canonical_repository(reference.clone()));
+    let mut workspace = verified_workspace(&request);
     let error = registry
-        .operate(&source_operation(canonical_repository(reference.clone())))
+        .operate(&request, workspace.capability())
         .await
         .unwrap_err();
     assert_eq!(
@@ -153,7 +155,7 @@ async fn unsupported_issue_capability_is_rejected_before_fake_invocation() {
 }
 
 #[tokio::test]
-async fn inspect_before_repeat_only_invokes_with_positive_or_native_evidence() {
+async fn inspect_before_repeat_invokes_only_from_proven_unobserved_state() {
     let reference = source_ref("source.github", 1);
     let provider = Arc::new(FakeSourceProvider::new(
         source_descriptor(
@@ -166,12 +168,19 @@ async fn inspect_before_repeat_only_invokes_with_positive_or_native_evidence() {
     let mut registry = SourceCodeProviderRegistry::new();
     registry.register(provider.clone()).unwrap();
     let request = source_operation(canonical_repository(reference));
+    let mut workspace = verified_workspace(&request);
 
     let applied = SourceOperationReceipt::Merge(provider.merge_receipt(&request));
     provider.set_inspection(SourceOperationInspection::Applied(Box::new(
         applied.clone(),
     )));
-    assert_eq!(registry.operate(&request).await.unwrap(), applied);
+    assert_eq!(
+        registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap(),
+        applied
+    );
     assert_eq!(provider.operation_calls.load(Ordering::SeqCst), 0);
 
     for inspection in [
@@ -185,7 +194,10 @@ async fn inspect_before_repeat_only_invokes_with_positive_or_native_evidence() {
     ] {
         provider.set_inspection(inspection.clone());
         assert_eq!(
-            registry.operate(&request).await.unwrap_err(),
+            registry
+                .operate(&request, workspace.capability())
+                .await
+                .unwrap_err(),
             SourceCallError::UnsafeToInvoke { inspection }
         );
     }
@@ -193,7 +205,10 @@ async fn inspect_before_repeat_only_invokes_with_positive_or_native_evidence() {
 
     provider.set_inspection(SourceOperationInspection::Unobserved);
     assert!(matches!(
-        registry.operate(&request).await.unwrap(),
+        registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap(),
         SourceOperationReceipt::Merge(_)
     ));
     assert_eq!(provider.operation_calls.load(Ordering::SeqCst), 1);
@@ -210,16 +225,23 @@ async fn inspect_before_repeat_only_invokes_with_positive_or_native_evidence() {
     let mut native_registry = SourceCodeProviderRegistry::new();
     native_registry.register(native.clone()).unwrap();
     let native_request = source_operation(canonical_repository(native_reference));
+    let mut native_workspace = verified_workspace(&native_request);
     for inspection in [
         SourceOperationInspection::Pending,
         SourceOperationInspection::Indeterminate {
             evidence: SourceFailureMessage::new("connection ended after submission").unwrap(),
         },
     ] {
-        native.set_inspection(inspection);
-        native_registry.operate(&native_request).await.unwrap();
+        native.set_inspection(inspection.clone());
+        assert_eq!(
+            native_registry
+                .operate(&native_request, native_workspace.capability())
+                .await
+                .unwrap_err(),
+            SourceCallError::UnsafeToInvoke { inspection }
+        );
     }
-    assert_eq!(native.operation_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(native.operation_calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]
@@ -292,12 +314,13 @@ async fn applied_inspections_must_match_the_authoritative_request() {
         repository,
         SourceCredentialHandleId::new("source-lease-7").unwrap(),
         (
+            source_request.workspace().clone(),
             SourceOperationId::new("different-operation").unwrap(),
-            source_request.fingerprint().clone(),
         ),
         source_request.operation().clone(),
     )
     .unwrap();
+    let mut source_workspace = verified_workspace(&source_request);
     let source = Arc::new(FakeSourceProvider::new(
         source_descriptor(source_reference, [SourceCapability::Merge], []),
         SourceOperationInspection::Unobserved,
@@ -308,7 +331,9 @@ async fn applied_inspections_must_match_the_authoritative_request() {
     let mut sources = SourceCodeProviderRegistry::new();
     sources.register(source.clone()).unwrap();
     assert!(matches!(
-        sources.operate(&source_request).await,
+        sources
+            .operate(&source_request, source_workspace.capability())
+            .await,
         Err(SourceCallError::InvalidEvidence { .. })
     ));
     assert_eq!(source.operation_calls.load(Ordering::SeqCst), 0);
@@ -362,13 +387,15 @@ async fn linear_issue_close_is_gated_by_github_merge_receipt() {
     )
     .unwrap();
     let repository = sources.identify_repository(&identify).await.unwrap();
+    let request = source_operation(repository);
+    let mut workspace = verified_workspace(&request);
     let merge = match sources
-        .operate(&source_operation(repository))
+        .operate(&request, workspace.capability())
         .await
         .unwrap()
     {
         SourceOperationReceipt::Merge(receipt) => receipt,
-        SourceOperationReceipt::Applied(_) => panic!("merge must return a typed merge receipt"),
+        other => panic!("merge must return a typed merge receipt, got {other:?}"),
     };
 
     let issue_reference = issue_ref("issue.linear", 1);
@@ -410,7 +437,7 @@ async fn linear_issue_close_is_gated_by_github_merge_receipt() {
     let close_receipt = issues.close(&close_request).await.unwrap();
 
     assert_eq!(close_receipt.source_merge(), &merge);
-    assert_eq!(merge.repository().provider(), &source_reference);
+    assert_eq!(merge.request().repository().provider(), &source_reference);
     assert_eq!(close_receipt.issue().provider(), &issue_reference);
     assert_eq!(source.identify_calls.load(Ordering::SeqCst), 1);
     assert_eq!(source.operation_calls.load(Ordering::SeqCst), 1);

--- a/zeroshot-rust/tests/provider_contracts/merge_evidence.rs
+++ b/zeroshot-rust/tests/provider_contracts/merge_evidence.rs
@@ -5,17 +5,32 @@ fn mismatched_receipt(
     receipt_base: SourceRevisionId,
     receipt_head: SourceRevisionId,
 ) -> SourceOperationReceipt {
+    let SourceOperation::Merge {
+        review,
+        checked_revision,
+        policy,
+        integrated_revision,
+        ..
+    } = request.operation()
+    else {
+        panic!("test request must be a merge")
+    };
+    let mismatched_request = SourceOperationRequest::new(
+        request.repository().clone(),
+        request.credential_handle().clone(),
+        (request.workspace().clone(), request.operation_id().clone()),
+        SourceOperation::Merge {
+            review: review.clone(),
+            expected_base: receipt_base,
+            expected_head: receipt_head,
+            checked_revision: checked_revision.clone(),
+            policy: policy.clone(),
+            integrated_revision: integrated_revision.clone(),
+        },
+    )
+    .unwrap();
     SourceOperationReceipt::Merge(
-        SourceMergeReceipt::new(
-            request.repository().clone(),
-            (
-                request.operation_id().clone(),
-                request.fingerprint().clone(),
-            ),
-            (receipt_base, receipt_head),
-            (SourceRevisionId::new("integrated-sha").unwrap(), Vec::new()),
-        )
-        .unwrap(),
+        SourceMergeReceipt::new(mismatched_request, integrated_revision.clone()).unwrap(),
     )
 }
 
@@ -31,9 +46,12 @@ async fn assert_mismatch_rejected(
     ));
     let mut inspection_registry = SourceCodeProviderRegistry::new();
     inspection_registry.register(inspected.clone()).unwrap();
+    let mut workspace = verified_workspace(request);
     assert!(
         matches!(
-            inspection_registry.operate(request).await,
+            inspection_registry
+                .operate(request, workspace.capability())
+                .await,
             Err(SourceCallError::InvalidEvidence { .. })
         ),
         "applied inspection with mismatched {field} was accepted"
@@ -49,8 +67,10 @@ async fn assert_mismatch_rejected(
     invocation_registry.register(invoked.clone()).unwrap();
     assert!(
         matches!(
-            invocation_registry.operate(request).await,
-            Err(SourceCallError::InvalidEvidence { .. })
+            invocation_registry
+                .operate(request, workspace.capability())
+                .await,
+            Err(SourceCallError::PostEffectInvalidEvidence { .. })
         ),
         "invocation result with mismatched {field} was accepted"
     );
@@ -64,6 +84,7 @@ async fn merge_evidence_must_match_requested_base_and_head() {
     let SourceOperation::Merge {
         expected_base,
         expected_head,
+        ..
     } = request.operation()
     else {
         panic!("test request must be a merge")

--- a/zeroshot-rust/tests/source_authority_contract.rs
+++ b/zeroshot-rust/tests/source_authority_contract.rs
@@ -1,0 +1,886 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use zeroshot_engine::source_code_provider::*;
+
+fn digest(character: char) -> String {
+    std::iter::repeat_n(character, 64).collect()
+}
+
+struct ContractWorkspace {
+    identity: SourceWorkspaceId,
+    runtime_marker: (),
+}
+
+impl ContractWorkspace {
+    fn new(identity: SourceWorkspaceId) -> Self {
+        Self {
+            identity,
+            runtime_marker: (),
+        }
+    }
+
+    fn capability(&mut self) -> SourceWorkspaceCapability<'_> {
+        // SAFETY: this test-only marker is the runtime handle for exactly `identity`.
+        unsafe {
+            SourceWorkspaceCapability::from_verified_contract_test(
+                self.identity.clone(),
+                &mut self.runtime_marker,
+            )
+        }
+    }
+}
+
+fn repository() -> CanonicalRepository {
+    CanonicalRepository::new(
+        SourceProviderRef::new(SourceProviderId::new("source.fake").unwrap(), 1).unwrap(),
+        SourceProfileId::new("production").unwrap(),
+        SourceAccountId::new("authority-tests").unwrap(),
+        SourceRepositoryId::new("open-engine/zeroshot").unwrap(),
+    )
+    .unwrap()
+}
+
+fn review(name: &str) -> SourceReviewIdentity {
+    SourceReviewIdentity::new(
+        SourceReviewId::new(name).unwrap(),
+        SourceBranchId::new("main").unwrap(),
+        SourceBranchId::new("delivery/758").unwrap(),
+    )
+    .unwrap()
+}
+
+fn policy(digest_character: char, conclusion: SourceCheckConclusion) -> SourceRequiredPolicy {
+    SourceRequiredPolicy::new(
+        SourcePolicyDigest::new(digest(digest_character)).unwrap(),
+        BTreeMap::from([(SourceCheckId::new("required/build").unwrap(), conclusion)]),
+    )
+    .unwrap()
+}
+
+fn request(operation_id: &str, operation: SourceOperation) -> SourceOperationRequest {
+    SourceOperationRequest::new(
+        repository(),
+        SourceCredentialHandleId::new("credential-handle").unwrap(),
+        (
+            SourceWorkspaceId::new(digest('1')).unwrap(),
+            SourceOperationId::new(operation_id).unwrap(),
+        ),
+        operation,
+    )
+    .unwrap()
+}
+
+struct MergeRequestInput {
+    review: SourceReviewIdentity,
+    base: &'static str,
+    head: &'static str,
+    checked: &'static str,
+    policy: SourceRequiredPolicy,
+    integrated: &'static str,
+}
+
+impl MergeRequestInput {
+    fn exact() -> Self {
+        Self {
+            review: review("review-758"),
+            base: "base-sha",
+            head: "head-sha",
+            checked: "head-sha",
+            policy: policy('2', SourceCheckConclusion::Satisfied),
+            integrated: "integrated-sha",
+        }
+    }
+}
+
+fn merge_request(input: MergeRequestInput) -> SourceOperationRequest {
+    request(
+        "merge-758",
+        SourceOperation::Merge {
+            review: input.review,
+            expected_base: SourceRevisionId::new(input.base).unwrap(),
+            expected_head: SourceRevisionId::new(input.head).unwrap(),
+            checked_revision: SourceRevisionId::new(input.checked).unwrap(),
+            policy: input.policy,
+            integrated_revision: SourceRevisionId::new(input.integrated).unwrap(),
+        },
+    )
+}
+
+fn all_requests() -> Vec<SourceOperationRequest> {
+    let exact_review = review("review-758");
+    let exact_policy = policy('2', SourceCheckConclusion::Satisfied);
+    vec![
+        request(
+            "branch-758",
+            SourceOperation::Branch {
+                expected_parent: SourceRevisionId::new("parent-sha").unwrap(),
+                branch: SourceBranchId::new("delivery/758").unwrap(),
+                pre_effect: SourceStateDigest::new(digest('3')).unwrap(),
+            },
+        ),
+        request(
+            "commit-758",
+            SourceOperation::Commit {
+                expected_head: SourceRevisionId::new("parent-sha").unwrap(),
+                branch: SourceBranchId::new("delivery/758").unwrap(),
+                message_digest: SourceMessageDigest::new(digest('4')).unwrap(),
+                change_digest: SourceContentDigest::new(digest('5')).unwrap(),
+                pre_effect: SourceStateDigest::new(digest('6')).unwrap(),
+            },
+        ),
+        request(
+            "push-758",
+            SourceOperation::Push {
+                expected_head: SourceRevisionId::new("commit-sha").unwrap(),
+                branch: SourceBranchId::new("delivery/758").unwrap(),
+                remote: SourceRemoteId::new("origin").unwrap(),
+                expected_remote_head: Some(SourceRevisionId::new("parent-sha").unwrap()),
+                revision: SourceRevisionId::new("commit-sha").unwrap(),
+                pre_effect: SourceStateDigest::new(digest('7')).unwrap(),
+            },
+        ),
+        request(
+            "pull-request-758",
+            SourceOperation::PullRequest {
+                review: exact_review.clone(),
+                expected_base: SourceRevisionId::new("base-sha").unwrap(),
+                expected_head: SourceRevisionId::new("head-sha").unwrap(),
+                checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+                policy: exact_policy.clone(),
+            },
+        ),
+        request(
+            "checks-758",
+            SourceOperation::Checks {
+                review: exact_review.clone(),
+                expected_base: SourceRevisionId::new("base-sha").unwrap(),
+                expected_head: SourceRevisionId::new("head-sha").unwrap(),
+                checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+                policy: exact_policy.clone(),
+            },
+        ),
+        request(
+            "auto-merge-758",
+            SourceOperation::AutoMerge {
+                review: exact_review.clone(),
+                expected_base: SourceRevisionId::new("base-sha").unwrap(),
+                expected_head: SourceRevisionId::new("head-sha").unwrap(),
+                checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+                policy: exact_policy.clone(),
+            },
+        ),
+        request(
+            "merge-queue-758",
+            SourceOperation::MergeQueue {
+                review: exact_review.clone(),
+                expected_base: SourceRevisionId::new("base-sha").unwrap(),
+                expected_head: SourceRevisionId::new("head-sha").unwrap(),
+                checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+                policy: exact_policy.clone(),
+            },
+        ),
+        merge_request(MergeRequestInput {
+            review: exact_review,
+            policy: exact_policy,
+            ..MergeRequestInput::exact()
+        }),
+    ]
+}
+
+fn receipt(request: &SourceOperationRequest) -> SourceOperationReceipt {
+    match request.operation() {
+        SourceOperation::Branch {
+            expected_parent, ..
+        } => SourceOperationReceipt::Branch(
+            SourceBranchReceipt::new(request.clone(), expected_parent.clone()).unwrap(),
+        ),
+        SourceOperation::Commit { .. } => SourceOperationReceipt::Commit(
+            SourceCommitReceipt::new(
+                request.clone(),
+                SourceRevisionId::new("committed-sha").unwrap(),
+            )
+            .unwrap(),
+        ),
+        SourceOperation::Push { revision, .. } => SourceOperationReceipt::Push(
+            SourcePushReceipt::new(request.clone(), revision.clone()).unwrap(),
+        ),
+        SourceOperation::PullRequest { review, .. } => SourceOperationReceipt::PullRequest(
+            SourcePullRequestReceipt::new(request.clone(), review.clone()).unwrap(),
+        ),
+        SourceOperation::Checks { policy, .. } => SourceOperationReceipt::Checks(
+            SourceChecksReceipt::new(request.clone(), policy.clone()).unwrap(),
+        ),
+        SourceOperation::AutoMerge { review, .. } => SourceOperationReceipt::AutoMerge(
+            SourceAutoMergeReceipt::new(request.clone(), review.clone()).unwrap(),
+        ),
+        SourceOperation::MergeQueue { review, .. } => SourceOperationReceipt::MergeQueue(
+            SourceMergeQueueReceipt::new(request.clone(), review.clone()).unwrap(),
+        ),
+        SourceOperation::Merge {
+            integrated_revision,
+            ..
+        } => SourceOperationReceipt::Merge(
+            SourceMergeReceipt::new(request.clone(), integrated_revision.clone()).unwrap(),
+        ),
+    }
+}
+
+fn descriptor() -> SourceProviderDescriptor {
+    let capabilities = BTreeSet::from([
+        SourceCapability::Branch,
+        SourceCapability::Commit,
+        SourceCapability::Push,
+        SourceCapability::PullRequest,
+        SourceCapability::Checks,
+        SourceCapability::AutoMerge,
+        SourceCapability::MergeQueue,
+        SourceCapability::Merge,
+    ]);
+    SourceProviderDescriptor::new(
+        repository().provider().clone(),
+        BTreeMap::from([(
+            SourceProfileId::new("production").unwrap(),
+            SourceProfileDescriptor::new(capabilities, BTreeSet::new()).unwrap(),
+        )]),
+    )
+    .unwrap()
+}
+
+struct AuthorityFake {
+    descriptor: SourceProviderDescriptor,
+    inspections: Mutex<VecDeque<Result<SourceOperationInspection, SourceProviderFailure>>>,
+    performed: Result<SourceOperationReceipt, SourceProviderFailure>,
+    inspection_calls: AtomicUsize,
+    calls: AtomicUsize,
+}
+
+impl AuthorityFake {
+    fn new(
+        inspections: Vec<SourceOperationInspection>,
+        performed: Result<SourceOperationReceipt, SourceProviderFailure>,
+    ) -> Self {
+        Self::with_inspection_results(inspections.into_iter().map(Ok).collect(), performed)
+    }
+
+    fn with_inspection_results(
+        inspections: Vec<Result<SourceOperationInspection, SourceProviderFailure>>,
+        performed: Result<SourceOperationReceipt, SourceProviderFailure>,
+    ) -> Self {
+        Self {
+            descriptor: descriptor(),
+            inspections: Mutex::new(inspections.into()),
+            performed,
+            inspection_calls: AtomicUsize::new(0),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl SourceCodeProvider for AuthorityFake {
+    fn descriptor(&self) -> &SourceProviderDescriptor {
+        &self.descriptor
+    }
+
+    async fn identify_repository(
+        &self,
+        _request: &SourceIdentifyRepositoryRequest,
+    ) -> Result<CanonicalRepository, SourceProviderFailure> {
+        unreachable!("authority fake has no repository adapter")
+    }
+
+    async fn inspect_repository(
+        &self,
+        _request: &SourceInspectRepositoryRequest,
+    ) -> Result<SourceRepositoryInspection, SourceProviderFailure> {
+        unreachable!("authority fake has no repository adapter")
+    }
+
+    async fn materialize(
+        &self,
+        _request: &SourceMaterializeRequest,
+        _destination: SourceMaterializationDestination<'_>,
+    ) -> Result<SourceMaterializationReceipt, SourceProviderFailure> {
+        unreachable!("authority fake has no source delivery")
+    }
+
+    async fn inspect_operation(
+        &self,
+        _request: &SourceOperationRequest,
+    ) -> Result<SourceOperationInspection, SourceProviderFailure> {
+        self.inspection_calls.fetch_add(1, Ordering::SeqCst);
+        self.inspections
+            .lock()
+            .await
+            .pop_front()
+            .expect("scripted authoritative inspection")
+    }
+
+    async fn operate(
+        &self,
+        _request: &SourceOperationRequest,
+        _workspace: SourceWorkspaceCapability<'_>,
+    ) -> Result<SourceOperationReceipt, SourceProviderFailure> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.performed.clone()
+    }
+}
+
+async fn registry_with(provider: Arc<AuthorityFake>) -> SourceCodeProviderRegistry {
+    let mut registry = SourceCodeProviderRegistry::new();
+    registry.register(provider).unwrap();
+    registry
+}
+
+#[test]
+fn every_operation_has_an_exact_closed_receipt() {
+    for request in all_requests() {
+        let receipt = receipt(&request);
+        assert_eq!(receipt.capability(), request.operation().capability());
+        assert!(receipt.matches_request(&request));
+        let encoded = serde_json::to_string(&receipt).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SourceOperationReceipt>(&encoded).unwrap(),
+            receipt
+        );
+    }
+}
+
+#[tokio::test]
+async fn contract_fake_proves_every_mutating_capability_independently() {
+    for request in all_requests() {
+        let expected = receipt(&request);
+        let provider = Arc::new(AuthorityFake::new(
+            vec![
+                SourceOperationInspection::Unobserved,
+                SourceOperationInspection::Applied(Box::new(expected.clone())),
+            ],
+            Ok(expected.clone()),
+        ));
+        let registry = registry_with(provider.clone()).await;
+        let mut workspace = ContractWorkspace::new(request.workspace().clone());
+        assert_eq!(
+            registry
+                .operate(&request, workspace.capability())
+                .await
+                .unwrap(),
+            expected
+        );
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn cross_operation_receipts_are_rejected() {
+    let requests = all_requests();
+    let branch = requests
+        .iter()
+        .find(|request| request.operation().capability() == SourceCapability::Branch)
+        .unwrap();
+    let commit = requests
+        .iter()
+        .find(|request| request.operation().capability() == SourceCapability::Commit)
+        .unwrap();
+    assert!(
+        SourceBranchReceipt::new(commit.clone(), SourceRevisionId::new("parent-sha").unwrap())
+            .is_err()
+    );
+    assert!(!receipt(branch).matches_request(commit));
+}
+
+#[test]
+fn typed_receipts_reject_same_operation_contradictions() {
+    let requests = all_requests();
+    let find = |capability| {
+        requests
+            .iter()
+            .find(|request| request.operation().capability() == capability)
+            .unwrap()
+            .clone()
+    };
+
+    assert!(
+        SourceBranchReceipt::new(
+            find(SourceCapability::Branch),
+            SourceRevisionId::new("wrong-parent").unwrap(),
+        )
+        .is_err()
+    );
+    assert!(
+        SourcePushReceipt::new(
+            find(SourceCapability::Push),
+            SourceRevisionId::new("wrong-push").unwrap(),
+        )
+        .is_err()
+    );
+    assert!(
+        SourcePullRequestReceipt::new(find(SourceCapability::PullRequest), review("review-other"),)
+            .is_err()
+    );
+    assert!(
+        SourceChecksReceipt::new(
+            find(SourceCapability::Checks),
+            policy('3', SourceCheckConclusion::Satisfied),
+        )
+        .is_err()
+    );
+    assert!(
+        SourceAutoMergeReceipt::new(find(SourceCapability::AutoMerge), review("review-other"),)
+            .is_err()
+    );
+    assert!(
+        SourceMergeQueueReceipt::new(find(SourceCapability::MergeQueue), review("review-other"),)
+            .is_err()
+    );
+    assert!(
+        SourceMergeReceipt::new(
+            find(SourceCapability::Merge),
+            SourceRevisionId::new("wrong-integrated").unwrap(),
+        )
+        .is_err()
+    );
+
+    let failed_merge = merge_request(MergeRequestInput {
+        policy: policy('2', SourceCheckConclusion::Failed),
+        ..MergeRequestInput::exact()
+    });
+    assert!(
+        SourceMergeReceipt::new(
+            failed_merge,
+            SourceRevisionId::new("integrated-sha").unwrap(),
+        )
+        .is_err()
+    );
+}
+
+#[tokio::test]
+async fn workspace_mismatch_and_cross_workspace_replay_fail_before_effect() {
+    let request = all_requests().pop().unwrap();
+    let expected = receipt(&request);
+    let provider = Arc::new(AuthorityFake::new(
+        vec![SourceOperationInspection::Unobserved],
+        Ok(expected),
+    ));
+    let registry = registry_with(provider.clone()).await;
+    let mut wrong = ContractWorkspace::new(SourceWorkspaceId::new(digest('8')).unwrap());
+    assert_eq!(
+        registry
+            .operate(&request, wrong.capability())
+            .await
+            .unwrap_err(),
+        SourceCallError::WorkspaceMismatch
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+
+    let replay_request = SourceOperationRequest::new(
+        request.repository().clone(),
+        request.credential_handle().clone(),
+        (
+            SourceWorkspaceId::new(digest('8')).unwrap(),
+            request.operation_id().clone(),
+        ),
+        request.operation().clone(),
+    )
+    .unwrap();
+    let mut original = ContractWorkspace::new(request.workspace().clone());
+    assert_eq!(
+        registry
+            .operate(&replay_request, original.capability())
+            .await
+            .unwrap_err(),
+        SourceCallError::WorkspaceMismatch
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn review_base_head_policy_conclusion_and_integrated_revision_are_exact() {
+    let exact = merge_request(MergeRequestInput::exact());
+    let receipt = receipt(&exact);
+    for mismatch in [
+        merge_request(MergeRequestInput {
+            review: review("review-other"),
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            base: "base-other",
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            head: "head-other",
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            checked: "checked-other",
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            policy: policy('3', SourceCheckConclusion::Satisfied),
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            policy: policy('2', SourceCheckConclusion::Failed),
+            ..MergeRequestInput::exact()
+        }),
+        merge_request(MergeRequestInput {
+            integrated: "integrated-other",
+            ..MergeRequestInput::exact()
+        }),
+    ] {
+        assert!(!receipt.matches_request(&mismatch));
+    }
+}
+
+fn large_auto_merge_receipt(
+    emoji_characters: usize,
+    tail_characters: usize,
+) -> Option<SourceAutoMergeReceipt> {
+    let mut conclusions = BTreeMap::new();
+    for index in 0..63 {
+        conclusions.insert(
+            SourceCheckId::new(format!("{index:02}{}", "😀".repeat(emoji_characters))).ok()?,
+            SourceCheckConclusion::Satisfied,
+        );
+    }
+    conclusions.insert(
+        SourceCheckId::new(format!("zz{}", "x".repeat(tail_characters))).ok()?,
+        SourceCheckConclusion::Satisfied,
+    );
+    let review = review("review-size-bound");
+    let policy =
+        SourceRequiredPolicy::new(SourcePolicyDigest::new(digest('6')).ok()?, conclusions).ok()?;
+    let request = SourceOperationRequest::new(
+        repository(),
+        SourceCredentialHandleId::new("credential-handle").ok()?,
+        (
+            SourceWorkspaceId::new(digest('1')).ok()?,
+            SourceOperationId::new("auto-merge-size-bound").ok()?,
+        ),
+        SourceOperation::AutoMerge {
+            review: review.clone(),
+            expected_base: SourceRevisionId::new("base-sha").ok()?,
+            expected_head: SourceRevisionId::new("head-sha").ok()?,
+            checked_revision: SourceRevisionId::new("head-sha").ok()?,
+            policy,
+        },
+    )
+    .ok()?;
+    SourceAutoMergeReceipt::new(request, review).ok()
+}
+
+fn operation_envelope_value(
+    receipt: &SourceAutoMergeReceipt,
+    inspection: bool,
+) -> serde_json::Value {
+    let receipt = serde_json::json!({
+        "kind": "auto_merge",
+        "receipt": receipt,
+    });
+    if inspection {
+        serde_json::json!({
+            "state": "applied",
+            "evidence": receipt,
+        })
+    } else {
+        receipt
+    }
+}
+
+fn receipt_at_envelope_size(target: usize, inspection: bool) -> SourceAutoMergeReceipt {
+    for emoji_characters in 200..=254 {
+        let Some(baseline) = large_auto_merge_receipt(emoji_characters, 0) else {
+            continue;
+        };
+        let baseline_size = serde_json::to_vec(&operation_envelope_value(&baseline, inspection))
+            .unwrap()
+            .len();
+        let Some(tail_characters) = target.checked_sub(baseline_size) else {
+            continue;
+        };
+        if tail_characters > 254 {
+            continue;
+        }
+        let candidate = large_auto_merge_receipt(emoji_characters, tail_characters).unwrap();
+        if serde_json::to_vec(&operation_envelope_value(&candidate, inspection))
+            .unwrap()
+            .len()
+            == target
+        {
+            return candidate;
+        }
+    }
+    panic!("could not construct a valid {target}-byte operation envelope")
+}
+
+#[test]
+fn complete_receipt_and_inspection_envelopes_enforce_the_total_bound() {
+    for target in [65_535, 65_536, 65_537] {
+        let receipt = receipt_at_envelope_size(target, false);
+        let raw = operation_envelope_value(&receipt, false);
+        let outer = SourceOperationReceipt::AutoMerge(receipt);
+        if target <= 65_536 {
+            assert_eq!(serde_json::to_vec(&outer).unwrap().len(), target);
+            assert!(serde_json::from_value::<SourceOperationReceipt>(raw).is_ok());
+        } else {
+            assert!(serde_json::to_vec(&outer).is_err());
+            assert!(serde_json::from_value::<SourceOperationReceipt>(raw).is_err());
+        }
+
+        let receipt = receipt_at_envelope_size(target, true);
+        let raw = operation_envelope_value(&receipt, true);
+        let outer = SourceOperationInspection::Applied(Box::new(
+            SourceOperationReceipt::AutoMerge(receipt),
+        ));
+        if target <= 65_536 {
+            assert_eq!(serde_json::to_vec(&outer).unwrap().len(), target);
+            assert!(serde_json::from_value::<SourceOperationInspection>(raw).is_ok());
+        } else {
+            assert!(serde_json::to_vec(&outer).is_err());
+            assert!(serde_json::from_value::<SourceOperationInspection>(raw).is_err());
+        }
+    }
+}
+
+#[test]
+fn canonical_intent_is_stable_bounded_and_strict() {
+    let first_policy = SourceRequiredPolicy::new(
+        SourcePolicyDigest::new(digest('2')).unwrap(),
+        BTreeMap::from([
+            (
+                SourceCheckId::new("required/test").unwrap(),
+                SourceCheckConclusion::Satisfied,
+            ),
+            (
+                SourceCheckId::new("required/build").unwrap(),
+                SourceCheckConclusion::Satisfied,
+            ),
+        ]),
+    )
+    .unwrap();
+    let mut reversed = BTreeMap::new();
+    reversed.insert(
+        SourceCheckId::new("required/build").unwrap(),
+        SourceCheckConclusion::Satisfied,
+    );
+    reversed.insert(
+        SourceCheckId::new("required/test").unwrap(),
+        SourceCheckConclusion::Satisfied,
+    );
+    let second_policy =
+        SourceRequiredPolicy::new(SourcePolicyDigest::new(digest('2')).unwrap(), reversed).unwrap();
+    let first = merge_request(MergeRequestInput {
+        policy: first_policy,
+        ..MergeRequestInput::exact()
+    });
+    let second = merge_request(MergeRequestInput {
+        policy: second_policy,
+        ..MergeRequestInput::exact()
+    });
+    assert_eq!(first.fingerprint(), second.fingerprint());
+    assert_eq!(
+        serde_json::to_vec(&first).unwrap(),
+        serde_json::to_vec(&second).unwrap()
+    );
+
+    let mut unknown = serde_json::to_value(&first).unwrap();
+    unknown["providerMetadata"] = serde_json::json!({"requestId": "opaque"});
+    assert!(serde_json::from_value::<SourceOperationRequest>(unknown).is_err());
+    let mut unknown_receipt = serde_json::to_value(receipt(&first)).unwrap();
+    unknown_receipt["receipt"]["providerMetadata"] = serde_json::json!("opaque");
+    assert!(serde_json::from_value::<SourceOperationReceipt>(unknown_receipt).is_err());
+
+    let oversized = (0..65)
+        .map(|index| {
+            (
+                SourceCheckId::new(format!("required/{index}")).unwrap(),
+                SourceCheckConclusion::Satisfied,
+            )
+        })
+        .collect();
+    assert!(
+        SourceRequiredPolicy::new(SourcePolicyDigest::new(digest('2')).unwrap(), oversized)
+            .is_err()
+    );
+    let encoded = serde_json::to_string(&first).unwrap();
+    assert!(!encoded.contains("/home/"));
+    assert!(!encoded.contains("runtime_marker"));
+}
+
+#[test]
+fn stale_or_failed_policy_cannot_produce_satisfied_receipts() {
+    let failed = request(
+        "checks-failed",
+        SourceOperation::Checks {
+            review: review("review-758"),
+            expected_base: SourceRevisionId::new("base-sha").unwrap(),
+            expected_head: SourceRevisionId::new("head-sha").unwrap(),
+            checked_revision: SourceRevisionId::new("head-sha").unwrap(),
+            policy: policy('2', SourceCheckConclusion::Failed),
+        },
+    );
+    let SourceOperation::Checks { policy, .. } = failed.operation() else {
+        panic!("test request must be checks")
+    };
+    assert!(SourceChecksReceipt::new(failed.clone(), policy.clone()).is_err());
+}
+
+#[tokio::test]
+async fn success_requires_matching_authoritative_post_effect_inspection() {
+    let request = all_requests().pop().unwrap();
+    let receipt = receipt(&request);
+    let provider = Arc::new(AuthorityFake::new(
+        vec![
+            SourceOperationInspection::Unobserved,
+            SourceOperationInspection::Applied(Box::new(receipt.clone())),
+        ],
+        Ok(receipt.clone()),
+    ));
+    let registry = registry_with(provider.clone()).await;
+    let mut workspace = ContractWorkspace::new(request.workspace().clone());
+    assert_eq!(
+        registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap(),
+        receipt
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.inspection_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn invalid_direct_success_still_performs_authoritative_inspection() {
+    let request = all_requests().pop().unwrap();
+    let exact = receipt(&request);
+    let mismatched_request = merge_request(MergeRequestInput {
+        review: review("review-other"),
+        ..MergeRequestInput::exact()
+    });
+    let provider = Arc::new(AuthorityFake::new(
+        vec![
+            SourceOperationInspection::Unobserved,
+            SourceOperationInspection::Applied(Box::new(exact)),
+        ],
+        Ok(receipt(&mismatched_request)),
+    ));
+    let registry = registry_with(provider.clone()).await;
+    let mut workspace = ContractWorkspace::new(request.workspace().clone());
+    assert!(matches!(
+        registry.operate(&request, workspace.capability()).await,
+        Err(SourceCallError::PostEffectInvalidEvidence {
+            outcome: SourceInvocationOutcome::ReturnedReceipt,
+            ..
+        })
+    ));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.inspection_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn post_effect_inspection_errors_preserve_the_invocation_stage() {
+    let request = all_requests().pop().unwrap();
+    let exact = receipt(&request);
+    let unavailable = SourceProviderFailure::new(
+        SourceProviderFailureCode::Unavailable,
+        SourceFailureMessage::new("authority unavailable").unwrap(),
+    )
+    .unwrap();
+    let returned = Arc::new(AuthorityFake::with_inspection_results(
+        vec![
+            Ok(SourceOperationInspection::Unobserved),
+            Err(unavailable.clone()),
+        ],
+        Ok(exact),
+    ));
+    let returned_registry = registry_with(returned.clone()).await;
+    let mut workspace = ContractWorkspace::new(request.workspace().clone());
+    assert_eq!(
+        returned_registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap_err(),
+        SourceCallError::PostEffectInspectionFailed {
+            outcome: SourceInvocationOutcome::ReturnedReceipt,
+            failure: unavailable.clone(),
+        }
+    );
+
+    let indeterminate = SourceProviderFailure::new(
+        SourceProviderFailureCode::Indeterminate,
+        SourceFailureMessage::new("response lost").unwrap(),
+    )
+    .unwrap();
+    let uncertain = Arc::new(AuthorityFake::with_inspection_results(
+        vec![
+            Ok(SourceOperationInspection::Unobserved),
+            Err(unavailable.clone()),
+        ],
+        Err(indeterminate),
+    ));
+    let uncertain_registry = registry_with(uncertain.clone()).await;
+    assert_eq!(
+        uncertain_registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap_err(),
+        SourceCallError::PostEffectInspectionFailed {
+            outcome: SourceInvocationOutcome::Indeterminate,
+            failure: unavailable,
+        }
+    );
+    assert_eq!(returned.inspection_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(uncertain.inspection_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn post_uncertainty_reconciles_only_exact_authority() {
+    let request = all_requests().pop().unwrap();
+    let exact_receipt = receipt(&request);
+    let uncertainty = SourceProviderFailure::new(
+        SourceProviderFailureCode::Indeterminate,
+        SourceFailureMessage::new("response lost after possible effect").unwrap(),
+    )
+    .unwrap();
+    let exact = Arc::new(AuthorityFake::new(
+        vec![
+            SourceOperationInspection::Unobserved,
+            SourceOperationInspection::Applied(Box::new(exact_receipt.clone())),
+        ],
+        Err(uncertainty.clone()),
+    ));
+    let exact_registry = registry_with(exact.clone()).await;
+    let mut workspace = ContractWorkspace::new(request.workspace().clone());
+    assert_eq!(
+        exact_registry
+            .operate(&request, workspace.capability())
+            .await
+            .unwrap(),
+        exact_receipt
+    );
+
+    let mismatch_request = merge_request(MergeRequestInput {
+        review: review("review-other"),
+        ..MergeRequestInput::exact()
+    });
+    let mismatch = receipt(&mismatch_request);
+    let wrong = Arc::new(AuthorityFake::new(
+        vec![
+            SourceOperationInspection::Unobserved,
+            SourceOperationInspection::Applied(Box::new(mismatch)),
+        ],
+        Err(uncertainty),
+    ));
+    let wrong_registry = registry_with(wrong.clone()).await;
+    assert!(matches!(
+        wrong_registry
+            .operate(&request, workspace.capability())
+            .await,
+        Err(SourceCallError::PostEffectInvalidEvidence { .. })
+    ));
+    assert_eq!(exact.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(wrong.calls.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
Closes #758

## Decision

Bind every source mutation to a non-serializable verified-workspace capability and fingerprint the complete canonical intent, including expected parent/head, branch, remote, commit/change digests, review identity, and pre-effect state. Providers must reconcile authoritative post-effect state after success, invalid evidence, or uncertainty; typed receipts validate their complete operation-specific evidence before registry dispatch or consumption.

Capability minting remains product-authority-only. Test minting is crate-private/doc-hidden and guarded by an explicit unsafe test contract, preventing normal downstream callers from forging workspace authority.

## Scope

- Product-private source-provider contracts and tests only.
- No real Git/GitHub/GitLab/Azure operations, generic delivery orchestration, ledger reconciliation, proof execution, issue closing, or runtime registration.
- `AGENTS.md` records the authority and receipt boundaries.

## Verification

Focused targets first:
- `cargo test -p zeroshot-rust --test provider_contracts` — 10 passed
- `cargo test -p zeroshot-rust --test source_authority_contract` — 13 passed
- `cargo test -p zeroshot-rust --test architecture` — 11 passed

Common gates:
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` — 1953 passed, 18 pending
- `opcore check --changed`

Two independent final verifier passes completed all gates and reported no findings.