### PR TITLE
refactor(cluster-protocol): centralize method routing registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | NDJSON watch client          | `crates/openengine-cluster-client/src/ndjson_watch.rs`                  |
 | Connection core/admission    | `crates/openengine-cluster-server/src/connection.rs`, `connection/`     |
 | JSON-RPC envelope/routing    | `crates/openengine-cluster-server/src/dispatch.rs`                      |
+| Protocol method registry     | `crates/openengine-cluster-server/src/method_registry.rs`               |
 | NDJSON response pump         | `crates/openengine-cluster-client/src/ndjson_pump.rs`                   |
 | Cluster typed transports     | `crates/openengine-cluster-client/`                                     |
 | TypeScript cluster client    | `src/cluster/`                                                          |
@@ -264,6 +265,9 @@ legacy typed-request classification used for duplicate-ID and task-slot admissio
 envelope outcome; malformed and wrong-version responses still cross that shared admission boundary.
 `Dispatcher::dispatch_decoded` owns method lookup before params-shape validation, while
 `Dispatcher::dispatch` is only the JSON-RPC envelope decoder.
+`method_registry.rs` is the sole source of truth for server method names, unary/subscription kind,
+transport requirements, and advertised OpenRPC order/metadata. Bindings resolve subscription kinds
+through that registry; the connection core exhaustively maps every `SubscriptionKind` to its runner.
 Authoritative admission snapshots fail closed: `empty` has no durable fields, `running` has the
 complete matching control/seed tuple, and transient `admitting` preserves one of those two shapes.
 Operational suspend is a dispatch gate: existing leases may land verified I/O, but successors wait

--- a/crates/openengine-cluster-server/src/connection.rs
+++ b/crates/openengine-cluster-server/src/connection.rs
@@ -29,6 +29,7 @@ use parking_lot::Mutex;
 use serde_json::Value;
 use tokio::sync::{mpsc, Notify};
 
+use crate::method_registry::SubscriptionKind;
 use crate::watch::{WatchEventStream, WatchHandle, WatchStreamItem};
 use crate::{serialize_backend_error, serialize_error, serialize_success, ClusterBackend, Dispatcher};
 
@@ -141,15 +142,8 @@ pub(crate) enum DecodedOutcome {
 
 /// A decoded request classified for the shared connection multiplexer.
 pub(crate) enum RequestKind {
-    Watch {
-        id: RequestId,
-        params: Value,
-    },
-    Logs {
-        id: RequestId,
-        params: Value,
-    },
-    AgentAttach {
+    Subscription {
+        kind: SubscriptionKind,
         id: RequestId,
         params: Value,
     },

--- a/crates/openengine-cluster-server/src/connection/dispatch.rs
+++ b/crates/openengine-cluster-server/src/connection/dispatch.rs
@@ -17,6 +17,7 @@ use super::{
     agent_attach, logs, run_watch_subscription, ConnectionState, DecodedOutcome, RequestKind,
     SubscriptionMap,
 };
+use crate::method_registry::SubscriptionKind;
 use crate::{ClusterBackend, Dispatcher};
 
 /// Grace period given to already-spawned bounded backend dispatches to finish once the connection
@@ -47,8 +48,7 @@ pub(crate) struct DispatchCtx<'a, B> {
 }
 
 /// Spawns `run` as a bounded, duplicate-id-rejecting, admission-controlled subscription task for
-/// `id`/`params` -- shared by [`dispatch_classified_request`]'s `Watch`/`Logs`/`AgentAttach` arms,
-/// which otherwise differ only in which subscription runner they spawn.
+/// `id`/`params`.
 async fn spawn_subscription_task<B, F, Fut>(
     ctx: &mut DispatchCtx<'_, B>,
     id: RequestId,
@@ -76,9 +76,8 @@ async fn spawn_subscription_task<B, F, Fut>(
     });
 }
 
-/// Handles the transport-neutral core for one classified request: `subscription/cancel`
-/// notifications and `watch`/`logs`/`agent/attach` establishment, including their admission
-/// control (duplicate-id rejection, task-slot acquisition). Only
+/// Handles the transport-neutral core for one classified request: `subscription/cancel` and
+/// subscription establishment, including duplicate-id rejection and task-slot admission. Only
 /// [`RequestKind::Passthrough`] is handed back to the caller as
 /// [`RequestDispatch::Passthrough`], with its own admission already applied, so each binding can
 /// run its own passthrough dispatch.
@@ -96,17 +95,24 @@ where
             }
             RequestDispatch::Handled
         }
