### PR TITLE
feat(zeroshot-rust): define canonical required-proof gate and receipt contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Protocol ledger adapters     | `zeroshot-rust/src/cluster_ledger/adapters.rs`                          |
 | Artifact store port/fake     | `zeroshot-rust/src/artifact_store.rs`, `artifact_store/fake.rs`         |
 | Product-local artifact CAS   | `zeroshot-rust/src/artifact_store/local_cas.rs`, `local_cas/`           |
+| Required-proof contracts     | `zeroshot-rust/src/required_proof.rs`                                   |
 | Issue provider contracts     | `zeroshot-rust/src/issue_provider.rs`, `issue_provider/`                |
 | Source provider contracts    | `zeroshot-rust/src/source_code_provider.rs`, `source_code_provider/`    |
 | Provider value bounds        | `zeroshot-rust/src/provider_value.rs`, `provider_value/`                |
@@ -161,6 +162,13 @@ Mutating source calls carry an exclusively borrowed, non-serializable verified-w
 their serializable intent and closed operation-specific receipts contain only canonical workspace,
 pre-effect, branch/revision, review, policy/conclusion, and idempotency identities. Successful or
 uncertain effects reconcile only through exact authoritative post-effect inspection.
+Required-command proof gates, immutable attempt intents/receipts, acceptance references, and
+artifact re-verification remain product-private in `required_proof.rs`. Graph-visible selection is
+limited to an admitted gate ID and repository/base/head revision bindings. Explicit environment
+entries use the fixed non-secret name/value set, and proof output artifact lineage must match the
+native `run:<sequence>` and attempt. Proof persistence uses the existing `ClusterLedger`
+record/fold and mutation-receipt path, while output bytes, paths, environment credentials, and
+command execution remain outside both ledger and protocol.
 Keep protocol, transport, daemon, compatibility, adapter, credential resolution, ledger, and
 workspace behavior outside it.
 `worker_catalog` is the native product's sole hand-authored, versioned worker-provider inventory.

--- a/zeroshot-rust/src/cluster_ledger/record.rs
+++ b/zeroshot-rust/src/cluster_ledger/record.rs
@@ -200,6 +200,9 @@ pub enum RecordKind {
     VerifiedInput = 9,
     VerifiedOutput = 10,
     MutationReceipt = 11,
+    RequiredProofIntent = 12,
+    RequiredProofReceipt = 13,
+    RequiredProofAcceptance = 14,
 }
 
 impl RecordKind {
@@ -277,6 +280,24 @@ pub enum RecordPayload {
     VerifiedOutput {
         run: RunSequence,
         execution: ExecutionId,
+        digest: CanonicalDigest,
+        canonical_bytes: Vec<u8>,
+    },
+    RequiredProofIntent {
+        run: RunSequence,
+        attempt: u32,
+        digest: CanonicalDigest,
+        canonical_bytes: Vec<u8>,
+    },
+    RequiredProofReceipt {
+        run: RunSequence,
+        attempt: u32,
+        digest: CanonicalDigest,
+        canonical_bytes: Vec<u8>,
+    },
+    RequiredProofAcceptance {
+        run: RunSequence,
+        attempt: u32,
         digest: CanonicalDigest,
         canonical_bytes: Vec<u8>,
     },

--- a/zeroshot-rust/src/cluster_ledger/record/payload.rs
+++ b/zeroshot-rust/src/cluster_ledger/record/payload.rs
@@ -14,7 +14,10 @@ impl RecordPayload {
             | Self::CleanupReceipt { .. }
             | Self::VerifiedInput { .. }
             | Self::VerifiedOutput { .. }
-            | Self::MutationReceipt { .. } => self.final_kind(),
+            | Self::MutationReceipt { .. }
+            | Self::RequiredProofIntent { .. }
+            | Self::RequiredProofReceipt { .. }
+            | Self::RequiredProofAcceptance { .. } => self.final_kind(),
         }
     }
 
@@ -37,6 +40,9 @@ impl RecordPayload {
             Self::VerifiedInput { .. } => RecordKind::VerifiedInput,
             Self::VerifiedOutput { .. } => RecordKind::VerifiedOutput,
             Self::MutationReceipt { .. } => RecordKind::MutationReceipt,
+            Self::RequiredProofIntent { .. } => RecordKind::RequiredProofIntent,
+            Self::RequiredProofReceipt { .. } => RecordKind::RequiredProofReceipt,
+            Self::RequiredProofAcceptance { .. } => RecordKind::RequiredProofAcceptance,
             _ => unreachable!(),
         }
     }
@@ -65,6 +71,7 @@ impl RecordPayload {
         }
         value.validate_verified_digest()?;
         value.validate_graph_digest()?;
+        value.validate_required_proof()?;
         Ok(value)
     }
 
@@ -101,5 +108,45 @@ impl RecordPayload {
             return Err(RecordError::DigestMismatch);
         }
         Ok(())
+    }
+    fn validate_required_proof(&self) -> Result<(), RecordError> {
+        use crate::required_proof::{AcceptedProofRef, ProofAttemptIntent, ProofAttemptReceipt};
+
+        let valid = match self {
+            Self::RequiredProofIntent {
+                run,
+                attempt,
+                digest,
+                canonical_bytes,
+            } => ProofAttemptIntent::decode(canonical_bytes).is_ok_and(|value| {
+                value.run() == *run && value.attempt() == *attempt && value.intent_id() == *digest
+            }),
+            Self::RequiredProofReceipt {
+                run,
+                attempt,
+                digest,
+                canonical_bytes,
+            } => ProofAttemptReceipt::decode(canonical_bytes).is_ok_and(|value| {
+                value.run() == *run
+                    && value.attempt() == *attempt
+                    && value.receipt_digest() == *digest
+            }),
+            Self::RequiredProofAcceptance {
+                run,
+                attempt,
+                digest,
+                canonical_bytes,
+            } => AcceptedProofRef::decode(canonical_bytes).is_ok_and(|value| {
+                value.run() == *run
+                    && value.attempt() == *attempt
+                    && value.acceptance_digest() == *digest
+            }),
+            _ => return Ok(()),
+        };
+        if valid {
+            Ok(())
+        } else {
+            Err(RecordError::DigestMismatch)
+        }
     }
 }

--- a/zeroshot-rust/src/cluster_ledger/replay.rs
+++ b/zeroshot-rust/src/cluster_ledger/replay.rs
@@ -3,11 +3,15 @@ mod receipts;
 mod state;
 
 pub use error::ReplayError;
-pub use state::{AdmissionState, DispatchState, EffectState, ReplayState, VerifiedValue};
+pub use state::{
+    AdmissionState, DispatchState, EffectState, ReplayState, RequiredProofAttemptState,
+    VerifiedValue,
+};
 use receipts::validate_receipt_binding;
 
 use super::record::{CanonicalDigest, RecordPayload, RunSequence, StoredRecord};
 use super::store::{MutationReceipt, Position, PrefixSnapshot, ResourceId};
+use crate::required_proof::{AcceptedProofRef, ProofAttemptIntent, ProofAttemptReceipt};
 
 pub fn replay(
     snapshot: &PrefixSnapshot,
@@ -103,6 +107,11 @@ fn fold_payload(
         payload @ (RecordPayload::VerifiedInput { .. } | RecordPayload::VerifiedOutput { .. }) => {
             fold_verified_payload(state, payload, position)
         }
+        payload @ (RecordPayload::RequiredProofIntent { .. }
+        | RecordPayload::RequiredProofReceipt { .. }
+        | RecordPayload::RequiredProofAcceptance { .. }) => {
+            fold_required_proof_payload(state, payload)
+        }
         RecordPayload::MutationReceipt { receipt } => {
             fold_mutation_receipt(state, pending_mutation, receipt, position)
         }
@@ -147,6 +156,79 @@ fn fold_verified_payload(
             fold_verified_output(state, payload, position)
         }
         _ => unreachable!("verified fold receives verified payload"),
+    }
+}
+
+fn fold_required_proof_payload(
+    state: &mut ReplayState,
+    payload: RecordPayload,
+) -> Result<(), ReplayError> {
+    match payload {
+        RecordPayload::RequiredProofIntent {
+            run,
+            attempt,
+            canonical_bytes,
+            ..
+        } => {
+            let intent = ProofAttemptIntent::decode(&canonical_bytes)
+                .map_err(|_| ReplayError::InvalidOrder)?;
+            require_current_run(state, run)?;
+            if intent.run() != run
+                || intent.attempt() != attempt
+                || state
+                    .required_proofs
+                    .iter()
+                    .any(|proof| proof.intent.run() == run && proof.intent.attempt() == attempt)
+            {
+                return Err(ReplayError::InvalidOrder);
+            }
+            state.required_proofs.push(RequiredProofAttemptState {
+                intent,
+                receipt: None,
+                accepted: None,
+            });
+            Ok(())
+        }
+        RecordPayload::RequiredProofReceipt {
+            run,
+            attempt,
+            canonical_bytes,
+            ..
+        } => {
+            let receipt = ProofAttemptReceipt::decode(&canonical_bytes)
+                .map_err(|_| ReplayError::InvalidOrder)?;
+            let proof = state
+                .required_proofs
+                .iter_mut()
+                .find(|proof| proof.intent.run() == run && proof.intent.attempt() == attempt)
+                .ok_or(ReplayError::InvalidOrder)?;
+            if proof.receipt.is_some() || receipt.matches_intent(&proof.intent).is_err() {
+                return Err(ReplayError::InvalidOrder);
+            }
+            proof.receipt = Some(receipt);
+            Ok(())
+        }
+        RecordPayload::RequiredProofAcceptance {
+            run,
+            attempt,
+            canonical_bytes,
+            ..
+        } => {
+            let accepted = AcceptedProofRef::decode(&canonical_bytes)
+                .map_err(|_| ReplayError::InvalidOrder)?;
+            let proof = state
+                .required_proofs
+                .iter_mut()
+                .find(|proof| proof.intent.run() == run && proof.intent.attempt() == attempt)
+                .ok_or(ReplayError::InvalidOrder)?;
+            let receipt = proof.receipt.as_ref().ok_or(ReplayError::InvalidOrder)?;
+            if proof.accepted.is_some() || accepted.matches(&proof.intent, receipt).is_err() {
+                return Err(ReplayError::InvalidOrder);
+            }
+            proof.accepted = Some(accepted);
+            Ok(())
+        }
+        _ => unreachable!("required proof fold receives required proof payload"),
     }
 }
 

--- a/zeroshot-rust/src/cluster_ledger/replay/receipts.rs
+++ b/zeroshot-rust/src/cluster_ledger/replay/receipts.rs
@@ -40,6 +40,27 @@ fn receipt_validator(method: &str) -> Result<ReceiptValidator, ReplayError> {
         "terminal" => Ok(validate_terminal_receipt),
         "cleanup_receipt" => Ok(validate_cleanup_receipt),
         "protocol_apply" => Ok(validate_protocol_apply_receipt),
+        "required_proof_intent" | "required_proof_receipt" | "required_proof_acceptance" => {
+            Ok(validate_required_proof_receipt)
+        }
+        _ => Err(ReplayError::ReceiptCorrupt),
+    }
+}
+
+fn validate_required_proof_receipt(
+    receipt: &MutationReceipt,
+    _state: &ReplayState,
+    records: &[RecordPayload],
+) -> Result<(), ReplayError> {
+    let response = decode_receipt_response::<CanonicalDigest>(receipt)?;
+    match (receipt.method.as_str(), records) {
+        ("required_proof_intent", [RecordPayload::RequiredProofIntent { digest, .. }])
+        | ("required_proof_receipt", [RecordPayload::RequiredProofReceipt { digest, .. }])
+        | ("required_proof_acceptance", [RecordPayload::RequiredProofAcceptance { digest, .. }])
+            if response == *digest && receipt.fingerprint == digest.as_bytes() =>
+        {
+            Ok(())
+        }
         _ => Err(ReplayError::ReceiptCorrupt),
     }
 }

--- a/zeroshot-rust/src/cluster_ledger/replay/state.rs
+++ b/zeroshot-rust/src/cluster_ledger/replay/state.rs
@@ -8,6 +8,14 @@ use super::super::record::{
 };
 use super::super::store::{IdempotencyId, MutationReceipt, Position, ResourceId};
 use super::ReplayError;
