### PR TITLE
fix(release): install Rust script dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 24
+          cache: npm
 
       - name: Install pinned script dependencies
         run: npm ci --ignore-scripts
@@ -444,6 +445,12 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.action == 'dry-run' && github.sha || inputs.action == 'recover-rust-distribution' && inputs.release_commit || github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24
+          cache: npm
 
       - name: Install pinned script dependencies
         run: npm ci --ignore-scripts
@@ -591,6 +598,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 24
+          cache: npm
           registry-url: https://registry.npmjs.org
 
       - name: Install pinned script dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,9 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.action == 'dry-run' && github.sha || inputs.action == 'recover-rust-distribution' && inputs.release_commit || github.event.workflow_run.head_sha }}
 
+      - name: Install pinned script dependencies
+        run: npm ci --ignore-scripts
+
       - name: Download every target archive
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -589,6 +592,9 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - name: Install pinned script dependencies
+        run: npm ci --ignore-scripts
 
       - name: Download complete Rust distribution
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,6 +366,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install pinned script dependencies
+        run: npm ci --ignore-scripts
+
       - name: Setup Rust 1.97.0 target
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -270,6 +270,22 @@ function findStep(job, name) {
   return step;
 }
 
+function checkScriptInstall(job, jobName) {
+  const install = findStep(job, 'Install pinned script dependencies');
+  if (install.if !== undefined || install.run?.trim() !== 'npm ci --ignore-scripts') {
+    failIntegrity(`${jobName} must install pinned script dependencies without lifecycle scripts`);
+  }
+  if (
+    job.steps.some(
+      (step, index) =>
+        index < job.steps.indexOf(install) &&
+        step.run?.includes('node scripts/rust-distribution.js')
+    )
+  ) {
+    failIntegrity(`${jobName} must install pinned script dependencies before every invocation`);
+  }
+}
+
 function checkBuildJob(jobs) {
   const job = jobs['rust-binaries'];
   if (!job) failIntegrity('release workflow has no rust-binaries job');
@@ -310,21 +326,14 @@ function checkBuildJob(jobs) {
     failIntegrity('Windows bundled-SQLite MSVC setup is missing');
   }
 
-  const install = findStep(job, 'Install pinned script dependencies');
-  if (
-    install.if !== undefined ||
-    install.run?.trim() !== 'npm ci --ignore-scripts'
-  ) {
-    failIntegrity('pinned script dependencies must install without lifecycle scripts');
-  }
+  checkScriptInstall(job, 'rust-binaries');
 
   const stage = findStep(job, 'Stage planned Rust package version');
   if (
     stage.if !== undefined ||
-    stage.run?.trim() !== 'node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"' ||
-    job.steps.indexOf(install) > job.steps.indexOf(stage)
+    stage.run?.trim() !== 'node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"'
   ) {
-    failIntegrity('planned Rust version staging requires pinned script dependencies first');
+    failIntegrity('planned Rust version staging is missing before locked target builds');
   }
   const coupling = findStep(job, 'Verify Rust and release tag versions are coupled');
   if (
@@ -380,6 +389,7 @@ function checkManifestJob(jobs) {
     ['dry-run', 'release-plan', 'rust-binaries', 'rust-recovery-plan'],
     [...(job.needs || [])].sort()
   );
+  checkScriptInstall(job, 'rust-manifest');
   const manifest = findStep(job, 'Build and verify complete checksum manifest');
   if (
     manifest.run?.trim() !==
@@ -443,6 +453,7 @@ function checkPublicationJobs(document, jobs) {
     ['release', 'rust-manifest', 'rust-recovery-plan'],
     [...(publish?.needs || [])].sort()
   );
+  checkScriptInstall(publish, 'rust-publish');
   if (!publish.if?.includes("inputs.action == 'recover-rust-distribution'")) {
     failIntegrity('post-tag Rust publication is not recoverable');
   }

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -270,19 +270,58 @@ function findStep(job, name) {
   return step;
 }
 
-function checkScriptInstall(job, jobName) {
-  const install = findStep(job, 'Install pinned script dependencies');
-  if (install.if !== undefined || install.run?.trim() !== 'npm ci --ignore-scripts') {
-    failIntegrity(`${jobName} must install pinned script dependencies without lifecycle scripts`);
+const RUST_DISTRIBUTION_INVOCATION =
+  /(?:(?:\bnode\s+(?:\.\/)?)|(?:^|[\s"'(])\.\/)scripts\/rust-distribution\.js(?=$|[\s"'`)])/;
+
+const SCRIPT_INSTALL_CONTRACTS = Object.freeze([
+  { jobName: 'dry-run', installName: 'Install pinned dependencies', command: 'npm ci' },
+  { jobName: 'release', installName: 'Install pinned dependencies', command: 'npm ci' },
+  {
+    jobName: 'rust-binaries',
+    installName: 'Install pinned script dependencies',
+    command: 'npm ci --ignore-scripts',
+  },
+  {
+    jobName: 'rust-manifest',
+    installName: 'Install pinned script dependencies',
+    command: 'npm ci --ignore-scripts',
+  },
+  {
+    jobName: 'rust-publish',
+    installName: 'Install pinned script dependencies',
+    command: 'npm ci --ignore-scripts',
+  },
+]);
+
+function invokesRustDistribution(step) {
+  return (
+    typeof step.run === 'string' && RUST_DISTRIBUTION_INVOCATION.test(step.run)
+  );
+}
+
+function checkScriptInstall(job, { jobName, installName, command }) {
+  if (!job) failIntegrity(`release workflow has no ${jobName} job`);
+  const install = findStep(job, installName);
+  if (install.if !== undefined || install.run?.trim() !== command) {
+    failIntegrity(`${jobName} dependency install must execute exactly: ${command}`);
   }
-  if (
-    job.steps.some(
-      (step, index) =>
-        index < job.steps.indexOf(install) &&
-        step.run?.includes('node scripts/rust-distribution.js')
-    )
-  ) {
-    failIntegrity(`${jobName} must install pinned script dependencies before every invocation`);
+  const installIndex = job.steps.indexOf(install);
+  const checkoutIndex = job.steps.findIndex((step) =>
+    step.uses?.startsWith('actions/checkout@')
+  );
+  if (checkoutIndex === -1 || checkoutIndex >= installIndex) {
+    failIntegrity(`${jobName} must checkout source before dependency installation`);
+  }
+  if (job.steps.slice(0, installIndex).some(invokesRustDistribution)) {
+    failIntegrity(
+      `${jobName} must install dependencies before every rust-distribution.js invocation`
+    );
+  }
+}
+
+function checkScriptInstalls(jobs) {
+  for (const contract of SCRIPT_INSTALL_CONTRACTS) {
+    checkScriptInstall(jobs[contract.jobName], contract);
   }
 }
 
@@ -325,8 +364,6 @@ function checkBuildJob(jobs) {
   ) {
     failIntegrity('Windows bundled-SQLite MSVC setup is missing');
   }
-
-  checkScriptInstall(job, 'rust-binaries');
 
   const stage = findStep(job, 'Stage planned Rust package version');
   if (
@@ -389,7 +426,6 @@ function checkManifestJob(jobs) {
     ['dry-run', 'release-plan', 'rust-binaries', 'rust-recovery-plan'],
     [...(job.needs || [])].sort()
   );
-  checkScriptInstall(job, 'rust-manifest');
   const manifest = findStep(job, 'Build and verify complete checksum manifest');
   if (
     manifest.run?.trim() !==
@@ -453,7 +489,6 @@ function checkPublicationJobs(document, jobs) {
     ['release', 'rust-manifest', 'rust-recovery-plan'],
     [...(publish?.needs || [])].sort()
   );
-  checkScriptInstall(publish, 'rust-publish');
   if (!publish.if?.includes("inputs.action == 'recover-rust-distribution'")) {
     failIntegrity('post-tag Rust publication is not recoverable');
   }
@@ -483,9 +518,22 @@ function checkShimTargets(shimTargets) {
   exactJson('npm shim host mapping', projected, actual);
 }
 
-function checkScriptDependencies(packageManifest) {
-  if (!Object.hasOwn(packageManifest.devDependencies || {}, 'js-yaml')) {
+function checkScriptDependencies(packageManifest, packageLock) {
+  const directSpec = packageManifest.devDependencies?.['js-yaml'];
+  if (typeof directSpec !== 'string' || directSpec.length === 0) {
     failIntegrity('rust-distribution.js requires a direct js-yaml devDependency');
+  }
+  const lockSpec = packageLock.packages?.['']?.devDependencies?.['js-yaml'];
+  if (lockSpec !== directSpec) {
+    failIntegrity('package-lock root js-yaml spec must match package.json');
+  }
+  const resolved = packageLock.packages?.['node_modules/js-yaml'];
+  if (
+    typeof resolved?.version !== 'string' ||
+    typeof resolved.resolved !== 'string' ||
+    !/^sha(?:256|384|512)-/.test(resolved.integrity || '')
+  ) {
+    failIntegrity('package-lock must contain an integrity-pinned resolved js-yaml package');
   }
 }
 
@@ -499,6 +547,9 @@ function checkRepository(
   ),
   packageManifest = JSON.parse(
     fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8')
+  ),
+  packageLock = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, 'package-lock.json'), 'utf8')
   )
 ) {
   let document;
@@ -508,11 +559,12 @@ function checkRepository(
     failIntegrity(`release workflow is invalid YAML: ${error.message}`);
   }
   if (!document?.jobs) failIntegrity('release workflow has no jobs');
+  checkScriptInstalls(document.jobs);
   checkBuildJob(document.jobs);
   checkManifestJob(document.jobs);
   checkPublicationJobs(document, document.jobs);
   checkShimTargets(shimTargets);
-  checkScriptDependencies(packageManifest);
+  checkScriptDependencies(packageManifest, packageLock);
   return true;
 }
 

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -342,6 +342,19 @@ function checkScriptInstall(job, { jobName, installName, command, checkoutRef })
   if (checkoutIndex >= installIndex) {
     failIntegrity(`${jobName} must checkout source before dependency installation`);
   }
+  const nodeSetup = job.steps.find((step) => step.uses?.startsWith('actions/setup-node@'));
+  const nodeSetupIndex = job.steps.indexOf(nodeSetup);
+  if (
+    !nodeSetup ||
+    nodeSetup.if !== undefined ||
+    nodeSetup.uses !== 'actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903' ||
+    String(nodeSetup.with?.['node-version']) !== '24' ||
+    nodeSetup.with?.cache !== 'npm' ||
+    nodeSetupIndex <= checkoutIndex ||
+    nodeSetupIndex >= installIndex
+  ) {
+    failIntegrity(`${jobName} must enable pinned Node 24 npm cache before dependency installation`);
+  }
   if (job.steps.slice(0, installIndex).some(invokesRustDistribution)) {
     failIntegrity(
       `${jobName} must install dependencies before every rust-distribution.js invocation`

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -271,25 +271,40 @@ function findStep(job, name) {
 }
 
 const RUST_DISTRIBUTION_INVOCATION =
-  /(?:(?:\bnode\s+(?:\.\/)?)|(?:^|[\s"'(])\.\/)scripts\/rust-distribution\.js(?=$|[\s"'`)])/;
+  /(?:(?:\bnode\s+)|(?:^|[\s(]))["']?(?:\.\/)?scripts\/rust-distribution\.js["']?(?=$|[\s)`;&|])/;
 
 const SCRIPT_INSTALL_CONTRACTS = Object.freeze([
-  { jobName: 'dry-run', installName: 'Install pinned dependencies', command: 'npm ci' },
-  { jobName: 'release', installName: 'Install pinned dependencies', command: 'npm ci' },
+  {
+    jobName: 'dry-run',
+    installName: 'Install pinned dependencies',
+    command: 'npm ci',
+    checkoutRef: '${{ github.sha }}',
+  },
+  {
+    jobName: 'release',
+    installName: 'Install pinned dependencies',
+    command: 'npm ci',
+    checkoutRef: '${{ github.event.workflow_run.head_sha }}',
+  },
   {
     jobName: 'rust-binaries',
     installName: 'Install pinned script dependencies',
     command: 'npm ci --ignore-scripts',
+    checkoutRef:
+      "${{ inputs.action == 'dry-run' && github.sha || inputs.action == 'recover-rust-distribution' && inputs.release_commit || github.event.workflow_run.head_sha }}",
   },
   {
     jobName: 'rust-manifest',
     installName: 'Install pinned script dependencies',
     command: 'npm ci --ignore-scripts',
+    checkoutRef:
+      "${{ inputs.action == 'dry-run' && github.sha || inputs.action == 'recover-rust-distribution' && inputs.release_commit || github.event.workflow_run.head_sha }}",
   },
   {
     jobName: 'rust-publish',
     installName: 'Install pinned script dependencies',
     command: 'npm ci --ignore-scripts',
+    checkoutRef: '${{ env.RELEASE_TAG }}',
   },
 ]);
 
@@ -299,17 +314,32 @@ function invokesRustDistribution(step) {
   );
 }
 
-function checkScriptInstall(job, { jobName, installName, command }) {
+function checkScriptInstall(job, { jobName, installName, command, checkoutRef }) {
   if (!job) failIntegrity(`release workflow has no ${jobName} job`);
   const install = findStep(job, installName);
-  if (install.if !== undefined || install.run?.trim() !== command) {
-    failIntegrity(`${jobName} dependency install must execute exactly: ${command}`);
+  if (
+    install.if !== undefined ||
+    install['working-directory'] !== undefined ||
+    install.run?.trim() !== command
+  ) {
+    failIntegrity(`${jobName} dependency install must execute at workspace root: ${command}`);
+  }
+  const checkout = job.steps.find((step) => step.uses?.startsWith('actions/checkout@'));
+  if (
+    !checkout ||
+    checkout.if !== undefined ||
+    checkout.with?.path !== undefined ||
+    (checkout.with?.repository !== undefined &&
+      checkout.with.repository !== '${{ github.repository }}') ||
+    checkout.with?.ref !== checkoutRef
+  ) {
+    failIntegrity(
+      `${jobName} must checkout expected current repository source at workspace root`
+    );
   }
   const installIndex = job.steps.indexOf(install);
-  const checkoutIndex = job.steps.findIndex((step) =>
-    step.uses?.startsWith('actions/checkout@')
-  );
-  if (checkoutIndex === -1 || checkoutIndex >= installIndex) {
+  const checkoutIndex = job.steps.indexOf(checkout);
+  if (checkoutIndex >= installIndex) {
     failIntegrity(`${jobName} must checkout source before dependency installation`);
   }
   if (job.steps.slice(0, installIndex).some(invokesRustDistribution)) {
@@ -518,6 +548,15 @@ function checkShimTargets(shimTargets) {
   exactJson('npm shim host mapping', projected, actual);
 }
 
+function hasValidSri(integrity) {
+  if (typeof integrity !== 'string') return false;
+  const match = /^(sha256|sha384|sha512)-([A-Za-z0-9+/]+={0,2})$/.exec(integrity);
+  if (!match) return false;
+  const expectedBytes = { sha256: 32, sha384: 48, sha512: 64 }[match[1]];
+  const digest = Buffer.from(match[2], 'base64');
+  return digest.length === expectedBytes && digest.toString('base64') === match[2];
+}
+
 function checkScriptDependencies(packageManifest, packageLock) {
   const directSpec = packageManifest.devDependencies?.['js-yaml'];
   if (typeof directSpec !== 'string' || directSpec.length === 0) {
@@ -530,8 +569,10 @@ function checkScriptDependencies(packageManifest, packageLock) {
   const resolved = packageLock.packages?.['node_modules/js-yaml'];
   if (
     typeof resolved?.version !== 'string' ||
+    resolved.version.trim().length === 0 ||
     typeof resolved.resolved !== 'string' ||
-    !/^sha(?:256|384|512)-/.test(resolved.integrity || '')
+    resolved.resolved.trim().length === 0 ||
+    !hasValidSri(resolved.integrity)
   ) {
     failIntegrity('package-lock must contain an integrity-pinned resolved js-yaml package');
   }

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -310,12 +310,21 @@ function checkBuildJob(jobs) {
     failIntegrity('Windows bundled-SQLite MSVC setup is missing');
   }
 
+  const install = findStep(job, 'Install pinned script dependencies');
+  if (
+    install.if !== undefined ||
+    install.run?.trim() !== 'npm ci --ignore-scripts'
+  ) {
+    failIntegrity('pinned script dependencies must install without lifecycle scripts');
+  }
+
   const stage = findStep(job, 'Stage planned Rust package version');
   if (
     stage.if !== undefined ||
-    stage.run?.trim() !== 'node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"'
+    stage.run?.trim() !== 'node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"' ||
+    job.steps.indexOf(install) > job.steps.indexOf(stage)
   ) {
-    failIntegrity('planned Rust version staging is missing before locked target builds');
+    failIntegrity('planned Rust version staging requires pinned script dependencies first');
   }
   const coupling = findStep(job, 'Verify Rust and release tag versions are coupled');
   if (
@@ -463,6 +472,12 @@ function checkShimTargets(shimTargets) {
   exactJson('npm shim host mapping', projected, actual);
 }
 
+function checkScriptDependencies(packageManifest) {
+  if (!Object.hasOwn(packageManifest.devDependencies || {}, 'js-yaml')) {
+    failIntegrity('rust-distribution.js requires a direct js-yaml devDependency');
+  }
+}
+
 function checkRepository(
   workflow = fs.readFileSync(
     path.join(repositoryRoot, '.github', 'workflows', 'release.yml'),
@@ -470,6 +485,9 @@ function checkRepository(
   ),
   shimTargets = JSON.parse(
     fs.readFileSync(path.join(repositoryRoot, 'npm', 'zeroshot-rust', 'targets.json'), 'utf8')
+  ),
+  packageManifest = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8')
   )
 ) {
   let document;
@@ -483,6 +501,7 @@ function checkRepository(
   checkManifestJob(document.jobs);
   checkPublicationJobs(document, document.jobs);
   checkShimTargets(shimTargets);
+  checkScriptDependencies(packageManifest);
   return true;
 }
 

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -149,6 +149,48 @@ describe('Rust release integration', function () {
     );
     assert.strictEqual(distribution.checkRepository(workflow), true);
 
+    for (const [before, after] of [
+      ['run: npm ci --ignore-scripts', 'run: echo npm ci --ignore-scripts'],
+      [
+        `      - name: Install pinned script dependencies
+        run: npm ci --ignore-scripts
+`,
+        '',
+      ],
+    ]) {
+      assert.throws(
+        () => distribution.checkRepository(mutation(workflow, before, after)),
+        /pinned script dependencies/
+      );
+    }
+
+    const installStep = `      - name: Install pinned script dependencies
+        run: npm ci --ignore-scripts
+`;
+    const stageStep = `      - name: Stage planned Rust package version
+        run: node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"
+        shell: bash
+`;
+    const workflowWithLateInstall = mutation(
+      mutation(workflow, `${installStep}\n`, ''),
+      stageStep,
+      `${stageStep}
+${installStep}`
+    );
+    assert.throws(
+      () => distribution.checkRepository(workflowWithLateInstall),
+      /requires pinned script dependencies first/
+    );
+
+    const packageManifest = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
+    );
+    delete packageManifest.devDependencies['js-yaml'];
+    assert.throws(
+      () => distribution.checkRepository(workflow, undefined, packageManifest),
+      /direct js-yaml devDependency/
+    );
+
     assert.throws(
       () =>
         distribution.checkRepository(

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -174,7 +174,7 @@ describe('Rust release integration', function () {
                 `${installCommand} --foreground-scripts`;
             })
           ),
-        new RegExp(`${jobName} dependency install must execute exactly`)
+        new RegExp(`${jobName} dependency install must execute at workspace root`)
       );
       assert.throws(
         () =>
@@ -202,6 +202,14 @@ describe('Rust release integration', function () {
       for (const command of [
         'node ./scripts/rust-distribution.js print-version',
         './scripts/rust-distribution.js print-version',
+        'node "scripts/rust-distribution.js" print-version',
+        "node 'scripts/rust-distribution.js' print-version",
+        'node "./scripts/rust-distribution.js" print-version',
+        "node './scripts/rust-distribution.js' print-version",
+        '"scripts/rust-distribution.js" print-version',
+        "'scripts/rust-distribution.js' print-version",
+        '"./scripts/rust-distribution.js" print-version',
+        "'./scripts/rust-distribution.js' print-version",
       ]) {
         assert.throws(
           () =>
@@ -216,6 +224,43 @@ describe('Rust release integration', function () {
           new RegExp(`${jobName} must install dependencies before every`)
         );
       }
+      for (const mutateCheckout of [
+        (checkout) => {
+          checkout.if = false;
+        },
+        (checkout) => {
+          checkout.with.path = 'nested';
+        },
+        (checkout) => {
+          checkout.with.repository = 'other/repository';
+        },
+        (checkout) => {
+          checkout.with.ref = 'main';
+        },
+      ]) {
+        assert.throws(
+          () =>
+            distribution.checkRepository(
+              mutateInstall((job) => {
+                const checkout = job.steps.find((step) =>
+                  step.uses?.startsWith('actions/checkout@')
+                );
+                mutateCheckout(checkout);
+              })
+            ),
+          new RegExp(`${jobName} must checkout expected current repository source`)
+        );
+      }
+      assert.throws(
+        () =>
+          distribution.checkRepository(
+            mutateInstall((job) => {
+              job.steps.find((step) => step.name === installName)['working-directory'] =
+                'nested';
+            })
+          ),
+        new RegExp(`${jobName} dependency install must execute at workspace root`)
+      );
       assert.throws(
         () =>
           distribution.checkRepository(
@@ -298,6 +343,31 @@ describe('Rust release integration', function () {
         ),
       /integrity-pinned resolved js-yaml/
     );
+    for (const mutateResolution of [
+      (candidate) => {
+        candidate.packages['node_modules/js-yaml'].version = '';
+      },
+      (candidate) => {
+        candidate.packages['node_modules/js-yaml'].resolved = ' ';
+      },
+      (candidate) => {
+        candidate.packages['node_modules/js-yaml'].integrity = 'sha512-';
+      },
+      (candidate) => {
+        candidate.packages['node_modules/js-yaml'].integrity = 'sha512-YQ==';
+      },
+    ]) {
+      assert.throws(
+        () =>
+          distribution.checkRepository(
+            workflow,
+            undefined,
+            packageManifest,
+            mutatePackageLock(mutateResolution)
+          ),
+        /integrity-pinned resolved js-yaml/
+      );
+    }
 
     assert.throws(
       () =>

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const jsYaml = require('js-yaml');
 
 const distribution = require('../../scripts/rust-distribution');
 const shim = require('../../npm/zeroshot-rust/lib/install');
@@ -22,6 +23,14 @@ function relativeFiles(root, directory = root) {
 function mutation(source, before, after = '') {
   assert(source.includes(before), `mutation precondition missing: ${before}`);
   return source.replace(before, after);
+}
+
+function mutateWorkflowJob(source, jobName, mutateJob) {
+  const document = jsYaml.load(source);
+  const job = document.jobs[jobName];
+  assert(job, `workflow job missing: ${jobName}`);
+  mutateJob(job);
+  return JSON.stringify(document);
 }
 
 describe('Rust product distribution', function () {
@@ -149,38 +158,59 @@ describe('Rust release integration', function () {
     );
     assert.strictEqual(distribution.checkRepository(workflow), true);
 
-    for (const [before, after] of [
-      ['run: npm ci --ignore-scripts', 'run: echo npm ci --ignore-scripts'],
-      [
-        `      - name: Install pinned script dependencies
-        run: npm ci --ignore-scripts
-`,
-        '',
-      ],
-    ]) {
+    for (const jobName of ['rust-binaries', 'rust-manifest', 'rust-publish']) {
+      const mutateInstall = (mutateJob) => mutateWorkflowJob(workflow, jobName, mutateJob);
       assert.throws(
-        () => distribution.checkRepository(mutation(workflow, before, after)),
-        /pinned script dependencies/
+        () =>
+          distribution.checkRepository(
+            mutateInstall((job) => {
+              job.steps.find(
+                (step) => step.name === 'Install pinned script dependencies'
+              ).run = 'npm ci';
+            })
+          ),
+        new RegExp(`${jobName} must install pinned script dependencies`)
+      );
+      assert.throws(
+        () =>
+          distribution.checkRepository(
+            mutateInstall((job) => {
+              job.steps = job.steps.filter(
+                (step) => step.name !== 'Install pinned script dependencies'
+              );
+            })
+          ),
+        /Install pinned script dependencies/
+      );
+      assert.throws(
+        () =>
+          distribution.checkRepository(
+            mutateInstall((job) => {
+              const installIndex = job.steps.findIndex(
+                (step) => step.name === 'Install pinned script dependencies'
+              );
+              const [install] = job.steps.splice(installIndex, 1);
+              const invocationIndex = job.steps.findIndex((step) =>
+                step.run?.includes('node scripts/rust-distribution.js')
+              );
+              job.steps.splice(invocationIndex + 1, 0, install);
+            })
+          ),
+        new RegExp(`${jobName} must install pinned script dependencies before every invocation`)
+      );
+      assert.throws(
+        () =>
+          distribution.checkRepository(
+            mutateInstall((job) => {
+              job.steps.unshift({
+                name: 'Invoke Rust distribution before dependency installation',
+                run: 'node scripts/rust-distribution.js print-version',
+              });
+            })
+          ),
+        new RegExp(`${jobName} must install pinned script dependencies before every invocation`)
       );
     }
-
-    const installStep = `      - name: Install pinned script dependencies
-        run: npm ci --ignore-scripts
-`;
-    const stageStep = `      - name: Stage planned Rust package version
-        run: node scripts/rust-distribution.js stage-version --tag "$RELEASE_TAG"
-        shell: bash
-`;
-    const workflowWithLateInstall = mutation(
-      mutation(workflow, `${installStep}\n`, ''),
-      stageStep,
-      `${stageStep}
-${installStep}`
-    );
-    assert.throws(
-      () => distribution.checkRepository(workflowWithLateInstall),
-      /requires pinned script dependencies first/
-    );
 
     const packageManifest = JSON.parse(
       fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -158,67 +158,145 @@ describe('Rust release integration', function () {
     );
     assert.strictEqual(distribution.checkRepository(workflow), true);
 
-    for (const jobName of ['rust-binaries', 'rust-manifest', 'rust-publish']) {
+    for (const [jobName, installName, installCommand] of [
+      ['dry-run', 'Install pinned dependencies', 'npm ci'],
+      ['release', 'Install pinned dependencies', 'npm ci'],
+      ['rust-binaries', 'Install pinned script dependencies', 'npm ci --ignore-scripts'],
+      ['rust-manifest', 'Install pinned script dependencies', 'npm ci --ignore-scripts'],
+      ['rust-publish', 'Install pinned script dependencies', 'npm ci --ignore-scripts'],
+    ]) {
       const mutateInstall = (mutateJob) => mutateWorkflowJob(workflow, jobName, mutateJob);
       assert.throws(
         () =>
           distribution.checkRepository(
             mutateInstall((job) => {
-              job.steps.find(
-                (step) => step.name === 'Install pinned script dependencies'
-              ).run = 'npm ci';
+              job.steps.find((step) => step.name === installName).run =
+                `${installCommand} --foreground-scripts`;
             })
           ),
-        new RegExp(`${jobName} must install pinned script dependencies`)
+        new RegExp(`${jobName} dependency install must execute exactly`)
       );
       assert.throws(
         () =>
           distribution.checkRepository(
             mutateInstall((job) => {
-              job.steps = job.steps.filter(
-                (step) => step.name !== 'Install pinned script dependencies'
-              );
+              job.steps = job.steps.filter((step) => step.name !== installName);
             })
           ),
-        /Install pinned script dependencies/
+        new RegExp(installName)
       );
       assert.throws(
         () =>
           distribution.checkRepository(
             mutateInstall((job) => {
-              const installIndex = job.steps.findIndex(
-                (step) => step.name === 'Install pinned script dependencies'
-              );
+              const installIndex = job.steps.findIndex((step) => step.name === installName);
               const [install] = job.steps.splice(installIndex, 1);
               const invocationIndex = job.steps.findIndex((step) =>
-                step.run?.includes('node scripts/rust-distribution.js')
+                step.run?.includes('scripts/rust-distribution.js')
               );
               job.steps.splice(invocationIndex + 1, 0, install);
             })
           ),
-        new RegExp(`${jobName} must install pinned script dependencies before every invocation`)
+        new RegExp(`${jobName} must install dependencies before every`)
       );
+      for (const command of [
+        'node ./scripts/rust-distribution.js print-version',
+        './scripts/rust-distribution.js print-version',
+      ]) {
+        assert.throws(
+          () =>
+            distribution.checkRepository(
+              mutateInstall((job) => {
+                job.steps.unshift({
+                  name: 'Invoke Rust distribution before dependency installation',
+                  run: command,
+                });
+              })
+            ),
+          new RegExp(`${jobName} must install dependencies before every`)
+        );
+      }
       assert.throws(
         () =>
           distribution.checkRepository(
             mutateInstall((job) => {
-              job.steps.unshift({
-                name: 'Invoke Rust distribution before dependency installation',
-                run: 'node scripts/rust-distribution.js print-version',
-              });
+              const installIndex = job.steps.findIndex((step) => step.name === installName);
+              const [install] = job.steps.splice(installIndex, 1);
+              const checkoutIndex = job.steps.findIndex((step) =>
+                step.uses?.startsWith('actions/checkout@')
+              );
+              job.steps.splice(checkoutIndex, 0, install);
             })
           ),
-        new RegExp(`${jobName} must install pinned script dependencies before every invocation`)
+        new RegExp(`${jobName} must checkout source before dependency installation`)
       );
     }
 
     const packageManifest = JSON.parse(
       fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
     );
-    delete packageManifest.devDependencies['js-yaml'];
+    const packageWithoutYaml = JSON.parse(JSON.stringify(packageManifest));
+    delete packageWithoutYaml.devDependencies['js-yaml'];
     assert.throws(
-      () => distribution.checkRepository(workflow, undefined, packageManifest),
+      () => distribution.checkRepository(workflow, undefined, packageWithoutYaml),
       /direct js-yaml devDependency/
+    );
+
+    const packageLock = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'package-lock.json'), 'utf8')
+    );
+    const mutatePackageLock = (mutateLock) => {
+      const candidate = JSON.parse(JSON.stringify(packageLock));
+      mutateLock(candidate);
+      return candidate;
+    };
+    assert.throws(
+      () =>
+        distribution.checkRepository(
+          workflow,
+          undefined,
+          packageManifest,
+          mutatePackageLock((candidate) => {
+            delete candidate.packages[''].devDependencies['js-yaml'];
+          })
+        ),
+      /package-lock root js-yaml spec must match/
+    );
+    assert.throws(
+      () =>
+        distribution.checkRepository(
+          workflow,
+          undefined,
+          packageManifest,
+          mutatePackageLock((candidate) => {
+            candidate.packages[''].devDependencies['js-yaml'] = '^9.0.0';
+          })
+        ),
+      /package-lock root js-yaml spec must match/
+    );
+    assert.throws(
+      () =>
+        distribution.checkRepository(
+          workflow,
+          undefined,
+          packageManifest,
+          mutatePackageLock((candidate) => {
+            delete candidate.packages['node_modules/js-yaml'];
+          })
+        ),
+      /integrity-pinned resolved js-yaml/
+    );
+    assert.throws(
+      () =>
+        distribution.checkRepository(
+          workflow,
+          undefined,
+          packageManifest,
+          mutatePackageLock((candidate) => {
+            delete candidate.packages['node_modules/js-yaml'].integrity;
+          })
+        ),
+      /integrity-pinned resolved js-yaml/
     );
 
     assert.throws(

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -251,6 +251,39 @@ describe('Rust release integration', function () {
           new RegExp(`${jobName} must checkout expected current repository source`)
         );
       }
+      for (const mutateNodeSetup of [
+        (job, setup) => {
+          job.steps = job.steps.filter((step) => step !== setup);
+        },
+        (_job, setup) => {
+          setup.if = false;
+        },
+        (_job, setup) => {
+          setup.with.cache = '';
+        },
+        (_job, setup) => {
+          setup.with['node-version'] = 20;
+        },
+        (job, setup) => {
+          const setupIndex = job.steps.indexOf(setup);
+          job.steps.splice(setupIndex, 1);
+          const installIndex = job.steps.findIndex((step) => step.name === installName);
+          job.steps.splice(installIndex + 1, 0, setup);
+        },
+      ]) {
+        assert.throws(
+          () =>
+            distribution.checkRepository(
+              mutateInstall((job) => {
+                const setup = job.steps.find((step) =>
+                  step.uses?.startsWith('actions/setup-node@')
+                );
+                mutateNodeSetup(job, setup);
+              })
+            ),
+          new RegExp(`${jobName} must enable pinned Node 24 npm cache`)
+        );
+      }
       assert.throws(
         () =>
           distribution.checkRepository(


### PR DESCRIPTION
## Summary

Install lockfile-pinned Node dependencies before every `scripts/rust-distribution.js` invocation in the Rust-only release jobs, while disabling npm lifecycle scripts those jobs do not need. Use setup-node's lockfile-backed npm cache to avoid reinstalling the full graph from the registry on every Rust runner. Harden the repository contract around all five release jobs that invoke the script.

## Failed-run evidence

Release run https://github.com/the-open-engine/zeroshot/actions/runs/30486651162 planned `v6.12.0`. All five Linux, macOS, and Windows `rust-binaries` jobs failed at **Stage planned Rust package version** because Node reported `Cannot find module 'js-yaml'` from `scripts/rust-distribution.js`.

The matrix checked out the immutable release source and configured Node 24, but did not install the dependencies pinned by `package-lock.json` before calling the eagerly-loading script. The fresh `rust-manifest` and `rust-publish` jobs had the same missing-install precondition before their own calls. The script directly requires the existing `js-yaml` devDependency.

## Changes Made

- run `npm ci --ignore-scripts` before script use in `rust-binaries`, `rust-manifest`, and `rust-publish`
- configure pinned Node 24 with setup-node `cache: npm` after checkout and before install in all three Rust jobs, including adding deterministic Node setup to `rust-manifest`
- guard dependency installation in all script-using jobs: `dry-run` and `release` retain `npm ci`; the three Rust-only jobs require `npm ci --ignore-scripts`
- require each guarded job's enabled current-repository checkout at workspace root, then enabled pinned Node 24 npm caching, then its workspace-root dependency install
- require install before every detected script invocation, including bare or `./` paths, Node or shebang execution, and optional single/double path quotes
- require package.json's direct `js-yaml` spec to match the lockfile root declaration and require nonempty version/resolved values plus a canonical, correctly-sized SRI digest on `node_modules/js-yaml`
- add mutation coverage for install, checkout, Node setup/cache ordering/configuration, invocation forms, and package/lock integrity

Immutable release ref selection, SHA/tag coupling, publication/recovery behavior, and the five-runner matrix are unchanged.

## Testing

- baseline `node scripts/rust-distribution.js print-version` before install — failed with `Cannot find module 'js-yaml'`
- `npm ci --ignore-scripts` — added 881 lockfile packages successfully with lifecycle scripts disabled
- `node scripts/rust-distribution.js print-version` — output `0.1.0`
- `npx mocha tests/unit/rust-distribution.test.js` — 11 passing (481ms) after merging current `main`
- `npm run rust:distribution:check` — `Rust distribution workflow declares 5 complete targets`
- `git diff --check` — clean

## Checklist

- [x] Focused tests pass
- [x] Documentation not needed
- [x] Follows commit guidelines