-        RequestKind::Watch { id, params } => {
-            spawn_subscription_task(ctx, id, params, run_watch_subscription).await;
-            RequestDispatch::Handled
-        }
-        RequestKind::Logs { id, params } => {
-            spawn_subscription_task(ctx, id, params, logs::run_logs_subscription).await;
-            RequestDispatch::Handled
-        }
-        RequestKind::AgentAttach { id, params } => {
-            spawn_subscription_task(ctx, id, params, agent_attach::run_agent_attach_subscription)
-                .await;
+        RequestKind::Subscription { kind, id, params } => {
+            match kind {
+                SubscriptionKind::Watch => {
+                    spawn_subscription_task(ctx, id, params, run_watch_subscription).await;
+                }
+                SubscriptionKind::Logs => {
+                    spawn_subscription_task(ctx, id, params, logs::run_logs_subscription).await;
+                }
+                SubscriptionKind::AgentAttach => {
+                    spawn_subscription_task(
+                        ctx,
+                        id,
+                        params,
+                        agent_attach::run_agent_attach_subscription,
+                    )
+                    .await;
+                }
+            }
             RequestDispatch::Handled
         }
         RequestKind::Passthrough {

--- a/crates/openengine-cluster-server/src/connection/frame.rs
+++ b/crates/openengine-cluster-server/src/connection/frame.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
 use super::{DecodedOutcome, DecodedRequest, RequestKind};
+use crate::method_registry::{method_descriptor, MethodKind};
 use crate::serialize_error;
 
 /// One-pass JSON tree retaining duplicate object members until transport-specific notification
@@ -202,26 +203,14 @@ impl DecodedFrame {
         match DecodedRequest::from_value(self.root.into_value()) {
             Ok(request) => {
                 if legacy_classified {
-                    match request.method.as_str() {
-                        "watch" => {
-                            return RequestKind::Watch {
-                                id: request.id,
-                                params: request.params,
-                            };
-                        }
-                        "logs" => {
-                            return RequestKind::Logs {
-                                id: request.id,
-                                params: request.params,
-                            };
-                        }
-                        "agent/attach" => {
-                            return RequestKind::AgentAttach {
-                                id: request.id,
-                                params: request.params,
-                            };
-                        }
-                        _ => {}
+                    if let Some(MethodKind::Subscription(kind)) =
+                        method_descriptor(&request.method).map(|descriptor| descriptor.kind)
+                    {
+                        return RequestKind::Subscription {
+                            kind,
+                            id: request.id,
+                            params: request.params,
+                        };
                     }
                 }
                 RequestKind::Passthrough {

--- a/crates/openengine-cluster-server/src/dispatch.rs
+++ b/crates/openengine-cluster-server/src/dispatch.rs
@@ -11,6 +11,7 @@ use openengine_cluster_protocol::{
 use serde_json::{json, Value};
 
 use crate::connection::DecodedRequest;
+use crate::method_registry::{method_descriptor, MethodDescriptor, MethodKind};
 use crate::{
     serialize_backend_error, serialize_error, serialize_success, BackendError, ClusterBackend,
     ConnectionContext, Dispatcher,
@@ -51,26 +52,33 @@ where
     }
 
     pub async fn dispatch_decoded(&self, id: RequestId, method: &str, params: Value) -> String {
-        let Some(method) = ImplementedMethod::from_name(method) else {
+        let Some(descriptor) = method_descriptor(method) else {
             return serialize_error(Some(id), METHOD_NOT_FOUND, "Method not found", None);
         };
+        match descriptor.kind {
+            MethodKind::Unary => {}
+            MethodKind::Subscription(_) => {
+                return serialize_error(Some(id), METHOD_NOT_FOUND, "Method not found", None);
+            }
+        }
         if !params.is_object() {
             return serialize_error(Some(id), INVALID_PARAMS, "Invalid params", None);
         }
-        self.route(method, id, params).await
+        self.route(descriptor, id, params).await
     }
 
-    async fn route(&self, method: ImplementedMethod, id: RequestId, params: Value) -> String {
-        match method {
-            ImplementedMethod::Initialize => self.dispatch_initialize(id, params).await,
-            ImplementedMethod::Plan => self.dispatch_plan(id, params).await,
-            ImplementedMethod::Apply => self.dispatch_apply(id, params).await,
-            ImplementedMethod::Get => self.dispatch_get(id, params).await,
-            ImplementedMethod::Update => self.dispatch_update(id, params).await,
-            ImplementedMethod::Stop => self.dispatch_stop(id, params).await,
-            ImplementedMethod::Retry => self.dispatch_retry(id, params).await,
-            ImplementedMethod::Resubmit => self.dispatch_resubmit(id, params).await,
-            ImplementedMethod::Delete => self.dispatch_delete(id, params).await,
+    async fn route(&self, descriptor: &MethodDescriptor, id: RequestId, params: Value) -> String {
+        match descriptor.name {
+            "initialize" => self.dispatch_initialize(id, params).await,
+            "plan" => self.dispatch_plan(id, params).await,
+            "apply" => self.dispatch_apply(id, params).await,
+            "get" => self.dispatch_get(id, params).await,
+            "update" => self.dispatch_update(id, params).await,
+            "stop" => self.dispatch_stop(id, params).await,
+            "retry" => self.dispatch_retry(id, params).await,
+            "resubmit" => self.dispatch_resubmit(id, params).await,
+            "delete" => self.dispatch_delete(id, params).await,
+            name => unreachable!("unrouted unary method in METHOD_REGISTRY: {name}"),
         }
     }
 
@@ -261,39 +269,5 @@ where
             Ok(result) => serialize_success(id, result),
             Err(error) => serialize_backend_error(id, error),
         }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum ImplementedMethod {
-    Initialize,
-    Plan,
-    Apply,
-    Get,
-    Update,
-    Stop,
-    Retry,
-    Resubmit,
-    Delete,
-}
-
-impl ImplementedMethod {
-    const NAMES: &'static [(&'static str, Self)] = &[
-        ("initialize", Self::Initialize),
-        ("plan", Self::Plan),
-        ("apply", Self::Apply),
-        ("get", Self::Get),
-        ("update", Self::Update),
-        ("stop", Self::Stop),
-        ("retry", Self::Retry),
-        ("resubmit", Self::Resubmit),
-        ("delete", Self::Delete),
-    ];
-
-    fn from_name(name: &str) -> Option<Self> {
-        Self::NAMES
-            .iter()
-            .find(|(candidate, _)| *candidate == name)
-            .map(|(_, method)| *method)
     }
 }

--- a/crates/openengine-cluster-server/src/lib.rs
+++ b/crates/openengine-cluster-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod agent_attach;
 pub mod graph_verifier;
 pub mod lifecycle;
 pub mod logs;
+pub mod method_registry;
 pub mod stdio;
 pub mod watch;
 pub mod websocket;

--- a/crates/openengine-cluster-server/src/method_registry.rs
+++ b/crates/openengine-cluster-server/src/method_registry.rs
@@ -1,0 +1,89 @@
+//! Authoritative protocol method inventory shared by dispatch, connection bindings, and artifacts.
+
+/// The routing shape of a protocol method.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MethodKind {
+    Unary,
+    Subscription(SubscriptionKind),
+}
+
+/// Subscription establishment routes owned by the transport-neutral connection core.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubscriptionKind {
+    Watch,
+    Logs,
+    AgentAttach,
+}
+
+/// Transport capabilities a method requires in addition to request/response exchange.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TransportRequirements {
+    pub server_push: bool,
+    pub inbound_notifications: bool,
+}
+
+/// One public method and the transport behavior needed to serve it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MethodDescriptor {
+    pub name: &'static str,
+    pub kind: MethodKind,
+    pub transport_requirements: TransportRequirements,
+}
+
+const REQUEST_RESPONSE: TransportRequirements = TransportRequirements {
+    server_push: false,
+    inbound_notifications: false,
+};
+const SUBSCRIPTION_TRANSPORT: TransportRequirements = TransportRequirements {
+    server_push: true,
+    inbound_notifications: true,
+};
+
+/// The complete Open Engine Cluster Protocol server method surface, in advertised order.
+pub static METHOD_REGISTRY: &[MethodDescriptor] = &[
+    unary("initialize"),
+    unary("plan"),
+    unary("apply"),
+    unary("update"),
+    unary("stop"),
+    unary("retry"),
+    unary("resubmit"),
+    unary("delete"),
+    unary("get"),
+    subscription("watch", SubscriptionKind::Watch),
+    subscription("logs", SubscriptionKind::Logs),
+    subscription("agent/attach", SubscriptionKind::AgentAttach),
+];
+
+const fn unary(name: &'static str) -> MethodDescriptor {
+    MethodDescriptor {
+        name,
+        kind: MethodKind::Unary,
+        transport_requirements: REQUEST_RESPONSE,
+    }
+}
+
+const fn subscription(name: &'static str, kind: SubscriptionKind) -> MethodDescriptor {
+    MethodDescriptor {
+        name,
+        kind: MethodKind::Subscription(kind),
+        transport_requirements: SUBSCRIPTION_TRANSPORT,
+    }
+}
+
+/// Resolves a wire method name through the authoritative registry.
+#[must_use]
+pub fn method_descriptor(name: &str) -> Option<&'static MethodDescriptor> {
+    METHOD_REGISTRY
+        .iter()
+        .find(|descriptor| descriptor.name == name)
+}
+
+/// Enumerates methods with exactly the supplied transport requirements.
+pub fn methods_requiring(
+    requirements: TransportRequirements,
+) -> impl Iterator<Item = &'static MethodDescriptor> {
+    METHOD_REGISTRY
+        .iter()
+        .filter(move |descriptor| descriptor.transport_requirements == requirements)
+}

--- a/crates/openengine-cluster-server/tests/method_registry.rs
+++ b/crates/openengine-cluster-server/tests/method_registry.rs
@@ -1,0 +1,137 @@
+use std::fs;
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, RequestId,
+    ServerCapabilities,
+};
+use openengine_cluster_server::method_registry::{
+    methods_requiring, MethodKind, SubscriptionKind, TransportRequirements, METHOD_REGISTRY,
+};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
+use serde_json::Value;
+
+struct EmptyBackend;
+
+#[async_trait]
+impl ClusterBackend for EmptyBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        Ok(InitializeResult::new(
+            ServerCapabilities::default(),
+            ClusterStatus::empty(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult {
+            spec: None,
+            status: ClusterStatus::empty(),
+            at_cursor: None,
+        })
+    }
+}
+
+#[test]
+fn registry_is_the_exact_protocol_method_surface() {
+    let names = METHOD_REGISTRY
+        .iter()
+        .map(|descriptor| descriptor.name)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        [
+            "initialize",
+            "plan",
+            "apply",
+            "update",
+            "stop",
+            "retry",
+            "resubmit",
+            "delete",
+            "get",
+            "watch",
+            "logs",
+            "agent/attach",
+        ]
+    );
+
+    let subscriptions = METHOD_REGISTRY
+        .iter()
+        .filter_map(|descriptor| match descriptor.kind {
+            MethodKind::Unary => None,
+            MethodKind::Subscription(kind) => Some((descriptor.name, kind)),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        subscriptions,
+        [
+            ("watch", SubscriptionKind::Watch),
+            ("logs", SubscriptionKind::Logs),
+            ("agent/attach", SubscriptionKind::AgentAttach),
+        ]
+    );
+
+    for descriptor in METHOD_REGISTRY {
+        let is_subscription = matches!(descriptor.kind, MethodKind::Subscription(_));
+        assert_eq!(
+            descriptor.transport_requirements,
+            TransportRequirements {
+                server_push: is_subscription,
+                inbound_notifications: is_subscription,
+            },
+            "wrong transport requirements for {}",
+            descriptor.name
+        );
+    }
+
+    let request_response = methods_requiring(TransportRequirements::default())
+        .map(|descriptor| descriptor.name)
+        .collect::<Vec<_>>();
+    assert_eq!(request_response, &names[..9]);
+    let subscription_transport = methods_requiring(TransportRequirements {
+        server_push: true,
+        inbound_notifications: true,
+    })
+    .map(|descriptor| descriptor.name)
+    .collect::<Vec<_>>();
+    assert_eq!(subscription_transport, &names[9..]);
+}
+
+#[test]
+fn bindings_do_not_classify_subscriptions_with_method_name_literals() {
+    let source_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    for relative in ["stdio.rs", "connection/frame.rs"] {
+        let source = fs::read_to_string(source_root.join(relative)).unwrap();
+        for method in ["watch", "logs", "agent/attach"] {
+            assert!(
+                !source.contains(&format!("\"{method}\"")),
+                "{relative} hardcodes subscription method {method}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn subscription_methods_remain_unavailable_to_unary_dispatch() {
+    let dispatcher = Dispatcher::new(EmptyBackend, ConnectionContext::default());
+
+    for (index, method) in ["watch", "logs", "agent/attach"].into_iter().enumerate() {
+        let id = RequestId::String(format!("subscription-{index}"));
+        let response = dispatcher
+            .dispatch_decoded(id.clone(), method, Value::Array(Vec::new()))
+            .await;
+        let response: Value = serde_json::from_str(&response).unwrap();
+        assert_eq!(response["id"], serde_json::to_value(id).unwrap());
+        assert_eq!(response["error"]["code"], -32601);
+        assert_eq!(response["error"]["message"], "Method not found");
+    }
+}

--- a/crates/openengine-cluster-testkit/src/artifacts/openrpc.rs
+++ b/crates/openengine-cluster-testkit/src/artifacts/openrpc.rs
@@ -2,30 +2,22 @@ use openengine_cluster_protocol::{
     AgentAttachParams, ApplyParams, DeleteParams, ResubmitParams, RetryParams, StopParams,
     UpdateParams,
 };
+use openengine_cluster_server::method_registry::{MethodDescriptor, MethodKind, METHOD_REGISTRY};
 use schemars::schema_for;
 use serde_json::{json, Value};
 
 pub(super) fn document() -> Value {
+    let methods = METHOD_REGISTRY
+        .iter()
+        .map(method_document)
+        .collect::<Vec<_>>();
     json!({
         "openrpc": "1.3.2",
         "info": {
             "title": "Open Engine Cluster Protocol",
             "version": "1.0.0"
         },
-        "methods": [
-            initialize_method(),
-            plan_method(),
-            apply_method(),
-            update_method(),
-            stop_method(),
-            retry_method(),
-            resubmit_method(),
-            delete_method(),
-            get_method(),
-            watch_method(),
-            logs_method(),
-            agent_attach_method(),
-        ],
+        "methods": methods,
         "components": {
             "schemas": {
                 "GraphSpec": { "$ref": "graph.schema.json" },
@@ -38,12 +30,14 @@ pub(super) fn document() -> Value {
         "x-generic-subscription-framing": {
             "description": "watch, logs, and agent/attach each establish a subscription via one \
                 normal JSON-RPC result; subsequent delivery uses the generic notification methods \
-                below, shared by every subscription-based method. There is no watch/event, \
-                watch/cancel, watch/closed, logs/event, logs/cancel, logs/closed, \
-                agent/attach/event, agent/attach/cancel, or agent/attach/closed method on the \
-                wire. `$/cancelRequest` is a transport-level best-effort cancellation of any \
-                in-flight unary request by its RequestId; it is silently a no-op for an unknown \
-                or already-completed id and carries no rollback claim after backend commit.",
+                below, shared by every subscription-based method. watch, logs, and agent/attach \
+                are established through the connection layer and are not answerable by \
+                Dispatcher::dispatch alone. There is no watch/event, watch/cancel, watch/closed, \
+                logs/event, logs/cancel, logs/closed, agent/attach/event, agent/attach/cancel, or \
+                agent/attach/closed method on the wire. `$/cancelRequest` is a transport-level \
+                best-effort cancellation of any in-flight unary request by its RequestId; it is \
+                silently a no-op for an unknown or already-completed id and carries no rollback \
+                claim after backend commit.",
             "notifications": {
                 "event": { "$ref": "schema.json#/$defs/EventNotification" },
                 "subscription/cancel": { "$ref": "schema.json#/$defs/SubscriptionCancelParams" },
@@ -53,10 +47,42 @@ pub(super) fn document() -> Value {
         }
     })
 }
+fn method_document(descriptor: &MethodDescriptor) -> Value {
+    let mut method = match descriptor.name {
+        "initialize" => initialize_method(),
+        "plan" => plan_method(),
+        "apply" => apply_method(),
+        "update" => update_method(),
+        "stop" => stop_method(),
+        "retry" => retry_method(),
+        "resubmit" => resubmit_method(),
+        "delete" => delete_method(),
+        "get" => get_method(),
+        "watch" => watch_method(),
+        "logs" => logs_method(),
+        "agent/attach" => agent_attach_method(),
+        name => panic!("METHOD_REGISTRY method has no OpenRPC schema: {name}"),
+    };
+    let object = method
+        .as_object_mut()
+        .expect("OpenRPC method builders must return objects");
+    object.insert("name".to_owned(), json!(descriptor.name));
+    object.insert(
+        "x-subscription".to_owned(),
+        json!(matches!(descriptor.kind, MethodKind::Subscription(_))),
+    );
+    object.insert(
+        "x-transport-requirements".to_owned(),
+        json!({
+            "serverPush": descriptor.transport_requirements.server_push,
+            "inboundNotifications": descriptor.transport_requirements.inbound_notifications,
+        }),
+    );
+    method
+}
 
 fn initialize_method() -> Value {
     json!({
-        "name": "initialize",
         "paramStructure": "by-name",
         "params": [{
             "name": "protocolVersion",
@@ -75,7 +101,6 @@ fn initialize_method() -> Value {
 
 fn plan_method() -> Value {
     json!({
-        "name": "plan",
         "paramStructure": "by-name",
         "params": [{
             "name": "graph",
@@ -93,7 +118,6 @@ fn apply_method() -> Value {
     let apply_schema = serde_json::to_value(schema_for!(ApplyParams))
         .expect("apply parameter JSON Schema serialization must succeed");
     json!({
-        "name": "apply",
         "paramStructure": "by-name",
         "params": [
             {
@@ -132,7 +156,6 @@ fn update_method() -> Value {
     let schema = serde_json::to_value(schema_for!(UpdateParams))
         .expect("update parameter JSON Schema serialization must succeed");
     json!({
-        "name": "update",
         "paramStructure": "by-name",
         "x-params-schema": schema,
         "params": [
@@ -153,7 +176,6 @@ fn stop_method() -> Value {
     let schema = serde_json::to_value(schema_for!(StopParams))
         .expect("stop parameter JSON Schema serialization must succeed");
     json!({
-        "name": "stop",
         "paramStructure": "by-name",
         "params": [
             { "name": "mode", "required": true, "schema": { "$ref": "schema.json#/$defs/StopMode" } },
@@ -171,7 +193,6 @@ fn retry_method() -> Value {
     let schema = serde_json::to_value(schema_for!(RetryParams))
         .expect("retry parameter JSON Schema serialization must succeed");
     json!({
-        "name": "retry",
         "paramStructure": "by-name",
         "params": [
             { "name": "ifGeneration", "required": true, "schema": property_schema(&schema, "ifGeneration") },
@@ -188,7 +209,6 @@ fn resubmit_method() -> Value {
     let schema = serde_json::to_value(schema_for!(ResubmitParams))
         .expect("resubmit parameter JSON Schema serialization must succeed");
     json!({
-        "name": "resubmit",
         "paramStructure": "by-name",
         "params": [
             { "name": "ifGeneration", "required": true, "schema": property_schema(&schema, "ifGeneration") },
@@ -207,7 +227,6 @@ fn delete_method() -> Value {
     let schema = serde_json::to_value(schema_for!(DeleteParams))
         .expect("delete parameter JSON Schema serialization must succeed");
     json!({
-        "name": "delete",
         "paramStructure": "by-name",
         "params": [
             { "name": "ifGeneration", "required": true, "schema": property_schema(&schema, "ifGeneration") },
@@ -230,7 +249,6 @@ fn property_schema(schema: &Value, property: &str) -> Value {
 
 fn get_method() -> Value {
     json!({
-        "name": "get",
         "paramStructure": "by-name",
         "params": [{
             "name": "atCursor",
@@ -246,7 +264,6 @@ fn get_method() -> Value {
 
 fn watch_method() -> Value {
     json!({
-        "name": "watch",
         "paramStructure": "by-name",
         "params": [
             {
@@ -267,7 +284,6 @@ fn watch_method() -> Value {
 
 fn logs_method() -> Value {
     json!({
-        "name": "logs",
         "paramStructure": "by-name",
         "params": [],
         "result": {
@@ -284,7 +300,6 @@ fn agent_attach_method() -> Value {
     let schema = serde_json::to_value(schema_for!(AgentAttachParams))
         .expect("agent_attach parameter JSON Schema serialization must succeed");
     json!({
-        "name": "agent/attach",
         "paramStructure": "by-name",
         "params": [{
             "name": "execution",

--- a/crates/openengine-cluster-testkit/tests/artifacts.rs
+++ b/crates/openengine-cluster-testkit/tests/artifacts.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use openengine_cluster_protocol::PROTOCOL_VERSION;
+use openengine_cluster_server::method_registry::METHOD_REGISTRY;
 use openengine_cluster_testkit::artifacts::{
     ArtifactError, check_artifacts, generate_artifacts, write_artifacts,
 };
@@ -123,23 +124,11 @@ async fn openrpc_exposes_only_the_implemented_protocol_methods() {
         .iter()
         .map(|method| method["name"].as_str().unwrap())
         .collect();
-    assert_eq!(
-        methods,
-        [
-            "initialize",
-            "plan",
-            "apply",
-            "update",
-            "stop",
-            "retry",
-            "resubmit",
-            "delete",
-            "get",
-            "watch",
-            "logs",
-            "agent/attach"
-        ]
-    );
+    let registry_methods = METHOD_REGISTRY
+        .iter()
+        .map(|descriptor| descriptor.name)
+        .collect::<Vec<_>>();
+    assert_eq!(methods, registry_methods);
     for component in [
         "GraphSpec",
         "CompiledGraphIr",

--- a/crates/openengine-cluster-testkit/tests/method_surface.rs
+++ b/crates/openengine-cluster-testkit/tests/method_surface.rs
@@ -1,0 +1,65 @@
+use std::fs;
+use std::path::PathBuf;
+
+use openengine_cluster_server::method_registry::{MethodKind, METHOD_REGISTRY};
+use openengine_cluster_testkit::artifacts::generate_artifacts;
+use serde_json::Value;
+
+fn assert_method_surface(document: &Value, source: &str) {
+    let methods = document["methods"]
+        .as_array()
+        .unwrap_or_else(|| panic!("{source} OpenRPC methods must be an array"));
+    assert_eq!(
+        methods.len(),
+        METHOD_REGISTRY.len(),
+        "{source} OpenRPC and registry method counts differ"
+    );
+
+    for (method, descriptor) in methods.iter().zip(METHOD_REGISTRY) {
+        assert_eq!(
+            method["name"], descriptor.name,
+            "{source} method order drift"
+        );
+        assert_eq!(
+            method["x-subscription"],
+            matches!(descriptor.kind, MethodKind::Subscription(_)),
+            "{source} subscription metadata drift for {}",
+            descriptor.name
+        );
+        assert_eq!(
+            method["x-transport-requirements"]["serverPush"],
+            descriptor.transport_requirements.server_push,
+            "{source} server-push metadata drift for {}",
+            descriptor.name
+        );
+        assert_eq!(
+            method["x-transport-requirements"]["inboundNotifications"],
+            descriptor.transport_requirements.inbound_notifications,
+            "{source} inbound-notification metadata drift for {}",
+            descriptor.name
+        );
+    }
+}
+
+#[tokio::test]
+async fn generated_and_committed_openrpc_match_the_server_method_registry() {
+    let artifacts = generate_artifacts().await;
+    let generated = artifacts
+        .iter()
+        .find(|artifact| artifact.relative_path.ends_with("/openrpc.json"))
+        .expect("generator must emit OpenRPC");
+    let generated: Value = serde_json::from_slice(&generated.bytes).unwrap();
+    assert_method_surface(&generated, "generated");
+
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let committed =
+        fs::read(workspace.join("protocol/openengine-cluster/v1/openrpc.json")).unwrap();
+    let committed: Value = serde_json::from_slice(&committed).unwrap();
+    assert_method_surface(&committed, "committed");
+    assert_eq!(generated, committed, "committed OpenRPC artifact drifted");
+}

--- a/protocol/openengine-cluster/v1/openrpc.json
+++ b/protocol/openengine-cluster/v1/openrpc.json
@@ -53,6 +53,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/InitializeResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -72,6 +77,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/PlanResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -123,6 +133,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/ApplyResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -252,6 +267,11 @@
         ],
         "title": "UpdateParams",
         "type": "object"
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -290,6 +310,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/StopResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -321,6 +346,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/RetryResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -364,6 +394,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/ResubmitResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -405,6 +440,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/DeleteResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -427,6 +467,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/GetResult"
         }
+      },
+      "x-subscription": false,
+      "x-transport-requirements": {
+        "inboundNotifications": false,
+        "serverPush": false
       }
     },
     {
@@ -459,6 +504,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/WatchResult"
         }
+      },
+      "x-subscription": true,
+      "x-transport-requirements": {
+        "inboundNotifications": true,
+        "serverPush": true
       }
     },
     {
@@ -470,6 +520,11 @@
         "schema": {
           "$ref": "schema.json#/$defs/LogsResult"
         }
+      },
+      "x-subscription": true,
+      "x-transport-requirements": {
+        "inboundNotifications": true,
+        "serverPush": true
       }
     },
     {
@@ -492,12 +547,17 @@
         "schema": {
           "$ref": "schema.json#/$defs/AgentAttachResult"
         }
+      },
+      "x-subscription": true,
+      "x-transport-requirements": {
+        "inboundNotifications": true,
+        "serverPush": true
       }
     }
   ],
   "openrpc": "1.3.2",
   "x-generic-subscription-framing": {
-    "description": "watch, logs, and agent/attach each establish a subscription via one normal JSON-RPC result; subsequent delivery uses the generic notification methods below, shared by every subscription-based method. There is no watch/event, watch/cancel, watch/closed, logs/event, logs/cancel, logs/closed, agent/attach/event, agent/attach/cancel, or agent/attach/closed method on the wire. `$/cancelRequest` is a transport-level best-effort cancellation of any in-flight unary request by its RequestId; it is silently a no-op for an unknown or already-completed id and carries no rollback claim after backend commit.",
+    "description": "watch, logs, and agent/attach each establish a subscription via one normal JSON-RPC result; subsequent delivery uses the generic notification methods below, shared by every subscription-based method. watch, logs, and agent/attach are established through the connection layer and are not answerable by Dispatcher::dispatch alone. There is no watch/event, watch/cancel, watch/closed, logs/event, logs/cancel, logs/closed, agent/attach/event, agent/attach/cancel, or agent/attach/closed method on the wire. `$/cancelRequest` is a transport-level best-effort cancellation of any in-flight unary request by its RequestId; it is silently a no-op for an unknown or already-completed id and carries no rollback claim after backend commit.",
     "notifications": {
       "$/cancelRequest": {
         "$ref": "schema.json#/$defs/CancelRequestParams"


### PR DESCRIPTION
Closes #828

## Decision
Make the server-owned method registry the sole source of method names, kinds, and binding requirements. Unary dispatch and connection subscription routing consume the same descriptors, while subscription methods remain intentionally unavailable through `Dispatcher::dispatch_decoded`.

## Changes
- adds the public 12-entry `method_registry` with `MethodKind`, exhaustive `SubscriptionKind`, and `TransportRequirements`
- replaces `ImplementedMethod::NAMES` / `from_name` and hardcoded subscription classification
- centralizes the exhaustive subscription-kind-to-runner match in the connection core
- adds `methods_requiring(...)` for deterministic binding surface enumeration
- derives OpenRPC method order and per-method `x-subscription` / `x-transport-requirements` metadata from the registry
- updates the generic subscription-framing note and regenerates `openrpc.json`
- replaces the hardcoded artifact method array and adds server + cross-artifact focused tests
- records registry ownership and routing conventions in AGENTS.md

The only generated protocol change is `protocol/openengine-cluster/v1/openrpc.json`: 12 metadata additions plus the required framing sentence. No method schema, error, params, result, notification, or binding behavior changed.

## Verification
- `cargo test -p openengine-cluster-server --test method_registry` — 3 passed
- `cargo test -p openengine-cluster-testkit --test method_surface` — 1 passed
- `cargo test -p openengine-cluster-testkit --test artifacts` — 6 passed
- `npm run rust:check` — passed (fmt, clippy `-D warnings`, workspace tests)
- `npm run protocol:check` — passed, generated output byte-clean
- `npm run typecheck` — passed
- `npm run lint` — passed (0 errors; existing warnings only)
- `npm run test:unit` — 2,113 passed, 18 pending
- `opcore check --changed` — 25 checks passed, 0 findings
- two independent executable verifiers returned zero findings; mutation checks proved registry/artifact drift and missing subscription runner variants fail