+use crate::required_proof::{AcceptedProofRef, ProofAttemptIntent, ProofAttemptReceipt};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RequiredProofAttemptState {
+    pub intent: ProofAttemptIntent,
+    pub receipt: Option<ProofAttemptReceipt>,
+    pub accepted: Option<AcceptedProofRef>,
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AdmissionState {
@@ -61,6 +69,7 @@ pub struct ReplayState {
     pub safe_faults: Vec<Vec<u8>>,
     pub terminal_outcome: Option<CanonicalDigest>,
     pub cleanup_receipts: Vec<CanonicalDigest>,
+    pub required_proofs: Vec<RequiredProofAttemptState>,
     pub mutation_receipts: BTreeMap<IdempotencyId, MutationReceipt>,
 }
 
@@ -82,6 +91,7 @@ impl ReplayState {
             safe_faults: Vec::new(),
             terminal_outcome: None,
             cleanup_receipts: Vec::new(),
+            required_proofs: Vec::new(),
             mutation_receipts: BTreeMap::new(),
         }
     }

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cluster_ledger;
 pub mod execution;
 pub mod issue_provider;
 mod provider_value;
+pub mod required_proof;
 pub mod scheduler;
 pub mod source_code_provider;
 pub mod worker_catalog;

--- a/zeroshot-rust/src/required_proof.rs
+++ b/zeroshot-rust/src/required_proof.rs
@@ -1,0 +1,1401 @@
+//! Product-private required-command proof contracts.
+//!
+//! This module defines trusted configuration, immutable attempt intent/receipt values, and
+//! fail-closed acceptance. It deliberately contains no command runner or persistence adapter.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{ArtifactRef, Sha256Digest};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+
+use crate::artifact_store::ArtifactStore;
+use crate::cluster_ledger::record::{CanonicalDigest, RecordPayload, RunSequence};
+use crate::cluster_ledger::store::IdempotencyId;
+use crate::cluster_ledger::{
+    ClusterLedger, CommitRequest, CommitResult, LedgerError, LedgerErrorKind, MutationIdentity,
+    ReceiptExpectation,
+};
+use crate::fault::FaultContext;
+
+pub const REQUIRED_PROOF_VERSION_V1: u16 = 1;
+pub const MAX_GATE_ID_BYTES: usize = 128;
+pub const MAX_ARGUMENTS: usize = 64;
+pub const MAX_ARGUMENT_BYTES: usize = 1_024;
+pub const MAX_CWD_BYTES: usize = 1_024;
+pub const MAX_ENVIRONMENT_ENTRIES: usize = 64;
+pub const MAX_ENVIRONMENT_NAME_BYTES: usize = 128;
+pub const MAX_ENVIRONMENT_VALUE_BYTES: usize = 4_096;
+pub const MAX_TOOL_VALUE_BYTES: usize = 256;
+pub const MAX_REPOSITORY_BYTES: usize = 512;
+pub const MAX_RUN_ATTEMPTS: u32 = 1_024;
+pub const MAX_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1_000;
+pub const MAX_FRESHNESS_MS: u64 = 30 * 24 * 60 * 60 * 1_000;
+const GATE_DIGEST_DOMAIN: &[u8] = b"zeroshot.required-proof.gate/v1\0";
+const INTENT_DIGEST_DOMAIN: &[u8] = b"zeroshot.required-proof.intent/v1\0";
+const RECEIPT_DIGEST_DOMAIN: &[u8] = b"zeroshot.required-proof.receipt/v1\0";
+const ACCEPTANCE_DIGEST_DOMAIN: &[u8] = b"zeroshot.required-proof.acceptance/v1\0";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RequiredProofError {
+    Decode,
+    UnknownVersion,
+    NonCanonical,
+    Empty(&'static str),
+    Oversized(&'static str),
+    Invalid(&'static str),
+    DigestMismatch(&'static str),
+    BindingMismatch(&'static str),
+    Incomplete,
+    Indeterminate,
+    NotPassing,
+    Stale,
+    FutureTimestamp,
+    ArtifactMissing,
+    ArtifactMismatch,
+    ArtifactUnavailable,
+    AuthorityUncertain,
+    ConflictingAttempt,
+}
+
+impl fmt::Display for RequiredProofError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode => formatter.write_str("required-proof value cannot be decoded"),
+            Self::UnknownVersion => formatter.write_str("required-proof version is unsupported"),
+            Self::NonCanonical => formatter.write_str("required-proof encoding is not canonical"),
+            Self::Empty(field) => write!(formatter, "{field} must not be empty"),
+            Self::Oversized(field) => write!(formatter, "{field} exceeds its bound"),
+            Self::Invalid(field) => write!(formatter, "{field} is invalid"),
+            Self::DigestMismatch(field) => write!(formatter, "{field} digest does not match"),
+            Self::BindingMismatch(field) => write!(formatter, "{field} binding does not match"),
+            Self::Incomplete => formatter.write_str("proof attempt is incomplete"),
+            Self::Indeterminate => formatter.write_str("proof attempt is indeterminate"),
+            Self::NotPassing => formatter.write_str("proof attempt did not pass"),
+            Self::Stale => formatter.write_str("proof attempt is stale"),
+            Self::FutureTimestamp => {
+                formatter.write_str("proof attempt timestamp is in the future")
+            }
+            Self::ArtifactMissing => formatter.write_str("proof output artifact is missing"),
+            Self::ArtifactMismatch => formatter.write_str("proof output artifact does not match"),
+            Self::ArtifactUnavailable => {
+                formatter.write_str("proof output artifact is unavailable")
+            }
+            Self::AuthorityUncertain => formatter.write_str("proof attempt authority is uncertain"),
+            Self::ConflictingAttempt => {
+                formatter.write_str("proof attempt conflicts with authority")
+            }
+        }
+    }
+}
+
+impl Error for RequiredProofError {}
+
+#[derive(Clone, Debug)]
+pub struct TrustedGateRequest {
+    pub gate_id: String,
+    pub argv: Vec<String>,
+    pub cwd: String,
+    pub inherited_env: BTreeSet<String>,
+    pub explicit_env: BTreeMap<String, String>,
+    pub timeout_ms: u64,
+    pub freshness_ms: u64,
+    pub tool_identity: String,
+    pub tool_version: String,
+    pub tool_digest: CanonicalDigest,
+    pub repository: String,
+    pub base_revision: String,
+    pub head_revision: String,
+    pub config_digest: CanonicalDigest,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedGateBody {
+    version: u16,
+    gate_id: String,
+    argv: Vec<String>,
+    cwd: String,
+    inherited_env: BTreeSet<String>,
+    explicit_env: BTreeMap<String, String>,
+    timeout_ms: u64,
+    freshness_ms: u64,
+    tool_identity: String,
+    tool_version: String,
+    tool_digest: CanonicalDigest,
+    repository: String,
+    base_revision: String,
+    head_revision: String,
+    config_digest: CanonicalDigest,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedGate {
+    body: TrustedGateBody,
+    gate_digest: CanonicalDigest,
+}
+
+impl TrustedGate {
+    pub fn new(request: TrustedGateRequest) -> Result<Self, RequiredProofError> {
+        let body = TrustedGateBody {
+            version: REQUIRED_PROOF_VERSION_V1,
+            gate_id: request.gate_id,
+            argv: request.argv,
+            cwd: request.cwd,
+            inherited_env: request.inherited_env,
+            explicit_env: request.explicit_env,
+            timeout_ms: request.timeout_ms,
+            freshness_ms: request.freshness_ms,
+            tool_identity: request.tool_identity,
+            tool_version: request.tool_version,
+            tool_digest: request.tool_digest,
+            repository: request.repository,
+            base_revision: request.base_revision,
+            head_revision: request.head_revision,
+            config_digest: request.config_digest,
+        };
+        validate_gate_body(&body)?;
+        let gate_digest = domain_digest(GATE_DIGEST_DOMAIN, &canonical_json(&body)?);
+        Ok(Self { body, gate_digest })
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, RequiredProofError> {
+        decode_canonical(bytes, Self::validate)
+    }
+
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RequiredProofError> {
+        self.validate()?;
+        canonical_json(self)
+    }
+
+    pub fn validate(&self) -> Result<(), RequiredProofError> {
+        validate_gate_body(&self.body)?;
+        let expected = domain_digest(GATE_DIGEST_DOMAIN, &canonical_json(&self.body)?);
+        if self.gate_digest != expected {
+            return Err(RequiredProofError::DigestMismatch("gate"));
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn gate_id(&self) -> &str {
+        &self.body.gate_id
+    }
+    #[must_use]
+    pub fn argv(&self) -> &[String] {
+        &self.body.argv
+    }
+    #[must_use]
+    pub fn cwd(&self) -> &str {
+        &self.body.cwd
+    }
+    #[must_use]
+    pub fn inherited_env(&self) -> &BTreeSet<String> {
+        &self.body.inherited_env
+    }
+    #[must_use]
+    pub fn explicit_env(&self) -> &BTreeMap<String, String> {
+        &self.body.explicit_env
+    }
+    #[must_use]
+    pub const fn timeout_ms(&self) -> u64 {
+        self.body.timeout_ms
+    }
+    #[must_use]
+    pub const fn freshness_ms(&self) -> u64 {
+        self.body.freshness_ms
+    }
+    #[must_use]
+    pub fn tool_identity(&self) -> &str {
+        &self.body.tool_identity
+    }
+    #[must_use]
+    pub fn tool_version(&self) -> &str {
+        &self.body.tool_version
+    }
+    #[must_use]
+    pub const fn tool_digest(&self) -> CanonicalDigest {
+        self.body.tool_digest
+    }
+    #[must_use]
+    pub fn repository(&self) -> &str {
+        &self.body.repository
+    }
+    #[must_use]
+    pub fn base_revision(&self) -> &str {
+        &self.body.base_revision
+    }
+    #[must_use]
+    pub fn head_revision(&self) -> &str {
+        &self.body.head_revision
+    }
+    #[must_use]
+    pub const fn config_digest(&self) -> CanonicalDigest {
+        self.body.config_digest
+    }
+    #[must_use]
+    pub const fn gate_digest(&self) -> CanonicalDigest {
+        self.gate_digest
+    }
+}
+
+fn validate_gate_body(body: &TrustedGateBody) -> Result<(), RequiredProofError> {
+    require_version(body.version)?;
+    bounded_nonempty(&body.gate_id, MAX_GATE_ID_BYTES, "gate ID")?;
+    if body.argv.is_empty() {
+        return Err(RequiredProofError::Empty("argv"));
+    }
+    if body.argv.len() > MAX_ARGUMENTS {
+        return Err(RequiredProofError::Oversized("argv"));
+    }
+    for argument in &body.argv {
+        bounded_nonempty(argument, MAX_ARGUMENT_BYTES, "argument")?;
+        if argument.contains('\0') {
+            return Err(RequiredProofError::Invalid("argument"));
+        }
+    }
+    validate_cwd(&body.cwd)?;
+    if body.inherited_env.len() > MAX_ENVIRONMENT_ENTRIES
+        || body.explicit_env.len() > MAX_ENVIRONMENT_ENTRIES
+    {
+        return Err(RequiredProofError::Oversized("environment"));
+    }
+    for name in &body.inherited_env {
+        validate_env_name(name)?;
+    }
+    for (name, value) in &body.explicit_env {
+        validate_env_name(name)?;
+        if body.inherited_env.contains(name) {
+            return Err(RequiredProofError::Invalid("environment overlap"));
+        }
+        if value.len() > MAX_ENVIRONMENT_VALUE_BYTES {
+            return Err(RequiredProofError::Oversized("environment value"));
+        }
+        if value.contains('\0') || value.chars().any(char::is_control) {
+            return Err(RequiredProofError::Invalid("environment value"));
+        }
+        validate_explicit_environment(name, value)?;
+    }
+    if body.timeout_ms == 0 || body.timeout_ms > MAX_TIMEOUT_MS {
+        return Err(RequiredProofError::Invalid("timeout"));
+    }
+    if body.freshness_ms == 0 || body.freshness_ms > MAX_FRESHNESS_MS {
+        return Err(RequiredProofError::Invalid("freshness"));
+    }
+    bounded_nonempty(&body.tool_identity, MAX_TOOL_VALUE_BYTES, "tool identity")?;
+    bounded_nonempty(&body.tool_version, MAX_TOOL_VALUE_BYTES, "tool version")?;
+    validate_repository(&body.repository)?;
+    validate_revision(&body.base_revision)?;
+    validate_revision(&body.head_revision)?;
+    if body.base_revision == body.head_revision {
+        return Err(RequiredProofError::Invalid("revision range"));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofSelection {
+    gate_id: String,
+    repository: String,
+    base_revision: String,
+    head_revision: String,
+}
+
+impl ProofSelection {
+    pub fn admitted(gate: &TrustedGate) -> Self {
+        Self {
+            gate_id: gate.body.gate_id.clone(),
+            repository: gate.body.repository.clone(),
+            base_revision: gate.body.base_revision.clone(),
+            head_revision: gate.body.head_revision.clone(),
+        }
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, RequiredProofError> {
+        decode_canonical(bytes, Self::validate)
+    }
+
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RequiredProofError> {
+        self.validate()?;
+        canonical_json(self)
+    }
+
+    pub fn validate(&self) -> Result<(), RequiredProofError> {
+        bounded_nonempty(&self.gate_id, MAX_GATE_ID_BYTES, "gate ID")?;
+        validate_repository(&self.repository)?;
+        validate_revision(&self.base_revision)?;
+        validate_revision(&self.head_revision)
+    }
+
+    pub fn matches(&self, gate: &TrustedGate) -> Result<(), RequiredProofError> {
+        gate.validate()?;
+        binding(self.gate_id == gate.gate_id(), "gate")?;
+        binding(self.repository == gate.repository(), "repository")?;
+        binding(self.base_revision == gate.base_revision(), "base revision")?;
+        binding(self.head_revision == gate.head_revision(), "head revision")
+    }
+
+    #[must_use]
+    pub fn gate_id(&self) -> &str {
+        &self.gate_id
+    }
+    #[must_use]
+    pub fn repository(&self) -> &str {
+        &self.repository
+    }
+    #[must_use]
+    pub fn base_revision(&self) -> &str {
+        &self.base_revision
+    }
+    #[must_use]
+    pub fn head_revision(&self) -> &str {
+        &self.head_revision
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProofAttemptIntentRequest {
+    pub run: RunSequence,
+    pub attempt: u32,
+    pub requested_at_ms: u64,
+    pub selection: ProofSelection,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ProofAttemptIntentBody {
+    version: u16,
+    run: RunSequence,
+    attempt: u32,
+    requested_at_ms: u64,
+    selection: ProofSelection,
+    config_digest: CanonicalDigest,
+    gate_digest: CanonicalDigest,
+    tool_identity: String,
+    tool_version: String,
+    tool_digest: CanonicalDigest,
+    timeout_ms: u64,
+    freshness_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofAttemptIntent {
+    body: ProofAttemptIntentBody,
+    intent_id: CanonicalDigest,
+}
+
+impl ProofAttemptIntent {
+    pub fn new(
+        gate: &TrustedGate,
+        request: ProofAttemptIntentRequest,
+    ) -> Result<Self, RequiredProofError> {
+        gate.validate()?;
+        request.selection.matches(gate)?;
+        if request.attempt == 0 || request.attempt > MAX_RUN_ATTEMPTS {
+            return Err(RequiredProofError::Invalid("attempt"));
+        }
+        let body = ProofAttemptIntentBody {
+            version: REQUIRED_PROOF_VERSION_V1,
+            run: request.run,
+            attempt: request.attempt,
+            requested_at_ms: request.requested_at_ms,
+            selection: request.selection,
+            config_digest: gate.config_digest(),
+            gate_digest: gate.gate_digest(),
+            tool_identity: gate.tool_identity().to_owned(),
+            tool_version: gate.tool_version().to_owned(),
+            tool_digest: gate.tool_digest(),
+            timeout_ms: gate.timeout_ms(),
+            freshness_ms: gate.freshness_ms(),
+        };
+        validate_intent_body(&body)?;
+        let intent_id = domain_digest(INTENT_DIGEST_DOMAIN, &canonical_json(&body)?);
+        Ok(Self { body, intent_id })
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, RequiredProofError> {
+        decode_canonical(bytes, Self::validate)
+    }
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RequiredProofError> {
+        self.validate()?;
+        canonical_json(self)
+    }
+    pub fn validate(&self) -> Result<(), RequiredProofError> {
+        validate_intent_body(&self.body)?;
+        let expected = domain_digest(INTENT_DIGEST_DOMAIN, &canonical_json(&self.body)?);
+        if self.intent_id != expected {
+            return Err(RequiredProofError::DigestMismatch("intent"));
+        }
+        Ok(())
+    }
+    pub fn matches_gate(&self, gate: &TrustedGate) -> Result<(), RequiredProofError> {
+        self.validate()?;
+        self.body.selection.matches(gate)?;
+        binding(self.body.config_digest == gate.config_digest(), "config")?;
+        binding(self.body.gate_digest == gate.gate_digest(), "gate digest")?;
+        binding(
+            self.body.tool_identity == gate.tool_identity(),
+            "tool identity",
+        )?;
+        binding(
+            self.body.tool_version == gate.tool_version(),
+            "tool version",
+        )?;
+        binding(self.body.tool_digest == gate.tool_digest(), "tool digest")?;
+        binding(self.body.timeout_ms == gate.timeout_ms(), "timeout")?;
+        binding(self.body.freshness_ms == gate.freshness_ms(), "freshness")
+    }
+    #[must_use]
+    pub const fn intent_id(&self) -> CanonicalDigest {
+        self.intent_id
+    }
+    #[must_use]
+    pub const fn run(&self) -> RunSequence {
+        self.body.run
+    }
+    #[must_use]
+    pub const fn attempt(&self) -> u32 {
+        self.body.attempt
+    }
+    #[must_use]
+    pub const fn requested_at_ms(&self) -> u64 {
+        self.body.requested_at_ms
+    }
+    #[must_use]
+    pub fn selection(&self) -> &ProofSelection {
+        &self.body.selection
+    }
+    #[must_use]
+    pub const fn config_digest(&self) -> CanonicalDigest {
+        self.body.config_digest
+    }
+    #[must_use]
+    pub const fn gate_digest(&self) -> CanonicalDigest {
+        self.body.gate_digest
+    }
+    #[must_use]
+    pub const fn tool_digest(&self) -> CanonicalDigest {
+        self.body.tool_digest
+    }
+    #[must_use]
+    pub const fn timeout_ms(&self) -> u64 {
+        self.body.timeout_ms
+    }
+    #[must_use]
+    pub const fn freshness_ms(&self) -> u64 {
+        self.body.freshness_ms
+    }
+}
+
+fn validate_intent_body(body: &ProofAttemptIntentBody) -> Result<(), RequiredProofError> {
+    require_version(body.version)?;
+    if body.run.get() == 0 {
+        return Err(RequiredProofError::Invalid("run"));
+    }
+    if body.attempt == 0 || body.attempt > MAX_RUN_ATTEMPTS {
+        return Err(RequiredProofError::Invalid("attempt"));
+    }
+    body.selection.validate()?;
+    bounded_nonempty(&body.tool_identity, MAX_TOOL_VALUE_BYTES, "tool identity")?;
+    bounded_nonempty(&body.tool_version, MAX_TOOL_VALUE_BYTES, "tool version")?;
+    if body.timeout_ms == 0 || body.timeout_ms > MAX_TIMEOUT_MS {
+        return Err(RequiredProofError::Invalid("timeout"));
+    }
+    if body.freshness_ms == 0 || body.freshness_ms > MAX_FRESHNESS_MS {
+        return Err(RequiredProofError::Invalid("freshness"));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ProcessOutcome {
+    Exited { exit_code: i32 },
+    Signaled { signal: u8 },
+    TimedOut,
+    Incomplete,
+    Indeterminate,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofOutput {
+    digest: CanonicalDigest,
+    artifact: ArtifactRef,
+}
+
+impl ProofOutput {
+    pub fn new(artifact: ArtifactRef) -> Result<Self, RequiredProofError> {
+        let digest = protocol_digest(&artifact.sha256)?;
+        Ok(Self { digest, artifact })
+    }
+    fn validate(&self) -> Result<(), RequiredProofError> {
+        if self.digest != protocol_digest(&self.artifact.sha256)? {
+            return Err(RequiredProofError::DigestMismatch("artifact"));
+        }
+        Ok(())
+    }
+    #[must_use]
+    pub const fn digest(&self) -> CanonicalDigest {
+        self.digest
+    }
+    #[must_use]
+    pub fn artifact(&self) -> &ArtifactRef {
+        &self.artifact
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProofAttemptReceiptRequest {
+    pub started_at_ms: u64,
+    pub finished_at_ms: Option<u64>,
+    pub outcome: ProcessOutcome,
+    pub stdout: Option<ProofOutput>,
+    pub stderr: Option<ProofOutput>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ProofAttemptReceiptBody {
+    version: u16,
+    intent_id: CanonicalDigest,
+    run: RunSequence,
+    attempt: u32,
+    started_at_ms: u64,
+    finished_at_ms: Option<u64>,
+    outcome: ProcessOutcome,
+    stdout: Option<ProofOutput>,
+    stderr: Option<ProofOutput>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProofAttemptReceipt {
+    body: ProofAttemptReceiptBody,
+    receipt_digest: CanonicalDigest,
+}
+
+impl ProofAttemptReceipt {
+    pub fn new(
+        intent: &ProofAttemptIntent,
+        request: ProofAttemptReceiptRequest,
+    ) -> Result<Self, RequiredProofError> {
+        intent.validate()?;
+        let body = ProofAttemptReceiptBody {
+            version: REQUIRED_PROOF_VERSION_V1,
+            intent_id: intent.intent_id(),
+            run: intent.run(),
+            attempt: intent.attempt(),
+            started_at_ms: request.started_at_ms,
+            finished_at_ms: request.finished_at_ms,
+            outcome: request.outcome,
+            stdout: request.stdout,
+            stderr: request.stderr,
+        };
+        validate_receipt_body(&body)?;
+        let receipt_digest = domain_digest(RECEIPT_DIGEST_DOMAIN, &canonical_json(&body)?);
+        Ok(Self {
+            body,
+            receipt_digest,
+        })
+    }
+    pub fn decode(bytes: &[u8]) -> Result<Self, RequiredProofError> {
+        decode_canonical(bytes, Self::validate)
+    }
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RequiredProofError> {
+        self.validate()?;
+        canonical_json(self)
+    }
+    pub fn validate(&self) -> Result<(), RequiredProofError> {
+        validate_receipt_body(&self.body)?;
+        let expected = domain_digest(RECEIPT_DIGEST_DOMAIN, &canonical_json(&self.body)?);
+        if self.receipt_digest != expected {
+            return Err(RequiredProofError::DigestMismatch("receipt"));
+        }
+        Ok(())
+    }
+    pub fn matches_intent(&self, intent: &ProofAttemptIntent) -> Result<(), RequiredProofError> {
+        self.validate()?;
+        intent.validate()?;
+        binding(self.body.intent_id == intent.intent_id(), "intent")?;
+        binding(self.body.run == intent.run(), "run")?;
+        binding(self.body.attempt == intent.attempt(), "attempt")
+    }
+    #[must_use]
+    pub const fn receipt_digest(&self) -> CanonicalDigest {
+        self.receipt_digest
+    }
+    #[must_use]
+    pub const fn intent_id(&self) -> CanonicalDigest {
+        self.body.intent_id
+    }
+    #[must_use]
+    pub const fn run(&self) -> RunSequence {
+        self.body.run
+    }
+    #[must_use]
+    pub const fn attempt(&self) -> u32 {
+        self.body.attempt
+    }
+    #[must_use]
+    pub const fn started_at_ms(&self) -> u64 {
+        self.body.started_at_ms
+    }
+    #[must_use]
+    pub const fn finished_at_ms(&self) -> Option<u64> {
+        self.body.finished_at_ms
+    }
+    #[must_use]
+    pub const fn outcome(&self) -> ProcessOutcome {
+        self.body.outcome
+    }
+    #[must_use]
+    pub fn stdout(&self) -> Option<&ProofOutput> {
+        self.body.stdout.as_ref()
+    }
+    #[must_use]
+    pub fn stderr(&self) -> Option<&ProofOutput> {
+        self.body.stderr.as_ref()
+    }
+}
+
+fn validate_receipt_body(body: &ProofAttemptReceiptBody) -> Result<(), RequiredProofError> {
+    require_version(body.version)?;
+    if body.run.get() == 0 || body.attempt == 0 || body.attempt > MAX_RUN_ATTEMPTS {
+        return Err(RequiredProofError::Invalid("attempt identity"));
+    }
+    if let Some(finished) = body.finished_at_ms {
+        if finished < body.started_at_ms {
+            return Err(RequiredProofError::Invalid("timestamps"));
+        }
+    }
+    if matches!(body.outcome, ProcessOutcome::Signaled { signal: 0 }) {
+        return Err(RequiredProofError::Invalid("signal"));
+    }
+    if matches!(body.outcome, ProcessOutcome::Incomplete) {
+        if body.finished_at_ms.is_some() {
+            return Err(RequiredProofError::Invalid("incomplete timestamp"));
+        }
+    } else if body.finished_at_ms.is_none() {
+        return Err(RequiredProofError::Incomplete);
+    }
+    if matches!(body.outcome, ProcessOutcome::Indeterminate)
+        && (body.stdout.is_some() || body.stderr.is_some())
+    {
+        return Err(RequiredProofError::Invalid("indeterminate output"));
+    }
+    if let Some(output) = &body.stdout {
+        output.validate()?;
+        validate_output_lineage(output, body.run, body.attempt)?;
+    }
+    if let Some(output) = &body.stderr {
+        output.validate()?;
+        validate_output_lineage(output, body.run, body.attempt)?;
+    }
+    Ok(())
+}
+
+fn validate_output_lineage(
+    output: &ProofOutput,
+    run: RunSequence,
+    attempt: u32,
+) -> Result<(), RequiredProofError> {
+    let expected_run = format!("run:{}", run.get());
+    binding(
+        output.artifact.lineage.run_id.as_str() == expected_run,
+        "artifact run",
+    )?;
+    binding(
+        output.artifact.lineage.attempt.get() == u64::from(attempt),
+        "artifact attempt",
+    )
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptedProofRef {
+    version: u16,
+    gate_id: String,
+    repository: String,
+    base_revision: String,
+    head_revision: String,
+    run: RunSequence,
+    attempt: u32,
+    intent_id: CanonicalDigest,
+    receipt_digest: CanonicalDigest,
+    accepted_at_ms: u64,
+    acceptance_digest: CanonicalDigest,
+}
+
+#[derive(Serialize)]
+struct AcceptanceBody<'a> {
+    version: u16,
+    gate_id: &'a str,
+    repository: &'a str,
+    base_revision: &'a str,
+    head_revision: &'a str,
+    run: RunSequence,
+    attempt: u32,
+    intent_id: CanonicalDigest,
+    receipt_digest: CanonicalDigest,
+    accepted_at_ms: u64,
+}
+
+pub struct AcceptProofRequest<'a> {
+    pub gate: &'a TrustedGate,
+    pub intent: &'a ProofAttemptIntent,
+    pub receipt: &'a ProofAttemptReceipt,
+    pub accepted_at_ms: u64,
+    pub artifacts: &'a dyn ArtifactReverification,
+}
+
+impl AcceptedProofRef {
+    pub async fn accept(request: AcceptProofRequest<'_>) -> Result<Self, RequiredProofError> {
+        let AcceptProofRequest {
+            gate,
+            intent,
+            receipt,
+            accepted_at_ms,
+            artifacts,
+        } = request;
+        validate_passing_attempt(gate, intent, receipt, accepted_at_ms)?;
+        let stdout = receipt
+            .stdout()
+            .ok_or(RequiredProofError::ArtifactMissing)?;
+        let stderr = receipt
+            .stderr()
+            .ok_or(RequiredProofError::ArtifactMissing)?;
+        artifacts.reverify(stdout.artifact()).await?;
+        artifacts.reverify(stderr.artifact()).await?;
+        let selection = intent.selection();
+        let body = AcceptanceBody {
+            version: REQUIRED_PROOF_VERSION_V1,
+            gate_id: selection.gate_id(),
+            repository: selection.repository(),
+            base_revision: selection.base_revision(),
+            head_revision: selection.head_revision(),
+            run: intent.run(),
+            attempt: intent.attempt(),
+            intent_id: intent.intent_id(),
+            receipt_digest: receipt.receipt_digest(),
+            accepted_at_ms,
+        };
+        let acceptance_digest = domain_digest(ACCEPTANCE_DIGEST_DOMAIN, &canonical_json(&body)?);
+        Ok(Self {
+            version: body.version,
+            gate_id: body.gate_id.to_owned(),
+            repository: body.repository.to_owned(),
+            base_revision: body.base_revision.to_owned(),
+            head_revision: body.head_revision.to_owned(),
+            run: body.run,
+            attempt: body.attempt,
+            intent_id: body.intent_id,
+            receipt_digest: body.receipt_digest,
+            accepted_at_ms: body.accepted_at_ms,
+            acceptance_digest,
+        })
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, RequiredProofError> {
+        decode_canonical(bytes, Self::validate_self)
+    }
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, RequiredProofError> {
+        self.validate_self()?;
+        canonical_json(self)
+    }
+    fn validate_self(&self) -> Result<(), RequiredProofError> {
+        require_version(self.version)?;
+        bounded_nonempty(&self.gate_id, MAX_GATE_ID_BYTES, "gate ID")?;
+        validate_repository(&self.repository)?;
+        validate_revision(&self.base_revision)?;
+        validate_revision(&self.head_revision)?;
+        if self.run.get() == 0 || self.attempt == 0 || self.attempt > MAX_RUN_ATTEMPTS {
+            return Err(RequiredProofError::Invalid("attempt identity"));
+        }
+        let body = AcceptanceBody {
+            version: self.version,
+            gate_id: &self.gate_id,
+            repository: &self.repository,
+            base_revision: &self.base_revision,
+            head_revision: &self.head_revision,
+            run: self.run,
+            attempt: self.attempt,
+            intent_id: self.intent_id,
+            receipt_digest: self.receipt_digest,
+            accepted_at_ms: self.accepted_at_ms,
+        };
+        let expected = domain_digest(ACCEPTANCE_DIGEST_DOMAIN, &canonical_json(&body)?);
+        if self.acceptance_digest != expected {
+            return Err(RequiredProofError::DigestMismatch("acceptance"));
+        }
+        Ok(())
+    }
+    pub fn matches(
+        &self,
+        intent: &ProofAttemptIntent,
+        receipt: &ProofAttemptReceipt,
+    ) -> Result<(), RequiredProofError> {
+        self.validate_self()?;
+        receipt.matches_intent(intent)?;
+        binding(self.gate_id == intent.selection().gate_id(), "gate")?;
+        binding(
+            self.repository == intent.selection().repository(),
+            "repository",
+        )?;
+        binding(
+            self.base_revision == intent.selection().base_revision(),
+            "base revision",
+        )?;
+        binding(
+            self.head_revision == intent.selection().head_revision(),
+            "head revision",
+        )?;
+        binding(self.run == intent.run(), "run")?;
+        binding(self.attempt == intent.attempt(), "attempt")?;
+        binding(self.intent_id == intent.intent_id(), "intent")?;
+        binding(self.receipt_digest == receipt.receipt_digest(), "receipt")?;
+        validate_bound_passing_attempt(intent, receipt, self.accepted_at_ms)
+    }
+    #[must_use]
+    pub const fn run(&self) -> RunSequence {
+        self.run
+    }
+    #[must_use]
+    pub const fn attempt(&self) -> u32 {
+        self.attempt
+    }
+    #[must_use]
+    pub const fn intent_id(&self) -> CanonicalDigest {
+        self.intent_id
+    }
+    #[must_use]
+    pub const fn receipt_digest(&self) -> CanonicalDigest {
+        self.receipt_digest
+    }
+    #[must_use]
+    pub const fn acceptance_digest(&self) -> CanonicalDigest {
+        self.acceptance_digest
+    }
+}
+
+fn validate_passing_attempt(
+    gate: &TrustedGate,
+    intent: &ProofAttemptIntent,
+    receipt: &ProofAttemptReceipt,
+    now_ms: u64,
+) -> Result<(), RequiredProofError> {
+    intent.matches_gate(gate)?;
+    validate_bound_passing_attempt(intent, receipt, now_ms)
+}
+
+fn validate_bound_passing_attempt(
+    intent: &ProofAttemptIntent,
+    receipt: &ProofAttemptReceipt,
+    now_ms: u64,
+) -> Result<(), RequiredProofError> {
+    receipt.matches_intent(intent)?;
+    match receipt.outcome() {
+        ProcessOutcome::Exited { exit_code: 0 } => {}
+        ProcessOutcome::Incomplete => return Err(RequiredProofError::Incomplete),
+        ProcessOutcome::Indeterminate => return Err(RequiredProofError::Indeterminate),
+        _ => return Err(RequiredProofError::NotPassing),
+    }
+    let finished = receipt
+        .finished_at_ms()
+        .ok_or(RequiredProofError::Incomplete)?;
+    if finished > now_ms {
+        return Err(RequiredProofError::FutureTimestamp);
+    }
+    if now_ms.saturating_sub(finished) > intent.freshness_ms() {
+        return Err(RequiredProofError::Stale);
+    }
+    if receipt.started_at_ms() < intent.requested_at_ms() {
+        return Err(RequiredProofError::BindingMismatch("attempt timestamp"));
+    }
+    if finished.saturating_sub(receipt.started_at_ms()) > intent.timeout_ms() {
+        return Err(RequiredProofError::BindingMismatch("timeout"));
+    }
+    if receipt.stdout().is_none() || receipt.stderr().is_none() {
+        return Err(RequiredProofError::ArtifactMissing);
+    }
+    Ok(())
+}
+
+#[async_trait]
+pub trait ArtifactReverification: Send + Sync {
+    async fn reverify(&self, expected: &ArtifactRef) -> Result<(), RequiredProofError>;
+}
+
+#[async_trait]
+impl<T> ArtifactReverification for T
+where
+    T: ArtifactStore + Send + Sync + ?Sized,
+{
+    async fn reverify(&self, expected: &ArtifactRef) -> Result<(), RequiredProofError> {
+        let inspected = self
+            .inspect(&expected.artifact_id)
+            .await
+            .map_err(|_| RequiredProofError::ArtifactUnavailable)?;
+        if inspected.as_ref() != Some(expected) {
+            return Err(inspected.map_or(RequiredProofError::ArtifactMissing, |_| {
+                RequiredProofError::ArtifactMismatch
+            }));
+        }
+        let mut stream = self
+            .open(&expected.artifact_id)
+            .await
+            .map_err(|_| RequiredProofError::ArtifactUnavailable)?;
+        let mut hasher = Sha256::new();
+        let mut length = 0_u64;
+        let mut buffer = [0_u8; 8 * 1_024];
+        loop {
+            let read = stream
+                .read(&mut buffer)
+                .await
+                .map_err(|_| RequiredProofError::ArtifactUnavailable)?;
+            if read == 0 {
+                break;
+            }
+            length = length
+                .checked_add(read as u64)
+                .ok_or(RequiredProofError::ArtifactMismatch)?;
+            if length > expected.byte_length.get() {
+                return Err(RequiredProofError::ArtifactMismatch);
+            }
+            hasher.update(&buffer[..read]);
+        }
+        let actual_digest = CanonicalDigest::new(hasher.finalize().into());
+        if length != expected.byte_length.get()
+            || actual_digest != protocol_digest(&expected.sha256)?
+        {
+            return Err(RequiredProofError::ArtifactMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerformProofAttempt {
+    intent: ProofAttemptIntent,
+}
+
+impl PerformProofAttempt {
+    #[must_use]
+    pub fn new(intent: ProofAttemptIntent) -> Self {
+        Self { intent }
+    }
+    #[must_use]
+    pub fn idempotency_identity(&self) -> CanonicalDigest {
+        self.intent.intent_id()
+    }
+    #[must_use]
+    pub fn intent(&self) -> &ProofAttemptIntent {
+        &self.intent
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InspectProofAttempt {
+    run: RunSequence,
+    attempt: u32,
+    intent_id: CanonicalDigest,
+}
+
+impl InspectProofAttempt {
+    #[must_use]
+    pub fn for_intent(intent: &ProofAttemptIntent) -> Self {
+        Self {
+            run: intent.run(),
+            attempt: intent.attempt(),
+            intent_id: intent.intent_id(),
+        }
+    }
+
+    #[must_use]
+    pub const fn run(self) -> RunSequence {
+        self.run
+    }
+
+    #[must_use]
+    pub const fn attempt(self) -> u32 {
+        self.attempt
+    }
+
+    #[must_use]
+    pub const fn idempotency_identity(self) -> CanonicalDigest {
+        self.intent_id
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AuthoritativeAttempt {
+    Missing,
+    IntentOnly(Box<ProofAttemptIntent>),
+    Receipt {
+        intent: Box<ProofAttemptIntent>,
+        receipt: Box<ProofAttemptReceipt>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReconcileProofAttempt {
+    intent: ProofAttemptIntent,
+    authority: AuthoritativeAttempt,
+}
+
+impl ReconcileProofAttempt {
+    #[must_use]
+    pub fn new(intent: ProofAttemptIntent, authority: AuthoritativeAttempt) -> Self {
+        Self { intent, authority }
+    }
+
+    pub fn resolve(self) -> Result<ProofAttemptReceipt, RequiredProofError> {
+        reconcile_after_uncertainty(&self.intent, self.authority)
+    }
+}
+
+pub fn reconcile_after_uncertainty(
+    intent: &ProofAttemptIntent,
+    authority: AuthoritativeAttempt,
+) -> Result<ProofAttemptReceipt, RequiredProofError> {
+    intent.validate()?;
+    match authority {
+        AuthoritativeAttempt::Receipt {
+            intent: authoritative_intent,
+            receipt,
+        } => {
+            if authoritative_intent.as_ref() != intent {
+                return Err(RequiredProofError::ConflictingAttempt);
+            }
+            receipt.matches_intent(intent)?;
+            Ok(*receipt)
+        }
+        AuthoritativeAttempt::IntentOnly(authoritative) if authoritative.as_ref() != intent => {
+            Err(RequiredProofError::ConflictingAttempt)
+        }
+        AuthoritativeAttempt::Missing | AuthoritativeAttempt::IntentOnly(_) => {
+            Err(RequiredProofError::AuthorityUncertain)
+        }
+    }
+}
+
+impl ProofAttemptIntent {
+    pub fn ledger_record(&self) -> Result<RecordPayload, RequiredProofError> {
+        Ok(RecordPayload::RequiredProofIntent {
+            run: self.run(),
+            attempt: self.attempt(),
+            digest: self.intent_id(),
+            canonical_bytes: self.canonical_bytes()?,
+        })
+    }
+}
+
+impl ProofAttemptReceipt {
+    pub fn ledger_record(&self) -> Result<RecordPayload, RequiredProofError> {
+        Ok(RecordPayload::RequiredProofReceipt {
+            run: self.run(),
+            attempt: self.attempt(),
+            digest: self.receipt_digest(),
+            canonical_bytes: self.canonical_bytes()?,
+        })
+    }
+}
+
+impl AcceptedProofRef {
+    pub fn ledger_record(&self) -> Result<RecordPayload, RequiredProofError> {
+        Ok(RecordPayload::RequiredProofAcceptance {
+            run: self.run(),
+            attempt: self.attempt(),
+            digest: self.acceptance_digest(),
+            canonical_bytes: self.canonical_bytes()?,
+        })
+    }
+}
+struct RequiredProofCommit<F> {
+    key: IdempotencyId,
+    method: &'static str,
+    response: CanonicalDigest,
+    payload: Result<RecordPayload, RequiredProofError>,
+    is_legal: F,
+}
+
+impl ClusterLedger {
+    pub async fn record_required_proof_intent(
+        &self,
+        key: IdempotencyId,
+        intent: ProofAttemptIntent,
+    ) -> Result<CommitResult<CanonicalDigest>, LedgerError> {
+        self.commit_required_proof(RequiredProofCommit {
+            key,
+            method: "required_proof_intent",
+            response: intent.intent_id(),
+            payload: intent.ledger_record(),
+            is_legal: |state: &crate::cluster_ledger::ReplayState| {
+                state
+                    .admission
+                    .as_ref()
+                    .is_some_and(|admission| admission.run == intent.run())
+                    && !state.required_proofs.iter().any(|proof| {
+                        proof.intent.run() == intent.run()
+                            && proof.intent.attempt() == intent.attempt()
+                    })
+            },
+        })
+        .await
+    }
+
+    pub async fn record_required_proof_receipt(
+        &self,
+        key: IdempotencyId,
+        receipt: ProofAttemptReceipt,
+    ) -> Result<CommitResult<CanonicalDigest>, LedgerError> {
+        self.commit_required_proof(RequiredProofCommit {
+            key,
+            method: "required_proof_receipt",
+            response: receipt.receipt_digest(),
+            payload: receipt.ledger_record(),
+            is_legal: |state: &crate::cluster_ledger::ReplayState| {
+                state.required_proofs.iter().any(|proof| {
+                    proof.intent.run() == receipt.run()
+                        && proof.intent.attempt() == receipt.attempt()
+                        && proof.receipt.is_none()
+                        && receipt.matches_intent(&proof.intent).is_ok()
+                })
+            },
+        })
+        .await
+    }
+
+    pub async fn record_required_proof_acceptance(
+        &self,
+        key: IdempotencyId,
+        accepted: AcceptedProofRef,
+    ) -> Result<CommitResult<CanonicalDigest>, LedgerError> {
+        self.commit_required_proof(RequiredProofCommit {
+            key,
+            method: "required_proof_acceptance",
+            response: accepted.acceptance_digest(),
+            payload: accepted.ledger_record(),
+            is_legal: |state: &crate::cluster_ledger::ReplayState| {
+                state.required_proofs.iter().any(|proof| {
+                    proof.intent.run() == accepted.run()
+                        && proof.intent.attempt() == accepted.attempt()
+                        && proof.accepted.is_none()
+                        && proof
+                            .receipt
+                            .as_ref()
+                            .is_some_and(|receipt| accepted.matches(&proof.intent, receipt).is_ok())
+                })
+            },
+        })
+        .await
+    }
+
+    async fn commit_required_proof<F>(
+        &self,
+        request: RequiredProofCommit<F>,
+    ) -> Result<CommitResult<CanonicalDigest>, LedgerError>
+    where
+        F: FnOnce(&crate::cluster_ledger::ReplayState) -> bool,
+    {
+        let RequiredProofCommit {
+            key,
+            method,
+            response,
+            payload,
+            is_legal,
+        } = request;
+        let state = self.validated_state(FaultContext::Settlement).await?;
+        let fingerprint = response.as_bytes();
+        if let Some(receipt) = self.existing_receipt(
+            &state,
+            &key,
+            ReceiptExpectation::new(FaultContext::Settlement, method, fingerprint),
+        )? {
+            return Ok(receipt);
+        }
+        let payload = payload
+            .map_err(|_| self.domain_error(FaultContext::Settlement, LedgerErrorKind::Encoding))?;
+        if state.terminal_outcome.is_some() || !is_legal(&state) {
+            return Err(
+                self.domain_error(FaultContext::Settlement, LedgerErrorKind::InvalidLifecycle)
+            );
+        }
+        self.commit(
+            CommitRequest::new(
+                FaultContext::Settlement,
+                &state,
+                MutationIdentity::new(key, method, fingerprint),
+                &response,
+            )
+            .with_payloads(vec![payload]),
+        )
+        .await
+    }
+}
+
+fn decode_canonical<T>(
+    bytes: &[u8],
+    validate: fn(&T) -> Result<(), RequiredProofError>,
+) -> Result<T, RequiredProofError>
+where
+    T: DeserializeOwned + Serialize,
+{
+    if bytes.len() > crate::cluster_ledger::record::MAX_RECORD_PAYLOAD_BYTES {
+        return Err(RequiredProofError::Oversized("encoding"));
+    }
+    let value: T = serde_json::from_slice(bytes).map_err(|_| RequiredProofError::Decode)?;
+    validate(&value)?;
+    if canonical_json(&value)? != bytes {
+        return Err(RequiredProofError::NonCanonical);
+    }
+    Ok(value)
+}
+
+fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>, RequiredProofError> {
+    serde_json::to_vec(value).map_err(|_| RequiredProofError::Decode)
+}
+
+fn domain_digest(domain: &[u8], bytes: &[u8]) -> CanonicalDigest {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    CanonicalDigest::new(hasher.finalize().into())
+}
+
+fn protocol_digest(value: &Sha256Digest) -> Result<CanonicalDigest, RequiredProofError> {
+    let bytes = value.as_str().as_bytes();
+    let mut decoded = [0_u8; 32];
+    for (index, pair) in bytes.chunks_exact(2).enumerate() {
+        decoded[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Ok(CanonicalDigest::new(decoded))
+}
+
+fn hex_nibble(value: u8) -> Result<u8, RequiredProofError> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        _ => Err(RequiredProofError::Invalid("digest")),
+    }
+}
+
+fn require_version(version: u16) -> Result<(), RequiredProofError> {
+    if version == REQUIRED_PROOF_VERSION_V1 {
+        Ok(())
+    } else {
+        Err(RequiredProofError::UnknownVersion)
+    }
+}
+
+fn bounded_nonempty(
+    value: &str,
+    maximum: usize,
+    field: &'static str,
+) -> Result<(), RequiredProofError> {
+    if value.is_empty() {
+        return Err(RequiredProofError::Empty(field));
+    }
+    if value.len() > maximum {
+        return Err(RequiredProofError::Oversized(field));
+    }
+    if value.contains('\0') || value.chars().any(|character| character.is_control()) {
+        return Err(RequiredProofError::Invalid(field));
+    }
+    Ok(())
+}
+
+fn validate_cwd(cwd: &str) -> Result<(), RequiredProofError> {
+    bounded_nonempty(cwd, MAX_CWD_BYTES, "cwd")?;
+    if cwd == "." {
+        return Ok(());
+    }
+    if cwd.starts_with('/')
+        || cwd.ends_with('/')
+        || cwd.contains('\\')
+        || cwd
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(RequiredProofError::Invalid("cwd"));
+    }
+    Ok(())
+}
+
+fn validate_env_name(name: &str) -> Result<(), RequiredProofError> {
+    bounded_nonempty(name, MAX_ENVIRONMENT_NAME_BYTES, "environment name")?;
+    let mut characters = name.bytes();
+    let first = characters
+        .next()
+        .ok_or(RequiredProofError::Empty("environment name"))?;
+    if !(first.is_ascii_alphabetic() || first == b'_')
+        || !characters.all(|value| value.is_ascii_alphanumeric() || value == b'_')
+    {
+        return Err(RequiredProofError::Invalid("environment name"));
+    }
+    Ok(())
+}
+
+fn validate_explicit_environment(name: &str, value: &str) -> Result<(), RequiredProofError> {
+    let allowed = match name {
+        "CARGO_TERM_COLOR" => matches!(value, "auto" | "always" | "never"),
+        "CLICOLOR" | "CLICOLOR_FORCE" => matches!(value, "0" | "1"),
+        "NO_COLOR" => matches!(value, "" | "1"),
+        "RUST_BACKTRACE" => matches!(value, "0" | "1" | "full"),
+        "LANG" | "LC_ALL" => matches!(value, "C" | "C.UTF-8" | "en_US.UTF-8"),
+        "TERM" => matches!(value, "dumb" | "xterm" | "xterm-256color"),
+        "TZ" => value == "UTC",
+        _ => return Err(RequiredProofError::Invalid("explicit environment")),
+    };
+    if !allowed {
+        return Err(RequiredProofError::Invalid("explicit environment value"));
+    }
+    Ok(())
+}
+
+fn validate_repository(repository: &str) -> Result<(), RequiredProofError> {
+    bounded_nonempty(repository, MAX_REPOSITORY_BYTES, "repository")?;
+    let mut components = repository.split('/');
+    let valid_component = |component: &str| {
+        !component.is_empty()
+            && component != "."
+            && component != ".."
+            && component
+                .bytes()
+                .all(|value| value.is_ascii_alphanumeric() || matches!(value, b'-' | b'_' | b'.'))
+    };
+    let owner = components.next().unwrap_or_default();
+    let name = components.next().unwrap_or_default();
+    if !valid_component(owner) || !valid_component(name) || components.next().is_some() {
+        return Err(RequiredProofError::Invalid("repository"));
+    }
+    Ok(())
+}
+
+fn validate_revision(revision: &str) -> Result<(), RequiredProofError> {
+    if !matches!(revision.len(), 40 | 64)
+        || !revision
+            .bytes()
+            .all(|value| value.is_ascii_digit() || (b'a'..=b'f').contains(&value))
+    {
+        return Err(RequiredProofError::Invalid("revision"));
+    }
+    Ok(())
+}
+
+fn binding(matches: bool, field: &'static str) -> Result<(), RequiredProofError> {
+    if matches {
+        Ok(())
+    } else {
+        Err(RequiredProofError::BindingMismatch(field))
+    }
+}

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -43,6 +43,7 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         "src/main.rs",
         "src/observability.rs",
         "src/provider_value.rs",
+        "src/required_proof.rs",
         "src/scheduler.rs",
         "src/issue_provider.rs",
         "src/source_code_provider.rs",
@@ -57,6 +58,7 @@ fn product_uses_the_root_workspace_and_a_rust_only_layout() {
         "tests/local_process_runner.rs",
         "tests/observability_contract.rs",
         "tests/provider_contracts.rs",
+        "tests/required_proof_contract.rs",
         "tests/provider_bounds.rs",
         "tests/source_authority_contract.rs",
         "tests/scheduler_contract.rs",
@@ -169,6 +171,7 @@ fn workspace_metadata_preserves_package_lib_and_bin_identity() {
         ("local_process_runner".to_owned(), "test".to_owned()),
         ("observability_contract".to_owned(), "test".to_owned()),
         ("source_authority_contract".to_owned(), "test".to_owned()),
+        ("required_proof_contract".to_owned(), "test".to_owned()),
         ("scheduler_contract".to_owned(), "test".to_owned()),
     ] {
         assert!(
@@ -522,6 +525,7 @@ fn worker_catalog_adds_no_out_of_scope_product_construction() {
             "observability.rs",
             "provider_value",
             "provider_value.rs",
+            "required_proof.rs",
             "scheduler.rs",
             "source_code_provider",
             "source_code_provider.rs",
@@ -571,6 +575,72 @@ fn worker_catalog_adds_no_out_of_scope_product_construction() {
         assert!(
             !catalog_source.contains(forbidden),
             "worker catalog crossed its owned boundary: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn required_proof_contract_stays_product_private_byte_free_and_non_executing() {
+    let product = product_root();
+    let proof = read(&product.join("src/required_proof.rs"));
+    let ledger = rust_sources(&["src/cluster_ledger.rs", "src/cluster_ledger"]);
+    let protocol = rust_sources(&[
+        "../crates/openengine-cluster-protocol/src",
+        "../crates/openengine-cluster-server/src",
+    ]);
+    assert!(read(&product.join("src/lib.rs")).contains("pub mod required_proof;"));
+    for required in [
+        "struct TrustedGate",
+        "struct ProofAttemptIntent",
+        "struct ProofAttemptReceipt",
+        "struct AcceptedProofRef",
+        "trait ArtifactReverification",
+        "struct PerformProofAttempt",
+        "struct InspectProofAttempt",
+        "struct ReconcileProofAttempt",
+        "reconcile_after_uncertainty",
+    ] {
+        assert!(
+            proof.contains(required),
+            "missing required-proof contract: {required}"
+        );
+    }
+    for required in [
+        "RequiredProofIntent",
+        "RequiredProofReceipt",
+        "RequiredProofAcceptance",
+        "required_proofs",
+    ] {
+        assert!(
+            ledger.contains(required),
+            "ledger misses required-proof fold: {required}"
+        );
+    }
+    for forbidden in [
+        "std::process",
+        "tokio::process",
+        "Command::new",
+        "PathBuf",
+        "gh issue",
+        "octocrab",
+        "reqwest",
+        "SourceCodeProvider",
+    ] {
+        assert!(
+            !proof.contains(forbidden),
+            "required-proof contract crossed a non-goal boundary: {forbidden}"
+        );
+    }
+    for private_type in [
+        "TrustedGate",
+        "ProofAttemptIntent",
+        "ProofAttemptReceipt",
+        "AcceptedProofRef",
+        "ArtifactReverification",
+    ] {
+        assert!(
+            !protocol.contains(private_type),
+            "product-private proof type leaked into protocol/server: {private_type}"
         );
     }
 }

--- a/zeroshot-rust/tests/artifact_store.rs
+++ b/zeroshot-rust/tests/artifact_store.rs
@@ -1,13 +1,17 @@
+use std::io::Cursor;
 use std::sync::Arc;
 
-use openengine_cluster_protocol::{ByteLength, RunId};
+use async_trait::async_trait;
+use openengine_cluster_protocol::{ArtifactId, ArtifactRef, ByteLength, RunId, Sha256Digest};
 use tokio::io::AsyncReadExt;
 use zeroshot_engine::artifact_store::fake::{FakeArtifactStore, FakeFailurePoint};
 use zeroshot_engine::artifact_store::{
-    ArtifactStore, ArtifactStoreFailureKind, ArtifactStoreOperation, DiscardResult,
-    MAX_ARTIFACT_BYTES, ReleaseResult, derive_artifact_id,
+    ArtifactByteStream, ArtifactIntent, ArtifactStore, ArtifactStoreFailure,
+    ArtifactStoreFailureKind, ArtifactStoreOperation, DiscardResult, MAX_ARTIFACT_BYTES,
+    ReleaseResult, StagedArtifact, VerifiedArtifactStream, derive_artifact_id,
 };
 use zeroshot_engine::fault::{EvidenceClass, FaultContext, FaultModule};
+use zeroshot_engine::required_proof::{ArtifactReverification, RequiredProofError};
 
 #[path = "support/artifacts.rs"]
 mod artifacts;
@@ -331,4 +335,119 @@ fn failure_mapping_is_closed_and_contains_no_raw_text() {
         assert!(!failure.to_string().contains('/'));
         assert!(!format!("{failure:?}").contains("path"));
     }
+}
+
+struct CorruptOpenStore {
+    artifact_ref: ArtifactRef,
+    bytes: Vec<u8>,
+}
+
+#[async_trait]
+impl ArtifactStore for CorruptOpenStore {
+    async fn stage(
+        &self,
+        _intent: ArtifactIntent,
+        _bytes: ArtifactByteStream,
+    ) -> Result<StagedArtifact, ArtifactStoreFailure> {
+        Err(ArtifactStoreFailure::new(
+            ArtifactStoreFailureKind::InvalidStage,
+        ))
+    }
+
+    async fn publish(&self, _staged: &StagedArtifact) -> Result<ArtifactRef, ArtifactStoreFailure> {
+        Err(ArtifactStoreFailure::new(
+            ArtifactStoreFailureKind::InvalidStage,
+        ))
+    }
+
+    async fn inspect(
+        &self,
+        artifact_id: &ArtifactId,
+    ) -> Result<Option<ArtifactRef>, ArtifactStoreFailure> {
+        Ok((artifact_id == &self.artifact_ref.artifact_id).then(|| self.artifact_ref.clone()))
+    }
+
+    async fn open(
+        &self,
+        artifact_id: &ArtifactId,
+    ) -> Result<VerifiedArtifactStream, ArtifactStoreFailure> {
+        if artifact_id != &self.artifact_ref.artifact_id {
+            return Err(ArtifactStoreFailure::new(
+                ArtifactStoreFailureKind::MissingCommittedContent,
+            ));
+        }
+        Ok(Box::new(Cursor::new(self.bytes.clone())))
+    }
+
+    async fn discard(
+        &self,
+        _staged: &StagedArtifact,
+    ) -> Result<DiscardResult, ArtifactStoreFailure> {
+        Err(ArtifactStoreFailure::new(
+            ArtifactStoreFailureKind::InvalidStage,
+        ))
+    }
+
+    async fn release(
+        &self,
+        _artifact_id: &ArtifactId,
+    ) -> Result<ReleaseResult, ArtifactStoreFailure> {
+        Err(ArtifactStoreFailure::new(
+            ArtifactStoreFailureKind::InvalidStage,
+        ))
+    }
+}
+
+#[tokio::test]
+async fn required_proof_reverification_hashes_exact_short_and_overlong_streams() {
+    let source = FakeArtifactStore::new();
+    let expected_bytes = b"proof output".to_vec();
+    let staged = source
+        .stage(
+            intent(&expected_bytes, "proof-corrupt-open"),
+            stream(expected_bytes.clone()),
+        )
+        .await
+        .unwrap();
+    let artifact_ref = source.publish(&staged).await.unwrap();
+
+    for bytes in [
+        vec![b'x'; expected_bytes.len()],
+        expected_bytes[..expected_bytes.len() - 1].to_vec(),
+        [expected_bytes.as_slice(), b"x"].concat(),
+    ] {
+        let store = CorruptOpenStore {
+            artifact_ref: artifact_ref.clone(),
+            bytes,
+        };
+        assert_eq!(
+            ArtifactReverification::reverify(&store, &artifact_ref)
+                .await
+                .unwrap_err(),
+            RequiredProofError::ArtifactMismatch
+        );
+    }
+}
+
+#[tokio::test]
+async fn required_proof_reverification_checks_exact_ref_length_and_digest() {
+    let store = FakeArtifactStore::new();
+    let bytes = b"proof output".to_vec();
+    let staged = store
+        .stage(intent(&bytes, "proof-reverify"), stream(bytes))
+        .await
+        .unwrap();
+    let artifact_ref = store.publish(&staged).await.unwrap();
+    ArtifactReverification::reverify(&store, &artifact_ref)
+        .await
+        .unwrap();
+
+    let mut forged = artifact_ref;
+    forged.sha256 = Sha256Digest::new("0".repeat(64)).unwrap();
+    assert_eq!(
+        ArtifactReverification::reverify(&store, &forged)
+            .await
+            .unwrap_err(),
+        RequiredProofError::ArtifactMismatch
+    );
 }

--- a/zeroshot-rust/tests/cluster_ledger_replay.rs
+++ b/zeroshot-rust/tests/cluster_ledger_replay.rs
@@ -107,6 +107,8 @@ async fn admit_and_dispatch(
 mod protocol;
 #[path = "cluster_ledger_replay/races.rs"]
 mod races;
+#[path = "cluster_ledger_replay/required_proof.rs"]
+mod required_proof;
 #[path = "cluster_ledger_replay/snapshot_race_store.rs"]
 mod snapshot_race_store;
 #[path = "cluster_ledger_replay/validation.rs"]

--- a/zeroshot-rust/tests/cluster_ledger_replay/required_proof.rs
+++ b/zeroshot-rust/tests/cluster_ledger_replay/required_proof.rs
@@ -1,0 +1,309 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use openengine_cluster_protocol::PositiveInteger;
+use zeroshot_engine::artifact_store::fake::FakeArtifactStore;
+use zeroshot_engine::artifact_store::ArtifactStore;
+use zeroshot_engine::cluster_ledger::record::{CanonicalDigest, RecordPayload, StoredRecord};
+use zeroshot_engine::cluster_ledger::replay::ReplayError;
+use zeroshot_engine::cluster_ledger::store::{
+    IdempotencyId, MutationReceipt, Position, PrefixSnapshot, ResourceId,
+};
+use zeroshot_engine::required_proof::{
+    AcceptProofRequest, AcceptedProofRef, ProcessOutcome, ProofAttemptIntent,
+    ProofAttemptIntentRequest, ProofAttemptReceipt, ProofAttemptReceiptRequest, ProofOutput,
+    ProofSelection, TrustedGate, TrustedGateRequest,
+};
+
+#[path = "../support/artifacts.rs"]
+mod artifacts;
+
+fn revision(character: char) -> String {
+    std::iter::repeat_n(character, 40).collect()
+}
+
+fn gate() -> TrustedGate {
+    TrustedGate::new(TrustedGateRequest {
+        gate_id: "required.replay".to_owned(),
+        argv: vec!["cargo".to_owned(), "test".to_owned()],
+        cwd: "zeroshot-rust".to_owned(),
+        inherited_env: BTreeSet::from(["PATH".to_owned()]),
+        explicit_env: BTreeMap::new(),
+        timeout_ms: 30_000,
+        freshness_ms: 5_000,
+        tool_identity: "cargo".to_owned(),
+        tool_version: "1.88.0".to_owned(),
+        tool_digest: CanonicalDigest::of(b"tool"),
+        repository: "the-open-engine/zeroshot".to_owned(),
+        base_revision: revision('a'),
+        head_revision: revision('b'),
+        config_digest: CanonicalDigest::of(b"config"),
+    })
+    .unwrap()
+}
+
+async fn receipt(store: &FakeArtifactStore, intent: &ProofAttemptIntent) -> ProofAttemptReceipt {
+    let mut outputs = Vec::new();
+    for bytes in [b"stdout".as_slice(), b"stderr".as_slice()] {
+        let mut artifact_intent =
+            artifacts::test_intent(bytes, &format!("run:{}", intent.run().get()));
+        artifact_intent.lineage.attempt =
+            PositiveInteger::new(u64::from(intent.attempt())).unwrap();
+        let staged = store
+            .stage(artifact_intent, artifacts::byte_stream(bytes.to_vec()))
+            .await
+            .unwrap();
+        outputs.push(ProofOutput::new(store.publish(&staged).await.unwrap()).unwrap());
+    }
+    ProofAttemptReceipt::new(
+        intent,
+        ProofAttemptReceiptRequest {
+            started_at_ms: 1_100,
+            finished_at_ms: Some(1_200),
+            outcome: ProcessOutcome::Exited { exit_code: 0 },
+            stdout: Some(outputs.remove(0)),
+            stderr: Some(outputs.remove(0)),
+        },
+    )
+    .unwrap()
+}
+
+fn append_intent_mutation(
+    snapshot: &mut PrefixSnapshot,
+    resource: &ResourceId,
+    key: IdempotencyId,
+    intent: &ProofAttemptIntent,
+) {
+    let payload = intent.ledger_record().unwrap();
+    let proof_position = snapshot.position.checked_add(1).unwrap();
+    let previous_hash = snapshot
+        .records
+        .last()
+        .map_or([0; 32], |record| record.record_hash);
+    let proof_record =
+        StoredRecord::build(resource.clone(), proof_position, &payload, previous_hash).unwrap();
+    let receipt_position = proof_position.checked_add(1).unwrap();
+    let receipt = MutationReceipt {
+        idempotency_key: key,
+        method: "required_proof_intent".to_owned(),
+        fingerprint: intent.intent_id().as_bytes(),
+        response: serde_json::to_vec(&intent.intent_id()).unwrap(),
+        committed_position: receipt_position,
+    };
+    let receipt_record = StoredRecord::build(
+        resource.clone(),
+        receipt_position,
+        &RecordPayload::MutationReceipt {
+            receipt: receipt.clone(),
+        },
+        proof_record.record_hash,
+    )
+    .unwrap();
+    snapshot.records.push(proof_record);
+    snapshot.records.push(receipt_record);
+    snapshot.receipts.push(receipt);
+    snapshot.position = receipt_position;
+}
+
+fn assert_forged_required_proof_fingerprint_rejected(
+    snapshot: &PrefixSnapshot,
+    resource: &ResourceId,
+    method: &str,
+) {
+    let mut forged = snapshot.clone();
+    let forged_receipt = forged
+        .receipts
+        .iter_mut()
+        .find(|receipt| receipt.method == method)
+        .unwrap();
+    forged_receipt.fingerprint = [0; 32];
+    let forged_receipt = forged_receipt.clone();
+    let record_index = forged
+        .records
+        .iter()
+        .position(|record| {
+            matches!(
+                RecordPayload::decode(record.kind, record.version, &record.payload),
+                Ok(RecordPayload::MutationReceipt { receipt })
+                    if receipt.idempotency_key == forged_receipt.idempotency_key
+            )
+        })
+        .unwrap();
+    super::replace_payload(
+        &mut forged,
+        record_index,
+        RecordPayload::MutationReceipt {
+            receipt: forged_receipt,
+        },
+    );
+    assert_eq!(
+        super::replay(&forged, resource).unwrap_err(),
+        ReplayError::ReceiptCorrupt
+    );
+}
+
+#[test]
+fn replay_rejects_required_proof_intent_without_admission() {
+    let resource = super::resource("proof-before-admission");
+    let trusted = gate();
+    let intent = ProofAttemptIntent::new(
+        &trusted,
+        ProofAttemptIntentRequest {
+            run: zeroshot_engine::cluster_ledger::RunSequence::new(7).unwrap(),
+            attempt: 1,
+            requested_at_ms: 1_000,
+            selection: ProofSelection::admitted(&trusted),
+        },
+    )
+    .unwrap();
+    let mut snapshot = PrefixSnapshot {
+        position: Position::ZERO,
+        records: Vec::new(),
+        receipts: Vec::new(),
+    };
+    append_intent_mutation(
+        &mut snapshot,
+        &resource,
+        super::key("proof-before-admission"),
+        &intent,
+    );
+    assert_eq!(
+        super::replay(&snapshot, &resource).unwrap_err(),
+        ReplayError::InvalidOrder
+    );
+}
+
+#[tokio::test]
+async fn replay_rejects_required_proof_intent_for_non_current_run() {
+    let (store, cluster) = super::ledger("proof-wrong-run").await;
+    cluster
+        .admit(
+            super::key("wrong-run-admit"),
+            [9; 32],
+            super::admission(b"wrong-run-graph"),
+        )
+        .await
+        .unwrap();
+    let trusted = gate();
+    let intent = ProofAttemptIntent::new(
+        &trusted,
+        ProofAttemptIntentRequest {
+            run: zeroshot_engine::cluster_ledger::RunSequence::new(7).unwrap(),
+            attempt: 1,
+            requested_at_ms: 1_000,
+            selection: ProofSelection::admitted(&trusted),
+        },
+    )
+    .unwrap();
+    let mut snapshot = store.read_prefix(cluster.resource(), None).await.unwrap();
+    append_intent_mutation(
+        &mut snapshot,
+        cluster.resource(),
+        super::key("proof-wrong-run"),
+        &intent,
+    );
+    assert_eq!(
+        super::replay(&snapshot, cluster.resource()).unwrap_err(),
+        ReplayError::InvalidOrder
+    );
+}
+
+#[tokio::test]
+async fn required_proof_records_round_trip_and_fold_exact_immutable_attempts() {
+    let (store, cluster) = super::ledger("required-proof-replay").await;
+    let allocation = cluster
+        .admit(
+            super::key("proof-admit"),
+            [7; 32],
+            super::admission(b"proof-graph"),
+        )
+        .await
+        .unwrap()
+        .value;
+    let trusted = gate();
+    let first = ProofAttemptIntent::new(
+        &trusted,
+        ProofAttemptIntentRequest {
+            run: allocation.run,
+            attempt: 1,
+            requested_at_ms: 1_000,
+            selection: ProofSelection::admitted(&trusted),
+        },
+    )
+    .unwrap();
+    let first_commit = cluster
+        .record_required_proof_intent(super::key("proof-intent-1"), first.clone())
+        .await
+        .unwrap();
+    assert!(!first_commit.replayed);
+    assert!(
+        cluster
+            .record_required_proof_intent(super::key("proof-intent-1"), first.clone())
+            .await
+            .unwrap()
+            .replayed
+    );
+
+    let artifacts = FakeArtifactStore::new();
+    let first_receipt = receipt(&artifacts, &first).await;
+    cluster
+        .record_required_proof_receipt(super::key("proof-receipt-1"), first_receipt.clone())
+        .await
+        .unwrap();
+    let accepted = AcceptedProofRef::accept(AcceptProofRequest {
+        gate: &trusted,
+        intent: &first,
+        receipt: &first_receipt,
+        accepted_at_ms: 1_300,
+        artifacts: &artifacts,
+    })
+    .await
+    .unwrap();
+    cluster
+        .record_required_proof_acceptance(super::key("proof-acceptance-1"), accepted.clone())
+        .await
+        .unwrap();
+
+    let later = ProofAttemptIntent::new(
+        &trusted,
+        ProofAttemptIntentRequest {
+            run: allocation.run,
+            attempt: 2,
+            requested_at_ms: 1_400,
+            selection: ProofSelection::admitted(&trusted),
+        },
+    )
+    .unwrap();
+    cluster
+        .record_required_proof_intent(super::key("proof-intent-2"), later.clone())
+        .await
+        .unwrap();
+    let later_receipt = receipt(&artifacts, &later).await;
+    cluster
+        .record_required_proof_receipt(super::key("proof-receipt-2"), later_receipt.clone())
+        .await
+        .unwrap();
+
+    let state = cluster.state().await.unwrap();
+    assert_eq!(state.required_proofs.len(), 2);
+    assert_eq!(state.required_proofs[0].intent, first);
+    assert_eq!(state.required_proofs[0].receipt, Some(first_receipt));
+    assert_eq!(state.required_proofs[0].accepted, Some(accepted));
+    assert_eq!(state.required_proofs[1].intent, later);
+    assert_eq!(state.required_proofs[1].receipt, Some(later_receipt));
+    assert_eq!(state.required_proofs[1].accepted, None);
+
+    let snapshot = store.read_prefix(cluster.resource(), None).await.unwrap();
+    let replayed = super::replay(&snapshot, cluster.resource()).unwrap();
+    assert_eq!(replayed.required_proofs, state.required_proofs);
+    assert_eq!(
+        replayed.public_bytes().unwrap(),
+        state.public_bytes().unwrap()
+    );
+    for method in [
+        "required_proof_intent",
+        "required_proof_receipt",
+        "required_proof_acceptance",
+    ] {
+        assert_forged_required_proof_fingerprint_rejected(&snapshot, cluster.resource(), method);
+    }
+}

--- a/zeroshot-rust/tests/required_proof_contract.rs
+++ b/zeroshot-rust/tests/required_proof_contract.rs
@@ -1,0 +1,525 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{ArtifactRef, PositiveInteger};
+use zeroshot_engine::artifact_store::fake::FakeArtifactStore;
+use zeroshot_engine::artifact_store::ArtifactStore;
+use zeroshot_engine::cluster_ledger::record::{CanonicalDigest, RunSequence};
+use zeroshot_engine::required_proof::{
+    reconcile_after_uncertainty, AcceptProofRequest, AcceptedProofRef, ArtifactReverification,
+    AuthoritativeAttempt, InspectProofAttempt, PerformProofAttempt, ProcessOutcome,
+    ProofAttemptIntent, ProofAttemptIntentRequest, ProofAttemptReceipt, ProofAttemptReceiptRequest,
+    ProofOutput, ProofSelection, ReconcileProofAttempt, RequiredProofError, TrustedGate,
+    TrustedGateRequest, MAX_ARGUMENT_BYTES,
+};
+
+#[path = "support/artifacts.rs"]
+mod artifacts;
+
+fn digest(label: &[u8]) -> CanonicalDigest {
+    CanonicalDigest::of(label)
+}
+
+fn revision(character: char) -> String {
+    std::iter::repeat_n(character, 40).collect()
+}
+
+fn gate_with(
+    config_digest: CanonicalDigest,
+    tool_digest: CanonicalDigest,
+    base_revision: String,
+    head_revision: String,
+) -> TrustedGate {
+    TrustedGate::new(TrustedGateRequest {
+        gate_id: "required.unit".to_owned(),
+        argv: vec!["cargo".to_owned(), "test".to_owned(), "--locked".to_owned()],
+        cwd: "zeroshot-rust".to_owned(),
+        inherited_env: BTreeSet::from(["PATH".to_owned()]),
+        explicit_env: BTreeMap::from([("CARGO_TERM_COLOR".to_owned(), "never".to_owned())]),
+        timeout_ms: 60_000,
+        freshness_ms: 5_000,
+        tool_identity: "cargo".to_owned(),
+        tool_version: "1.88.0".to_owned(),
+        tool_digest,
+        repository: "the-open-engine/zeroshot".to_owned(),
+        base_revision,
+        head_revision,
+        config_digest,
+    })
+    .unwrap()
+}
+
+fn gate() -> TrustedGate {
+    gate_with(
+        digest(b"config"),
+        digest(b"tool"),
+        revision('a'),
+        revision('b'),
+    )
+}
+
+fn intent_for(gate: &TrustedGate, attempt: u32) -> ProofAttemptIntent {
+    ProofAttemptIntent::new(
+        gate,
+        ProofAttemptIntentRequest {
+            run: RunSequence::new(7).unwrap(),
+            attempt,
+            requested_at_ms: 10_000,
+            selection: ProofSelection::admitted(gate),
+        },
+    )
+    .unwrap()
+}
+
+async fn artifact_with_lineage(
+    store: &FakeArtifactStore,
+    bytes: &[u8],
+    run_id: &str,
+    attempt: u64,
+) -> ArtifactRef {
+    let mut artifact_intent = artifacts::test_intent(bytes, run_id);
+    artifact_intent.lineage.attempt = PositiveInteger::new(attempt).unwrap();
+    let staged = store
+        .stage(artifact_intent, artifacts::byte_stream(bytes.to_vec()))
+        .await
+        .unwrap();
+    store.publish(&staged).await.unwrap()
+}
+
+async fn artifact(
+    store: &FakeArtifactStore,
+    bytes: &[u8],
+    intent: &ProofAttemptIntent,
+) -> ArtifactRef {
+    artifact_with_lineage(
+        store,
+        bytes,
+        &format!("run:{}", intent.run().get()),
+        u64::from(intent.attempt()),
+    )
+    .await
+}
+
+async fn passing_receipt(
+    store: &FakeArtifactStore,
+    intent: &ProofAttemptIntent,
+) -> ProofAttemptReceipt {
+    let stdout = artifact(store, b"stdout", intent).await;
+    let stderr = artifact(store, b"stderr", intent).await;
+    ProofAttemptReceipt::new(
+        intent,
+        ProofAttemptReceiptRequest {
+            started_at_ms: 10_100,
+            finished_at_ms: Some(10_500),
+            outcome: ProcessOutcome::Exited { exit_code: 0 },
+            stdout: Some(ProofOutput::new(stdout).unwrap()),
+            stderr: Some(ProofOutput::new(stderr).unwrap()),
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn trusted_gate_rejects_unknown_oversized_and_non_normal_values() {
+    let value = gate();
+    let bytes = value.canonical_bytes().unwrap();
+    let mut json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    json.as_object_mut()
+        .unwrap()
+        .insert("unknown".to_owned(), serde_json::json!(true));
+    assert_eq!(
+        TrustedGate::decode(&serde_json::to_vec(&json).unwrap()).unwrap_err(),
+        RequiredProofError::Decode
+    );
+
+    let mut request = TrustedGateRequest {
+        gate_id: "required.unit".to_owned(),
+        argv: vec!["x".repeat(MAX_ARGUMENT_BYTES + 1)],
+        cwd: ".".to_owned(),
+        inherited_env: BTreeSet::new(),
+        explicit_env: BTreeMap::new(),
+        timeout_ms: 1,
+        freshness_ms: 1,
+        tool_identity: "tool".to_owned(),
+        tool_version: "1".to_owned(),
+        tool_digest: digest(b"tool"),
+        repository: "repository".to_owned(),
+        base_revision: revision('a'),
+        head_revision: revision('b'),
+        config_digest: digest(b"config"),
+    };
+    assert_eq!(
+        TrustedGate::new(request.clone()).unwrap_err(),
+        RequiredProofError::Oversized("argument")
+    );
+    for cwd in ["/absolute", "a/../b", "a//b", "./a", "a/./b", "a\\b"] {
+        request.argv = vec!["tool".to_owned()];
+        request.cwd = cwd.to_owned();
+        assert_eq!(
+            TrustedGate::new(request.clone()).unwrap_err(),
+            RequiredProofError::Invalid("cwd")
+        );
+    }
+}
+
+#[test]
+fn explicit_environment_is_bounded_valid_and_credential_free() {
+    let base = gate();
+    let mut request = TrustedGateRequest {
+        gate_id: base.gate_id().to_owned(),
+        argv: base.argv().to_vec(),
+        cwd: base.cwd().to_owned(),
+        inherited_env: BTreeSet::new(),
+        explicit_env: BTreeMap::new(),
+        timeout_ms: base.timeout_ms(),
+        freshness_ms: base.freshness_ms(),
+        tool_identity: base.tool_identity().to_owned(),
+        tool_version: base.tool_version().to_owned(),
+        tool_digest: base.tool_digest(),
+        repository: base.repository().to_owned(),
+        base_revision: base.base_revision().to_owned(),
+        head_revision: base.head_revision().to_owned(),
+        config_digest: base.config_digest(),
+    };
+    for credential_name in [
+        "API_KEY",
+        "GITHUB_PAT",
+        "GITHUB_TOKEN",
+        "CI_JOB_JWT",
+        "NPM_AUTH",
+    ] {
+        request.explicit_env =
+            BTreeMap::from([(credential_name.to_owned(), "credential".to_owned())]);
+        assert_eq!(
+            TrustedGate::new(request.clone()).unwrap_err(),
+            RequiredProofError::Invalid("explicit environment")
+        );
+    }
+    request.explicit_env = BTreeMap::from([("BAD=NAME".to_owned(), "value".to_owned())]);
+    assert_eq!(
+        TrustedGate::new(request.clone()).unwrap_err(),
+        RequiredProofError::Invalid("environment name")
+    );
+    request.explicit_env = BTreeMap::from([("SAFE_NAME".to_owned(), "line\nvalue".to_owned())]);
+    assert_eq!(
+        TrustedGate::new(request.clone()).unwrap_err(),
+        RequiredProofError::Invalid("environment value")
+    );
+    request.explicit_env =
+        BTreeMap::from([("CARGO_TERM_COLOR".to_owned(), "credential".to_owned())]);
+    assert_eq!(
+        TrustedGate::new(request).unwrap_err(),
+        RequiredProofError::Invalid("explicit environment value")
+    );
+}
+
+#[tokio::test]
+async fn receipt_rejects_cross_run_and_cross_attempt_artifact_lineage() {
+    let trusted = gate();
+    let intent = intent_for(&trusted, 1);
+    let store = FakeArtifactStore::new();
+    let stderr = artifact(&store, b"correct-stderr", &intent).await;
+    let wrong_run = artifact_with_lineage(&store, b"wrong-run", "run:99", 1).await;
+    let wrong_attempt = artifact_with_lineage(&store, b"wrong-attempt", "run:7", 2).await;
+
+    for (stdout, expected) in [
+        (
+            wrong_run,
+            RequiredProofError::BindingMismatch("artifact run"),
+        ),
+        (
+            wrong_attempt,
+            RequiredProofError::BindingMismatch("artifact attempt"),
+        ),
+    ] {
+        assert_eq!(
+            ProofAttemptReceipt::new(
+                &intent,
+                ProofAttemptReceiptRequest {
+                    started_at_ms: 10_100,
+                    finished_at_ms: Some(10_500),
+                    outcome: ProcessOutcome::Exited { exit_code: 0 },
+                    stdout: Some(ProofOutput::new(stdout).unwrap()),
+                    stderr: Some(ProofOutput::new(stderr.clone()).unwrap()),
+                },
+            )
+            .unwrap_err(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn graph_visible_selection_contains_only_gate_and_revision_bindings() {
+    let trusted = gate();
+    let selection = ProofSelection::admitted(&trusted);
+    let json = String::from_utf8(selection.canonical_bytes().unwrap()).unwrap();
+    for present in ["gate_id", "repository", "base_revision", "head_revision"] {
+        assert!(json.contains(present));
+    }
+    for absent in ["argv", "cwd", "env", "tool", "digest", "credential", "path"] {
+        assert!(!json.contains(absent), "selection leaked {absent}: {json}");
+    }
+}
+
+#[test]
+fn canonical_encoding_and_identity_are_stable_and_strict() {
+    let trusted = gate();
+    let decoded = TrustedGate::decode(&trusted.canonical_bytes().unwrap()).unwrap();
+    assert_eq!(decoded, trusted);
+    assert_eq!(decoded.gate_digest(), trusted.gate_digest());
+
+    let first = intent_for(&trusted, 1);
+    let second = intent_for(&trusted, 1);
+    assert_eq!(first, second);
+    assert_eq!(first.intent_id(), second.intent_id());
+    assert_eq!(
+        PerformProofAttempt::new(first.clone()).idempotency_identity(),
+        first.intent_id()
+    );
+    let inspect = InspectProofAttempt::for_intent(&first);
+    assert_eq!(inspect.run(), first.run());
+    assert_eq!(inspect.attempt(), first.attempt());
+    assert_eq!(inspect.idempotency_identity(), first.intent_id());
+    let padded = format!(
+        " {}",
+        String::from_utf8(first.canonical_bytes().unwrap()).unwrap()
+    );
+    assert_eq!(
+        ProofAttemptIntent::decode(padded.as_bytes()).unwrap_err(),
+        RequiredProofError::NonCanonical
+    );
+}
+
+#[tokio::test]
+async fn wrong_revision_config_tool_and_gate_digest_fail_closed() {
+    let trusted = gate();
+    let attempt = intent_for(&trusted, 1);
+    let store = FakeArtifactStore::new();
+    let receipt = passing_receipt(&store, &attempt).await;
+
+    let variants = [
+        gate_with(
+            digest(b"other-config"),
+            digest(b"tool"),
+            revision('a'),
+            revision('b'),
+        ),
+        gate_with(
+            digest(b"config"),
+            digest(b"other-tool"),
+            revision('a'),
+            revision('b'),
+        ),
+        gate_with(
+            digest(b"config"),
+            digest(b"tool"),
+            revision('c'),
+            revision('b'),
+        ),
+    ];
+    for wrong in variants {
+        assert!(
+            AcceptedProofRef::accept(AcceptProofRequest {
+                gate: &wrong,
+                intent: &attempt,
+                receipt: &receipt,
+                accepted_at_ms: 11_000,
+                artifacts: &store,
+            })
+            .await
+            .is_err()
+        );
+    }
+
+    let mut json: serde_json::Value =
+        serde_json::from_slice(&attempt.canonical_bytes().unwrap()).unwrap();
+    json["body"]["gate_digest"] = serde_json::json!(vec![0; 32]);
+    assert_eq!(
+        ProofAttemptIntent::decode(&serde_json::to_vec(&json).unwrap()).unwrap_err(),
+        RequiredProofError::DigestMismatch("intent")
+    );
+}
+
+#[tokio::test]
+async fn stale_failed_incomplete_and_indeterminate_attempts_are_never_accepted() {
+    let trusted = gate();
+    let attempt = intent_for(&trusted, 1);
+    let store = FakeArtifactStore::new();
+    let passing = passing_receipt(&store, &attempt).await;
+    assert_eq!(
+        AcceptedProofRef::accept(AcceptProofRequest {
+            gate: &trusted,
+            intent: &attempt,
+            receipt: &passing,
+            accepted_at_ms: 20_000,
+            artifacts: &store,
+        })
+        .await
+        .unwrap_err(),
+        RequiredProofError::Stale
+    );
+
+    for (outcome, finished, expected) in [
+        (
+            ProcessOutcome::Exited { exit_code: 1 },
+            Some(10_500),
+            RequiredProofError::NotPassing,
+        ),
+        (
+            ProcessOutcome::Incomplete,
+            None,
+            RequiredProofError::Incomplete,
+        ),
+        (
+            ProcessOutcome::Indeterminate,
+            Some(10_500),
+            RequiredProofError::Indeterminate,
+        ),
+    ] {
+        let receipt = ProofAttemptReceipt::new(
+            &attempt,
+            ProofAttemptReceiptRequest {
+                started_at_ms: 10_100,
+                finished_at_ms: finished,
+                outcome,
+                stdout: None,
+                stderr: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            AcceptedProofRef::accept(AcceptProofRequest {
+                gate: &trusted,
+                intent: &attempt,
+                receipt: &receipt,
+                accepted_at_ms: 11_000,
+                artifacts: &store,
+            })
+            .await
+            .unwrap_err(),
+            expected
+        );
+    }
+}
+
+#[tokio::test]
+async fn acceptance_is_bound_to_one_exact_attempt_and_later_attempts_are_distinct() {
+    let trusted = gate();
+    let first = intent_for(&trusted, 1);
+    let later = intent_for(&trusted, 2);
+    let store = FakeArtifactStore::new();
+    let first_receipt = passing_receipt(&store, &first).await;
+    let later_receipt = passing_receipt(&store, &later).await;
+    let accepted = AcceptedProofRef::accept(AcceptProofRequest {
+        gate: &trusted,
+        intent: &first,
+        receipt: &first_receipt,
+        accepted_at_ms: 11_000,
+        artifacts: &store,
+    })
+    .await
+    .unwrap();
+    accepted.matches(&first, &first_receipt).unwrap();
+    assert!(accepted.matches(&later, &later_receipt).is_err());
+    assert_ne!(first.intent_id(), later.intent_id());
+    assert_ne!(
+        first_receipt.receipt_digest(),
+        later_receipt.receipt_digest()
+    );
+
+    let mut forged: serde_json::Value =
+        serde_json::from_slice(&accepted.canonical_bytes().unwrap()).unwrap();
+    forged["attempt"] = serde_json::json!(2);
+    assert_eq!(
+        AcceptedProofRef::decode(&serde_json::to_vec(&forged).unwrap()).unwrap_err(),
+        RequiredProofError::DigestMismatch("acceptance")
+    );
+}
+
+struct RejectArtifacts;
+
+#[async_trait]
+impl ArtifactReverification for RejectArtifacts {
+    async fn reverify(&self, _expected: &ArtifactRef) -> Result<(), RequiredProofError> {
+        Err(RequiredProofError::ArtifactMismatch)
+    }
+}
+
+#[tokio::test]
+async fn acceptance_requires_artifact_digest_reverification() {
+    let trusted = gate();
+    let attempt = intent_for(&trusted, 1);
+    let store = FakeArtifactStore::new();
+    let receipt = passing_receipt(&store, &attempt).await;
+    assert_eq!(
+        AcceptedProofRef::accept(AcceptProofRequest {
+            gate: &trusted,
+            intent: &attempt,
+            receipt: &receipt,
+            accepted_at_ms: 11_000,
+            artifacts: &RejectArtifacts,
+        })
+        .await
+        .unwrap_err(),
+        RequiredProofError::ArtifactMismatch
+    );
+    AcceptedProofRef::accept(AcceptProofRequest {
+        gate: &trusted,
+        intent: &attempt,
+        receipt: &receipt,
+        accepted_at_ms: 11_000,
+        artifacts: &store,
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn reconciliation_after_uncertainty_uses_only_exact_authoritative_receipt() {
+    let trusted = gate();
+    let intent = intent_for(&trusted, 1);
+    assert_eq!(
+        reconcile_after_uncertainty(&intent, AuthoritativeAttempt::Missing).unwrap_err(),
+        RequiredProofError::AuthorityUncertain
+    );
+    assert_eq!(
+        reconcile_after_uncertainty(
+            &intent,
+            AuthoritativeAttempt::IntentOnly(Box::new(intent.clone())),
+        )
+        .unwrap_err(),
+        RequiredProofError::AuthorityUncertain
+    );
+    let store = FakeArtifactStore::new();
+    let receipt = passing_receipt(&store, &intent).await;
+    assert_eq!(
+        reconcile_after_uncertainty(
+            &intent,
+            AuthoritativeAttempt::Receipt {
+                intent: Box::new(intent.clone()),
+                receipt: Box::new(receipt.clone()),
+            },
+        )
+        .unwrap(),
+        receipt
+    );
+    assert_eq!(
+        ReconcileProofAttempt::new(
+            intent.clone(),
+            AuthoritativeAttempt::Receipt {
+                intent: Box::new(intent.clone()),
+                receipt: Box::new(receipt.clone()),
+            },
+        )
+        .resolve()
+        .unwrap(),
+        receipt
+    );
+    let other = intent_for(&trusted, 2);
+    assert_eq!(
+        reconcile_after_uncertainty(&intent, AuthoritativeAttempt::IntentOnly(Box::new(other)),)
+            .unwrap_err(),
+        RequiredProofError::ConflictingAttempt
+    );
+}


### PR DESCRIPTION
Closes #761

## Decision

Define one closed native required-proof algebra: immutable attempt, exact accepted-proof references, mutation intent identity, authoritative reconciliation receipt, and gate outcome. Acceptance binds run/attempt, required command identity, revision/config/tool inputs, verified stdout/stderr artifact lineage and bytes, freshness, and the current admitted mutation fingerprint. Replay requires the current admission and exact receipt projection; incomplete, indeterminate, forged, stale, and cross-attempt evidence fail closed.

Explicit environment admission uses a closed allowlist plus value-kind validation, rejecting secret-shaped names and invalid values without persisting raw secrets. Artifact bytes are re-opened and digest/length verified before receipt construction and acceptance.

## Scope

Contracts, ledger records/replay, artifact verification, and architecture guards only. No proof execution, source mutation/delivery, forge inspection, protocol wire changes, second ledger, or secret detector.

## Verification

Focused targets first:
- `cargo test -p zeroshot-rust --test required_proof_contract` — 10 passed
- `cargo test -p zeroshot-rust --test cluster_ledger_replay` — 25 passed
- `cargo test -p zeroshot-rust --test artifact_store` — 9 passed
- `cargo test -p zeroshot-rust --test architecture` — 12 passed

Common gates:
- `npm run rust:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit` — 1953 passed, 18 pending
- `opcore check --changed`

Two independent final verifier passes completed all gates and reported no findings.