### PR TITLE
feat(zeroshot-rust): add authenticated local-daemon discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,22 +183,26 @@ configuration, credential acquisition, executable codecs, concrete drivers, prot
 and Node registry synchronization outside it.
 Daemon locators are owner-only connection hints, never liveness evidence. Startup holds the
 profile lock only through stale authenticated-initialize probing and atomic bind/publication.
+Locator reads open `O_NOFOLLOW` first: a mode-0600 same-owner file with more than one link is
+insecure, while an opened descriptor concurrently unlinked to zero links may yield its complete
+prior value. Never reclassify that proven unlink-after-open race as corruption.
 Upgrade authorization uses domain-separated client/server challenge proofs: capability and daemon
 nonce are never transmitted, the server proof is verified before initialize, and the exact route,
 profile digest, nonce, and rotating 256-bit capability must be proven before backend construction.
 Probe results are closed: authenticated initialize is `Alive`, connection refusal or conclusive
 invalid-owner/protocol proof is `DefinitelyStale`, and capacity/reset/timeout ambiguity is
-`Indeterminate`; only `DefinitelyStale` authorizes locator removal and handoff. Pre-auth handshake
-task/FD ownership, authenticated liveness, and ordinary active sessions each have independent
-finite capacity. Full ordinary capacity cannot consume the reserved liveness capacity. These are
-resource bounds, not an availability claim against unbounded sustained unauthenticated arrivals on
-the single endpoint, which cannot be classified before reading the upgrade. Graceful shutdown uses
-one absolute deadline across acceptance stop, abort/reap, and matching locator cleanup; timeout
-paths still attempt cleanup and report the defined failure. The daemon host reuses the server
-crate's WebSocket binding and dispatcher; keep
-protocol definitions, compatibility, credential resolution, ledger/catalog/recovery,
-runtime/scheduler/pools, exporter, CLI, hosted/cloud control-plane, Node-daemon, and workspace
-behavior outside these modules.
+`Indeterminate`; only `DefinitelyStale` authorizes locator removal and handoff. The response
+envelope is exactly correlated and its result is decoded and canonicalized through the
+authoritative protocol `InitializeResult`; partial or unknown result fields are not liveness.
+Pre-auth handshake task/FD ownership, authenticated liveness, and ordinary active sessions each
+have independent finite capacity. Full ordinary capacity cannot consume reserved liveness.
+These are resource bounds, not an availability claim against unbounded sustained unauthenticated
+arrivals on the single endpoint, which cannot be classified before reading the upgrade. Graceful
+shutdown uses one absolute deadline across acceptance stop, abort/reap, and matching locator
+cleanup; timeout paths still attempt cleanup and report the defined failure. The daemon host reuses
+the server crate's WebSocket binding and dispatcher; keep protocol definitions, compatibility,
+credential resolution, ledger/catalog/recovery, runtime/scheduler/pools, exporter, CLI,
+hosted/cloud control-plane, Node-daemon, and workspace behavior outside these modules.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair
 scheduler are engine-private seams. They own local dispatch placement, fencing, deadlines,
 workspace conflict arbitration, cancellation, and local-process containment only. They do not own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,13 +186,16 @@ profile lock only through stale authenticated-initialize probing and atomic bind
 Upgrade authorization uses domain-separated client/server challenge proofs: capability and daemon
 nonce are never transmitted, the server proof is verified before initialize, and the exact route,
 profile digest, nonce, and rotating 256-bit capability must be proven before backend construction.
-Pre-auth handshake task/FD ownership is finite; ordinary active-session capacity applies only after
-an authenticated upgrade, and authenticated liveness does not consume an ordinary session slot.
-This is a resource bound, not an availability claim against unbounded sustained unauthenticated
-arrivals on the single endpoint, which cannot be classified before reading the upgrade. Graceful
-shutdown has an outer deadline as well as bounded connection drain, releases the loopback socket,
-and removes only its matching locator. The daemon host reuses the server crate's WebSocket binding
-and dispatcher; keep
+Probe results are closed: authenticated initialize is `Alive`, connection refusal or conclusive
+invalid-owner/protocol proof is `DefinitelyStale`, and capacity/reset/timeout ambiguity is
+`Indeterminate`; only `DefinitelyStale` authorizes locator removal and handoff. Pre-auth handshake
+task/FD ownership, authenticated liveness, and ordinary active sessions each have independent
+finite capacity. Full ordinary capacity cannot consume the reserved liveness capacity. These are
+resource bounds, not an availability claim against unbounded sustained unauthenticated arrivals on
+the single endpoint, which cannot be classified before reading the upgrade. Graceful shutdown uses
+one absolute deadline across acceptance stop, abort/reap, and matching locator cleanup; timeout
+paths still attempt cleanup and report the defined failure. The daemon host reuses the server
+crate's WebSocket binding and dispatcher; keep
 protocol definitions, compatibility, credential resolution, ledger/catalog/recovery,
 runtime/scheduler/pools, exporter, CLI, hosted/cloud control-plane, Node-daemon, and workspace
 behavior outside these modules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | SQLite ledger store          | `zeroshot-rust/src/cluster_ledger/store/sqlite.rs`, `store/sqlite/`     |
 | SQLite append/query helpers  | `zeroshot-rust/src/cluster_ledger/store/sqlite/{operations,queries}.rs` |
 | Ledger records/replay        | `zeroshot-rust/src/cluster_ledger/record.rs`, `replay.rs`               |
-| Full-v1 pure graph reducer    | `zeroshot-rust/src/full_v1_reducer.rs`                              |
+| Full-v1 pure graph reducer   | `zeroshot-rust/src/full_v1_reducer.rs`                                  |
 | Protocol ledger adapters     | `zeroshot-rust/src/cluster_ledger/adapters.rs`                          |
 | Artifact store port/fake     | `zeroshot-rust/src/artifact_store.rs`, `artifact_store/fake.rs`         |
 | Product-local artifact CAS   | `zeroshot-rust/src/artifact_store/local_cas.rs`, `local_cas/`           |
@@ -201,8 +201,11 @@ have independent finite capacity. Full ordinary capacity cannot consume reserved
 These are resource bounds, not an availability claim against unbounded sustained unauthenticated
 arrivals on the single endpoint, which cannot be classified before reading the upgrade. Graceful
 shutdown uses one absolute deadline across acceptance stop, abort/reap, and matching locator
-cleanup; timeout paths still attempt cleanup and report the defined failure. The daemon host reuses
-the server crate's WebSocket binding and dispatcher; keep protocol definitions, compatibility,
+cleanup; timeout paths still attempt cleanup and report the defined failure. Every accepted daemon
+session and liveness handshake enters through the server crate's `ConnectionBinding`, with an
+immutable profile-digest principal and tenant identity resolved before backend access; the daemon
+host never constructs `ConnectionContext` directly and reuses the server WebSocket dispatcher.
+Keep protocol definitions, compatibility,
 credential resolution, ledger/catalog/recovery, runtime/scheduler/pools, exporter, CLI,
 hosted/cloud control-plane, Node-daemon, and workspace behavior outside these modules.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,9 +183,11 @@ configuration, credential acquisition, executable codecs, concrete drivers, prot
 and Node registry synchronization outside it.
 Daemon locators are owner-only connection hints, never liveness evidence. Startup holds the
 profile lock only through stale authenticated-initialize probing and atomic bind/publication.
-Locator reads open `O_NOFOLLOW` first: a mode-0600 same-owner file with more than one link is
-insecure, while an opened descriptor concurrently unlinked to zero links may yield its complete
-prior value. Never reclassify that proven unlink-after-open race as corruption.
+Unix locator reads open `O_NOFOLLOW` first and enforce owner UID, mode 0600, and link count.
+Windows uses reparse-point-safe handles, a protected current-user-only DACL, handle link counts,
+and write-through atomic replacement. On either platform, extra links are insecure while an opened
+locator concurrently unlinked to zero links may yield its complete prior value; never reclassify
+that proven unlink-after-open race as corruption.
 Upgrade authorization uses domain-separated client/server challenge proofs: capability and daemon
 nonce are never transmitted, the server proof is verified before initialize, and the exact route,
 profile digest, nonce, and rotating 256-bit capability must be proven before backend construction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Native fault taxonomy        | `zeroshot-rust/src/fault/taxonomy.rs`                                   |
 | Native diagnostic redaction  | `zeroshot-rust/src/fault/redaction.rs`                                  |
 | Native observability         | `zeroshot-rust/src/observability.rs`                                    |
+| Native daemon discovery      | `zeroshot-rust/src/daemon_discovery.rs`                                 |
+| Native daemon authorization  | `zeroshot-rust/src/daemon_auth.rs`                                      |
+| Native loopback listener     | `zeroshot-rust/src/daemon_listener.rs`                                  |
 | Admission coordinator        | `crates/openengine-cluster-server/src/admission.rs`                     |
 | Admission durable ports      | `crates/openengine-cluster-server/src/admission/ports.rs`               |
 | Admission snapshot folding   | `crates/openengine-cluster-server/src/admission/snapshot.rs`            |
@@ -154,8 +157,9 @@ backend-neutral behavior observable through public dispatcher and typed subscrip
 The existing integration binaries remain the richer reference regression suite; their
 implementation-specific vectors are not represented as portable external certification.
 `zeroshot-rust/` owns the concrete `NativeBackend`, product-local `NativeBackendFactory`
-construction root, product-private artifact byte-store port/local CAS, and product-private,
-secret-free issue/source provider contracts. Artifact stages, bytes, roots, filesystem paths,
+construction root, product-private artifact byte-store port/local CAS, product-private,
+secret-free issue/source provider contracts, and native-profile daemon discovery,
+authorization, and loopback-listener lifecycle. Artifact stages, bytes, roots, filesystem paths,
 locks, and manifests remain product-private; only verified protocol `ArtifactRef` receipts cross
 the engine boundary. `LocalCasArtifactStore` takes an explicit root, is a single-writer local
 filesystem store, and must preserve ref-first release plus synchronized blob-then-ref publication.
@@ -177,6 +181,14 @@ workspace behavior outside it.
 It owns bounded provider policy and deterministic identity only; keep role contracts, registries,
 configuration, credential acquisition, executable codecs, concrete drivers, protocol descriptors,
 and Node registry synchronization outside it.
+Daemon locators are owner-only connection hints, never liveness evidence. Startup holds the
+profile lock only through stale authenticated-initialize probing and atomic bind/publication;
+upgrade authorization must validate the exact route, profile digest, daemon nonce, and rotating
+256-bit capability before backend construction. Graceful shutdown stops acceptance, bounds active
+connection drain, releases the loopback socket, and removes only its matching locator. The daemon
+host reuses the server crate's WebSocket binding and dispatcher; keep protocol definitions,
+compatibility, credential resolution, ledger/catalog/recovery, runtime/scheduler/pools, exporter,
+CLI, hosted/cloud control-plane, Node-daemon, and workspace behavior outside these modules.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair
 scheduler are engine-private seams. They own local dispatch placement, fencing, deadlines,
 workspace conflict arbitration, cancellation, and local-process containment only. They do not own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,13 +182,17 @@ It owns bounded provider policy and deterministic identity only; keep role contr
 configuration, credential acquisition, executable codecs, concrete drivers, protocol descriptors,
 and Node registry synchronization outside it.
 Daemon locators are owner-only connection hints, never liveness evidence. Startup holds the
-profile lock only through stale authenticated-initialize probing and atomic bind/publication;
-upgrade authorization must validate the exact route, profile digest, daemon nonce, and rotating
-256-bit capability before backend construction. Graceful shutdown stops acceptance, bounds active
-connection drain, releases the loopback socket, and removes only its matching locator. The daemon
-host reuses the server crate's WebSocket binding and dispatcher; keep protocol definitions,
-compatibility, credential resolution, ledger/catalog/recovery, runtime/scheduler/pools, exporter,
-CLI, hosted/cloud control-plane, Node-daemon, and workspace behavior outside these modules.
+profile lock only through stale authenticated-initialize probing and atomic bind/publication.
+Upgrade authorization uses domain-separated client/server challenge proofs: capability and daemon
+nonce are never transmitted, the server proof is verified before initialize, and the exact route,
+profile digest, nonce, and rotating 256-bit capability must be proven before backend construction.
+Ordinary active-session capacity applies only after an authenticated upgrade; pending handshakes
+and full ordinary capacity must never starve authenticated liveness. Graceful shutdown stops
+acceptance, bounds active connection drain, releases the loopback socket, and removes only its
+matching locator. The daemon host reuses the server crate's WebSocket binding and dispatcher; keep
+protocol definitions, compatibility, credential resolution, ledger/catalog/recovery,
+runtime/scheduler/pools, exporter, CLI, hosted/cloud control-plane, Node-daemon, and workspace
+behavior outside these modules.
 `ExecutionRuntime`, `LocalExecutionRuntime`, `LocalProcessRunner`, and the daemon-scoped fair
 scheduler are engine-private seams. They own local dispatch placement, fencing, deadlines,
 workspace conflict arbitration, cancellation, and local-process containment only. They do not own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,10 +186,13 @@ profile lock only through stale authenticated-initialize probing and atomic bind
 Upgrade authorization uses domain-separated client/server challenge proofs: capability and daemon
 nonce are never transmitted, the server proof is verified before initialize, and the exact route,
 profile digest, nonce, and rotating 256-bit capability must be proven before backend construction.
-Ordinary active-session capacity applies only after an authenticated upgrade; pending handshakes
-and full ordinary capacity must never starve authenticated liveness. Graceful shutdown stops
-acceptance, bounds active connection drain, releases the loopback socket, and removes only its
-matching locator. The daemon host reuses the server crate's WebSocket binding and dispatcher; keep
+Pre-auth handshake task/FD ownership is finite; ordinary active-session capacity applies only after
+an authenticated upgrade, and authenticated liveness does not consume an ordinary session slot.
+This is a resource bound, not an availability claim against unbounded sustained unauthenticated
+arrivals on the single endpoint, which cannot be classified before reading the upgrade. Graceful
+shutdown has an outer deadline as well as bounded connection drain, releases the loopback socket,
+and removes only its matching locator. The daemon host reuses the server crate's WebSocket binding
+and dispatcher; keep
 protocol definitions, compatibility, credential resolution, ledger/catalog/recovery,
 runtime/scheduler/pools, exporter, CLI, hosted/cloud control-plane, Node-daemon, and workspace
 behavior outside these modules.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,8 +2105,8 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
- "windows-sys",
  "tokio-tungstenite",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "fs2",
+ "futures-util",
+ "getrandom 0.3.4",
  "libc",
  "openengine-cluster-protocol",
  "openengine-cluster-server",
@@ -2104,6 +2106,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "windows-sys",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/the-open-engine/zeroshot"
 [workspace.dependencies]
 async-trait = "0.1.89"
 fs2 = "0.4.3"
+getrandom = "0.3.4"
 libc = "0.2.177"
 parking_lot = "0.12.5"
 rust_decimal = { version = "1.39.0", features = ["serde"] }

--- a/crates/openengine-cluster-server/src/identity.rs
+++ b/crates/openengine-cluster-server/src/identity.rs
@@ -238,6 +238,15 @@ where
     R: ConnectionIdentityResolver,
     T: ConnectionTimeSource,
 {
+    /// Resolves the binding-owned identity before exposing a dispatcher to a specialized host.
+    ///
+    /// General-purpose transports should use their `serve_*` entry point so per-request identity
+    /// expiry is enforced by the binding. This escape hatch is for bounded host handshakes whose
+    /// injected identity cannot expire during the transaction.
+    pub async fn into_dispatcher(self) -> io::Result<Dispatcher<B>> {
+        Ok(self.resolve().await?.dispatcher)
+    }
+
     pub(crate) async fn resolve(self) -> io::Result<ResolvedConnection<B, T>> {
         let identity = self
             .identity_resolver

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -35,6 +35,8 @@ tokio-tungstenite.workspace = true
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_Storage_FileSystem",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_JobObjects",
   "Win32_System_Threading",

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 [dependencies]
 async-trait.workspace = true
 fs2.workspace = true
+futures-util.workspace = true
+getrandom.workspace = true
 libc.workspace = true
 openengine-cluster-protocol.workspace = true
 openengine-cluster-server.workspace = true
@@ -27,6 +29,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-tungstenite.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/zeroshot-rust/src/daemon_auth.rs
+++ b/zeroshot-rust/src/daemon_auth.rs
@@ -1,12 +1,15 @@
-//! Fail-closed authorization for the native daemon WebSocket upgrade.
+//! Fail-closed mutual authorization for the native daemon WebSocket upgrade.
 //!
-//! Every rejected route or credential receives the same response. Authorization completes in the
-//! HTTP upgrade callback, before a backend is constructed or any Cluster Protocol bytes are read.
+//! The client proves possession of the locator capability without transmitting it, and the daemon
+//! returns a domain-separated proof before the client sends Cluster Protocol bytes. Every rejected
+//! route or credential receives the same response, before backend construction.
 
-use tokio_tungstenite::tungstenite::handshake::server::{
-    Callback, ErrorResponse, Request, Response,
-};
-use tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue;
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio_tungstenite::tungstenite::handshake::server::{Callback, ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::http::header::{InvalidHeaderValue, SEC_WEBSOCKET_KEY};
 use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
 
 use crate::daemon_discovery::{DaemonLocator, DiscoveryError, random_hex};
@@ -14,8 +17,36 @@ use crate::daemon_discovery::{DaemonLocator, DiscoveryError, random_hex};
 pub const DAEMON_ROUTE: &str = "/daemon/initialize";
 pub const AUTHORIZATION_HEADER: &str = "authorization";
 pub const PROFILE_DIGEST_HEADER: &str = "x-zeroshot-profile-digest";
-pub const DAEMON_NONCE_HEADER: &str = "x-zeroshot-daemon-nonce";
-const BEARER_PREFIX: &str = "Bearer ";
+pub const CLIENT_CHALLENGE_HEADER: &str = "x-zeroshot-client-challenge";
+pub const CONNECTION_PURPOSE_HEADER: &str = "x-zeroshot-connection-purpose";
+pub const SERVER_PROOF_HEADER: &str = "x-zeroshot-server-proof";
+const AUTHORIZATION_PREFIX: &str = "Zeroshot-HMAC ";
+const CLIENT_DOMAIN: &[u8] = b"zeroshot.daemon/v1/client-auth";
+const SERVER_DOMAIN: &[u8] = b"zeroshot.daemon/v1/server-auth";
+const HEX_256_LEN: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConnectionPurpose {
+    Session,
+    Liveness,
+}
+
+impl ConnectionPurpose {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Session => "session",
+            Self::Liveness => "liveness",
+        }
+    }
+
+    fn parse(value: &[u8]) -> Option<Self> {
+        match value {
+            b"session" => Some(Self::Session),
+            b"liveness" => Some(Self::Liveness),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DaemonCredentials {
@@ -42,67 +73,237 @@ impl DaemonCredentials {
         }
     }
 
-    pub fn apply_to_request(&self, request: &mut Request) -> Result<(), InvalidHeaderValue> {
-        let authorization = HeaderValue::from_str(&format!("{BEARER_PREFIX}{}", self.capability))?;
-        let profile = HeaderValue::from_str(&self.profile_digest)?;
-        let nonce = HeaderValue::from_str(&self.daemon_nonce)?;
+    pub fn apply_to_request(
+        &self,
+        request: &mut Request,
+    ) -> Result<ServerProofExpectation, AuthBuildError> {
+        self.prepare_request(request, ConnectionPurpose::Session)
+    }
+
+    pub fn prepare_request(
+        &self,
+        request: &mut Request,
+        purpose: ConnectionPurpose,
+    ) -> Result<ServerProofExpectation, AuthBuildError> {
+        let websocket_key = request
+            .headers()
+            .get(SEC_WEBSOCKET_KEY)
+            .ok_or(AuthBuildError::MissingWebSocketKey)?
+            .as_bytes()
+            .to_vec();
+        let challenge = random_hex()?;
+        let proof_context = ProofContext {
+            challenge: &challenge,
+            websocket_key: &websocket_key,
+            purpose,
+        };
+        let request_proof = proof(CLIENT_DOMAIN, self, &proof_context);
+        let server_proof = proof(SERVER_DOMAIN, self, &proof_context);
+        request.headers_mut().insert(
+            AUTHORIZATION_HEADER,
+            HeaderValue::from_str(&format!("{AUTHORIZATION_PREFIX}{request_proof}"))?,
+        );
+        request.headers_mut().insert(
+            PROFILE_DIGEST_HEADER,
+            HeaderValue::from_str(&self.profile_digest)?,
+        );
         request
             .headers_mut()
-            .insert(AUTHORIZATION_HEADER, authorization);
-        request
-            .headers_mut()
-            .insert(PROFILE_DIGEST_HEADER, profile);
-        request.headers_mut().insert(DAEMON_NONCE_HEADER, nonce);
-        Ok(())
+            .insert(CLIENT_CHALLENGE_HEADER, HeaderValue::from_str(&challenge)?);
+        request.headers_mut().insert(
+            CONNECTION_PURPOSE_HEADER,
+            HeaderValue::from_static(purpose.as_str()),
+        );
+        Ok(ServerProofExpectation {
+            expected: server_proof,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AuthBuildError {
+    #[error("WebSocket request has no client handshake key")]
+    MissingWebSocketKey,
+    #[error("daemon authentication header is invalid")]
+    InvalidHeader(#[from] InvalidHeaderValue),
+    #[error("daemon authentication randomness failed: {0}")]
+    Discovery(#[from] DiscoveryError),
+}
+
+#[derive(Debug)]
+pub struct ServerProofExpectation {
+    expected: String,
+}
+
+impl ServerProofExpectation {
+    #[must_use]
+    pub fn verify<B>(&self, response: &tokio_tungstenite::tungstenite::http::Response<B>) -> bool {
+        exact_response_header(response, SERVER_PROOF_HEADER, self.expected.as_bytes())
     }
 }
 
 /// Exact request authorization. Query strings, alternate paths, duplicate/comma-joined headers,
-/// malformed header text, and stale values all fail the same predicate.
+/// malformed header text, and stale credentials all fail the same predicate.
 #[must_use]
 pub fn authorize_request(request: &Request, expected: &DaemonCredentials) -> bool {
-    if request.uri().path() != DAEMON_ROUTE || request.uri().query().is_some() {
-        return false;
-    }
-    let expected_bearer = format!("{BEARER_PREFIX}{}", expected.capability);
-    exact_header(request, AUTHORIZATION_HEADER, expected_bearer.as_bytes())
-        && exact_header(
-            request,
-            PROFILE_DIGEST_HEADER,
-            expected.profile_digest.as_bytes(),
-        )
-        && exact_header(
-            request,
-            DAEMON_NONCE_HEADER,
-            expected.daemon_nonce.as_bytes(),
-        )
+    authorized_request(request, expected).is_some()
 }
 
-pub(crate) struct AuthorizationCallback(pub DaemonCredentials);
+pub(crate) struct AuthorizationCallback {
+    expected: DaemonCredentials,
+    receipt: AuthorizationReceipt,
+}
+
+#[derive(Clone)]
+pub(crate) struct AuthorizationReceipt(Arc<Mutex<Option<ConnectionPurpose>>>);
+
+impl AuthorizationCallback {
+    pub(crate) fn new(expected: DaemonCredentials) -> (Self, AuthorizationReceipt) {
+        let receipt = AuthorizationReceipt(Arc::new(Mutex::new(None)));
+        (
+            Self {
+                expected,
+                receipt: receipt.clone(),
+            },
+            receipt,
+        )
+    }
+}
+
+impl AuthorizationReceipt {
+    pub(crate) fn take(&self) -> Option<ConnectionPurpose> {
+        self.0.lock().ok()?.take()
+    }
+}
 
 impl Callback for AuthorizationCallback {
     fn on_request(
         self,
         request: &Request,
-        response: Response,
+        mut response: Response,
     ) -> Result<Response, ErrorResponse> {
-        if authorize_request(request, &self.0) {
-            Ok(response)
-        } else {
-            Err(uniform_rejection())
-        }
+        let Some(authorization) = authorized_request(request, &self.expected) else {
+            return Err(uniform_rejection());
+        };
+        let proof = proof(SERVER_DOMAIN, &self.expected, &authorization);
+        let Ok(proof) = HeaderValue::from_str(&proof) else {
+            return Err(uniform_rejection());
+        };
+        response.headers_mut().insert(SERVER_PROOF_HEADER, proof);
+        let Ok(mut accepted) = self.receipt.0.lock() else {
+            return Err(uniform_rejection());
+        };
+        *accepted = Some(authorization.purpose);
+        drop(accepted);
+        Ok(response)
     }
 }
 
-fn exact_header(request: &Request, name: &'static str, expected: &[u8]) -> bool {
+struct ProofContext<'a> {
+    challenge: &'a str,
+    websocket_key: &'a [u8],
+    purpose: ConnectionPurpose,
+}
+
+fn authorized_request<'a>(
+    request: &'a Request,
+    expected: &DaemonCredentials,
+) -> Option<ProofContext<'a>> {
+    if request.uri().path() != DAEMON_ROUTE || request.uri().query().is_some() {
+        return None;
+    }
+    let profile = single_header(request, PROFILE_DIGEST_HEADER)?;
+    if !constant_time_eq(profile, expected.profile_digest.as_bytes()) {
+        return None;
+    }
+    let challenge = std::str::from_utf8(single_header(request, CLIENT_CHALLENGE_HEADER)?).ok()?;
+    if !is_lower_hex(challenge, HEX_256_LEN) {
+        return None;
+    }
+    let purpose = ConnectionPurpose::parse(single_header(request, CONNECTION_PURPOSE_HEADER)?)?;
+    let websocket_key = single_header(request, SEC_WEBSOCKET_KEY.as_str())?;
+    let presented = single_header(request, AUTHORIZATION_HEADER)?;
+    let proof_context = ProofContext {
+        challenge,
+        websocket_key,
+        purpose,
+    };
+    let request_proof = proof(CLIENT_DOMAIN, expected, &proof_context);
+    let expected_authorization = format!("{AUTHORIZATION_PREFIX}{request_proof}");
+    if !constant_time_eq(presented, expected_authorization.as_bytes()) {
+        return None;
+    }
+    Some(proof_context)
+}
+
+fn proof(domain: &[u8], credentials: &DaemonCredentials, context: &ProofContext<'_>) -> String {
+    let parts: [&[u8]; 6] = [
+        DAEMON_ROUTE.as_bytes(),
+        credentials.profile_digest.as_bytes(),
+        credentials.daemon_nonce.as_bytes(),
+        context.challenge.as_bytes(),
+        context.websocket_key,
+        context.purpose.as_str().as_bytes(),
+    ];
+    hex(&hmac_sha256(
+        credentials.capability.as_bytes(),
+        domain,
+        &parts,
+    ))
+}
+
+fn hmac_sha256(key: &[u8], domain: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+    const BLOCK_BYTES: usize = 64;
+    let mut key_block = [0_u8; BLOCK_BYTES];
+    if key.len() > BLOCK_BYTES {
+        key_block[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        key_block[..key.len()].copy_from_slice(key);
+    }
+    let mut inner_pad = [0x36_u8; BLOCK_BYTES];
+    let mut outer_pad = [0x5c_u8; BLOCK_BYTES];
+    for index in 0..BLOCK_BYTES {
+        inner_pad[index] ^= key_block[index];
+        outer_pad[index] ^= key_block[index];
+    }
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    update_proof_message(&mut inner, domain, parts);
+    let inner_digest = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+fn update_proof_message(hasher: &mut Sha256, domain: &[u8], parts: &[&[u8]]) {
+    hasher.update((domain.len() as u64).to_be_bytes());
+    hasher.update(domain);
+    for part in parts {
+        hasher.update((part.len() as u64).to_be_bytes());
+        hasher.update(part);
+    }
+}
+
+fn single_header<'a>(request: &'a Request, name: &str) -> Option<&'a [u8]> {
     let mut values = request.headers().get_all(name).iter();
+    let value = values.next()?;
+    if values.next().is_some() {
+        return None;
+    }
+    Some(value.as_bytes())
+}
+
+fn exact_response_header<B>(
+    response: &tokio_tungstenite::tungstenite::http::Response<B>,
+    name: &str,
+    expected: &[u8],
+) -> bool {
+    let mut values = response.headers().get_all(name).iter();
     let Some(value) = values.next() else {
         return false;
     };
-    if values.next().is_some() {
-        return false;
-    }
-    constant_time_eq(value.as_bytes(), expected)
+    values.next().is_none() && constant_time_eq(value.as_bytes(), expected)
 }
 
 fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
@@ -114,6 +315,23 @@ fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
         difference |= usize::from(left ^ right);
     }
     difference == 0
+}
+
+fn is_lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 fn uniform_rejection() -> ErrorResponse {

--- a/zeroshot-rust/src/daemon_auth.rs
+++ b/zeroshot-rust/src/daemon_auth.rs
@@ -1,0 +1,123 @@
+//! Fail-closed authorization for the native daemon WebSocket upgrade.
+//!
+//! Every rejected route or credential receives the same response. Authorization completes in the
+//! HTTP upgrade callback, before a backend is constructed or any Cluster Protocol bytes are read.
+
+use tokio_tungstenite::tungstenite::handshake::server::{
+    Callback, ErrorResponse, Request, Response,
+};
+use tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue;
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+
+use crate::daemon_discovery::{DaemonLocator, DiscoveryError, random_hex};
+
+pub const DAEMON_ROUTE: &str = "/daemon/initialize";
+pub const AUTHORIZATION_HEADER: &str = "authorization";
+pub const PROFILE_DIGEST_HEADER: &str = "x-zeroshot-profile-digest";
+pub const DAEMON_NONCE_HEADER: &str = "x-zeroshot-daemon-nonce";
+const BEARER_PREFIX: &str = "Bearer ";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DaemonCredentials {
+    pub profile_digest: String,
+    pub daemon_nonce: String,
+    pub capability: String,
+}
+
+impl DaemonCredentials {
+    pub fn generate(profile_digest: impl Into<String>) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            profile_digest: profile_digest.into(),
+            daemon_nonce: random_hex()?,
+            capability: random_hex()?,
+        })
+    }
+
+    #[must_use]
+    pub fn from_locator(locator: &DaemonLocator) -> Self {
+        Self {
+            profile_digest: locator.profile_digest.clone(),
+            daemon_nonce: locator.daemon_nonce.clone(),
+            capability: locator.capability.clone(),
+        }
+    }
+
+    pub fn apply_to_request(&self, request: &mut Request) -> Result<(), InvalidHeaderValue> {
+        let authorization = HeaderValue::from_str(&format!("{BEARER_PREFIX}{}", self.capability))?;
+        let profile = HeaderValue::from_str(&self.profile_digest)?;
+        let nonce = HeaderValue::from_str(&self.daemon_nonce)?;
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION_HEADER, authorization);
+        request
+            .headers_mut()
+            .insert(PROFILE_DIGEST_HEADER, profile);
+        request.headers_mut().insert(DAEMON_NONCE_HEADER, nonce);
+        Ok(())
+    }
+}
+
+/// Exact request authorization. Query strings, alternate paths, duplicate/comma-joined headers,
+/// malformed header text, and stale values all fail the same predicate.
+#[must_use]
+pub fn authorize_request(request: &Request, expected: &DaemonCredentials) -> bool {
+    if request.uri().path() != DAEMON_ROUTE || request.uri().query().is_some() {
+        return false;
+    }
+    let expected_bearer = format!("{BEARER_PREFIX}{}", expected.capability);
+    exact_header(request, AUTHORIZATION_HEADER, expected_bearer.as_bytes())
+        && exact_header(
+            request,
+            PROFILE_DIGEST_HEADER,
+            expected.profile_digest.as_bytes(),
+        )
+        && exact_header(
+            request,
+            DAEMON_NONCE_HEADER,
+            expected.daemon_nonce.as_bytes(),
+        )
+}
+
+pub(crate) struct AuthorizationCallback(pub DaemonCredentials);
+
+impl Callback for AuthorizationCallback {
+    fn on_request(
+        self,
+        request: &Request,
+        response: Response,
+    ) -> Result<Response, ErrorResponse> {
+        if authorize_request(request, &self.0) {
+            Ok(response)
+        } else {
+            Err(uniform_rejection())
+        }
+    }
+}
+
+fn exact_header(request: &Request, name: &'static str, expected: &[u8]) -> bool {
+    let mut values = request.headers().get_all(name).iter();
+    let Some(value) = values.next() else {
+        return false;
+    };
+    if values.next().is_some() {
+        return false;
+    }
+    constant_time_eq(value.as_bytes(), expected)
+}
+
+fn constant_time_eq(actual: &[u8], expected: &[u8]) -> bool {
+    let mut difference = actual.len() ^ expected.len();
+    let compared_len = actual.len().max(expected.len());
+    for index in 0..compared_len {
+        let left = actual.get(index).copied().unwrap_or(0);
+        let right = expected.get(index).copied().unwrap_or(0);
+        difference |= usize::from(left ^ right);
+    }
+    difference == 0
+}
+
+fn uniform_rejection() -> ErrorResponse {
+    let mut response = ErrorResponse::new(None);
+    *response.status_mut() = StatusCode::NOT_FOUND;
+    response
+}

--- a/zeroshot-rust/src/daemon_auth.rs
+++ b/zeroshot-rust/src/daemon_auth.rs
@@ -149,16 +149,17 @@ pub fn authorize_request(request: &Request, expected: &DaemonCredentials) -> boo
     authorized_request(request, expected).is_some()
 }
 
-pub(crate) struct AuthorizationCallback {
+/// Server-side WebSocket upgrade callback plus its one-shot authenticated-purpose receipt.
+pub struct AuthorizationCallback {
     expected: DaemonCredentials,
     receipt: AuthorizationReceipt,
 }
 
 #[derive(Clone)]
-pub(crate) struct AuthorizationReceipt(Arc<Mutex<Option<ConnectionPurpose>>>);
+pub struct AuthorizationReceipt(Arc<Mutex<Option<ConnectionPurpose>>>);
 
 impl AuthorizationCallback {
-    pub(crate) fn new(expected: DaemonCredentials) -> (Self, AuthorizationReceipt) {
+    pub fn new(expected: DaemonCredentials) -> (Self, AuthorizationReceipt) {
         let receipt = AuthorizationReceipt(Arc::new(Mutex::new(None)));
         (
             Self {
@@ -171,7 +172,7 @@ impl AuthorizationCallback {
 }
 
 impl AuthorizationReceipt {
-    pub(crate) fn take(&self) -> Option<ConnectionPurpose> {
+    pub fn take(&self) -> Option<ConnectionPurpose> {
         self.0.lock().ok()?.take()
     }
 }

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -219,19 +219,16 @@ pub(crate) fn random_hex() -> Result<String, DiscoveryError> {
 }
 
 fn read_locator_existing(profile: &NativeProfile) -> Result<Option<DaemonLocator>, DiscoveryError> {
-    let path = profile.locator_path();
-    let metadata = match fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
+    let file = match open_owner_file(&profile.locator_path(), false) {
+        Ok(file) => file,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(DiscoveryError::InsecureFile);
+        }
         Err(error) => return Err(error.into()),
     };
-    validate_owner_file(&metadata)?;
-    if metadata.len() > MAX_LOCATOR_BYTES {
-        return Err(DiscoveryError::LocatorTooLarge);
-    }
-    let file = open_owner_file(&path, false)?;
     let opened_metadata = file.metadata()?;
-    validate_owner_file(&opened_metadata)?;
+    validate_open_locator_file(&opened_metadata)?;
     if opened_metadata.len() > MAX_LOCATOR_BYTES {
         return Err(DiscoveryError::LocatorTooLarge);
     }
@@ -279,15 +276,25 @@ fn validate_owner_file(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
     Ok(())
 }
 
-fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
-    let file = OpenOptions::new()
+fn validate_open_locator_file(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
+    if !metadata.file_type().is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o077 != 0
+        || metadata.nlink() > 1
+    {
+        return Err(DiscoveryError::InsecureFile);
+    }
+    Ok(())
+}
+
+fn open_owner_file(path: &Path, create: bool) -> io::Result<File> {
+    OpenOptions::new()
         .read(true)
         .write(create)
         .create(create)
         .mode(0o600)
         .custom_flags(libc::O_NOFOLLOW)
-        .open(path)?;
-    Ok(file)
+        .open(path)
 }
 
 fn is_lower_hex(value: &str, len: usize) -> bool {

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -1,0 +1,308 @@
+//! Product-private native-profile daemon discovery.
+//!
+//! A locator is only a connection hint. Callers must prove liveness with the authenticated
+//! initialize exchange in [`crate::daemon_listener`]; neither this module nor a locator treats a
+//! PID or an open port as proof of a daemon.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub const CLUSTER_PROTOCOL: &str = "openengine.cluster/v1";
+pub const DAEMON_PROTOCOL: &str = "zeroshot.daemon/v1";
+pub const MAX_LOCATOR_BYTES: u64 = 4_096;
+const LOCATOR_FILE: &str = "daemon-locator.json";
+const START_LOCK_FILE: &str = ".daemon-start.lock";
+const SECRET_HEX_LEN: usize = 64;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativeProfile {
+    root: PathBuf,
+    digest: String,
+}
+
+impl NativeProfile {
+    #[must_use]
+    pub fn new(root: impl Into<PathBuf>, profile_identity: impl AsRef<[u8]>) -> Self {
+        let digest = Sha256::digest(profile_identity.as_ref());
+        Self {
+            root: root.into(),
+            digest: hex(&digest),
+        }
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    #[must_use]
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    #[must_use]
+    pub fn locator_path(&self) -> PathBuf {
+        self.root.join(LOCATOR_FILE)
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.root.join(START_LOCK_FILE)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DaemonLocator {
+    pub endpoint: String,
+    pub cluster_protocol: String,
+    pub daemon_protocol: String,
+    pub profile_digest: String,
+    pub daemon_nonce: String,
+    pub capability: String,
+}
+
+impl DaemonLocator {
+    pub fn validate_for(&self, profile: &NativeProfile) -> Result<(), DiscoveryError> {
+        if self.cluster_protocol != CLUSTER_PROTOCOL
+            || self.daemon_protocol != DAEMON_PROTOCOL
+            || self.profile_digest != profile.digest
+            || !is_lower_hex(&self.profile_digest, SECRET_HEX_LEN)
+            || !is_lower_hex(&self.daemon_nonce, SECRET_HEX_LEN)
+            || !is_lower_hex(&self.capability, SECRET_HEX_LEN)
+        {
+            return Err(DiscoveryError::InvalidLocator);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    #[error("daemon profile directory is not owner-only")]
+    InsecureProfileDirectory,
+    #[error("daemon discovery file is not an owner-only regular file")]
+    InsecureFile,
+    #[error("daemon locator exceeds {MAX_LOCATOR_BYTES} bytes")]
+    LocatorTooLarge,
+    #[error("daemon locator is invalid")]
+    InvalidLocator,
+    #[error("timed out serializing daemon profile startup")]
+    StartupLockTimeout,
+    #[error("operating-system randomness is unavailable")]
+    Randomness,
+    #[error("daemon discovery I/O failed: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Exclusive, bounded profile-start serialization. Its only intended critical section is stale
+/// probing plus bind/publish (or matching-owner removal), never the listener lifetime.
+pub struct ProfileStartGuard {
+    file: File,
+}
+
+impl Drop for ProfileStartGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub fn acquire_start_guard(
+    profile: &NativeProfile,
+    timeout: Duration,
+) -> Result<ProfileStartGuard, DiscoveryError> {
+    ensure_profile_directory(profile.root())?;
+    let file = open_owner_file(&profile.lock_path(), true)?;
+    validate_owner_file(&file.metadata()?)?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(ProfileStartGuard { file }),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(DiscoveryError::StartupLockTimeout);
+                }
+                thread::sleep(Duration::from_millis(2));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+pub fn read_locator(profile: &NativeProfile) -> Result<Option<DaemonLocator>, DiscoveryError> {
+    ensure_profile_directory(profile.root())?;
+    read_locator_existing(profile)
+}
+
+pub fn replace_locator(
+    profile: &NativeProfile,
+    locator: &DaemonLocator,
+) -> Result<(), DiscoveryError> {
+    let _guard = acquire_start_guard(profile, Duration::from_secs(1))?;
+    replace_locator_locked(profile, locator)
+}
+
+pub fn remove_locator_if_matches(
+    profile: &NativeProfile,
+    expected: &DaemonLocator,
+) -> Result<bool, DiscoveryError> {
+    let _guard = acquire_start_guard(profile, Duration::from_secs(1))?;
+    remove_locator_if_matches_locked(profile, expected)
+}
+
+pub(crate) fn read_locator_locked(
+    profile: &NativeProfile,
+) -> Result<Option<DaemonLocator>, DiscoveryError> {
+    read_locator_existing(profile)
+}
+
+pub(crate) fn replace_locator_locked(
+    profile: &NativeProfile,
+    locator: &DaemonLocator,
+) -> Result<(), DiscoveryError> {
+    locator.validate_for(profile)?;
+    let bytes = serde_json::to_vec(locator).map_err(|_| DiscoveryError::InvalidLocator)?;
+    if bytes.len() as u64 > MAX_LOCATOR_BYTES {
+        return Err(DiscoveryError::LocatorTooLarge);
+    }
+
+    let suffix = random_hex()?;
+    let temporary = profile.root().join(format!(".{LOCATOR_FILE}.{suffix}.tmp"));
+    let write_result = (|| -> Result<(), DiscoveryError> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, profile.locator_path())?;
+        File::open(profile.root())?.sync_all()?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    write_result
+}
+
+pub(crate) fn remove_locator_if_matches_locked(
+    profile: &NativeProfile,
+    expected: &DaemonLocator,
+) -> Result<bool, DiscoveryError> {
+    if read_locator_existing(profile)?.as_ref() != Some(expected) {
+        return Ok(false);
+    }
+    match fs::remove_file(profile.locator_path()) {
+        Ok(()) => {
+            File::open(profile.root())?.sync_all()?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn random_hex() -> Result<String, DiscoveryError> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes).map_err(|_| DiscoveryError::Randomness)?;
+    Ok(hex(&bytes))
+}
+
+fn read_locator_existing(profile: &NativeProfile) -> Result<Option<DaemonLocator>, DiscoveryError> {
+    let path = profile.locator_path();
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    validate_owner_file(&metadata)?;
+    if metadata.len() > MAX_LOCATOR_BYTES {
+        return Err(DiscoveryError::LocatorTooLarge);
+    }
+    let file = open_owner_file(&path, false)?;
+    let opened_metadata = file.metadata()?;
+    validate_owner_file(&opened_metadata)?;
+    if opened_metadata.len() > MAX_LOCATOR_BYTES {
+        return Err(DiscoveryError::LocatorTooLarge);
+    }
+    let mut bytes = Vec::with_capacity(opened_metadata.len() as usize);
+    file.take(MAX_LOCATOR_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_LOCATOR_BYTES {
+        return Err(DiscoveryError::LocatorTooLarge);
+    }
+    let locator: DaemonLocator =
+        serde_json::from_slice(&bytes).map_err(|_| DiscoveryError::InvalidLocator)?;
+    locator.validate_for(profile)?;
+    Ok(Some(locator))
+}
+
+fn ensure_profile_directory(path: &Path) -> Result<(), DiscoveryError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => validate_owner_directory(&metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            fs::create_dir_all(path)?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+            validate_owner_directory(&fs::symlink_metadata(path)?)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn validate_owner_directory(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
+    if !metadata.file_type().is_dir()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o077 != 0
+    {
+        return Err(DiscoveryError::InsecureProfileDirectory);
+    }
+    Ok(())
+}
+
+fn validate_owner_file(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
+    if !metadata.file_type().is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o077 != 0
+        || metadata.nlink() != 1
+    {
+        return Err(DiscoveryError::InsecureFile);
+    }
+    Ok(())
+}
+
+fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(create)
+        .create(create)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    Ok(file)
+}
+
+fn is_lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -221,11 +221,10 @@ pub(crate) fn random_hex() -> Result<String, DiscoveryError> {
 fn read_locator_existing(profile: &NativeProfile) -> Result<Option<DaemonLocator>, DiscoveryError> {
     let file = match open_owner_file(&profile.locator_path(), false) {
         Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
-            return Err(DiscoveryError::InsecureFile);
+        Err(DiscoveryError::Io(error)) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(None);
         }
-        Err(error) => return Err(error.into()),
+        Err(error) => return Err(error),
     };
     let opened_metadata = file.metadata()?;
     validate_open_locator_file(&opened_metadata)?;
@@ -287,7 +286,7 @@ fn validate_open_locator_file(metadata: &fs::Metadata) -> Result<(), DiscoveryEr
     Ok(())
 }
 
-fn open_owner_file(path: &Path, create: bool) -> io::Result<File> {
+fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
     OpenOptions::new()
         .read(true)
         .write(create)
@@ -295,6 +294,13 @@ fn open_owner_file(path: &Path, create: bool) -> io::Result<File> {
         .mode(0o600)
         .custom_flags(libc::O_NOFOLLOW)
         .open(path)
+        .map_err(|error| {
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                DiscoveryError::InsecureFile
+            } else {
+                error.into()
+            }
+        })
 }
 
 fn is_lower_hex(value: &str, len: usize) -> bool {

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -4,9 +4,8 @@
 //! initialize exchange in [`crate::daemon_listener`]; neither this module nor a locator treats a
 //! PID or an open port as proof of a daemon.
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -15,6 +14,14 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use platform::{
+    atomic_replace, create_owner_file, ensure_profile_directory, open_owner_file, sync_directory,
+    validate_open_locator_file, validate_owner_file,
+};
+
+#[cfg(not(any(unix, windows)))]
+compile_error!("native daemon discovery requires an owner-security platform implementation");
 
 pub const CLUSTER_PROTOCOL: &str = "openengine.cluster/v1";
 pub const DAEMON_PROTOCOL: &str = "zeroshot.daemon/v1";
@@ -121,7 +128,7 @@ pub fn acquire_start_guard(
 ) -> Result<ProfileStartGuard, DiscoveryError> {
     ensure_profile_directory(profile.root())?;
     let file = open_owner_file(&profile.lock_path(), true)?;
-    validate_owner_file(&file.metadata()?)?;
+    validate_owner_file(&file)?;
     let deadline = Instant::now() + timeout;
     loop {
         match file.try_lock_exclusive() {
@@ -177,16 +184,12 @@ pub(crate) fn replace_locator_locked(
     let suffix = random_hex()?;
     let temporary = profile.root().join(format!(".{LOCATOR_FILE}.{suffix}.tmp"));
     let write_result = (|| -> Result<(), DiscoveryError> {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(&temporary)?;
+        let mut file = create_owner_file(&temporary)?;
         file.write_all(&bytes)?;
         file.sync_all()?;
-        fs::rename(&temporary, profile.locator_path())?;
-        File::open(profile.root())?.sync_all()?;
+        drop(file);
+        atomic_replace(&temporary, &profile.locator_path())?;
+        sync_directory(profile.root())?;
         Ok(())
     })();
     if write_result.is_err() {
@@ -204,7 +207,7 @@ pub(crate) fn remove_locator_if_matches_locked(
     }
     match fs::remove_file(profile.locator_path()) {
         Ok(()) => {
-            File::open(profile.root())?.sync_all()?;
+            sync_directory(profile.root())?;
             Ok(true)
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
@@ -234,7 +237,7 @@ fn decode_open_locator(
     file: File,
 ) -> Result<DaemonLocator, DiscoveryError> {
     let opened_metadata = file.metadata()?;
-    validate_open_locator_file(&opened_metadata)?;
+    validate_open_locator_file(&file)?;
     if opened_metadata.len() > MAX_LOCATOR_BYTES {
         return Err(DiscoveryError::LocatorTooLarge);
     }
@@ -249,65 +252,474 @@ fn decode_open_locator(
     Ok(locator)
 }
 
-fn ensure_profile_directory(path: &Path) -> Result<(), DiscoveryError> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => validate_owner_directory(&metadata),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            fs::create_dir_all(path)?;
-            fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
-            validate_owner_directory(&fs::symlink_metadata(path)?)
-        }
-        Err(error) => Err(error.into()),
-    }
-}
+#[cfg(unix)]
+mod platform {
+    use std::fs::{self, File, OpenOptions};
+    use std::io;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::path::Path;
 
-fn validate_owner_directory(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
-    if !metadata.file_type().is_dir()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.mode() & 0o077 != 0
-    {
-        return Err(DiscoveryError::InsecureProfileDirectory);
-    }
-    Ok(())
-}
+    use super::DiscoveryError;
 
-fn validate_owner_file(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
-    if !metadata.file_type().is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.mode() & 0o077 != 0
-        || metadata.nlink() != 1
-    {
-        return Err(DiscoveryError::InsecureFile);
-    }
-    Ok(())
-}
-
-fn validate_open_locator_file(metadata: &fs::Metadata) -> Result<(), DiscoveryError> {
-    if !metadata.file_type().is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.mode() & 0o077 != 0
-        || metadata.nlink() > 1
-    {
-        return Err(DiscoveryError::InsecureFile);
-    }
-    Ok(())
-}
-
-fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
-    OpenOptions::new()
-        .read(true)
-        .write(create)
-        .create(create)
-        .mode(0o600)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-        .map_err(|error| {
-            if error.raw_os_error() == Some(libc::ELOOP) {
-                DiscoveryError::InsecureFile
-            } else {
-                error.into()
+    pub(super) fn ensure_profile_directory(path: &Path) -> Result<(), DiscoveryError> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                if !metadata.file_type().is_dir()
+                    || metadata.uid() != unsafe { libc::geteuid() }
+                    || metadata.mode() & 0o077 != 0
+                {
+                    return Err(DiscoveryError::InsecureProfileDirectory);
+                }
+                Ok(())
             }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir_all(path)?;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+                ensure_profile_directory(path)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn validate_owner_file(file: &File) -> Result<(), DiscoveryError> {
+        let metadata = file.metadata()?;
+        if !metadata.file_type().is_file()
+            || metadata.uid() != unsafe { libc::geteuid() }
+            || metadata.mode() & 0o077 != 0
+            || metadata.nlink() != 1
+        {
+            return Err(DiscoveryError::InsecureFile);
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_open_locator_file(file: &File) -> Result<(), DiscoveryError> {
+        let metadata = file.metadata()?;
+        if !metadata.file_type().is_file()
+            || metadata.uid() != unsafe { libc::geteuid() }
+            || metadata.mode() & 0o077 != 0
+            || metadata.nlink() > 1
+        {
+            return Err(DiscoveryError::InsecureFile);
+        }
+        Ok(())
+    }
+
+    pub(super) fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
+        OpenOptions::new()
+            .read(true)
+            .write(create)
+            .create(create)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(|error| {
+                if error.raw_os_error() == Some(libc::ELOOP) {
+                    DiscoveryError::InsecureFile
+                } else {
+                    error.into()
+                }
+            })
+    }
+
+    pub(super) fn create_owner_file(path: &Path) -> Result<File, DiscoveryError> {
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(Into::into)
+    }
+
+    pub(super) fn atomic_replace(source: &Path, destination: &Path) -> io::Result<()> {
+        fs::rename(source, destination)
+    }
+
+    pub(super) fn sync_directory(path: &Path) -> io::Result<()> {
+        File::open(path)?.sync_all()
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::ffi::c_void;
+    use std::fs::{self, File, OpenOptions};
+    use std::io;
+    use std::mem::{size_of, zeroed};
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+    use std::ptr::{null, null_mut};
+
+    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
+    };
+    use windows_sys::Win32::Security::{
+        ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, AddAccessAllowedAce,
+        AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid, GetAce, GetAclInformation,
+        GetLengthSid, GetSecurityDescriptorControl, GetTokenInformation, InitializeAcl,
+        OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION, PSID, SE_DACL_PROTECTED,
+        TOKEN_QUERY, TOKEN_USER, TokenUser,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, FILE_ALL_ACCESS, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle,
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW, WRITE_DAC,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    use super::DiscoveryError;
+
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    struct LocalSecurityDescriptor(*mut c_void);
+
+    impl Drop for LocalSecurityDescriptor {
+        fn drop(&mut self) {
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+
+    struct UserSid {
+        storage: Vec<usize>,
+        offset: usize,
+        length: usize,
+    }
+
+    impl UserSid {
+        fn as_ptr(&self) -> PSID {
+            unsafe {
+                self.storage
+                    .as_ptr()
+                    .cast::<u8>()
+                    .add(self.offset)
+                    .cast_mut()
+                    .cast()
+            }
+        }
+    }
+
+    pub(super) fn ensure_profile_directory(path: &Path) -> Result<(), DiscoveryError> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+                    || !metadata.file_type().is_dir()
+                {
+                    return Err(DiscoveryError::InsecureProfileDirectory);
+                }
+                let directory = open_directory(path, false)?;
+                validate_owner_acl(&directory, true)
+                    .map_err(|_| DiscoveryError::InsecureProfileDirectory)
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir_all(path)?;
+                let directory = open_directory(path, true)?;
+                set_owner_only_acl(&directory)?;
+                validate_owner_acl(&directory, true)
+                    .map_err(|_| DiscoveryError::InsecureProfileDirectory)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn validate_owner_file(file: &File) -> Result<(), DiscoveryError> {
+        validate_file_shape(file, false)?;
+        validate_owner_acl(file, false)
+    }
+
+    pub(super) fn validate_open_locator_file(file: &File) -> Result<(), DiscoveryError> {
+        validate_file_shape(file, true)?;
+        validate_owner_acl(file, false)
+    }
+
+    pub(super) fn open_owner_file(path: &Path, create: bool) -> Result<File, DiscoveryError> {
+        reject_reparse_path(path)?;
+        if create {
+            match create_new_owner_file(path, true) {
+                Ok(file) => return Ok(file),
+                Err(DiscoveryError::Io(error)) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+        let mut options = OpenOptions::new();
+        options
+            .access_mode(if create {
+                GENERIC_READ | GENERIC_WRITE
+            } else {
+                GENERIC_READ
+            })
+            .share_mode(if create {
+                FILE_SHARE_READ | FILE_SHARE_WRITE
+            } else {
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+            })
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        options
+            .open(path)
+            .map_err(|error| map_open_error(path, error))
+    }
+
+    pub(super) fn create_owner_file(path: &Path) -> Result<File, DiscoveryError> {
+        create_new_owner_file(path, false)
+    }
+
+    pub(super) fn atomic_replace(source: &Path, destination: &Path) -> Result<(), DiscoveryError> {
+        let source = wide_path(source);
+        let destination = wide_path(destination);
+        let succeeded = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if succeeded == 0 {
+            Err(io::Error::last_os_error().into())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn sync_directory(_path: &Path) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn create_new_owner_file(path: &Path, lock_file: bool) -> Result<File, DiscoveryError> {
+        reject_reparse_path(path)?;
+        let mut options = OpenOptions::new();
+        options
+            .access_mode(GENERIC_READ | GENERIC_WRITE | WRITE_DAC)
+            .share_mode(if lock_file {
+                FILE_SHARE_READ | FILE_SHARE_WRITE
+            } else {
+                FILE_SHARE_READ
+            })
+            .create_new(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        let file = options
+            .open(path)
+            .map_err(|error| map_open_error(path, error))?;
+        set_owner_only_acl(&file)?;
+        validate_owner_file(&file)?;
+        Ok(file)
+    }
+
+    fn open_directory(path: &Path, write_acl: bool) -> Result<File, DiscoveryError> {
+        let mut options = OpenOptions::new();
+        options
+            .access_mode(if write_acl {
+                GENERIC_READ | WRITE_DAC
+            } else {
+                GENERIC_READ
+            })
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+        options.open(path).map_err(Into::into)
+    }
+
+    fn reject_reparse_path(path: &Path) -> Result<(), DiscoveryError> {
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 => {
+                Err(DiscoveryError::InsecureFile)
+            }
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn map_open_error(path: &Path, error: io::Error) -> DiscoveryError {
+        if fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+            .unwrap_or(false)
+        {
+            DiscoveryError::InsecureFile
+        } else {
+            error.into()
+        }
+    }
+
+    fn validate_file_shape(file: &File, allow_unlinked: bool) -> Result<(), DiscoveryError> {
+        let information = file_information(file)?;
+        if information.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)
+            != 0
+            || if allow_unlinked {
+                information.nNumberOfLinks > 1
+            } else {
+                information.nNumberOfLinks != 1
+            }
+        {
+            return Err(DiscoveryError::InsecureFile);
+        }
+        Ok(())
+    }
+
+    fn file_information(file: &File) -> Result<BY_HANDLE_FILE_INFORMATION, DiscoveryError> {
+        let mut information = unsafe { zeroed::<BY_HANDLE_FILE_INFORMATION>() };
+        let succeeded =
+            unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information) };
+        if succeeded == 0 {
+            Err(io::Error::last_os_error().into())
+        } else {
+            Ok(information)
+        }
+    }
+
+    fn set_owner_only_acl(file: &File) -> Result<(), DiscoveryError> {
+        let sid = current_user_sid()?;
+        let acl_bytes =
+            size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid.length;
+        let mut storage = vec![0_usize; acl_bytes.div_ceil(size_of::<usize>())];
+        let acl = storage.as_mut_ptr().cast::<ACL>();
+        if unsafe { InitializeAcl(acl, acl_bytes as u32, ACL_REVISION) } == 0
+            || unsafe { AddAccessAllowedAce(acl, ACL_REVISION, FILE_ALL_ACCESS, sid.as_ptr()) } == 0
+        {
+            return Err(io::Error::last_os_error().into());
+        }
+        let status = unsafe {
+            SetSecurityInfo(
+                file.as_raw_handle().cast(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                null_mut(),
+                null_mut(),
+                acl,
+                null(),
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::from_raw_os_error(status as i32).into())
+        }
+    }
+
+    fn validate_owner_acl(file: &File, directory: bool) -> Result<(), DiscoveryError> {
+        let sid = current_user_sid()?;
+        let mut owner: PSID = null_mut();
+        let mut dacl: *mut ACL = null_mut();
+        let mut descriptor = null_mut();
+        let status = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle().cast(),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                &mut owner,
+                null_mut(),
+                &mut dacl,
+                null_mut(),
+                &mut descriptor,
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32).into());
+        }
+        let _descriptor = LocalSecurityDescriptor(descriptor);
+        let mut control = 0;
+        let mut revision = 0;
+        let control_ok =
+            unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } != 0;
+        let owner_ok = !owner.is_null() && unsafe { EqualSid(owner, sid.as_ptr()) } != 0;
+        if !control_ok || control & SE_DACL_PROTECTED == 0 || !owner_ok || dacl.is_null() {
+            return Err(if directory {
+                DiscoveryError::InsecureProfileDirectory
+            } else {
+                DiscoveryError::InsecureFile
+            });
+        }
+        let mut information = ACL_SIZE_INFORMATION::default();
+        if unsafe {
+            GetAclInformation(
+                dacl,
+                (&mut information as *mut ACL_SIZE_INFORMATION).cast(),
+                size_of::<ACL_SIZE_INFORMATION>() as u32,
+                AclSizeInformation,
+            )
+        } == 0
+            || information.AceCount != 1
+        {
+            return Err(if directory {
+                DiscoveryError::InsecureProfileDirectory
+            } else {
+                DiscoveryError::InsecureFile
+            });
+        }
+        let mut raw_ace = null_mut();
+        if unsafe { GetAce(dacl, 0, &mut raw_ace) } == 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        let ace = unsafe { &*raw_ace.cast::<ACCESS_ALLOWED_ACE>() };
+        let ace_sid = (&raw const ace.SidStart).cast_mut().cast();
+        let valid = ace.Header.AceType == 0
+            && ace.Mask & FILE_ALL_ACCESS == FILE_ALL_ACCESS
+            && unsafe { EqualSid(ace_sid, sid.as_ptr()) } != 0;
+        if valid {
+            Ok(())
+        } else if directory {
+            Err(DiscoveryError::InsecureProfileDirectory)
+        } else {
+            Err(DiscoveryError::InsecureFile)
+        }
+    }
+
+    fn current_user_sid() -> Result<UserSid, DiscoveryError> {
+        let mut token = null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        let _token = OwnedHandle(token);
+        let mut needed = 0;
+        unsafe {
+            GetTokenInformation(token, TokenUser, null_mut(), 0, &mut needed);
+        }
+        if needed == 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        let mut storage = vec![0_usize; (needed as usize).div_ceil(size_of::<usize>())];
+        if unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                needed,
+                &mut needed,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error().into());
+        }
+        let base = storage.as_ptr().cast::<u8>();
+        let user = unsafe { &*storage.as_ptr().cast::<TOKEN_USER>() };
+        let sid = user.User.Sid.cast::<u8>();
+        let length = unsafe { GetLengthSid(user.User.Sid) } as usize;
+        let offset = unsafe { sid.offset_from(base) } as usize;
+        if length == 0 || offset.saturating_add(length) > storage.len() * size_of::<usize>() {
+            return Err(DiscoveryError::InsecureFile);
+        }
+        Ok(UserSid {
+            storage,
+            offset,
+            length,
         })
+    }
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(Some(0)).collect()
+    }
 }
 
 fn is_lower_hex(value: &str, len: usize) -> bool {
@@ -327,8 +739,10 @@ fn hex(bytes: &[u8]) -> String {
     output
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
+    use std::os::unix::fs::MetadataExt;
+
     use super::*;
 
     #[test]

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -252,6 +252,11 @@ fn decode_open_locator(
     Ok(locator)
 }
 
+#[cfg(any(windows, test))]
+fn secure_directory_handle_shape(is_directory: bool, is_reparse_point: bool, links: u32) -> bool {
+    is_directory && !is_reparse_point && links == 1
+}
+
 #[cfg(unix)]
 mod platform {
     use std::fs::{self, File, OpenOptions};
@@ -422,6 +427,7 @@ mod platform {
                     return Err(DiscoveryError::InsecureProfileDirectory);
                 }
                 let directory = open_directory(path, false)?;
+                validate_directory_shape(&directory)?;
                 validate_owner_acl(&directory, true)
                     .map_err(|_| DiscoveryError::InsecureProfileDirectory)
             }
@@ -429,6 +435,7 @@ mod platform {
                 fs::create_dir_all(path)?;
                 let directory = open_directory(path, true)?;
                 set_owner_only_acl(&directory)?;
+                validate_directory_shape(&directory)?;
                 validate_owner_acl(&directory, true)
                     .map_err(|_| DiscoveryError::InsecureProfileDirectory)
             }
@@ -550,6 +557,19 @@ mod platform {
             DiscoveryError::InsecureFile
         } else {
             error.into()
+        }
+    }
+
+    fn validate_directory_shape(file: &File) -> Result<(), DiscoveryError> {
+        let information = file_information(file)?;
+        if super::secure_directory_handle_shape(
+            information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0,
+            information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0,
+            information.nNumberOfLinks,
+        ) {
+            Ok(())
+        } else {
+            Err(DiscoveryError::InsecureProfileDirectory)
         }
     }
 
@@ -737,6 +757,19 @@ fn hex(bytes: &[u8]) -> String {
         output.push(DIGITS[(byte & 0x0f) as usize] as char);
     }
     output
+}
+
+#[cfg(test)]
+mod platform_shape_tests {
+    use super::secure_directory_handle_shape;
+
+    #[test]
+    fn opened_windows_directory_shape_rejects_same_owner_reparse_substitution() {
+        assert!(secure_directory_handle_shape(true, false, 1));
+        assert!(!secure_directory_handle_shape(true, true, 1));
+        assert!(!secure_directory_handle_shape(false, false, 1));
+        assert!(!secure_directory_handle_shape(true, false, 2));
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -226,6 +226,13 @@ fn read_locator_existing(profile: &NativeProfile) -> Result<Option<DaemonLocator
         }
         Err(error) => return Err(error),
     };
+    decode_open_locator(profile, file).map(Some)
+}
+
+fn decode_open_locator(
+    profile: &NativeProfile,
+    file: File,
+) -> Result<DaemonLocator, DiscoveryError> {
     let opened_metadata = file.metadata()?;
     validate_open_locator_file(&opened_metadata)?;
     if opened_metadata.len() > MAX_LOCATOR_BYTES {
@@ -239,7 +246,7 @@ fn read_locator_existing(profile: &NativeProfile) -> Result<Option<DaemonLocator
     let locator: DaemonLocator =
         serde_json::from_slice(&bytes).map_err(|_| DiscoveryError::InvalidLocator)?;
     locator.validate_for(profile)?;
-    Ok(Some(locator))
+    Ok(locator)
 }
 
 fn ensure_profile_directory(path: &Path) -> Result<(), DiscoveryError> {
@@ -318,4 +325,38 @@ fn hex(bytes: &[u8]) -> String {
         output.push(DIGITS[(byte & 0x0f) as usize] as char);
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_locator_decoder_accepts_an_opened_owner_inode_unlinked_during_read() {
+        let root = std::env::temp_dir().join(format!(
+            "zeroshot-open-locator-race-{}-{}",
+            std::process::id(),
+            random_hex().expect("temporary profile suffix")
+        ));
+        let profile = NativeProfile::new(&root, "native-profile:opened-locator");
+        let locator = DaemonLocator {
+            endpoint: "ws://127.0.0.1:30109/daemon/initialize".to_owned(),
+            cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+            daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+            profile_digest: profile.digest().to_owned(),
+            daemon_nonce: "a".repeat(64),
+            capability: "b".repeat(64),
+        };
+        replace_locator(&profile, &locator).expect("publish locator");
+        let file = open_owner_file(&profile.locator_path(), false).expect("open locator");
+
+        fs::remove_file(profile.locator_path()).expect("unlink opened locator");
+        assert_eq!(file.metadata().expect("opened metadata").nlink(), 0);
+        assert_eq!(
+            decode_open_locator(&profile, file).expect("decode opened owner inode"),
+            locator
+        );
+
+        fs::remove_dir_all(root).expect("remove temporary profile");
+    }
 }

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -113,6 +113,10 @@ impl DaemonListener {
         if config.max_active_connections == 0
             || config.max_pending_handshakes == 0
             || config.max_liveness_connections == 0
+            || config.startup_lock_timeout.is_zero()
+            || config.liveness_timeout.is_zero()
+            || config.handshake_timeout.is_zero()
+            || config.drain_timeout.is_zero()
             || config.shutdown_timeout.is_zero()
         {
             return Err(DaemonListenerError::InvalidConfiguration);

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -162,7 +162,7 @@ impl DaemonListener {
         let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
         let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
         let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
-        let accept_task = tokio::spawn(run_accept_loop(AcceptLoop {
+        let host = AcceptLoop {
             listener: tcp,
             factory: Arc::new(factory),
             credentials,
@@ -171,13 +171,14 @@ impl DaemonListener {
             liveness_connection_permits: Arc::clone(&liveness_connection_permits),
             active_session_permits: Arc::clone(&active_session_permits),
             config,
-        }));
-        if let Err(error) = replace_locator_locked(&profile, &locator) {
-            accept_task.abort();
-            let _ = accept_task.await;
-            return Err(error.into());
-        }
+        };
+        replace_locator_locked(&profile, &locator)?;
         drop(guard);
+        let accept_task = tokio::spawn(run_owned_accept_loop(
+            host,
+            profile.clone(),
+            locator.clone(),
+        ));
 
         Ok(Self {
             profile,
@@ -328,33 +329,37 @@ async fn probe_liveness_inner(locator: &DaemonLocator) -> LivenessOutcome {
             Ok(response) => response,
             Err(_) => return LivenessOutcome::DefinitelyStale,
         };
-        return if valid_liveness_response(&response) {
-            LivenessOutcome::Alive
-        } else {
-            LivenessOutcome::DefinitelyStale
-        };
+        return classify_liveness_response(&response);
     }
     LivenessOutcome::Indeterminate
 }
 
-fn valid_liveness_response(response: &Value) -> bool {
+fn classify_liveness_response(response: &Value) -> LivenessOutcome {
     let Some(object) = response.as_object() else {
-        return false;
+        return LivenessOutcome::DefinitelyStale;
     };
     if object.len() != 3
         || object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION)
         || object.get("id").and_then(Value::as_str) != Some("daemon-liveness")
     {
-        return false;
+        return LivenessOutcome::DefinitelyStale;
+    }
+    if object.contains_key("error") && !object.contains_key("result") {
+        return LivenessOutcome::Indeterminate;
     }
     let Some(raw_result) = object.get("result") else {
-        return false;
+        return LivenessOutcome::DefinitelyStale;
     };
     let Ok(result) = serde_json::from_value::<InitializeResult>(raw_result.clone()) else {
-        return false;
+        return LivenessOutcome::DefinitelyStale;
     };
-    result.validate_protocol_version().is_ok()
+    if result.validate_protocol_version().is_ok()
         && serde_json::to_value(result).ok().as_ref() == Some(raw_result)
+    {
+        LivenessOutcome::Alive
+    } else {
+        LivenessOutcome::DefinitelyStale
+    }
 }
 
 fn rotate_away_from(value: &mut String, previous: &str) {
@@ -390,6 +395,23 @@ struct AcceptLoop<F> {
     pending_handshake_permits: Arc<Semaphore>,
     liveness_connection_permits: Arc<Semaphore>,
     active_session_permits: Arc<Semaphore>,
+}
+
+async fn run_owned_accept_loop<F>(
+    host: AcceptLoop<F>,
+    profile: NativeProfile,
+    locator: DaemonLocator,
+) -> Result<(), ()>
+where
+    F: NativeBackendFactory + Send + Sync + 'static,
+{
+    let result = run_accept_loop(host).await;
+    let cleanup =
+        tokio::task::spawn_blocking(move || remove_locator_if_matches(&profile, &locator)).await;
+    match cleanup {
+        Ok(Ok(_)) => result,
+        Ok(Err(_)) | Err(_) => Err(()),
+    }
 }
 
 async fn run_accept_loop<F>(host: AcceptLoop<F>) -> Result<(), ()>

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -19,7 +19,7 @@ use tokio_tungstenite::accept_hdr_async_with_config;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::Message;
 
-use crate::daemon_auth::{AuthorizationCallback, DAEMON_ROUTE, DaemonCredentials};
+use crate::daemon_auth::{AuthorizationCallback, ConnectionPurpose, DAEMON_ROUTE, DaemonCredentials};
 use crate::daemon_discovery::{
     CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, DiscoveryError, NativeProfile,
     acquire_start_guard, read_locator_locked, remove_locator_if_matches,
@@ -70,10 +70,7 @@ pub struct DaemonListener {
 }
 
 impl DaemonListener {
-    pub async fn start<F>(
-        profile: NativeProfile,
-        factory: F,
-    ) -> Result<Self, DaemonListenerError>
+    pub async fn start<F>(profile: NativeProfile, factory: F) -> Result<Self, DaemonListenerError>
     where
         F: NativeBackendFactory + Send + Sync + 'static,
     {
@@ -93,11 +90,10 @@ impl DaemonListener {
         }
         let lock_profile = profile.clone();
         let lock_timeout = config.startup_lock_timeout;
-        let guard = tokio::task::spawn_blocking(move || {
-            acquire_start_guard(&lock_profile, lock_timeout)
-        })
-        .await
-        .map_err(|_| DaemonListenerError::Task)??;
+        let guard =
+            tokio::task::spawn_blocking(move || acquire_start_guard(&lock_profile, lock_timeout))
+                .await
+                .map_err(|_| DaemonListenerError::Task)??;
 
         let previous_secrets = if let Some(existing) = read_locator_locked(&profile)? {
             if probe_liveness(&existing, config.liveness_timeout).await {
@@ -126,13 +122,13 @@ impl DaemonListener {
         };
 
         let shutdown = Arc::new(Notify::new());
-        let accept_task = tokio::spawn(run_accept_loop(
-            tcp,
-            Arc::new(factory),
+        let accept_task = tokio::spawn(run_accept_loop(AcceptLoop {
+            listener: tcp,
+            factory: Arc::new(factory),
             credentials,
-            Arc::clone(&shutdown),
+            shutdown: Arc::clone(&shutdown),
             config,
-        ));
+        }));
         if let Err(error) = replace_locator_locked(&profile, &locator) {
             accept_task.abort();
             let _ = accept_task.await;
@@ -160,11 +156,10 @@ impl DaemonListener {
         }
         let profile = self.profile.clone();
         let locator = self.locator.clone();
-        let removed = tokio::task::spawn_blocking(move || {
-            remove_locator_if_matches(&profile, &locator)
-        })
-        .await
-        .map_err(|_| DaemonListenerError::Task)??;
+        let removed =
+            tokio::task::spawn_blocking(move || remove_locator_if_matches(&profile, &locator))
+                .await
+                .map_err(|_| DaemonListenerError::Task)??;
         let _ = removed;
         Ok(())
     }
@@ -196,13 +191,16 @@ async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
         .into_client_request()
         .map_err(|_| ())?;
     let address = loopback_address(&request).ok_or(())?;
-    DaemonCredentials::from_locator(locator)
-        .apply_to_request(&mut request)
+    let expectation = DaemonCredentials::from_locator(locator)
+        .prepare_request(&mut request, ConnectionPurpose::Liveness)
         .map_err(|_| ())?;
     let stream = TcpStream::connect(address).await.map_err(|_| ())?;
-    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
         .await
         .map_err(|_| ())?;
+    if !expectation.verify(&response) {
+        return Ok(false);
+    }
     let initialize = serde_json::json!({
         "jsonrpc": JSON_RPC_VERSION,
         "id": "daemon-liveness",
@@ -222,11 +220,13 @@ async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
             continue;
         };
         let response: Value = serde_json::from_str(text.as_ref()).map_err(|_| ())?;
-        return Ok(response.get("id") == Some(&Value::String("daemon-liveness".to_owned()))
-            && response
-                .pointer("/result/protocolVersion")
-                .and_then(Value::as_str)
-                == Some(PROTOCOL_VERSION));
+        return Ok(
+            response.get("id") == Some(&Value::String("daemon-liveness".to_owned()))
+                && response
+                    .pointer("/result/protocolVersion")
+                    .and_then(Value::as_str)
+                    == Some(PROTOCOL_VERSION),
+        );
     }
     Ok(false)
 }
@@ -255,15 +255,25 @@ fn loopback_address(
     ))
 }
 
-async fn run_accept_loop<F>(
+struct AcceptLoop<F> {
     listener: TcpListener,
     factory: Arc<F>,
     credentials: DaemonCredentials,
     shutdown: Arc<Notify>,
     config: ListenerConfig,
-) where
+}
+
+async fn run_accept_loop<F>(host: AcceptLoop<F>)
+where
     F: NativeBackendFactory + Send + Sync + 'static,
 {
+    let AcceptLoop {
+        listener,
+        factory,
+        credentials,
+        shutdown,
+        config,
+    } = host;
     let permits = Arc::new(Semaphore::new(config.max_active_connections));
     let mut connections = JoinSet::new();
     loop {
@@ -275,15 +285,19 @@ async fn run_accept_loop<F>(
             }
             accepted = listener.accept() => {
                 let Ok((stream, peer)) = accepted else { break };
-                let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
-                    drop(stream);
-                    continue;
-                };
                 let factory = Arc::clone(&factory);
                 let credentials = credentials.clone();
+                let permits = Arc::clone(&permits);
                 connections.spawn(async move {
-                    let _permit = permit;
-                    serve_connection(stream, peer, factory, credentials, config.handshake_timeout).await;
+                    serve_connection(ConnectionTask {
+                        stream,
+                        peer,
+                        factory,
+                        credentials,
+                        permits,
+                        handshake_timeout: config.handshake_timeout,
+                        liveness_timeout: config.liveness_timeout,
+                    }).await;
                 });
             }
         }
@@ -304,21 +318,60 @@ async fn run_accept_loop<F>(
     }
 }
 
-async fn serve_connection<F>(
+struct ConnectionTask<F> {
     stream: TcpStream,
     peer: SocketAddr,
     factory: Arc<F>,
     credentials: DaemonCredentials,
+    permits: Arc<Semaphore>,
     handshake_timeout: Duration,
-) where
+    liveness_timeout: Duration,
+}
+
+async fn serve_connection<F>(connection: ConnectionTask<F>)
+where
     F: NativeBackendFactory + Send + Sync + 'static,
 {
-    let handshake = accept_hdr_async_with_config(
+    let ConnectionTask {
         stream,
-        AuthorizationCallback(credentials),
-        Some(websocket_config()),
-    );
-    let Ok(Ok(websocket)) = timeout(handshake_timeout, handshake).await else {
+        peer,
+        factory,
+        credentials,
+        permits,
+        handshake_timeout,
+        liveness_timeout,
+    } = connection;
+    let (callback, receipt) = AuthorizationCallback::new(credentials);
+    let handshake = accept_hdr_async_with_config(stream, callback, Some(websocket_config()));
+    let Ok(Ok(mut websocket)) = timeout(handshake_timeout, handshake).await else {
+        return;
+    };
+    let Some(purpose) = receipt.take() else {
+        return;
+    };
+    if purpose == ConnectionPurpose::Liveness {
+        let Ok(Some(Ok(Message::Text(request)))) =
+            timeout(liveness_timeout, websocket.next()).await
+        else {
+            return;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(request.as_ref()) else {
+            return;
+        };
+        if value.get("method").and_then(Value::as_str) != Some("initialize") {
+            return;
+        }
+        let context = ConnectionContext {
+            peer_label: Some(peer.to_string()),
+            ..ConnectionContext::default()
+        };
+        let dispatcher = dispatcher_for_route(factory.as_ref(), context);
+        let response = dispatcher.dispatch(request.as_ref()).await;
+        let _ = websocket.send(Message::Text(response.into())).await;
+        let _ = websocket.close(None).await;
+        return;
+    }
+    let Ok(_permit) = permits.try_acquire_owned() else {
         return;
     };
 

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -16,6 +16,7 @@ use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::{Instant, timeout, timeout_at};
 use tokio_tungstenite::accept_hdr_async_with_config;
+use tokio_tungstenite::tungstenite::Error as WebSocketError;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::Message;
 
@@ -36,6 +37,7 @@ pub struct ListenerConfig {
     pub shutdown_timeout: Duration,
     pub max_active_connections: usize,
     pub max_pending_handshakes: usize,
+    pub max_liveness_connections: usize,
 }
 
 impl Default for ListenerConfig {
@@ -48,6 +50,7 @@ impl Default for ListenerConfig {
             shutdown_timeout: Duration::from_secs(1),
             max_active_connections: 64,
             max_pending_handshakes: 64,
+            max_liveness_connections: 8,
         }
     }
 }
@@ -56,7 +59,9 @@ impl Default for ListenerConfig {
 pub enum DaemonListenerError {
     #[error("an authenticated daemon already owns this native profile")]
     AlreadyRunning,
-    #[error("daemon listener configuration requires at least one active connection slot")]
+    #[error("daemon liveness is indeterminate; preserving the incumbent locator")]
+    LivenessIndeterminate,
+    #[error("daemon listener configuration requires non-zero connection bounds and deadlines")]
     InvalidConfiguration,
     #[error("daemon discovery failed: {0}")]
     Discovery(#[from] DiscoveryError),
@@ -68,6 +73,13 @@ pub enum DaemonListenerError {
     ShutdownTimeout,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LivenessOutcome {
+    Alive,
+    DefinitelyStale,
+    Indeterminate,
+}
+
 pub struct DaemonListener {
     profile: NativeProfile,
     locator: DaemonLocator,
@@ -76,6 +88,8 @@ pub struct DaemonListener {
     shutdown_timeout: Duration,
     pending_handshake_limit: usize,
     pending_handshake_permits: Arc<Semaphore>,
+    liveness_connection_limit: usize,
+    liveness_connection_permits: Arc<Semaphore>,
 }
 
 impl DaemonListener {
@@ -96,6 +110,7 @@ impl DaemonListener {
     {
         if config.max_active_connections == 0
             || config.max_pending_handshakes == 0
+            || config.max_liveness_connections == 0
             || config.shutdown_timeout.is_zero()
         {
             return Err(DaemonListenerError::InvalidConfiguration);
@@ -108,8 +123,12 @@ impl DaemonListener {
                 .map_err(|_| DaemonListenerError::Task)??;
 
         let previous_secrets = if let Some(existing) = read_locator_locked(&profile)? {
-            if probe_liveness(&existing, config.liveness_timeout).await {
-                return Err(DaemonListenerError::AlreadyRunning);
+            match probe_liveness(&existing, config.liveness_timeout).await {
+                LivenessOutcome::Alive => return Err(DaemonListenerError::AlreadyRunning),
+                LivenessOutcome::Indeterminate => {
+                    return Err(DaemonListenerError::LivenessIndeterminate);
+                }
+                LivenessOutcome::DefinitelyStale => {}
             }
             remove_locator_if_matches_locked(&profile, &existing)?;
             Some((existing.capability, existing.daemon_nonce))
@@ -135,12 +154,14 @@ impl DaemonListener {
 
         let shutdown = Arc::new(Notify::new());
         let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
+        let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
         let accept_task = tokio::spawn(run_accept_loop(AcceptLoop {
             listener: tcp,
             factory: Arc::new(factory),
             credentials,
             shutdown: Arc::clone(&shutdown),
             pending_handshake_permits: Arc::clone(&pending_handshake_permits),
+            liveness_connection_permits: Arc::clone(&liveness_connection_permits),
             config,
         }));
         if let Err(error) = replace_locator_locked(&profile, &locator) {
@@ -158,6 +179,8 @@ impl DaemonListener {
             shutdown_timeout: config.shutdown_timeout,
             pending_handshake_limit: config.max_pending_handshakes,
             pending_handshake_permits,
+            liveness_connection_limit: config.max_liveness_connections,
+            liveness_connection_permits,
         })
     }
 
@@ -172,30 +195,45 @@ impl DaemonListener {
             .saturating_sub(self.pending_handshake_permits.available_permits())
     }
 
+    #[must_use]
+    pub fn active_liveness_connections(&self) -> usize {
+        self.liveness_connection_limit
+            .saturating_sub(self.liveness_connection_permits.available_permits())
+    }
+
     pub async fn shutdown(mut self) -> Result<(), DaemonListenerError> {
+        let started = Instant::now();
+        let deadline = started + self.shutdown_timeout;
+        let graceful_deadline = started + self.shutdown_timeout / 2;
+        let mut result = Ok(());
         self.shutdown.notify_one();
         if let Some(mut task) = self.accept_task.take() {
-            match timeout(self.shutdown_timeout, &mut task).await {
-                Ok(result) => result.map_err(|_| DaemonListenerError::Task)?,
+            match timeout_at(graceful_deadline, &mut task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => result = Err(DaemonListenerError::Task),
                 Err(_) => {
                     task.abort();
-                    let completion = timeout(self.shutdown_timeout, &mut task)
-                        .await
-                        .map_err(|_| DaemonListenerError::ShutdownTimeout)?;
-                    if completion.is_err_and(|error| !error.is_cancelled()) {
-                        return Err(DaemonListenerError::Task);
+                    match timeout_at(deadline, &mut task).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) if error.is_cancelled() => {}
+                        Ok(Err(_)) => result = Err(DaemonListenerError::Task),
+                        Err(_) => result = Err(DaemonListenerError::ShutdownTimeout),
                     }
                 }
             }
         }
+
         let profile = self.profile.clone();
         let locator = self.locator.clone();
-        let removed =
-            tokio::task::spawn_blocking(move || remove_locator_if_matches(&profile, &locator))
-                .await
-                .map_err(|_| DaemonListenerError::Task)??;
-        let _ = removed;
-        Ok(())
+        let cleanup =
+            tokio::task::spawn_blocking(move || remove_locator_if_matches(&profile, &locator));
+        match timeout_at(deadline, cleanup).await {
+            Ok(Ok(Ok(_))) => {}
+            Ok(Ok(Err(error))) => return Err(DaemonListenerError::Discovery(error)),
+            Ok(Err(_)) => return Err(DaemonListenerError::Task),
+            Err(_) => return Err(DaemonListenerError::ShutdownTimeout),
+        }
+        result
     }
 }
 
@@ -207,33 +245,43 @@ impl Drop for DaemonListener {
     }
 }
 
-pub async fn probe_liveness(locator: &DaemonLocator, deadline: Duration) -> bool {
+pub async fn probe_liveness(locator: &DaemonLocator, deadline: Duration) -> LivenessOutcome {
     timeout(deadline, probe_liveness_inner(locator))
         .await
-        .ok()
-        .and_then(Result::ok)
-        .unwrap_or(false)
+        .unwrap_or(LivenessOutcome::Indeterminate)
 }
 
-async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
+async fn probe_liveness_inner(locator: &DaemonLocator) -> LivenessOutcome {
     if locator.cluster_protocol != CLUSTER_PROTOCOL || locator.daemon_protocol != DAEMON_PROTOCOL {
-        return Ok(false);
+        return LivenessOutcome::DefinitelyStale;
     }
-    let mut request = locator
-        .endpoint
-        .as_str()
-        .into_client_request()
-        .map_err(|_| ())?;
-    let address = loopback_address(&request).ok_or(())?;
-    let expectation = DaemonCredentials::from_locator(locator)
+    let mut request = match locator.endpoint.as_str().into_client_request() {
+        Ok(request) => request,
+        Err(_) => return LivenessOutcome::DefinitelyStale,
+    };
+    let Some(address) = loopback_address(&request) else {
+        return LivenessOutcome::DefinitelyStale;
+    };
+    let expectation = match DaemonCredentials::from_locator(locator)
         .prepare_request(&mut request, ConnectionPurpose::Liveness)
-        .map_err(|_| ())?;
-    let stream = TcpStream::connect(address).await.map_err(|_| ())?;
-    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
-        .await
-        .map_err(|_| ())?;
+    {
+        Ok(expectation) => expectation,
+        Err(_) => return LivenessOutcome::Indeterminate,
+    };
+    let stream = match TcpStream::connect(address).await {
+        Ok(stream) => stream,
+        Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
+            return LivenessOutcome::DefinitelyStale;
+        }
+        Err(_) => return LivenessOutcome::Indeterminate,
+    };
+    let (mut websocket, response) = match tokio_tungstenite::client_async(request, stream).await {
+        Ok(connected) => connected,
+        Err(WebSocketError::Http(_)) => return LivenessOutcome::DefinitelyStale,
+        Err(_) => return LivenessOutcome::Indeterminate,
+    };
     if !expectation.verify(&response) {
-        return Ok(false);
+        return LivenessOutcome::DefinitelyStale;
     }
     let initialize = serde_json::json!({
         "jsonrpc": JSON_RPC_VERSION,
@@ -241,22 +289,35 @@ async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
         "method": "initialize",
         "params": { "protocolVersion": PROTOCOL_VERSION }
     });
-    websocket
+    if websocket
         .send(Message::Text(initialize.to_string().into()))
         .await
-        .map_err(|_| ())?;
+        .is_err()
+    {
+        return LivenessOutcome::Indeterminate;
+    }
     while let Some(message) = websocket.next().await {
-        let message = message.map_err(|_| ())?;
+        let message = match message {
+            Ok(message) => message,
+            Err(_) => return LivenessOutcome::Indeterminate,
+        };
         let Message::Text(text) = message else {
             if message.is_close() {
-                return Ok(false);
+                return LivenessOutcome::Indeterminate;
             }
             continue;
         };
-        let response: Value = serde_json::from_str(text.as_ref()).map_err(|_| ())?;
-        return Ok(valid_liveness_response(&response));
+        let response: Value = match serde_json::from_str(text.as_ref()) {
+            Ok(response) => response,
+            Err(_) => return LivenessOutcome::DefinitelyStale,
+        };
+        return if valid_liveness_response(&response) {
+            LivenessOutcome::Alive
+        } else {
+            LivenessOutcome::DefinitelyStale
+        };
     }
-    Ok(false)
+    LivenessOutcome::Indeterminate
 }
 
 fn valid_liveness_response(response: &Value) -> bool {
@@ -303,6 +364,7 @@ struct AcceptLoop<F> {
     shutdown: Arc<Notify>,
     config: ListenerConfig,
     pending_handshake_permits: Arc<Semaphore>,
+    liveness_connection_permits: Arc<Semaphore>,
 }
 
 async fn run_accept_loop<F>(host: AcceptLoop<F>)
@@ -316,6 +378,7 @@ where
         shutdown,
         config,
         pending_handshake_permits,
+        liveness_connection_permits,
     } = host;
     let active_permits = Arc::new(Semaphore::new(config.max_active_connections));
     let mut connections = JoinSet::new();
@@ -337,6 +400,8 @@ where
                 let factory = Arc::clone(&factory);
                 let credentials = credentials.clone();
                 let active_permits = Arc::clone(&active_permits);
+                let liveness_connection_permits =
+                    Arc::clone(&liveness_connection_permits);
                 connections.spawn(async move {
                     serve_connection(ConnectionTask {
                         stream,
@@ -344,6 +409,7 @@ where
                         factory,
                         credentials,
                         active_permits,
+                        liveness_connection_permits,
                         handshake_permit,
                         handshake_timeout: config.handshake_timeout,
                         liveness_timeout: config.liveness_timeout,
@@ -373,6 +439,7 @@ struct ConnectionTask<F> {
     factory: Arc<F>,
     credentials: DaemonCredentials,
     active_permits: Arc<Semaphore>,
+    liveness_connection_permits: Arc<Semaphore>,
     handshake_permit: OwnedSemaphorePermit,
     handshake_timeout: Duration,
     liveness_timeout: Duration,
@@ -388,6 +455,7 @@ where
         factory,
         credentials,
         active_permits,
+        liveness_connection_permits,
         handshake_permit,
         handshake_timeout,
         liveness_timeout,
@@ -402,6 +470,9 @@ where
         return;
     };
     if purpose == ConnectionPurpose::Liveness {
+        let Ok(_liveness_permit) = liveness_connection_permits.try_acquire_owned() else {
+            return;
+        };
         let Ok(Some(Ok(Message::Text(request)))) =
             timeout(liveness_timeout, websocket.next()).await
         else {

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -1,0 +1,331 @@
+//! One authenticated loopback WebSocket listener per native profile.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use openengine_cluster_protocol::{JSON_RPC_VERSION, PROTOCOL_VERSION};
+use openengine_cluster_server::websocket::{serve_websocket, websocket_config};
+use openengine_cluster_server::ConnectionContext;
+use serde_json::Value;
+use thiserror::Error;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Notify, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio::time::{Instant, timeout, timeout_at};
+use tokio_tungstenite::accept_hdr_async_with_config;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+use crate::daemon_auth::{AuthorizationCallback, DAEMON_ROUTE, DaemonCredentials};
+use crate::daemon_discovery::{
+    CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, DiscoveryError, NativeProfile,
+    acquire_start_guard, read_locator_locked, remove_locator_if_matches,
+    remove_locator_if_matches_locked, replace_locator_locked,
+};
+use crate::{NativeBackendFactory, dispatcher_for_route};
+
+#[derive(Clone, Copy, Debug)]
+pub struct ListenerConfig {
+    pub startup_lock_timeout: Duration,
+    pub liveness_timeout: Duration,
+    pub handshake_timeout: Duration,
+    pub drain_timeout: Duration,
+    pub max_active_connections: usize,
+}
+
+impl Default for ListenerConfig {
+    fn default() -> Self {
+        Self {
+            startup_lock_timeout: Duration::from_secs(1),
+            liveness_timeout: Duration::from_millis(500),
+            handshake_timeout: Duration::from_secs(2),
+            drain_timeout: Duration::from_millis(250),
+            max_active_connections: 64,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DaemonListenerError {
+    #[error("an authenticated daemon already owns this native profile")]
+    AlreadyRunning,
+    #[error("daemon listener configuration requires at least one active connection slot")]
+    InvalidConfiguration,
+    #[error("daemon discovery failed: {0}")]
+    Discovery(#[from] DiscoveryError),
+    #[error("daemon listener I/O failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("daemon listener task failed")]
+    Task,
+}
+
+pub struct DaemonListener {
+    profile: NativeProfile,
+    locator: DaemonLocator,
+    shutdown: Arc<Notify>,
+    accept_task: Option<JoinHandle<()>>,
+}
+
+impl DaemonListener {
+    pub async fn start<F>(
+        profile: NativeProfile,
+        factory: F,
+    ) -> Result<Self, DaemonListenerError>
+    where
+        F: NativeBackendFactory + Send + Sync + 'static,
+    {
+        Self::start_with_config(profile, factory, ListenerConfig::default()).await
+    }
+
+    pub async fn start_with_config<F>(
+        profile: NativeProfile,
+        factory: F,
+        config: ListenerConfig,
+    ) -> Result<Self, DaemonListenerError>
+    where
+        F: NativeBackendFactory + Send + Sync + 'static,
+    {
+        if config.max_active_connections == 0 {
+            return Err(DaemonListenerError::InvalidConfiguration);
+        }
+        let lock_profile = profile.clone();
+        let lock_timeout = config.startup_lock_timeout;
+        let guard = tokio::task::spawn_blocking(move || {
+            acquire_start_guard(&lock_profile, lock_timeout)
+        })
+        .await
+        .map_err(|_| DaemonListenerError::Task)??;
+
+        let previous_secrets = if let Some(existing) = read_locator_locked(&profile)? {
+            if probe_liveness(&existing, config.liveness_timeout).await {
+                return Err(DaemonListenerError::AlreadyRunning);
+            }
+            remove_locator_if_matches_locked(&profile, &existing)?;
+            Some((existing.capability, existing.daemon_nonce))
+        } else {
+            None
+        };
+
+        let tcp = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+        let address = tcp.local_addr()?;
+        let mut credentials = DaemonCredentials::generate(profile.digest().to_owned())?;
+        if let Some((previous_capability, previous_nonce)) = previous_secrets {
+            rotate_away_from(&mut credentials.capability, &previous_capability);
+            rotate_away_from(&mut credentials.daemon_nonce, &previous_nonce);
+        }
+        let locator = DaemonLocator {
+            endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
+            cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+            daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+            profile_digest: credentials.profile_digest.clone(),
+            daemon_nonce: credentials.daemon_nonce.clone(),
+            capability: credentials.capability.clone(),
+        };
+
+        let shutdown = Arc::new(Notify::new());
+        let accept_task = tokio::spawn(run_accept_loop(
+            tcp,
+            Arc::new(factory),
+            credentials,
+            Arc::clone(&shutdown),
+            config,
+        ));
+        if let Err(error) = replace_locator_locked(&profile, &locator) {
+            accept_task.abort();
+            let _ = accept_task.await;
+            return Err(error.into());
+        }
+        drop(guard);
+
+        Ok(Self {
+            profile,
+            locator,
+            shutdown,
+            accept_task: Some(accept_task),
+        })
+    }
+
+    #[must_use]
+    pub fn locator(&self) -> &DaemonLocator {
+        &self.locator
+    }
+
+    pub async fn shutdown(mut self) -> Result<(), DaemonListenerError> {
+        self.shutdown.notify_one();
+        if let Some(task) = self.accept_task.take() {
+            task.await.map_err(|_| DaemonListenerError::Task)?;
+        }
+        let profile = self.profile.clone();
+        let locator = self.locator.clone();
+        let removed = tokio::task::spawn_blocking(move || {
+            remove_locator_if_matches(&profile, &locator)
+        })
+        .await
+        .map_err(|_| DaemonListenerError::Task)??;
+        let _ = removed;
+        Ok(())
+    }
+}
+
+impl Drop for DaemonListener {
+    fn drop(&mut self) {
+        if let Some(task) = self.accept_task.take() {
+            task.abort();
+        }
+    }
+}
+
+pub async fn probe_liveness(locator: &DaemonLocator, deadline: Duration) -> bool {
+    timeout(deadline, probe_liveness_inner(locator))
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or(false)
+}
+
+async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
+    if locator.cluster_protocol != CLUSTER_PROTOCOL || locator.daemon_protocol != DAEMON_PROTOCOL {
+        return Ok(false);
+    }
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .map_err(|_| ())?;
+    let address = loopback_address(&request).ok_or(())?;
+    DaemonCredentials::from_locator(locator)
+        .apply_to_request(&mut request)
+        .map_err(|_| ())?;
+    let stream = TcpStream::connect(address).await.map_err(|_| ())?;
+    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .map_err(|_| ())?;
+    let initialize = serde_json::json!({
+        "jsonrpc": JSON_RPC_VERSION,
+        "id": "daemon-liveness",
+        "method": "initialize",
+        "params": { "protocolVersion": PROTOCOL_VERSION }
+    });
+    websocket
+        .send(Message::Text(initialize.to_string().into()))
+        .await
+        .map_err(|_| ())?;
+    while let Some(message) = websocket.next().await {
+        let message = message.map_err(|_| ())?;
+        let Message::Text(text) = message else {
+            if message.is_close() {
+                return Ok(false);
+            }
+            continue;
+        };
+        let response: Value = serde_json::from_str(text.as_ref()).map_err(|_| ())?;
+        return Ok(response.get("id") == Some(&Value::String("daemon-liveness".to_owned()))
+            && response
+                .pointer("/result/protocolVersion")
+                .and_then(Value::as_str)
+                == Some(PROTOCOL_VERSION));
+    }
+    Ok(false)
+}
+
+fn rotate_away_from(value: &mut String, previous: &str) {
+    if value == previous {
+        let replacement = if value.starts_with('0') { "1" } else { "0" };
+        value.replace_range(..1, replacement);
+    }
+}
+
+fn loopback_address(
+    request: &tokio_tungstenite::tungstenite::handshake::client::Request,
+) -> Option<SocketAddr> {
+    let uri = request.uri();
+    if uri.scheme_str() != Some("ws")
+        || uri.path() != DAEMON_ROUTE
+        || uri.query().is_some()
+        || uri.host() != Some("127.0.0.1")
+    {
+        return None;
+    }
+    Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        uri.port_u16()?,
+    ))
+}
+
+async fn run_accept_loop<F>(
+    listener: TcpListener,
+    factory: Arc<F>,
+    credentials: DaemonCredentials,
+    shutdown: Arc<Notify>,
+    config: ListenerConfig,
+) where
+    F: NativeBackendFactory + Send + Sync + 'static,
+{
+    let permits = Arc::new(Semaphore::new(config.max_active_connections));
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            biased;
+            () = shutdown.notified() => break,
+            completed = connections.join_next(), if !connections.is_empty() => {
+                let _ = completed;
+            }
+            accepted = listener.accept() => {
+                let Ok((stream, peer)) = accepted else { break };
+                let Ok(permit) = Arc::clone(&permits).try_acquire_owned() else {
+                    drop(stream);
+                    continue;
+                };
+                let factory = Arc::clone(&factory);
+                let credentials = credentials.clone();
+                connections.spawn(async move {
+                    let _permit = permit;
+                    serve_connection(stream, peer, factory, credentials, config.handshake_timeout).await;
+                });
+            }
+        }
+    }
+    drop(listener);
+
+    let drain_deadline = Instant::now() + config.drain_timeout;
+    while !connections.is_empty() {
+        match timeout_at(drain_deadline, connections.join_next()).await {
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(_) => {
+                connections.abort_all();
+                while connections.join_next().await.is_some() {}
+                break;
+            }
+        }
+    }
+}
+
+async fn serve_connection<F>(
+    stream: TcpStream,
+    peer: SocketAddr,
+    factory: Arc<F>,
+    credentials: DaemonCredentials,
+    handshake_timeout: Duration,
+) where
+    F: NativeBackendFactory + Send + Sync + 'static,
+{
+    let handshake = accept_hdr_async_with_config(
+        stream,
+        AuthorizationCallback(credentials),
+        Some(websocket_config()),
+    );
+    let Ok(Ok(websocket)) = timeout(handshake_timeout, handshake).await else {
+        return;
+    };
+
+    let context = ConnectionContext {
+        peer_label: Some(peer.to_string()),
+        ..ConnectionContext::default()
+    };
+    let dispatcher = dispatcher_for_route(factory.as_ref(), context);
+    let _ = serve_websocket(dispatcher, websocket).await;
+}

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -12,7 +12,7 @@ use openengine_cluster_server::ConnectionContext;
 use serde_json::Value;
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Notify, Semaphore};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::{Instant, timeout, timeout_at};
 use tokio_tungstenite::accept_hdr_async_with_config;
@@ -33,7 +33,9 @@ pub struct ListenerConfig {
     pub liveness_timeout: Duration,
     pub handshake_timeout: Duration,
     pub drain_timeout: Duration,
+    pub shutdown_timeout: Duration,
     pub max_active_connections: usize,
+    pub max_pending_handshakes: usize,
 }
 
 impl Default for ListenerConfig {
@@ -43,7 +45,9 @@ impl Default for ListenerConfig {
             liveness_timeout: Duration::from_millis(500),
             handshake_timeout: Duration::from_secs(2),
             drain_timeout: Duration::from_millis(250),
+            shutdown_timeout: Duration::from_secs(1),
             max_active_connections: 64,
+            max_pending_handshakes: 64,
         }
     }
 }
@@ -60,6 +64,8 @@ pub enum DaemonListenerError {
     Io(#[from] io::Error),
     #[error("daemon listener task failed")]
     Task,
+    #[error("daemon shutdown exceeded its outer deadline")]
+    ShutdownTimeout,
 }
 
 pub struct DaemonListener {
@@ -67,6 +73,9 @@ pub struct DaemonListener {
     locator: DaemonLocator,
     shutdown: Arc<Notify>,
     accept_task: Option<JoinHandle<()>>,
+    shutdown_timeout: Duration,
+    pending_handshake_limit: usize,
+    pending_handshake_permits: Arc<Semaphore>,
 }
 
 impl DaemonListener {
@@ -85,7 +94,10 @@ impl DaemonListener {
     where
         F: NativeBackendFactory + Send + Sync + 'static,
     {
-        if config.max_active_connections == 0 {
+        if config.max_active_connections == 0
+            || config.max_pending_handshakes == 0
+            || config.shutdown_timeout.is_zero()
+        {
             return Err(DaemonListenerError::InvalidConfiguration);
         }
         let lock_profile = profile.clone();
@@ -122,11 +134,13 @@ impl DaemonListener {
         };
 
         let shutdown = Arc::new(Notify::new());
+        let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
         let accept_task = tokio::spawn(run_accept_loop(AcceptLoop {
             listener: tcp,
             factory: Arc::new(factory),
             credentials,
             shutdown: Arc::clone(&shutdown),
+            pending_handshake_permits: Arc::clone(&pending_handshake_permits),
             config,
         }));
         if let Err(error) = replace_locator_locked(&profile, &locator) {
@@ -141,6 +155,9 @@ impl DaemonListener {
             locator,
             shutdown,
             accept_task: Some(accept_task),
+            shutdown_timeout: config.shutdown_timeout,
+            pending_handshake_limit: config.max_pending_handshakes,
+            pending_handshake_permits,
         })
     }
 
@@ -149,10 +166,27 @@ impl DaemonListener {
         &self.locator
     }
 
+    #[must_use]
+    pub fn pending_handshakes(&self) -> usize {
+        self.pending_handshake_limit
+            .saturating_sub(self.pending_handshake_permits.available_permits())
+    }
+
     pub async fn shutdown(mut self) -> Result<(), DaemonListenerError> {
         self.shutdown.notify_one();
-        if let Some(task) = self.accept_task.take() {
-            task.await.map_err(|_| DaemonListenerError::Task)?;
+        if let Some(mut task) = self.accept_task.take() {
+            match timeout(self.shutdown_timeout, &mut task).await {
+                Ok(result) => result.map_err(|_| DaemonListenerError::Task)?,
+                Err(_) => {
+                    task.abort();
+                    let completion = timeout(self.shutdown_timeout, &mut task)
+                        .await
+                        .map_err(|_| DaemonListenerError::ShutdownTimeout)?;
+                    if completion.is_err_and(|error| !error.is_cancelled()) {
+                        return Err(DaemonListenerError::Task);
+                    }
+                }
+            }
         }
         let profile = self.profile.clone();
         let locator = self.locator.clone();
@@ -231,7 +265,6 @@ fn valid_liveness_response(response: &Value) -> bool {
     };
     object.get("jsonrpc").and_then(Value::as_str) == Some(JSON_RPC_VERSION)
         && object.get("id").and_then(Value::as_str) == Some("daemon-liveness")
-        && object.get("result").is_some_and(Value::is_object)
         && !object.contains_key("error")
         && response
             .pointer("/result/protocolVersion")
@@ -269,6 +302,7 @@ struct AcceptLoop<F> {
     credentials: DaemonCredentials,
     shutdown: Arc<Notify>,
     config: ListenerConfig,
+    pending_handshake_permits: Arc<Semaphore>,
 }
 
 async fn run_accept_loop<F>(host: AcceptLoop<F>)
@@ -281,8 +315,9 @@ where
         credentials,
         shutdown,
         config,
+        pending_handshake_permits,
     } = host;
-    let permits = Arc::new(Semaphore::new(config.max_active_connections));
+    let active_permits = Arc::new(Semaphore::new(config.max_active_connections));
     let mut connections = JoinSet::new();
     loop {
         tokio::select! {
@@ -293,16 +328,23 @@ where
             }
             accepted = listener.accept() => {
                 let Ok((stream, peer)) = accepted else { break };
+                let Ok(handshake_permit) =
+                    Arc::clone(&pending_handshake_permits).try_acquire_owned()
+                else {
+                    drop(stream);
+                    continue;
+                };
                 let factory = Arc::clone(&factory);
                 let credentials = credentials.clone();
-                let permits = Arc::clone(&permits);
+                let active_permits = Arc::clone(&active_permits);
                 connections.spawn(async move {
                     serve_connection(ConnectionTask {
                         stream,
                         peer,
                         factory,
                         credentials,
-                        permits,
+                        active_permits,
+                        handshake_permit,
                         handshake_timeout: config.handshake_timeout,
                         liveness_timeout: config.liveness_timeout,
                     }).await;
@@ -319,7 +361,6 @@ where
             Ok(None) => break,
             Err(_) => {
                 connections.abort_all();
-                while connections.join_next().await.is_some() {}
                 break;
             }
         }
@@ -331,7 +372,8 @@ struct ConnectionTask<F> {
     peer: SocketAddr,
     factory: Arc<F>,
     credentials: DaemonCredentials,
-    permits: Arc<Semaphore>,
+    active_permits: Arc<Semaphore>,
+    handshake_permit: OwnedSemaphorePermit,
     handshake_timeout: Duration,
     liveness_timeout: Duration,
 }
@@ -345,7 +387,8 @@ where
         peer,
         factory,
         credentials,
-        permits,
+        active_permits,
+        handshake_permit,
         handshake_timeout,
         liveness_timeout,
     } = connection;
@@ -354,6 +397,7 @@ where
     let Ok(Ok(mut websocket)) = timeout(handshake_timeout, handshake).await else {
         return;
     };
+    drop(handshake_permit);
     let Some(purpose) = receipt.take() else {
         return;
     };
@@ -379,7 +423,7 @@ where
         let _ = websocket.close(None).await;
         return;
     }
-    let Ok(_permit) = permits.try_acquire_owned() else {
+    let Ok(_permit) = active_permits.try_acquire_owned() else {
         return;
     };
 

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -1,11 +1,13 @@
 //! One authenticated loopback WebSocket listener per native profile.
 
+use std::future::Future;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{FutureExt, SinkExt, StreamExt};
 use openengine_cluster_protocol::{InitializeResult, JSON_RPC_VERSION, PROTOCOL_VERSION};
 use openengine_cluster_server::websocket::{serve_websocket, websocket_config};
 use openengine_cluster_server::ConnectionContext;
@@ -163,7 +165,7 @@ impl DaemonListener {
         let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
         let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
         let host = AcceptLoop {
-            listener: tcp,
+            acceptor: tcp,
             factory: Arc::new(factory),
             credentials,
             shutdown: Arc::clone(&shutdown),
@@ -386,8 +388,18 @@ fn loopback_address(
     ))
 }
 
-struct AcceptLoop<F> {
-    listener: TcpListener,
+trait ConnectionAcceptor: Send + Sync + 'static {
+    fn accept(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send;
+}
+
+impl ConnectionAcceptor for TcpListener {
+    fn accept(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send {
+        TcpListener::accept(self)
+    }
+}
+
+struct AcceptLoop<A, F> {
+    acceptor: A,
     factory: Arc<F>,
     credentials: DaemonCredentials,
     shutdown: Arc<Notify>,
@@ -397,15 +409,19 @@ struct AcceptLoop<F> {
     active_session_permits: Arc<Semaphore>,
 }
 
-async fn run_owned_accept_loop<F>(
-    host: AcceptLoop<F>,
+async fn run_owned_accept_loop<A, F>(
+    host: AcceptLoop<A, F>,
     profile: NativeProfile,
     locator: DaemonLocator,
 ) -> Result<(), ()>
 where
+    A: ConnectionAcceptor,
     F: NativeBackendFactory + Send + Sync + 'static,
 {
-    let result = run_accept_loop(host).await;
+    let result = AssertUnwindSafe(run_accept_loop(host))
+        .catch_unwind()
+        .await
+        .unwrap_or(Err(()));
     let cleanup =
         tokio::task::spawn_blocking(move || remove_locator_if_matches(&profile, &locator)).await;
     match cleanup {
@@ -414,12 +430,13 @@ where
     }
 }
 
-async fn run_accept_loop<F>(host: AcceptLoop<F>) -> Result<(), ()>
+async fn run_accept_loop<A, F>(host: AcceptLoop<A, F>) -> Result<(), ()>
 where
+    A: ConnectionAcceptor,
     F: NativeBackendFactory + Send + Sync + 'static,
 {
     let AcceptLoop {
-        listener,
+        acceptor,
         factory,
         credentials,
         shutdown,
@@ -440,8 +457,14 @@ where
                     break;
                 }
             }
-            accepted = listener.accept() => {
-                let Ok((stream, peer)) = accepted else { break };
+            accepted = acceptor.accept() => {
+                let (stream, peer) = match accepted {
+                    Ok(accepted) => accepted,
+                    Err(_) => {
+                        connection_failed = true;
+                        break;
+                    }
+                };
                 let Ok(handshake_permit) =
                     Arc::clone(&pending_handshake_permits).try_acquire_owned()
                 else {
@@ -469,7 +492,7 @@ where
             }
         }
     }
-    drop(listener);
+    drop(acceptor);
 
     let drain_deadline = Instant::now() + config.drain_timeout;
     while !connections.is_empty() {
@@ -559,4 +582,151 @@ where
     };
     let dispatcher = dispatcher_for_route(factory.as_ref(), context);
     let _ = serve_websocket(dispatcher, websocket).await;
+}
+
+#[cfg(test)]
+mod accept_loop_tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::ProductionNativeBackendFactory;
+    use crate::daemon_discovery::{random_hex, read_locator, replace_locator};
+
+    #[derive(Clone, Copy)]
+    enum FailureMode {
+        Error,
+        Panic,
+    }
+
+    struct FailingAcceptor {
+        _listener: TcpListener,
+        mode: FailureMode,
+    }
+
+    impl ConnectionAcceptor for FailingAcceptor {
+        fn accept(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send {
+            let mode = self.mode;
+            async move {
+                match mode {
+                    FailureMode::Error => Err(io::Error::other("controlled accept failure")),
+                    FailureMode::Panic => panic!("controlled accept loop panic"),
+                }
+            }
+        }
+    }
+
+    struct TestProfile {
+        profile: NativeProfile,
+        root: PathBuf,
+    }
+
+    impl Drop for TestProfile {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    async fn failing_owner(
+        mode: FailureMode,
+        label: &str,
+    ) -> (DaemonListener, TestProfile, SocketAddr) {
+        let root = std::env::temp_dir().join(format!(
+            "zeroshot-accept-{label}-{}-{}",
+            std::process::id(),
+            random_hex().expect("temporary profile suffix")
+        ));
+        let profile = NativeProfile::new(&root, format!("native-profile:{label}"));
+        let tcp = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .expect("bind controlled acceptor");
+        let address = tcp.local_addr().expect("controlled acceptor address");
+        let credentials =
+            DaemonCredentials::generate(profile.digest().to_owned()).expect("credentials");
+        let locator = DaemonLocator {
+            endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
+            cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+            daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+            profile_digest: credentials.profile_digest.clone(),
+            daemon_nonce: credentials.daemon_nonce.clone(),
+            capability: credentials.capability.clone(),
+        };
+        replace_locator(&profile, &locator).expect("publish controlled locator");
+        let config = ListenerConfig::default();
+        let shutdown = Arc::new(Notify::new());
+        let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
+        let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
+        let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
+        let host = AcceptLoop {
+            acceptor: FailingAcceptor {
+                _listener: tcp,
+                mode,
+            },
+            factory: Arc::new(ProductionNativeBackendFactory),
+            credentials,
+            shutdown: Arc::clone(&shutdown),
+            config,
+            pending_handshake_permits: Arc::clone(&pending_handshake_permits),
+            liveness_connection_permits: Arc::clone(&liveness_connection_permits),
+            active_session_permits: Arc::clone(&active_session_permits),
+        };
+        let accept_task = tokio::spawn(run_owned_accept_loop(
+            host,
+            profile.clone(),
+            locator.clone(),
+        ));
+        let owner = DaemonListener {
+            profile: profile.clone(),
+            locator,
+            shutdown,
+            accept_task: Some(accept_task),
+            shutdown_timeout: config.shutdown_timeout,
+            pending_handshake_limit: config.max_pending_handshakes,
+            pending_handshake_permits,
+            liveness_connection_limit: config.max_liveness_connections,
+            liveness_connection_permits,
+            active_session_limit: config.max_active_connections,
+            active_session_permits,
+        };
+        (owner, TestProfile { profile, root }, address)
+    }
+
+    async fn assert_failure_cleanup_before_shutdown(mode: FailureMode, label: &str) {
+        let (owner, profile, address) = failing_owner(mode, label).await;
+        timeout(Duration::from_millis(500), async {
+            loop {
+                let locator_removed = read_locator(&profile.profile)
+                    .expect("automatic failure cleanup state")
+                    .is_none();
+                let socket_released = match TcpListener::bind(address).await {
+                    Ok(rebound) => {
+                        drop(rebound);
+                        true
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::AddrInUse => false,
+                    Err(error) => panic!("unexpected rebind failure: {error}"),
+                };
+                if locator_removed && socket_released {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("owned accept failure released locator and socket");
+        assert!(matches!(
+            owner.shutdown().await,
+            Err(DaemonListenerError::Task)
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accept_error_cleans_owner_before_shutdown_and_remains_task_failure() {
+        assert_failure_cleanup_before_shutdown(FailureMode::Error, "accept-error").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accept_loop_panic_cleans_owner_before_shutdown_and_remains_task_failure() {
+        assert_failure_cleanup_before_shutdown(FailureMode::Panic, "accept-panic").await;
+    }
 }

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -9,8 +9,10 @@ use std::time::Duration;
 
 use futures_util::{FutureExt, SinkExt, StreamExt};
 use openengine_cluster_protocol::{InitializeResult, JSON_RPC_VERSION, PROTOCOL_VERSION};
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionIdentity, ConnectionIdentityConfig, PrincipalId, TenantId,
+};
 use openengine_cluster_server::websocket::{serve_websocket, websocket_config};
-use openengine_cluster_server::ConnectionContext;
 use serde_json::Value;
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -28,7 +30,7 @@ use crate::daemon_discovery::{
     acquire_start_guard, read_locator_locked, remove_locator_if_matches,
     remove_locator_if_matches_locked, replace_locator_locked,
 };
-use crate::{NativeBackendFactory, dispatcher_for_route};
+use crate::{NativeBackendFactory, binding_for_route};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ListenerConfig {
@@ -364,6 +366,16 @@ fn classify_liveness_response(response: &Value) -> LivenessOutcome {
     }
 }
 
+fn identity_for_profile(profile_digest: &str) -> ConnectionIdentity {
+    ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new(profile_digest),
+        tenant: TenantId::new(profile_digest),
+        issued_at_ms: None,
+        expires_at_ms: u64::MAX,
+        binding_attributes: BindingAttributes::default(),
+    })
+}
+
 fn rotate_away_from(value: &mut String, previous: &str) {
     if value == previous {
         let replacement = if value.starts_with('0') { "1" } else { "0" };
@@ -458,7 +470,7 @@ where
                 }
             }
             accepted = acceptor.accept() => {
-                let (stream, peer) = match accepted {
+                let (stream, _peer) = match accepted {
                     Ok(accepted) => accepted,
                     Err(_) => {
                         connection_failed = true;
@@ -479,7 +491,6 @@ where
                 connections.spawn(async move {
                     serve_connection(ConnectionTask {
                         stream,
-                        peer,
                         factory,
                         credentials,
                         active_permits,
@@ -511,7 +522,6 @@ where
 
 struct ConnectionTask<F> {
     stream: TcpStream,
-    peer: SocketAddr,
     factory: Arc<F>,
     credentials: DaemonCredentials,
     active_permits: Arc<Semaphore>,
@@ -527,7 +537,6 @@ where
 {
     let ConnectionTask {
         stream,
-        peer,
         factory,
         credentials,
         active_permits,
@@ -536,6 +545,7 @@ where
         handshake_timeout,
         liveness_timeout,
     } = connection;
+    let identity = identity_for_profile(&credentials.profile_digest);
     let (callback, receipt) = AuthorizationCallback::new(credentials);
     let handshake = accept_hdr_async_with_config(stream, callback, Some(websocket_config()));
     let Ok(Ok(mut websocket)) = timeout(handshake_timeout, handshake).await else {
@@ -560,11 +570,10 @@ where
             if value.get("method").and_then(Value::as_str) != Some("initialize") {
                 return;
             }
-            let context = ConnectionContext {
-                peer_label: Some(peer.to_string()),
-                ..ConnectionContext::default()
+            let binding = binding_for_route(factory.as_ref(), identity);
+            let Ok(dispatcher) = binding.into_dispatcher().await else {
+                return;
             };
-            let dispatcher = dispatcher_for_route(factory.as_ref(), context);
             let response = dispatcher.dispatch(request.as_ref()).await;
             let _ = websocket.send(Message::Text(response.into())).await;
             let _ = websocket.close(None).await;
@@ -576,12 +585,8 @@ where
         return;
     };
 
-    let context = ConnectionContext {
-        peer_label: Some(peer.to_string()),
-        ..ConnectionContext::default()
-    };
-    let dispatcher = dispatcher_for_route(factory.as_ref(), context);
-    let _ = serve_websocket(dispatcher, websocket).await;
+    let binding = binding_for_route(factory.as_ref(), identity);
+    let _ = serve_websocket(binding, websocket).await;
 }
 
 #[cfg(test)]

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -504,25 +504,27 @@ where
         let Ok(_liveness_permit) = liveness_connection_permits.try_acquire_owned() else {
             return;
         };
-        let Ok(Some(Ok(Message::Text(request)))) =
-            timeout(liveness_timeout, websocket.next()).await
-        else {
-            return;
+        let deadline = Instant::now() + liveness_timeout;
+        let transaction = async {
+            let Some(Ok(Message::Text(request))) = websocket.next().await else {
+                return;
+            };
+            let Ok(value) = serde_json::from_str::<Value>(request.as_ref()) else {
+                return;
+            };
+            if value.get("method").and_then(Value::as_str) != Some("initialize") {
+                return;
+            }
+            let context = ConnectionContext {
+                peer_label: Some(peer.to_string()),
+                ..ConnectionContext::default()
+            };
+            let dispatcher = dispatcher_for_route(factory.as_ref(), context);
+            let response = dispatcher.dispatch(request.as_ref()).await;
+            let _ = websocket.send(Message::Text(response.into())).await;
+            let _ = websocket.close(None).await;
         };
-        let Ok(value) = serde_json::from_str::<Value>(request.as_ref()) else {
-            return;
-        };
-        if value.get("method").and_then(Value::as_str) != Some("initialize") {
-            return;
-        }
-        let context = ConnectionContext {
-            peer_label: Some(peer.to_string()),
-            ..ConnectionContext::default()
-        };
-        let dispatcher = dispatcher_for_route(factory.as_ref(), context);
-        let response = dispatcher.dispatch(request.as_ref()).await;
-        let _ = websocket.send(Message::Text(response.into())).await;
-        let _ = websocket.close(None).await;
+        let _ = timeout_at(deadline, transaction).await;
         return;
     }
     let Ok(_permit) = active_permits.try_acquire_owned() else {

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -220,15 +220,23 @@ async fn probe_liveness_inner(locator: &DaemonLocator) -> Result<bool, ()> {
             continue;
         };
         let response: Value = serde_json::from_str(text.as_ref()).map_err(|_| ())?;
-        return Ok(
-            response.get("id") == Some(&Value::String("daemon-liveness".to_owned()))
-                && response
-                    .pointer("/result/protocolVersion")
-                    .and_then(Value::as_str)
-                    == Some(PROTOCOL_VERSION),
-        );
+        return Ok(valid_liveness_response(&response));
     }
     Ok(false)
+}
+
+fn valid_liveness_response(response: &Value) -> bool {
+    let Some(object) = response.as_object() else {
+        return false;
+    };
+    object.get("jsonrpc").and_then(Value::as_str) == Some(JSON_RPC_VERSION)
+        && object.get("id").and_then(Value::as_str) == Some("daemon-liveness")
+        && object.get("result").is_some_and(Value::is_object)
+        && !object.contains_key("error")
+        && response
+            .pointer("/result/protocolVersion")
+            .and_then(Value::as_str)
+            == Some(PROTOCOL_VERSION)
 }
 
 fn rotate_away_from(value: &mut String, previous: &str) {

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -84,12 +84,14 @@ pub struct DaemonListener {
     profile: NativeProfile,
     locator: DaemonLocator,
     shutdown: Arc<Notify>,
-    accept_task: Option<JoinHandle<()>>,
+    accept_task: Option<JoinHandle<Result<(), ()>>>,
     shutdown_timeout: Duration,
     pending_handshake_limit: usize,
     pending_handshake_permits: Arc<Semaphore>,
     liveness_connection_limit: usize,
     liveness_connection_permits: Arc<Semaphore>,
+    active_session_limit: usize,
+    active_session_permits: Arc<Semaphore>,
 }
 
 impl DaemonListener {
@@ -155,6 +157,7 @@ impl DaemonListener {
         let shutdown = Arc::new(Notify::new());
         let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
         let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
+        let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
         let accept_task = tokio::spawn(run_accept_loop(AcceptLoop {
             listener: tcp,
             factory: Arc::new(factory),
@@ -162,6 +165,7 @@ impl DaemonListener {
             shutdown: Arc::clone(&shutdown),
             pending_handshake_permits: Arc::clone(&pending_handshake_permits),
             liveness_connection_permits: Arc::clone(&liveness_connection_permits),
+            active_session_permits: Arc::clone(&active_session_permits),
             config,
         }));
         if let Err(error) = replace_locator_locked(&profile, &locator) {
@@ -181,6 +185,8 @@ impl DaemonListener {
             pending_handshake_permits,
             liveness_connection_limit: config.max_liveness_connections,
             liveness_connection_permits,
+            active_session_limit: config.max_active_connections,
+            active_session_permits,
         })
     }
 
@@ -201,6 +207,12 @@ impl DaemonListener {
             .saturating_sub(self.liveness_connection_permits.available_permits())
     }
 
+    #[must_use]
+    pub fn active_sessions(&self) -> usize {
+        self.active_session_limit
+            .saturating_sub(self.active_session_permits.available_permits())
+    }
+
     pub async fn shutdown(mut self) -> Result<(), DaemonListenerError> {
         let started = Instant::now();
         let deadline = started + self.shutdown_timeout;
@@ -209,12 +221,13 @@ impl DaemonListener {
         self.shutdown.notify_one();
         if let Some(mut task) = self.accept_task.take() {
             match timeout_at(graceful_deadline, &mut task).await {
-                Ok(Ok(())) => {}
-                Ok(Err(_)) => result = Err(DaemonListenerError::Task),
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(()))) | Ok(Err(_)) => result = Err(DaemonListenerError::Task),
                 Err(_) => {
                     task.abort();
                     match timeout_at(deadline, &mut task).await {
-                        Ok(Ok(())) => {}
+                        Ok(Ok(Ok(()))) => {}
+                        Ok(Ok(Err(()))) => result = Err(DaemonListenerError::Task),
                         Ok(Err(error)) if error.is_cancelled() => {}
                         Ok(Err(_)) => result = Err(DaemonListenerError::Task),
                         Err(_) => result = Err(DaemonListenerError::ShutdownTimeout),
@@ -372,9 +385,10 @@ struct AcceptLoop<F> {
     config: ListenerConfig,
     pending_handshake_permits: Arc<Semaphore>,
     liveness_connection_permits: Arc<Semaphore>,
+    active_session_permits: Arc<Semaphore>,
 }
 
-async fn run_accept_loop<F>(host: AcceptLoop<F>)
+async fn run_accept_loop<F>(host: AcceptLoop<F>) -> Result<(), ()>
 where
     F: NativeBackendFactory + Send + Sync + 'static,
 {
@@ -386,15 +400,19 @@ where
         config,
         pending_handshake_permits,
         liveness_connection_permits,
+        active_session_permits,
     } = host;
-    let active_permits = Arc::new(Semaphore::new(config.max_active_connections));
     let mut connections = JoinSet::new();
+    let mut connection_failed = false;
     loop {
         tokio::select! {
             biased;
             () = shutdown.notified() => break,
             completed = connections.join_next(), if !connections.is_empty() => {
-                let _ = completed;
+                if matches!(completed, Some(Err(_))) {
+                    connection_failed = true;
+                    break;
+                }
             }
             accepted = listener.accept() => {
                 let Ok((stream, peer)) = accepted else { break };
@@ -406,7 +424,7 @@ where
                 };
                 let factory = Arc::clone(&factory);
                 let credentials = credentials.clone();
-                let active_permits = Arc::clone(&active_permits);
+                let active_permits = Arc::clone(&active_session_permits);
                 let liveness_connection_permits =
                     Arc::clone(&liveness_connection_permits);
                 connections.spawn(async move {
@@ -430,7 +448,8 @@ where
     let drain_deadline = Instant::now() + config.drain_timeout;
     while !connections.is_empty() {
         match timeout_at(drain_deadline, connections.join_next()).await {
-            Ok(Some(_)) => {}
+            Ok(Some(Ok(()))) => {}
+            Ok(Some(Err(_))) => connection_failed = true,
             Ok(None) => break,
             Err(_) => {
                 connections.abort_all();
@@ -438,6 +457,7 @@ where
             }
         }
     }
+    if connection_failed { Err(()) } else { Ok(()) }
 }
 
 struct ConnectionTask<F> {

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
-use openengine_cluster_protocol::{JSON_RPC_VERSION, PROTOCOL_VERSION};
+use openengine_cluster_protocol::{InitializeResult, JSON_RPC_VERSION, PROTOCOL_VERSION};
 use openengine_cluster_server::websocket::{serve_websocket, websocket_config};
 use openengine_cluster_server::ConnectionContext;
 use serde_json::Value;
@@ -324,13 +324,20 @@ fn valid_liveness_response(response: &Value) -> bool {
     let Some(object) = response.as_object() else {
         return false;
     };
-    object.get("jsonrpc").and_then(Value::as_str) == Some(JSON_RPC_VERSION)
-        && object.get("id").and_then(Value::as_str) == Some("daemon-liveness")
-        && !object.contains_key("error")
-        && response
-            .pointer("/result/protocolVersion")
-            .and_then(Value::as_str)
-            == Some(PROTOCOL_VERSION)
+    if object.len() != 3
+        || object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION)
+        || object.get("id").and_then(Value::as_str) != Some("daemon-liveness")
+    {
+        return false;
+    }
+    let Some(raw_result) = object.get("result") else {
+        return false;
+    };
+    let Ok(result) = serde_json::from_value::<InitializeResult>(raw_result.clone()) else {
+        return false;
+    };
+    result.validate_protocol_version().is_ok()
+        && serde_json::to_value(result).ok().as_ref() == Some(raw_result)
 }
 
 fn rotate_away_from(value: &mut String, previous: &str) {

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 pub mod artifact_store;
 pub mod cluster_ledger;
 pub mod daemon_auth;
@@ -15,6 +17,9 @@ pub mod worker_catalog;
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
     ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, ServerCapabilities,
+};
+use openengine_cluster_server::identity::{
+    ConnectionBinding, ConnectionIdentity, StaticConnectionIdentityResolver, SystemConnectionTime,
 };
 use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
 
@@ -53,7 +58,7 @@ impl ClusterBackend for NativeBackend {
 pub trait NativeBackendFactory {
     type Backend: ClusterBackend;
 
-    fn create(&self, context: &ConnectionContext) -> Self::Backend;
+    fn create(&self) -> Self::Backend;
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -62,7 +67,7 @@ pub struct ProductionNativeBackendFactory;
 impl NativeBackendFactory for ProductionNativeBackendFactory {
     type Backend = NativeBackend;
 
-    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+    fn create(&self) -> Self::Backend {
         NativeBackend
     }
 }
@@ -72,6 +77,22 @@ pub fn dispatcher_for_route<F>(factory: &F, context: ConnectionContext) -> Dispa
 where
     F: NativeBackendFactory,
 {
-    let backend = factory.create(&context);
+    let backend = factory.create();
     Dispatcher::new(backend, context)
+}
+
+#[must_use]
+pub fn binding_for_route<F>(
+    factory: &F,
+    identity: ConnectionIdentity,
+) -> ConnectionBinding<F::Backend, StaticConnectionIdentityResolver, SystemConnectionTime>
+where
+    F: NativeBackendFactory,
+{
+    ConnectionBinding::new(
+        Arc::new(factory.create()),
+        StaticConnectionIdentityResolver::new(identity),
+        SystemConnectionTime,
+        Default::default(),
+    )
 }

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod artifact_store;
 pub mod cluster_ledger;
+pub mod daemon_auth;
+pub mod daemon_discovery;
+pub mod daemon_listener;
 pub mod execution;
 pub mod full_v1_reducer;
 pub mod issue_provider;

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -534,6 +534,8 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
         "authorize_request",
         "accept_hdr_async_with_config",
         "serve_websocket",
+        "binding_for_route",
+        "into_dispatcher",
         "probe_liveness",
         "remove_locator_if_matches",
         "openengine.cluster/v1",
@@ -548,6 +550,10 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
             "missing native daemon boundary: {required}"
         );
     }
+    assert!(
+        !daemon.contains("ConnectionContext::new"),
+        "daemon host bypassed binding-injected connection identity"
+    );
     for required in [
         "#[cfg(unix)]\nmod platform",
         "#[cfg(windows)]\nmod platform",

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -548,6 +548,18 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
             "missing native daemon boundary: {required}"
         );
     }
+    for required in [
+        "#[cfg(unix)]\nmod platform",
+        "#[cfg(windows)]\nmod platform",
+        "FILE_FLAG_OPEN_REPARSE_POINT",
+        "PROTECTED_DACL_SECURITY_INFORMATION",
+        "MoveFileExW",
+    ] {
+        assert!(
+            daemon.contains(required),
+            "daemon discovery lost a supported-platform security boundary: {required}"
+        );
+    }
     for forbidden in [
         "ClusterLedger",
         "ExecutionRuntime",

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -44,6 +44,9 @@ fn product_contains_the_required_native_files() {
         "src/artifact_store/local_cas.rs",
         "src/artifact_store/local_cas/filesystem.rs",
         "src/artifact_store/local_cas/operations.rs",
+        "src/daemon_auth.rs",
+        "src/daemon_discovery.rs",
+        "src/daemon_listener.rs",
         "src/execution.rs",
         "src/execution/driver.rs",
         "src/execution/local.rs",
@@ -67,6 +70,9 @@ fn product_contains_the_required_native_files() {
         "tests/artifact_store.rs",
         "tests/backend_boundary.rs",
         "tests/execution_runtime_contract.rs",
+        "tests/daemon_auth.rs",
+        "tests/daemon_discovery.rs",
+        "tests/daemon_listener.rs",
         "tests/fault_contract.rs",
         "tests/local_cas.rs",
         "tests/local_execution_runtime.rs",
@@ -261,7 +267,6 @@ fn runtime_has_no_future_product_concerns() {
         "benchmark",
         "selector",
         "transport",
-        "daemon",
         "persistence",
         "verifier",
     ] {
@@ -516,4 +521,62 @@ fn full_v1_reduction_reuses_verified_ir_and_stays_pure() {
     let replay = read(&product_root().join("src/cluster_ledger/replay.rs"));
     assert!(replay.contains("fold_execution_context"));
     assert!(replay.contains("fold_execution_void"));
+}
+
+#[test]
+fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary() {
+    let daemon = rust_sources(&[
+        "src/daemon_auth.rs",
+        "src/daemon_discovery.rs",
+        "src/daemon_listener.rs",
+    ]);
+    for required in [
+        "authorize_request",
+        "accept_hdr_async_with_config",
+        "serve_websocket",
+        "probe_liveness",
+        "remove_locator_if_matches",
+        "openengine.cluster/v1",
+        "zeroshot.daemon/v1",
+    ] {
+        assert!(
+            daemon.contains(required),
+            "missing native daemon boundary: {required}"
+        );
+    }
+    for forbidden in [
+        "ClusterLedger",
+        "ExecutionRuntime",
+        "FairScheduler",
+        "ProviderPool",
+        "ClusterCatalog",
+        "RecoveryCoordinator",
+        "Exporter",
+        "Command::new",
+        "clap",
+        "hosted",
+        "cloud_control_plane",
+        "node_daemon",
+    ] {
+        assert!(
+            !daemon.contains(forbidden),
+            "native daemon crossed a non-goal boundary: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn manifest_has_no_client_testkit_or_node_dependencies() {
+    let manifest = read(&product_root().join("Cargo.toml"));
+    for forbidden_dependency in [
+        "openengine-cluster-client",
+        "openengine-cluster-testkit",
+        "node",
+        "npm",
+    ] {
+        assert!(
+            !manifest.contains(forbidden_dependency),
+            "forbidden product dependency: {forbidden_dependency}"
+        );
+    }
 }

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -554,6 +554,7 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
         "FILE_FLAG_OPEN_REPARSE_POINT",
         "PROTECTED_DACL_SECURITY_INFORMATION",
         "MoveFileExW",
+        "validate_directory_shape(&directory)?",
     ] {
         assert!(
             daemon.contains(required),

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -538,6 +538,10 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
         "remove_locator_if_matches",
         "openengine.cluster/v1",
         "zeroshot.daemon/v1",
+        "zeroshot.daemon/v1/client-auth",
+        "zeroshot.daemon/v1/server-auth",
+        "ConnectionPurpose::Liveness",
+        "expectation.verify",
     ] {
         assert!(
             daemon.contains(required),

--- a/zeroshot-rust/tests/backend_boundary.rs
+++ b/zeroshot-rust/tests/backend_boundary.rs
@@ -118,17 +118,13 @@ async fn valid_unsupported_operations_reach_backend_defaults() {
 
 struct FakeFactory;
 
-struct FakeBackend {
-    route: String,
-}
+struct FakeBackend;
 
 impl NativeBackendFactory for FakeFactory {
     type Backend = FakeBackend;
 
-    fn create(&self, context: &ConnectionContext) -> Self::Backend {
-        FakeBackend {
-            route: context.identity().tenant().as_str().to_owned(),
-        }
+    fn create(&self) -> Self::Backend {
+        FakeBackend
     }
 }
 
@@ -147,19 +143,19 @@ impl ClusterBackend for FakeBackend {
 
     async fn get(
         &self,
-        _context: &ConnectionContext,
+        context: &ConnectionContext,
         _params: GetParams,
     ) -> Result<GetResult, BackendError> {
         Ok(GetResult {
             spec: None,
             status: ClusterStatus::empty(),
-            at_cursor: Some(Cursor::new(self.route.clone())),
+            at_cursor: Some(Cursor::new(context.identity().tenant().as_str())),
         })
     }
 }
 
 #[tokio::test]
-async fn factory_injection_composes_the_selected_backend_with_its_route() {
+async fn factory_injection_composes_the_selected_backend_with_an_injected_route() {
     let context = ConnectionContext::new(
         ConnectionIdentity::new(ConnectionIdentityConfig {
             principal: PrincipalId::new("principal-7"),

--- a/zeroshot-rust/tests/daemon_auth.rs
+++ b/zeroshot-rust/tests/daemon_auth.rs
@@ -1,0 +1,131 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+#[path = "support/daemon.rs"]
+mod daemon_support;
+
+use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Error as WebSocketError;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use zeroshot_engine::daemon_auth::{
+    AUTHORIZATION_HEADER, DAEMON_NONCE_HEADER, DAEMON_ROUTE, PROFILE_DIGEST_HEADER,
+    DaemonCredentials, authorize_request,
+};
+use zeroshot_engine::daemon_listener::{DaemonListener, ListenerConfig};
+
+#[test]
+fn credentials_are_256_bit_capabilities_with_exact_request_values() {
+    let profile_digest = "a".repeat(64);
+    let first = DaemonCredentials::generate(&profile_digest).expect("first credentials");
+    assert_eq!(first.capability.len(), 64);
+    assert!(first.capability.bytes().all(|byte| byte.is_ascii_hexdigit()));
+
+    let mut request = "ws://127.0.0.1:31001/daemon/initialize"
+        .into_client_request()
+        .expect("request");
+    first.apply_to_request(&mut request).expect("headers");
+    assert!(authorize_request(&request, &first));
+
+    request
+        .headers_mut()
+        .append(PROFILE_DIGEST_HEADER, profile_digest.parse().expect("header"));
+    assert!(!authorize_request(&request, &first));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_stale_profile_nonce_and_route_are_indistinguishable_before_backend_access() {
+    let profile = TempProfile::new("auth-rejections");
+    let factory = CountingFactory::default();
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        factory.clone(),
+        ListenerConfig {
+            handshake_timeout: Duration::from_millis(200),
+            ..ListenerConfig::default()
+        },
+    )
+    .await
+    .expect("start daemon");
+    let locator = listener.locator().clone();
+    let valid = locator_credentials(&locator);
+
+    let mut cases = Vec::new();
+    let mut wrong_capability = valid.clone();
+    wrong_capability.capability = "0".repeat(64);
+    cases.push((DAEMON_ROUTE.to_owned(), wrong_capability));
+    let mut wrong_profile = valid.clone();
+    wrong_profile.profile_digest = "1".repeat(64);
+    cases.push((DAEMON_ROUTE.to_owned(), wrong_profile));
+    let mut wrong_nonce = valid.clone();
+    wrong_nonce.daemon_nonce = "2".repeat(64);
+    cases.push((DAEMON_ROUTE.to_owned(), wrong_nonce));
+    cases.push(("/other".to_owned(), valid.clone()));
+
+    let address = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|rest| rest.strip_suffix(DAEMON_ROUTE))
+        .expect("loopback endpoint")
+        .to_owned();
+    let mut rejection_shapes = Vec::new();
+    for (route, credentials) in cases {
+        let mut request = format!("ws://{address}{route}")
+            .into_client_request()
+            .expect("request");
+        credentials.apply_to_request(&mut request).expect("headers");
+        let stream = TcpStream::connect(&address).await.expect("loopback connect");
+        let error = tokio_tungstenite::client_async(request, stream)
+            .await
+            .expect_err("authorization must reject");
+        let WebSocketError::Http(response) = error else {
+            panic!("expected uniform HTTP rejection, got {error:?}");
+        };
+        rejection_shapes.push((response.status(), response.body().clone()));
+    }
+
+    assert!(
+        rejection_shapes
+            .iter()
+            .all(|shape| shape == &rejection_shapes[0]),
+        "rejections must be indistinguishable: {rejection_shapes:?}"
+    );
+    assert_eq!(rejection_shapes[0].0, StatusCode::NOT_FOUND);
+    assert_eq!(factory.created.load(Ordering::SeqCst), 0);
+    assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
+
+    let response = authenticated_initialize(&locator).await;
+    assert_eq!(response["result"]["protocolVersion"], "openengine.cluster/v1");
+    assert_eq!(factory.created.load(Ordering::SeqCst), 1);
+    assert_eq!(factory.initialized.load(Ordering::SeqCst), 1);
+    listener.shutdown().await.expect("shutdown daemon");
+}
+
+#[test]
+fn missing_and_malformed_authorization_headers_fail_the_same_predicate() {
+    let credentials = DaemonCredentials {
+        profile_digest: "3".repeat(64),
+        daemon_nonce: "4".repeat(64),
+        capability: "5".repeat(64),
+    };
+    let mut request = "ws://127.0.0.1:31002/daemon/initialize"
+        .into_client_request()
+        .expect("request");
+    request.headers_mut().insert(
+        PROFILE_DIGEST_HEADER,
+        credentials.profile_digest.parse().expect("profile"),
+    );
+    request.headers_mut().insert(
+        DAEMON_NONCE_HEADER,
+        credentials.daemon_nonce.parse().expect("nonce"),
+    );
+    assert!(!authorize_request(&request, &credentials));
+    request.headers_mut().insert(
+        AUTHORIZATION_HEADER,
+        format!("bearer {}", credentials.capability)
+            .parse()
+            .expect("authorization"),
+    );
+    assert!(!authorize_request(&request, &credentials));
+}

--- a/zeroshot-rust/tests/daemon_auth.rs
+++ b/zeroshot-rust/tests/daemon_auth.rs
@@ -21,7 +21,9 @@ use zeroshot_engine::daemon_auth::{
     DaemonCredentials, authorize_request,
 };
 use zeroshot_engine::daemon_discovery::{CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator};
-use zeroshot_engine::daemon_listener::{DaemonListener, ListenerConfig, probe_liveness};
+use zeroshot_engine::daemon_listener::{
+    DaemonListener, ListenerConfig, LivenessOutcome, probe_liveness,
+};
 
 #[test]
 fn credentials_are_256_bit_capabilities_with_exact_request_values() {
@@ -227,7 +229,10 @@ async fn stale_port_cannot_learn_secrets_or_forge_server_liveness_by_reflection(
         }
     });
 
-    assert!(!probe_liveness(&locator, Duration::from_millis(250)).await);
+    assert_eq!(
+        probe_liveness(&locator, Duration::from_millis(250)).await,
+        LivenessOutcome::DefinitelyStale
+    );
     let exposed_headers = captured_rx.await.expect("captured proof request");
     assert!(exposed_headers.iter().all(|value| {
         !value

--- a/zeroshot-rust/tests/daemon_auth.rs
+++ b/zeroshot-rust/tests/daemon_auth.rs
@@ -1,26 +1,39 @@
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+use futures_util::{SinkExt, StreamExt};
+
 #[path = "support/daemon.rs"]
 mod daemon_support;
 
 use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
 use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use tokio_tungstenite::accept_hdr_async;
 use tokio_tungstenite::tungstenite::Error as WebSocketError;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::handshake::server::{Callback, ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::protocol::Message;
 use zeroshot_engine::daemon_auth::{
-    AUTHORIZATION_HEADER, DAEMON_NONCE_HEADER, DAEMON_ROUTE, PROFILE_DIGEST_HEADER,
+    AUTHORIZATION_HEADER, DAEMON_ROUTE, PROFILE_DIGEST_HEADER, SERVER_PROOF_HEADER,
     DaemonCredentials, authorize_request,
 };
-use zeroshot_engine::daemon_listener::{DaemonListener, ListenerConfig};
+use zeroshot_engine::daemon_discovery::{CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator};
+use zeroshot_engine::daemon_listener::{DaemonListener, ListenerConfig, probe_liveness};
 
 #[test]
 fn credentials_are_256_bit_capabilities_with_exact_request_values() {
     let profile_digest = "a".repeat(64);
     let first = DaemonCredentials::generate(&profile_digest).expect("first credentials");
     assert_eq!(first.capability.len(), 64);
-    assert!(first.capability.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    assert!(
+        first
+            .capability
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    );
 
     let mut request = "ws://127.0.0.1:31001/daemon/initialize"
         .into_client_request()
@@ -28,9 +41,10 @@ fn credentials_are_256_bit_capabilities_with_exact_request_values() {
     first.apply_to_request(&mut request).expect("headers");
     assert!(authorize_request(&request, &first));
 
-    request
-        .headers_mut()
-        .append(PROFILE_DIGEST_HEADER, profile_digest.parse().expect("header"));
+    request.headers_mut().append(
+        PROFILE_DIGEST_HEADER,
+        profile_digest.parse().expect("header"),
+    );
     assert!(!authorize_request(&request, &first));
 }
 
@@ -75,7 +89,9 @@ async fn wrong_stale_profile_nonce_and_route_are_indistinguishable_before_backen
             .into_client_request()
             .expect("request");
         credentials.apply_to_request(&mut request).expect("headers");
-        let stream = TcpStream::connect(&address).await.expect("loopback connect");
+        let stream = TcpStream::connect(&address)
+            .await
+            .expect("loopback connect");
         let error = tokio_tungstenite::client_async(request, stream)
             .await
             .expect_err("authorization must reject");
@@ -96,7 +112,10 @@ async fn wrong_stale_profile_nonce_and_route_are_indistinguishable_before_backen
     assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
 
     let response = authenticated_initialize(&locator).await;
-    assert_eq!(response["result"]["protocolVersion"], "openengine.cluster/v1");
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        "openengine.cluster/v1"
+    );
     assert_eq!(factory.created.load(Ordering::SeqCst), 1);
     assert_eq!(factory.initialized.load(Ordering::SeqCst), 1);
     listener.shutdown().await.expect("shutdown daemon");
@@ -112,14 +131,8 @@ fn missing_and_malformed_authorization_headers_fail_the_same_predicate() {
     let mut request = "ws://127.0.0.1:31002/daemon/initialize"
         .into_client_request()
         .expect("request");
-    request.headers_mut().insert(
-        PROFILE_DIGEST_HEADER,
-        credentials.profile_digest.parse().expect("profile"),
-    );
-    request.headers_mut().insert(
-        DAEMON_NONCE_HEADER,
-        credentials.daemon_nonce.parse().expect("nonce"),
-    );
+    credentials.apply_to_request(&mut request).expect("headers");
+    request.headers_mut().remove(AUTHORIZATION_HEADER);
     assert!(!authorize_request(&request, &credentials));
     request.headers_mut().insert(
         AUTHORIZATION_HEADER,
@@ -128,4 +141,102 @@ fn missing_and_malformed_authorization_headers_fail_the_same_predicate() {
             .expect("authorization"),
     );
     assert!(!authorize_request(&request, &credentials));
+}
+
+struct ReflectingImpostor {
+    captured: oneshot::Sender<Vec<Vec<u8>>>,
+}
+
+impl Callback for ReflectingImpostor {
+    fn on_request(
+        self,
+        request: &Request,
+        mut response: Response,
+    ) -> Result<Response, ErrorResponse> {
+        let headers = request
+            .headers()
+            .iter()
+            .map(|(_, value)| value.as_bytes().to_vec())
+            .collect();
+        let authorization = request
+            .headers()
+            .get(AUTHORIZATION_HEADER)
+            .expect("client proof")
+            .to_str()
+            .expect("ASCII client proof");
+        let reflected = authorization
+            .strip_prefix("Zeroshot-HMAC ")
+            .expect("proof prefix");
+        response.headers_mut().insert(
+            SERVER_PROOF_HEADER,
+            HeaderValue::from_str(reflected).expect("reflected proof"),
+        );
+        let _ = self.captured.send(headers);
+        Ok(response)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_port_cannot_learn_secrets_or_forge_server_liveness_by_reflection() {
+    let profile = TempProfile::new("mutual-proof");
+    let credentials =
+        DaemonCredentials::generate(profile.profile.digest()).expect("locator credentials");
+    let impostor = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("impostor listener");
+    let address = impostor.local_addr().expect("impostor address");
+    let locator = DaemonLocator {
+        endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
+        cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+        daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+        profile_digest: credentials.profile_digest.clone(),
+        daemon_nonce: credentials.daemon_nonce.clone(),
+        capability: credentials.capability.clone(),
+    };
+    let (captured_tx, captured_rx) = oneshot::channel();
+    let impostor_task = tokio::spawn(async move {
+        let (stream, _) = impostor.accept().await.expect("probe connection");
+        let mut websocket = accept_hdr_async(
+            stream,
+            ReflectingImpostor {
+                captured: captured_tx,
+            },
+        )
+        .await
+        .expect("impostor upgrade");
+        if let Ok(Some(Ok(Message::Text(_)))) =
+            timeout(Duration::from_millis(100), websocket.next()).await
+        {
+            websocket
+                .send(Message::Text(
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": "daemon-liveness",
+                        "result": {
+                            "protocolVersion": "openengine.cluster/v1",
+                            "capabilities": {},
+                            "status": {}
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .expect("forged initialize response");
+        }
+    });
+
+    assert!(!probe_liveness(&locator, Duration::from_millis(250)).await);
+    let exposed_headers = captured_rx.await.expect("captured proof request");
+    assert!(exposed_headers.iter().all(|value| {
+        !value
+            .windows(credentials.capability.len())
+            .any(|window| window == credentials.capability.as_bytes())
+    }));
+    assert!(exposed_headers.iter().all(|value| {
+        !value
+            .windows(credentials.daemon_nonce.len())
+            .any(|window| window == credentials.daemon_nonce.as_bytes())
+    }));
+    impostor_task.await.expect("impostor task");
 }

--- a/zeroshot-rust/tests/daemon_auth.rs
+++ b/zeroshot-rust/tests/daemon_auth.rs
@@ -49,7 +49,7 @@ fn credentials_are_256_bit_capabilities_with_exact_request_values() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn wrong_stale_profile_nonce_and_route_are_indistinguishable_before_backend_access() {
+async fn wrong_stale_profile_nonce_route_and_query_are_neutral_before_backend_access() {
     let profile = TempProfile::new("auth-rejections");
     let factory = CountingFactory::default();
     let listener = DaemonListener::start_with_config(
@@ -76,6 +76,7 @@ async fn wrong_stale_profile_nonce_and_route_are_indistinguishable_before_backen
     wrong_nonce.daemon_nonce = "2".repeat(64);
     cases.push((DAEMON_ROUTE.to_owned(), wrong_nonce));
     cases.push(("/other".to_owned(), valid.clone()));
+    cases.push((format!("{DAEMON_ROUTE}?probe=1"), valid.clone()));
 
     let address = locator
         .endpoint

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -1,0 +1,103 @@
+use std::fs;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::time::Duration;
+
+#[path = "support/temp_profile.rs"]
+mod temp_profile;
+
+use temp_profile::TempProfile;
+use zeroshot_engine::daemon_auth::DaemonCredentials;
+use zeroshot_engine::daemon_discovery::{
+    CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, DiscoveryError, MAX_LOCATOR_BYTES,
+    acquire_start_guard, read_locator, remove_locator_if_matches, replace_locator,
+};
+
+fn locator(profile: &TempProfile, port: u16) -> DaemonLocator {
+    let credentials = DaemonCredentials::generate(profile.profile.digest()).expect("credentials");
+    DaemonLocator {
+        endpoint: format!("ws://127.0.0.1:{port}/daemon/initialize"),
+        cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+        daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+        profile_digest: credentials.profile_digest,
+        daemon_nonce: credentials.daemon_nonce,
+        capability: credentials.capability,
+    }
+}
+
+#[test]
+fn atomic_rotation_is_owner_only_and_old_owner_cannot_remove_winner() {
+    let profile = TempProfile::new("atomic-rotation");
+    let first = locator(&profile, 30101);
+    let winner = locator(&profile, 30102);
+
+    replace_locator(&profile.profile, &first).expect("publish first locator");
+    replace_locator(&profile.profile, &winner).expect("rotate locator");
+
+    let metadata = fs::metadata(profile.profile.locator_path()).expect("locator metadata");
+    assert_eq!(metadata.mode() & 0o777, 0o600);
+    assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
+    assert!(!remove_locator_if_matches(&profile.profile, &first).expect("old owner removal"));
+    assert_eq!(read_locator(&profile.profile).expect("read locator"), Some(winner.clone()));
+    assert!(remove_locator_if_matches(&profile.profile, &winner).expect("winner removal"));
+    assert_eq!(read_locator(&profile.profile).expect("locator absent"), None);
+}
+
+#[test]
+fn locator_permissions_and_profile_permissions_fail_closed() {
+    let profile = TempProfile::new("permissions");
+    let current = locator(&profile, 30201);
+    replace_locator(&profile.profile, &current).expect("publish locator");
+
+    fs::set_permissions(
+        profile.profile.locator_path(),
+        fs::Permissions::from_mode(0o640),
+    )
+    .expect("weaken locator permissions");
+    assert!(matches!(
+        read_locator(&profile.profile),
+        Err(DiscoveryError::InsecureFile)
+    ));
+
+    fs::set_permissions(profile.profile.root(), fs::Permissions::from_mode(0o750))
+        .expect("weaken profile permissions");
+    assert!(matches!(
+        read_locator(&profile.profile),
+        Err(DiscoveryError::InsecureProfileDirectory)
+    ));
+}
+
+#[test]
+fn oversized_locator_is_rejected_without_partial_parsing() {
+    let profile = TempProfile::new("oversize");
+    let _guard = acquire_start_guard(&profile.profile, Duration::from_secs(1)).expect("profile dir");
+    fs::write(
+        profile.profile.locator_path(),
+        vec![b'x'; MAX_LOCATOR_BYTES as usize + 1],
+    )
+    .expect("oversized locator");
+    fs::set_permissions(
+        profile.profile.locator_path(),
+        fs::Permissions::from_mode(0o600),
+    )
+    .expect("owner-only oversized locator");
+
+    assert!(matches!(
+        read_locator(&profile.profile),
+        Err(DiscoveryError::LocatorTooLarge)
+    ));
+}
+
+#[test]
+fn profile_start_serialization_has_a_bounded_loser() {
+    let profile = TempProfile::new("start-lock");
+    let _owner = acquire_start_guard(&profile.profile, Duration::from_secs(1)).expect("lock owner");
+    let contender_profile = profile.profile.clone();
+    let contender = std::thread::spawn(move || {
+        acquire_start_guard(&contender_profile, Duration::from_millis(20)).map(drop)
+    });
+
+    assert!(matches!(
+        contender.join().expect("contender thread"),
+        Err(DiscoveryError::StartupLockTimeout)
+    ));
+}

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -71,6 +71,36 @@ fn atomic_rotation_is_owner_only_and_old_owner_cannot_remove_winner() {
 }
 
 #[test]
+fn reader_opened_before_matching_removal_retains_complete_prior_locator() {
+    let profile = TempProfile::new("reader-removal-race");
+    let current = locator(&profile, 30103);
+    replace_locator(&profile.profile, &current).expect("publish locator");
+    let mut opened_before_removal =
+        fs::File::open(profile.profile.locator_path()).expect("open locator");
+
+    assert!(remove_locator_if_matches(&profile.profile, &current).expect("matching removal"));
+    assert_eq!(
+        opened_before_removal
+            .metadata()
+            .expect("opened metadata")
+            .nlink(),
+        0
+    );
+    let mut bytes = Vec::new();
+    opened_before_removal
+        .read_to_end(&mut bytes)
+        .expect("read unlinked prior locator");
+    assert_eq!(
+        serde_json::from_slice::<DaemonLocator>(&bytes).expect("complete prior locator"),
+        current
+    );
+    assert_eq!(
+        read_locator(&profile.profile).expect("locator absent"),
+        None
+    );
+}
+
+#[test]
 fn locator_permissions_and_profile_permissions_fail_closed() {
     let profile = TempProfile::new("permissions");
     let current = locator(&profile, 30201);

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -1,5 +1,7 @@
 use std::fs;
+use std::io::Read;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::sync::mpsc;
 use std::time::Duration;
 
 #[path = "support/temp_profile.rs"]
@@ -31,15 +33,41 @@ fn atomic_rotation_is_owner_only_and_old_owner_cannot_remove_winner() {
     let winner = locator(&profile, 30102);
 
     replace_locator(&profile.profile, &first).expect("publish first locator");
+    let path = profile.profile.locator_path();
+    let (opened_tx, opened_rx) = mpsc::sync_channel(0);
+    let (rotated_tx, rotated_rx) = mpsc::sync_channel(0);
+    let reader = std::thread::spawn(move || {
+        let mut opened_before_rotation = fs::File::open(path).expect("open old locator");
+        opened_tx.send(()).expect("signal opened locator");
+        rotated_rx.recv().expect("wait for rotation");
+        let mut bytes = Vec::new();
+        opened_before_rotation
+            .read_to_end(&mut bytes)
+            .expect("read opened locator");
+        serde_json::from_slice::<DaemonLocator>(&bytes).expect("complete old locator")
+    });
+    opened_rx.recv().expect("reader opened old locator");
     replace_locator(&profile.profile, &winner).expect("rotate locator");
+    rotated_tx.send(()).expect("release reader");
+    assert_eq!(
+        reader.join().expect("reader thread"),
+        first,
+        "an open reader must retain the complete pre-rotation inode"
+    );
 
     let metadata = fs::metadata(profile.profile.locator_path()).expect("locator metadata");
     assert_eq!(metadata.mode() & 0o777, 0o600);
     assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
     assert!(!remove_locator_if_matches(&profile.profile, &first).expect("old owner removal"));
-    assert_eq!(read_locator(&profile.profile).expect("read locator"), Some(winner.clone()));
+    assert_eq!(
+        read_locator(&profile.profile).expect("read locator"),
+        Some(winner.clone())
+    );
     assert!(remove_locator_if_matches(&profile.profile, &winner).expect("winner removal"));
-    assert_eq!(read_locator(&profile.profile).expect("locator absent"), None);
+    assert_eq!(
+        read_locator(&profile.profile).expect("locator absent"),
+        None
+    );
 }
 
 #[test]
@@ -69,7 +97,8 @@ fn locator_permissions_and_profile_permissions_fail_closed() {
 #[test]
 fn oversized_locator_is_rejected_without_partial_parsing() {
     let profile = TempProfile::new("oversize");
-    let _guard = acquire_start_guard(&profile.profile, Duration::from_secs(1)).expect("profile dir");
+    let _guard =
+        acquire_start_guard(&profile.profile, Duration::from_secs(1)).expect("profile dir");
     fs::write(
         profile.profile.locator_path(),
         vec![b'x'; MAX_LOCATOR_BYTES as usize + 1],

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::Read;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -151,6 +151,49 @@ fn same_owner_hard_links_fail_closed_for_locator_and_startup_lock() {
     assert_eq!(lock_metadata.nlink(), 2);
     assert!(matches!(
         acquire_start_guard(&profile.profile, Duration::from_millis(20)),
+        Err(DiscoveryError::InsecureFile)
+    ));
+}
+
+#[test]
+fn same_owner_symbolic_links_fail_closed_for_locator_and_startup_lock() {
+    let locator_profile = TempProfile::new("locator-symlink");
+    let current = locator(&locator_profile, 30203);
+    replace_locator(&locator_profile.profile, &current).expect("publish locator");
+    let locator_target = locator_profile
+        .profile
+        .root()
+        .join("locator-symlink-target");
+    fs::rename(locator_profile.profile.locator_path(), &locator_target)
+        .expect("move locator to same-owner target");
+    symlink(&locator_target, locator_profile.profile.locator_path()).expect("symlink locator path");
+    let target_metadata = fs::metadata(&locator_target).expect("locator target metadata");
+    assert_eq!(target_metadata.mode() & 0o777, 0o600);
+    assert_eq!(target_metadata.uid(), unsafe { libc::geteuid() });
+    assert_eq!(target_metadata.nlink(), 1);
+    assert!(matches!(
+        read_locator(&locator_profile.profile),
+        Err(DiscoveryError::InsecureFile)
+    ));
+
+    let lock_profile = TempProfile::new("startup-lock-symlink");
+    drop(
+        acquire_start_guard(&lock_profile.profile, Duration::from_secs(1))
+            .expect("create startup lock"),
+    );
+    let lock_path = lock_profile.profile.root().join(".daemon-start.lock");
+    let lock_target = lock_profile
+        .profile
+        .root()
+        .join("startup-lock-symlink-target");
+    fs::rename(&lock_path, &lock_target).expect("move startup lock to same-owner target");
+    symlink(&lock_target, &lock_path).expect("symlink startup lock path");
+    let target_metadata = fs::metadata(&lock_target).expect("startup lock target metadata");
+    assert_eq!(target_metadata.mode() & 0o777, 0o600);
+    assert_eq!(target_metadata.uid(), unsafe { libc::geteuid() });
+    assert_eq!(target_metadata.nlink(), 1);
+    assert!(matches!(
+        acquire_start_guard(&lock_profile.profile, Duration::from_millis(20)),
         Err(DiscoveryError::InsecureFile)
     ));
 }

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -95,6 +95,37 @@ fn locator_permissions_and_profile_permissions_fail_closed() {
 }
 
 #[test]
+fn same_owner_hard_links_fail_closed_for_locator_and_startup_lock() {
+    let profile = TempProfile::new("hard-links");
+    let current = locator(&profile, 30202);
+    replace_locator(&profile.profile, &current).expect("publish locator");
+
+    let locator_alias = profile.profile.root().join("locator-hard-link");
+    fs::hard_link(profile.profile.locator_path(), &locator_alias).expect("hard-link locator");
+    let locator_metadata = fs::metadata(profile.profile.locator_path()).expect("locator metadata");
+    assert_eq!(locator_metadata.mode() & 0o777, 0o600);
+    assert_eq!(locator_metadata.uid(), unsafe { libc::geteuid() });
+    assert_eq!(locator_metadata.nlink(), 2);
+    assert!(matches!(
+        read_locator(&profile.profile),
+        Err(DiscoveryError::InsecureFile)
+    ));
+    fs::remove_file(locator_alias).expect("remove locator hard link");
+
+    let lock_path = profile.profile.root().join(".daemon-start.lock");
+    let lock_alias = profile.profile.root().join("startup-lock-hard-link");
+    fs::hard_link(&lock_path, &lock_alias).expect("hard-link startup lock");
+    let lock_metadata = fs::metadata(&lock_path).expect("lock metadata");
+    assert_eq!(lock_metadata.mode() & 0o777, 0o600);
+    assert_eq!(lock_metadata.uid(), unsafe { libc::geteuid() });
+    assert_eq!(lock_metadata.nlink(), 2);
+    assert!(matches!(
+        acquire_start_guard(&profile.profile, Duration::from_millis(20)),
+        Err(DiscoveryError::InsecureFile)
+    ));
+}
+
+#[test]
 fn oversized_locator_is_rejected_without_partial_parsing() {
     let profile = TempProfile::new("oversize");
     let _guard =

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -1,0 +1,193 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+#[path = "support/daemon.rs"]
+mod daemon_support;
+
+use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{Instant, timeout};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use zeroshot_engine::daemon_auth::{DAEMON_ROUTE, DaemonCredentials};
+use zeroshot_engine::daemon_discovery::{
+    CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, read_locator, replace_locator,
+};
+use zeroshot_engine::daemon_listener::{DaemonListener, DaemonListenerError, ListenerConfig};
+
+fn test_config() -> ListenerConfig {
+    ListenerConfig {
+        startup_lock_timeout: Duration::from_millis(500),
+        liveness_timeout: Duration::from_millis(150),
+        handshake_timeout: Duration::from_millis(200),
+        drain_timeout: Duration::from_millis(80),
+        max_active_connections: 8,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
+    let profile = TempProfile::new("concurrent-start");
+    let factory = CountingFactory::default();
+    let first = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        factory.clone(),
+        test_config(),
+    );
+    let second = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        factory.clone(),
+        test_config(),
+    );
+    let (first, second) = tokio::join!(first, second);
+
+    let (owner, loser) = match (first, second) {
+        (Ok(owner), Err(loser)) | (Err(loser), Ok(owner)) => (owner, loser),
+        _ => panic!("expected exactly one owner and one loser"),
+    };
+    assert!(matches!(loser, DaemonListenerError::AlreadyRunning));
+    assert_eq!(
+        read_locator(&profile.profile).expect("read owner locator"),
+        Some(owner.locator().clone())
+    );
+    assert!(factory.initialized.load(Ordering::SeqCst) >= 1);
+
+    let response = authenticated_initialize(owner.locator()).await;
+    assert_eq!(response["result"]["protocolVersion"], "openengine.cluster/v1");
+    owner.shutdown().await.expect("owner shutdown");
+    assert_eq!(read_locator(&profile.profile).expect("locator removed"), None);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn open_port_without_authenticated_initialize_is_stale_and_rotated() {
+    let profile = TempProfile::new("initialize-only-liveness");
+    let impostor = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .await
+        .expect("impostor listener");
+    let impostor_address = impostor.local_addr().expect("impostor address");
+    let impostor_task = tokio::spawn(async move {
+        if let Ok((socket, _)) = impostor.accept().await {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            drop(socket);
+        }
+    });
+    let stale_credentials = DaemonCredentials::generate(profile.profile.digest()).expect("stale");
+    let stale = DaemonLocator {
+        endpoint: format!("ws://{impostor_address}{DAEMON_ROUTE}"),
+        cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+        daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+        profile_digest: stale_credentials.profile_digest,
+        daemon_nonce: stale_credentials.daemon_nonce,
+        capability: stale_credentials.capability,
+    };
+    replace_locator(&profile.profile, &stale).expect("publish stale locator");
+
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        test_config(),
+    )
+    .await
+    .expect("replace unauthenticated port");
+    assert_ne!(listener.locator().endpoint, stale.endpoint);
+    assert_ne!(listener.locator().capability, stale.capability);
+    assert_ne!(listener.locator().daemon_nonce, stale.daemon_nonce);
+    impostor_task.abort();
+    let _ = impostor_task.await;
+    listener.shutdown().await.expect("shutdown replacement");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_owner_locator() {
+    let profile = TempProfile::new("bounded-shutdown");
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        test_config(),
+    )
+    .await
+    .expect("start listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("request");
+    credentials.apply_to_request(&mut request).expect("credentials");
+    let address: SocketAddr = request
+        .uri()
+        .authority()
+        .expect("authority")
+        .as_str()
+        .parse()
+        .expect("socket address");
+    let stream = TcpStream::connect(address).await.expect("connect");
+    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authorized idle connection");
+
+    let started = Instant::now();
+    listener.shutdown().await.expect("bounded shutdown");
+    assert!(started.elapsed() < Duration::from_millis(500));
+    assert_eq!(read_locator(&profile.profile).expect("locator state"), None);
+    let rebound = TcpListener::bind(address).await.expect("listener released");
+    drop(rebound);
+    let ended = timeout(Duration::from_millis(200), websocket.next())
+        .await
+        .expect("idle connection terminated");
+    if let Some(Ok(message)) = ended {
+        assert!(message.is_close());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn crash_leaves_stale_locator_that_next_owner_cleans_without_reusing_secrets() {
+    let profile = TempProfile::new("crash-handoff");
+    let crashed = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        test_config(),
+    )
+    .await
+    .expect("start crashed listener");
+    let stale = crashed.locator().clone();
+    let stale_address: SocketAddr = stale
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("stale endpoint")
+        .parse()
+        .expect("stale address");
+    drop(crashed);
+    timeout(Duration::from_millis(200), async {
+        loop {
+            match TcpStream::connect(stale_address).await {
+                Ok(stream) => {
+                    drop(stream);
+                    tokio::task::yield_now().await;
+                }
+                Err(_) => break,
+            }
+        }
+    })
+    .await
+    .expect("crashed listener released");
+
+    let replacement = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        test_config(),
+    )
+    .await
+    .expect("clean stale crash locator");
+    assert_ne!(replacement.locator().endpoint, stale.endpoint);
+    assert_ne!(replacement.locator().capability, stale.capability);
+    assert_ne!(replacement.locator().daemon_nonce, stale.daemon_nonce);
+    assert_eq!(
+        read_locator(&profile.profile).expect("replacement locator"),
+        Some(replacement.locator().clone())
+    );
+    replacement.shutdown().await.expect("replacement shutdown");
+}

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -381,6 +381,20 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
         .as_object_mut()
         .expect("result object")
         .remove("protocolVersion");
+    let mut missing_capabilities = valid.clone();
+    missing_capabilities["result"]
+        .as_object_mut()
+        .expect("result object")
+        .remove("capabilities");
+    let mut missing_status = valid.clone();
+    missing_status["result"]
+        .as_object_mut()
+        .expect("result object")
+        .remove("status");
+    let mut unknown_result_field = valid.clone();
+    unknown_result_field["result"]["unexpected"] = serde_json::json!(true);
+    let mut unknown_top_level_field = valid.clone();
+    unknown_top_level_field["unexpected"] = serde_json::json!(true);
     let mut result_and_error = valid.clone();
     result_and_error["error"] = serde_json::json!({"code": -32603, "message": "stale response"});
     let cases = vec![
@@ -447,6 +461,22 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
         ),
         ("wrong protocol", wrong_protocol.to_string(), false),
         ("missing protocol", missing_protocol.to_string(), false),
+        (
+            "missing capabilities",
+            missing_capabilities.to_string(),
+            false,
+        ),
+        ("missing status", missing_status.to_string(), false),
+        (
+            "unknown result field",
+            unknown_result_field.to_string(),
+            false,
+        ),
+        (
+            "unknown top-level field",
+            unknown_top_level_field.to_string(),
+            false,
+        ),
         ("result and error", result_and_error.to_string(), false),
         (
             "error only",

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -18,10 +18,11 @@ use zeroshot_engine::daemon_auth::{
     AuthorizationCallback, ConnectionPurpose, DAEMON_ROUTE, DaemonCredentials,
 };
 use zeroshot_engine::daemon_discovery::{
-    CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, read_locator, replace_locator,
+    CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, acquire_start_guard, read_locator,
+    replace_locator,
 };
 use zeroshot_engine::daemon_listener::{
-    DaemonListener, DaemonListenerError, ListenerConfig, probe_liveness,
+    DaemonListener, DaemonListenerError, ListenerConfig, LivenessOutcome, probe_liveness,
 };
 
 fn test_config() -> ListenerConfig {
@@ -33,6 +34,7 @@ fn test_config() -> ListenerConfig {
         shutdown_timeout: Duration::from_millis(300),
         max_active_connections: 8,
         max_pending_handshakes: 8,
+        max_liveness_connections: 2,
     }
 }
 
@@ -106,6 +108,21 @@ async fn raw_handshake_burst_owns_only_the_configured_pre_auth_bound() {
     })
     .await
     .expect("listener admitted bounded raw handshakes");
+    let incumbent = listener.locator().clone();
+    let contender = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::LivenessIndeterminate)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("preserved incumbent locator"),
+        Some(incumbent)
+    );
 
     for _ in 0..16 {
         if let Ok(mut socket) = TcpStream::connect(address).await {
@@ -241,6 +258,93 @@ async fn liveness_purpose_accepts_only_initialize_before_backend_access() {
     assert_eq!(factory.created.load(Ordering::SeqCst), 0);
     assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
     listener.shutdown().await.expect("shutdown listener");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn authenticated_liveness_burst_owns_only_its_reserved_capacity() {
+    let profile = TempProfile::new("liveness-capacity");
+    let config = ListenerConfig {
+        liveness_timeout: Duration::from_secs(2),
+        max_liveness_connections: 2,
+        ..test_config()
+    };
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await
+    .expect("start listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let address: SocketAddr = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("liveness endpoint")
+        .parse()
+        .expect("liveness address");
+
+    let mut held = Vec::new();
+    for _ in 0..config.max_liveness_connections {
+        let mut request = locator
+            .endpoint
+            .as_str()
+            .into_client_request()
+            .expect("liveness request");
+        let proof = credentials
+            .prepare_request(&mut request, ConnectionPurpose::Liveness)
+            .expect("liveness proof");
+        let stream = TcpStream::connect(address)
+            .await
+            .expect("liveness connection");
+        let (websocket, response) = tokio_tungstenite::client_async(request, stream)
+            .await
+            .expect("liveness upgrade");
+        assert!(proof.verify(&response));
+        held.push(websocket);
+    }
+    timeout(Duration::from_millis(200), async {
+        while listener.active_liveness_connections() != config.max_liveness_connections {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reserved liveness capacity filled");
+
+    let mut overflow_request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("overflow request");
+    let overflow_proof = credentials
+        .prepare_request(&mut overflow_request, ConnectionPurpose::Liveness)
+        .expect("overflow proof");
+    let overflow_stream = TcpStream::connect(address)
+        .await
+        .expect("overflow connection");
+    let (mut overflow, overflow_response) =
+        tokio_tungstenite::client_async(overflow_request, overflow_stream)
+            .await
+            .expect("authenticated overflow upgrade");
+    assert!(overflow_proof.verify(&overflow_response));
+    let ended = timeout(Duration::from_millis(200), overflow.next())
+        .await
+        .expect("overflow liveness rejected");
+    if let Some(Ok(message)) = ended {
+        assert!(message.is_close());
+    }
+    assert_eq!(
+        listener.active_liveness_connections(),
+        config.max_liveness_connections
+    );
+
+    drop(overflow);
+    drop(held);
+    timeout(Duration::from_millis(500), listener.shutdown())
+        .await
+        .expect("bounded liveness shutdown")
+        .expect("liveness shutdown");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -387,9 +491,14 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
     });
 
     for (name, _, expected) in &cases {
+        let expected = if *expected {
+            LivenessOutcome::Alive
+        } else {
+            LivenessOutcome::DefinitelyStale
+        };
         assert_eq!(
             probe_liveness(&locator, Duration::from_millis(250)).await,
-            *expected,
+            expected,
             "case: {name}"
         );
     }
@@ -400,7 +509,7 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn open_port_without_authenticated_initialize_is_stale_and_rotated() {
+async fn open_port_timeout_is_indeterminate_and_preserves_incumbent_locator() {
     let profile = TempProfile::new("initialize-only-liveness");
     let impostor = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .await
@@ -423,19 +532,22 @@ async fn open_port_without_authenticated_initialize_is_stale_and_rotated() {
     };
     replace_locator(&profile.profile, &stale).expect("publish stale locator");
 
-    let listener = DaemonListener::start_with_config(
+    let contender = DaemonListener::start_with_config(
         profile.profile.clone(),
         CountingFactory::default(),
         test_config(),
     )
-    .await
-    .expect("replace unauthenticated port");
-    assert_ne!(listener.locator().endpoint, stale.endpoint);
-    assert_ne!(listener.locator().capability, stale.capability);
-    assert_ne!(listener.locator().daemon_nonce, stale.daemon_nonce);
+    .await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::LivenessIndeterminate)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("preserved ambiguous locator"),
+        Some(stale)
+    );
     impostor_task.abort();
     let _ = impostor_task.await;
-    listener.shutdown().await.expect("shutdown replacement");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -488,6 +600,48 @@ async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_
     if let Some(Ok(message)) = ended {
         assert!(message.is_close());
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_absolute_deadline_bounds_matching_cleanup_lock_and_reports_timeout() {
+    let profile = TempProfile::new("shutdown-cleanup-deadline");
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        ListenerConfig {
+            shutdown_timeout: Duration::from_millis(60),
+            ..test_config()
+        },
+    )
+    .await
+    .expect("start listener");
+    let locator = listener.locator().clone();
+    let cleanup_blocker =
+        acquire_start_guard(&profile.profile, Duration::from_millis(100)).expect("hold lock");
+
+    let result = timeout(Duration::from_millis(200), listener.shutdown())
+        .await
+        .expect("shutdown respected absolute product deadline");
+    assert!(matches!(result, Err(DaemonListenerError::ShutdownTimeout)));
+    assert_eq!(
+        read_locator(&profile.profile).expect("locator preserved while cleanup blocked"),
+        Some(locator)
+    );
+
+    drop(cleanup_blocker);
+    timeout(Duration::from_millis(500), async {
+        loop {
+            if read_locator(&profile.profile)
+                .expect("eventual cleanup state")
+                .is_none()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed-out cleanup attempt completed after lock release");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -6,8 +6,11 @@ use futures_util::{SinkExt, StreamExt};
 #[path = "support/daemon.rs"]
 mod daemon_support;
 
-use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
+use daemon_support::{
+    CountingBackend, CountingFactory, TempProfile, authenticated_initialize, locator_credentials,
+};
 use openengine_cluster_protocol::{ClusterStatus, InitializeResult, ServerCapabilities};
+use openengine_cluster_server::ConnectionContext;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
@@ -24,6 +27,7 @@ use zeroshot_engine::daemon_discovery::{
 use zeroshot_engine::daemon_listener::{
     DaemonListener, DaemonListenerError, ListenerConfig, LivenessOutcome, probe_liveness,
 };
+use zeroshot_engine::NativeBackendFactory;
 
 fn test_config() -> ListenerConfig {
     ListenerConfig {
@@ -35,6 +39,17 @@ fn test_config() -> ListenerConfig {
         max_active_connections: 8,
         max_pending_handshakes: 8,
         max_liveness_connections: 2,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PanicFactory;
+
+impl NativeBackendFactory for PanicFactory {
+    type Backend = CountingBackend;
+
+    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+        panic!("controlled connection factory panic")
     }
 }
 
@@ -142,6 +157,103 @@ async fn raw_handshake_burst_owns_only_the_configured_pre_auth_bound() {
         .await
         .expect("bounded listener shutdown")
         .expect("listener shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn ordinary_session_overflow_closes_before_backend_construction_or_dispatch() {
+    let profile = TempProfile::new("active-session-bound");
+    let config = ListenerConfig {
+        max_active_connections: 1,
+        ..test_config()
+    };
+    let factory = CountingFactory::default();
+    let listener =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), config)
+            .await
+            .expect("start listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let address: SocketAddr = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("session endpoint")
+        .parse()
+        .expect("session address");
+
+    let mut first_request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("first session request");
+    let first_proof = credentials
+        .apply_to_request(&mut first_request)
+        .expect("first session proof");
+    let first_stream = TcpStream::connect(address)
+        .await
+        .expect("first session connection");
+    let (mut first, first_response) = tokio_tungstenite::client_async(first_request, first_stream)
+        .await
+        .expect("first session upgrade");
+    assert!(first_proof.verify(&first_response));
+    timeout(Duration::from_millis(200), async {
+        while listener.active_sessions() != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first session owns active slot");
+    first
+        .send(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "openengine.cluster/v1"}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("dispatch initialize");
+    let first_result = timeout(Duration::from_millis(200), first.next())
+        .await
+        .expect("bounded initialize")
+        .expect("initialize response")
+        .expect("valid initialize response");
+    assert!(matches!(first_result, Message::Text(_)));
+    assert_eq!(factory.created.load(Ordering::SeqCst), 1);
+    assert_eq!(factory.initialized.load(Ordering::SeqCst), 1);
+
+    let mut overflow_request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("overflow session request");
+    let overflow_proof = credentials
+        .apply_to_request(&mut overflow_request)
+        .expect("overflow session proof");
+    let overflow_stream = TcpStream::connect(address)
+        .await
+        .expect("overflow session connection");
+    let (mut overflow, overflow_response) =
+        tokio_tungstenite::client_async(overflow_request, overflow_stream)
+            .await
+            .expect("authenticated overflow upgrade");
+    assert!(overflow_proof.verify(&overflow_response));
+    let ended = timeout(Duration::from_millis(200), overflow.next())
+        .await
+        .expect("overflow session closed");
+    if let Some(Ok(message)) = ended {
+        assert!(message.is_close());
+    }
+    assert_eq!(listener.active_sessions(), 1);
+    assert_eq!(factory.created.load(Ordering::SeqCst), 1);
+    assert_eq!(factory.initialized.load(Ordering::SeqCst), 1);
+
+    drop(overflow);
+    drop(first);
+    listener.shutdown().await.expect("shutdown listener");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -311,6 +423,20 @@ async fn authenticated_liveness_burst_owns_only_its_reserved_capacity() {
     })
     .await
     .expect("reserved liveness capacity filled");
+    let contender = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::LivenessIndeterminate)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("preserved liveness owner"),
+        Some(locator.clone())
+    );
 
     let mut overflow_request = locator
         .endpoint
@@ -611,6 +737,13 @@ async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_
         .as_str()
         .parse()
         .expect("socket address");
+    assert_eq!(
+        TcpListener::bind(address)
+            .await
+            .expect_err("live listener keeps its port")
+            .kind(),
+        std::io::ErrorKind::AddrInUse
+    );
     let stream = TcpStream::connect(address).await.expect("connect");
     let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
         .await
@@ -672,6 +805,73 @@ async fn shutdown_absolute_deadline_bounds_matching_cleanup_lock_and_reports_tim
     })
     .await
     .expect("timed-out cleanup attempt completed after lock release");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connection_task_panic_releases_listener_and_shutdown_cleans_locator_with_task_error() {
+    let profile = TempProfile::new("connection-task-panic");
+    let listener =
+        DaemonListener::start_with_config(profile.profile.clone(), PanicFactory, test_config())
+            .await
+            .expect("start panic listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let address: SocketAddr = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("panic endpoint")
+        .parse()
+        .expect("panic address");
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("panic request");
+    let proof = credentials
+        .apply_to_request(&mut request)
+        .expect("panic authorization");
+    let stream = TcpStream::connect(address).await.expect("panic connection");
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authorized panic upgrade");
+    assert!(proof.verify(&response));
+    let ended = timeout(Duration::from_millis(300), websocket.next())
+        .await
+        .expect("panicked connection terminated");
+    if let Some(Ok(message)) = ended {
+        assert!(message.is_close());
+    }
+
+    timeout(Duration::from_millis(300), async {
+        loop {
+            match TcpListener::bind(address).await {
+                Ok(rebound) => {
+                    drop(rebound);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => panic!("unexpected rebind failure: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("panicked accept loop released listener");
+
+    assert!(matches!(
+        listener.shutdown().await,
+        Err(DaemonListenerError::Task)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("panic cleanup state"),
+        None
+    );
+    let rebound = TcpListener::bind(address)
+        .await
+        .expect("panic listener remains released");
+    drop(rebound);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -7,16 +7,22 @@ use futures_util::{SinkExt, StreamExt};
 mod daemon_support;
 
 use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
+use openengine_cluster_protocol::{ClusterStatus, InitializeResult, ServerCapabilities};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
+use tokio_tungstenite::accept_hdr_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::protocol::Message;
-use zeroshot_engine::daemon_auth::{ConnectionPurpose, DAEMON_ROUTE, DaemonCredentials};
+use zeroshot_engine::daemon_auth::{
+    AuthorizationCallback, ConnectionPurpose, DAEMON_ROUTE, DaemonCredentials,
+};
 use zeroshot_engine::daemon_discovery::{
     CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, read_locator, replace_locator,
 };
-use zeroshot_engine::daemon_listener::{DaemonListener, DaemonListenerError, ListenerConfig};
+use zeroshot_engine::daemon_listener::{
+    DaemonListener, DaemonListenerError, ListenerConfig, probe_liveness,
+};
 
 fn test_config() -> ListenerConfig {
     ListenerConfig {
@@ -175,6 +181,162 @@ async fn liveness_purpose_accepts_only_initialize_before_backend_access() {
     assert_eq!(factory.created.load(Ordering::SeqCst), 0);
     assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
     listener.shutdown().await.expect("shutdown listener");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
+    let profile = TempProfile::new("liveness-response");
+    let credentials =
+        DaemonCredentials::generate(profile.profile.digest()).expect("locator credentials");
+    let responder = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("stale responder");
+    let address = responder.local_addr().expect("responder address");
+    let locator = DaemonLocator {
+        endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
+        cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+        daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+        profile_digest: credentials.profile_digest.clone(),
+        daemon_nonce: credentials.daemon_nonce.clone(),
+        capability: credentials.capability.clone(),
+    };
+    let initialize_result = serde_json::to_value(InitializeResult::new(
+        ServerCapabilities::default(),
+        ClusterStatus::empty(),
+    ))
+    .expect("initialize result");
+    let valid = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "daemon-liveness",
+        "result": initialize_result.clone()
+    });
+    let mut wrong_protocol = valid.clone();
+    wrong_protocol["result"]["protocolVersion"] = serde_json::json!("other/v1");
+    let mut missing_protocol = valid.clone();
+    missing_protocol["result"]
+        .as_object_mut()
+        .expect("result object")
+        .remove("protocolVersion");
+    let mut result_and_error = valid.clone();
+    result_and_error["error"] = serde_json::json!({"code": -32603, "message": "stale response"});
+    let cases = vec![
+        ("valid", valid.to_string(), true),
+        (
+            "wrong id with correct result",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "other-request",
+                "result": initialize_result.clone()
+            })
+            .to_string(),
+            false,
+        ),
+        (
+            "missing id",
+            serde_json::json!({"jsonrpc": "2.0", "result": initialize_result.clone()}).to_string(),
+            false,
+        ),
+        (
+            "numeric id",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": initialize_result.clone()
+            })
+            .to_string(),
+            false,
+        ),
+        (
+            "wrong jsonrpc version",
+            serde_json::json!({
+                "jsonrpc": "1.0",
+                "id": "daemon-liveness",
+                "result": initialize_result.clone()
+            })
+            .to_string(),
+            false,
+        ),
+        (
+            "missing jsonrpc version",
+            serde_json::json!({
+                "id": "daemon-liveness",
+                "result": initialize_result.clone()
+            })
+            .to_string(),
+            false,
+        ),
+        ("top-level array", serde_json::json!([]).to_string(), false),
+        (
+            "missing result",
+            serde_json::json!({"jsonrpc": "2.0", "id": "daemon-liveness"}).to_string(),
+            false,
+        ),
+        (
+            "non-object result",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "daemon-liveness",
+                "result": null
+            })
+            .to_string(),
+            false,
+        ),
+        ("wrong protocol", wrong_protocol.to_string(), false),
+        ("missing protocol", missing_protocol.to_string(), false),
+        ("result and error", result_and_error.to_string(), false),
+        (
+            "error only",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "daemon-liveness",
+                "error": {"code": -32603, "message": "stale response"}
+            })
+            .to_string(),
+            false,
+        ),
+        ("malformed json", "{".to_owned(), false),
+    ];
+    let responses = cases
+        .iter()
+        .map(|(_, response, _)| response.clone())
+        .collect::<Vec<_>>();
+    let responder_task = tokio::spawn(async move {
+        for response in responses {
+            let (stream, _) = responder.accept().await.expect("probe connection");
+            let (callback, receipt) = AuthorizationCallback::new(credentials.clone());
+            let mut websocket = accept_hdr_async(stream, callback)
+                .await
+                .expect("authenticated responder");
+            assert_eq!(receipt.take(), Some(ConnectionPurpose::Liveness));
+            let request = timeout(Duration::from_millis(200), websocket.next())
+                .await
+                .expect("bounded initialize request")
+                .expect("initialize request")
+                .expect("valid initialize frame");
+            let Message::Text(request) = request else {
+                panic!("liveness request must be text");
+            };
+            let request: serde_json::Value =
+                serde_json::from_str(request.as_ref()).expect("initialize JSON");
+            assert_eq!(request["id"], "daemon-liveness");
+            websocket
+                .send(Message::Text(response.into()))
+                .await
+                .expect("stale response");
+        }
+    });
+
+    for (name, _, expected) in &cases {
+        assert_eq!(
+            probe_liveness(&locator, Duration::from_millis(250)).await,
+            *expected,
+            "case: {name}"
+        );
+    }
+    timeout(Duration::from_secs(4), responder_task)
+        .await
+        .expect("bounded responder matrix")
+        .expect("responder task");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -30,7 +30,9 @@ fn test_config() -> ListenerConfig {
         liveness_timeout: Duration::from_millis(150),
         handshake_timeout: Duration::from_millis(200),
         drain_timeout: Duration::from_millis(80),
+        shutdown_timeout: Duration::from_millis(300),
         max_active_connections: 8,
+        max_pending_handshakes: 8,
     }
 }
 
@@ -65,6 +67,64 @@ async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
         read_locator(&profile.profile).expect("locator removed"),
         None
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn raw_handshake_burst_owns_only_the_configured_pre_auth_bound() {
+    let profile = TempProfile::new("pre-auth-bound");
+    let config = ListenerConfig {
+        handshake_timeout: Duration::from_secs(2),
+        max_pending_handshakes: 2,
+        ..test_config()
+    };
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await
+    .expect("start listener");
+    let address: SocketAddr = listener
+        .locator()
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("listener endpoint")
+        .parse()
+        .expect("listener address");
+
+    let mut sockets = Vec::new();
+    for _ in 0..2 {
+        let mut socket = TcpStream::connect(address).await.expect("raw connection");
+        socket.write_all(b"G").await.expect("partial handshake");
+        sockets.push(socket);
+    }
+    timeout(Duration::from_millis(200), async {
+        while listener.pending_handshakes() != config.max_pending_handshakes {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("listener admitted bounded raw handshakes");
+
+    for _ in 0..16 {
+        if let Ok(mut socket) = TcpStream::connect(address).await {
+            let _ = socket.write_all(b"G").await;
+            sockets.push(socket);
+        }
+        assert!(
+            listener.pending_handshakes() <= config.max_pending_handshakes,
+            "accepted pre-auth ownership exceeded its finite bound"
+        );
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(listener.pending_handshakes(), config.max_pending_handshakes);
+
+    drop(sockets);
+    timeout(Duration::from_millis(500), listener.shutdown())
+        .await
+        .expect("bounded listener shutdown")
+        .expect("listener shutdown");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -384,7 +444,11 @@ async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_
     let listener = DaemonListener::start_with_config(
         profile.profile.clone(),
         CountingFactory::default(),
-        test_config(),
+        ListenerConfig {
+            drain_timeout: Duration::from_secs(2),
+            shutdown_timeout: Duration::from_millis(30),
+            ..test_config()
+        },
     )
     .await
     .expect("start listener");

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -53,6 +53,72 @@ impl NativeBackendFactory for PanicFactory {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zero_capacity_or_deadline_is_rejected_before_profile_or_listener_creation() {
+    let mut cases = Vec::new();
+
+    let mut config = test_config();
+    config.max_active_connections = 0;
+    cases.push(("active-capacity", config));
+    let mut config = test_config();
+    config.max_pending_handshakes = 0;
+    cases.push(("handshake-capacity", config));
+    let mut config = test_config();
+    config.max_liveness_connections = 0;
+    cases.push(("liveness-capacity", config));
+    let mut config = test_config();
+    config.startup_lock_timeout = Duration::ZERO;
+    cases.push(("startup-lock-deadline", config));
+    let mut config = test_config();
+    config.liveness_timeout = Duration::ZERO;
+    cases.push(("liveness-deadline", config));
+    let mut config = test_config();
+    config.handshake_timeout = Duration::ZERO;
+    cases.push(("handshake-deadline", config));
+    let mut config = test_config();
+    config.drain_timeout = Duration::ZERO;
+    cases.push(("drain-deadline", config));
+    let mut config = test_config();
+    config.shutdown_timeout = Duration::ZERO;
+    cases.push(("shutdown-deadline", config));
+
+    for (name, invalid) in cases {
+        let profile = TempProfile::new(name);
+        assert!(matches!(
+            DaemonListener::start_with_config(
+                profile.profile.clone(),
+                CountingFactory::default(),
+                invalid,
+            )
+            .await,
+            Err(DaemonListenerError::InvalidConfiguration)
+        ));
+        assert!(
+            !profile.profile.root().exists(),
+            "{name} created profile resources before validation"
+        );
+        assert_eq!(
+            read_locator(&profile.profile).expect("invalid config locator state"),
+            None
+        );
+
+        let valid = ListenerConfig {
+            max_active_connections: 1,
+            max_pending_handshakes: 1,
+            max_liveness_connections: 1,
+            ..test_config()
+        };
+        let listener = DaemonListener::start_with_config(
+            profile.profile.clone(),
+            CountingFactory::default(),
+            valid,
+        )
+        .await
+        .expect("limit-plus-valid config starts");
+        listener.shutdown().await.expect("valid listener shutdown");
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
     let profile = TempProfile::new("concurrent-start");

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -52,7 +52,7 @@ struct PanicFactory;
 impl NativeBackendFactory for PanicFactory {
     type Backend = CountingBackend;
 
-    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+    fn create(&self) -> Self::Backend {
         panic!("controlled connection factory panic")
     }
 }
@@ -72,7 +72,7 @@ struct PendingInitializeBackend {
 impl NativeBackendFactory for PendingInitializeFactory {
     type Backend = PendingInitializeBackend;
 
-    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+    fn create(&self) -> Self::Backend {
         self.created.fetch_add(1, Ordering::SeqCst);
         PendingInitializeBackend {
             initialize_started: Arc::clone(&self.initialize_started),
@@ -119,7 +119,7 @@ struct ErrorInitializeBackend;
 impl NativeBackendFactory for ErrorInitializeFactory {
     type Backend = ErrorInitializeBackend;
 
-    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+    fn create(&self) -> Self::Backend {
         ErrorInitializeBackend
     }
 }
@@ -684,6 +684,42 @@ async fn liveness_purpose_accepts_only_initialize_before_backend_access() {
     }
     assert_eq!(factory.created.load(Ordering::SeqCst), 0);
     assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
+    listener.shutdown().await.expect("shutdown listener");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sessions_and_liveness_inject_the_authenticated_profile_identity() {
+    let profile = TempProfile::new("connection-identity");
+    let expected_digest = profile.profile.digest().to_owned();
+    let factory = CountingFactory::default();
+    let listener =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), test_config())
+            .await
+            .expect("start listener");
+
+    let response = authenticated_initialize(listener.locator()).await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        "openengine.cluster/v1"
+    );
+    let contender = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        test_config(),
+    )
+    .await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::AlreadyRunning)
+    ));
+
+    {
+        let identities = factory.identities.lock().expect("recorded identities");
+        assert_eq!(identities.len(), 2, "session and liveness initialize");
+        assert!(identities.iter().all(|(principal, tenant)| {
+            principal == &expected_digest && tenant == &expected_digest
+        }));
+    }
     listener.shutdown().await.expect("shutdown listener");
 }
 

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -119,6 +119,71 @@ async fn zero_capacity_or_deadline_is_rejected_before_profile_or_listener_creati
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_nanosecond_deadlines_pass_validation_and_leave_no_locator_or_socket() {
+    let mut cases = Vec::new();
+    let mut config = test_config();
+    config.startup_lock_timeout = Duration::from_nanos(1);
+    cases.push(("startup-lock-positive-boundary", config));
+    let mut config = test_config();
+    config.liveness_timeout = Duration::from_nanos(1);
+    cases.push(("liveness-positive-boundary", config));
+    let mut config = test_config();
+    config.handshake_timeout = Duration::from_nanos(1);
+    cases.push(("handshake-positive-boundary", config));
+    let mut config = test_config();
+    config.drain_timeout = Duration::from_nanos(1);
+    cases.push(("drain-positive-boundary", config));
+    let mut config = test_config();
+    config.shutdown_timeout = Duration::from_nanos(1);
+    cases.push(("shutdown-positive-boundary", config));
+
+    for (name, boundary) in cases {
+        let profile = TempProfile::new(name);
+        let listener = DaemonListener::start_with_config(
+            profile.profile.clone(),
+            CountingFactory::default(),
+            boundary,
+        )
+        .await
+        .expect("positive deadline boundary passes validation");
+        let address: SocketAddr = listener
+            .locator()
+            .endpoint
+            .strip_prefix("ws://")
+            .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+            .expect("boundary endpoint")
+            .parse()
+            .expect("boundary address");
+        assert!(matches!(
+            listener.shutdown().await,
+            Ok(()) | Err(DaemonListenerError::ShutdownTimeout)
+        ));
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                let locator_removed = read_locator(&profile.profile)
+                    .expect("boundary cleanup state")
+                    .is_none();
+                let socket_released = match TcpListener::bind(address).await {
+                    Ok(rebound) => {
+                        drop(rebound);
+                        true
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => false,
+                    Err(error) => panic!("unexpected boundary rebind failure: {error}"),
+                };
+                if locator_removed && socket_released {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("boundary shutdown released locator and socket");
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
     let profile = TempProfile::new("concurrent-start");
@@ -223,6 +288,56 @@ async fn raw_handshake_burst_owns_only_the_configured_pre_auth_bound() {
         .await
         .expect("bounded listener shutdown")
         .expect("listener shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn partial_raw_handshake_releases_its_permit_at_server_timeout_without_client_drop() {
+    let profile = TempProfile::new("raw-handshake-timeout");
+    let config = ListenerConfig {
+        handshake_timeout: Duration::from_millis(30),
+        max_pending_handshakes: 1,
+        ..test_config()
+    };
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await
+    .expect("start handshake-timeout listener");
+    let address: SocketAddr = listener
+        .locator()
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("handshake-timeout endpoint")
+        .parse()
+        .expect("handshake-timeout address");
+    let mut socket = TcpStream::connect(address)
+        .await
+        .expect("raw handshake connection");
+    socket.write_all(b"G").await.expect("partial raw handshake");
+    timeout(Duration::from_millis(200), async {
+        while listener.pending_handshakes() != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("raw handshake owns permit");
+
+    timeout(Duration::from_millis(500), async {
+        while listener.pending_handshakes() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("server handshake timeout released permit");
+    socket
+        .peer_addr()
+        .expect("client socket remains owned after server timeout");
+
+    drop(socket);
+    listener.shutdown().await.expect("shutdown listener");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -537,6 +652,69 @@ async fn authenticated_liveness_burst_owns_only_its_reserved_capacity() {
         .await
         .expect("bounded liveness shutdown")
         .expect("liveness shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_liveness_releases_its_permit_at_server_timeout_without_client_drop() {
+    let profile = TempProfile::new("authenticated-liveness-timeout");
+    let config = ListenerConfig {
+        liveness_timeout: Duration::from_millis(30),
+        max_liveness_connections: 1,
+        ..test_config()
+    };
+    let listener = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        CountingFactory::default(),
+        config,
+    )
+    .await
+    .expect("start liveness-timeout listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let address: SocketAddr = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("liveness-timeout endpoint")
+        .parse()
+        .expect("liveness-timeout address");
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("liveness request");
+    let proof = credentials
+        .prepare_request(&mut request, ConnectionPurpose::Liveness)
+        .expect("liveness proof");
+    let stream = TcpStream::connect(address)
+        .await
+        .expect("liveness connection");
+    let (websocket, response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authenticated liveness upgrade");
+    assert!(proof.verify(&response));
+    timeout(Duration::from_millis(200), async {
+        while listener.active_liveness_connections() != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("liveness owns permit");
+
+    timeout(Duration::from_millis(500), async {
+        while listener.active_liveness_connections() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("server liveness timeout released permit");
+    websocket
+        .get_ref()
+        .peer_addr()
+        .expect("client websocket remains owned after server timeout");
+
+    drop(websocket);
+    listener.shutdown().await.expect("shutdown listener");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -2,15 +2,17 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use futures_util::StreamExt;
+use futures_util::{SinkExt, StreamExt};
 #[path = "support/daemon.rs"]
 mod daemon_support;
 
 use daemon_support::{CountingFactory, TempProfile, authenticated_initialize, locator_credentials};
+use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::time::{Instant, timeout};
+use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use zeroshot_engine::daemon_auth::{DAEMON_ROUTE, DaemonCredentials};
+use tokio_tungstenite::tungstenite::protocol::Message;
+use zeroshot_engine::daemon_auth::{ConnectionPurpose, DAEMON_ROUTE, DaemonCredentials};
 use zeroshot_engine::daemon_discovery::{
     CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, read_locator, replace_locator,
 };
@@ -30,16 +32,10 @@ fn test_config() -> ListenerConfig {
 async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
     let profile = TempProfile::new("concurrent-start");
     let factory = CountingFactory::default();
-    let first = DaemonListener::start_with_config(
-        profile.profile.clone(),
-        factory.clone(),
-        test_config(),
-    );
-    let second = DaemonListener::start_with_config(
-        profile.profile.clone(),
-        factory.clone(),
-        test_config(),
-    );
+    let first =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), test_config());
+    let second =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), test_config());
     let (first, second) = tokio::join!(first, second);
 
     let (owner, loser) = match (first, second) {
@@ -54,9 +50,131 @@ async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
     assert!(factory.initialized.load(Ordering::SeqCst) >= 1);
 
     let response = authenticated_initialize(owner.locator()).await;
-    assert_eq!(response["result"]["protocolVersion"], "openengine.cluster/v1");
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        "openengine.cluster/v1"
+    );
     owner.shutdown().await.expect("owner shutdown");
-    assert_eq!(read_locator(&profile.profile).expect("locator removed"), None);
+    assert_eq!(
+        read_locator(&profile.profile).expect("locator removed"),
+        None
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn liveness_is_unstarvable_by_full_sessions_and_stalled_raw_handshakes() {
+    let profile = TempProfile::new("unstarvable-liveness");
+    let config = ListenerConfig {
+        liveness_timeout: Duration::from_millis(120),
+        handshake_timeout: Duration::from_millis(500),
+        drain_timeout: Duration::from_millis(50),
+        max_active_connections: 1,
+        ..test_config()
+    };
+    let factory = CountingFactory::default();
+    let owner = DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), config)
+        .await
+        .expect("start owner");
+    let locator = owner.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("session request");
+    let proof = credentials
+        .apply_to_request(&mut request)
+        .expect("session proof");
+    let address: SocketAddr = request
+        .uri()
+        .authority()
+        .expect("session authority")
+        .as_str()
+        .parse()
+        .expect("session address");
+    let stream = TcpStream::connect(address).await.expect("session connect");
+    let (session, response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authenticated occupying session");
+    assert!(proof.verify(&response));
+
+    let mut stalled = TcpStream::connect(address)
+        .await
+        .expect("stalled raw connect");
+    stalled.write_all(b"G").await.expect("partial handshake");
+    tokio::task::yield_now().await;
+
+    let contender =
+        DaemonListener::start_with_config(profile.profile.clone(), factory, config).await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::AlreadyRunning)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("owner locator"),
+        Some(locator)
+    );
+
+    drop(session);
+    drop(stalled);
+    timeout(Duration::from_millis(500), owner.shutdown())
+        .await
+        .expect("owner bounded shutdown")
+        .expect("owner shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn liveness_purpose_accepts_only_initialize_before_backend_access() {
+    let profile = TempProfile::new("liveness-method");
+    let factory = CountingFactory::default();
+    let listener =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), test_config())
+            .await
+            .expect("start listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("liveness request");
+    let proof = credentials
+        .prepare_request(&mut request, ConnectionPurpose::Liveness)
+        .expect("liveness proof");
+    let address = request
+        .uri()
+        .authority()
+        .expect("liveness authority")
+        .as_str();
+    let stream = TcpStream::connect(address)
+        .await
+        .expect("liveness connection");
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authenticated liveness upgrade");
+    assert!(proof.verify(&response));
+    websocket
+        .send(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "get",
+                "params": {}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send forbidden liveness method");
+    let ended = timeout(Duration::from_millis(200), websocket.next())
+        .await
+        .expect("liveness method rejected");
+    if let Some(Ok(message)) = ended {
+        assert!(message.is_close());
+    }
+    assert_eq!(factory.created.load(Ordering::SeqCst), 0);
+    assert_eq!(factory.initialized.load(Ordering::SeqCst), 0);
+    listener.shutdown().await.expect("shutdown listener");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -115,7 +233,9 @@ async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_
         .as_str()
         .into_client_request()
         .expect("request");
-    credentials.apply_to_request(&mut request).expect("credentials");
+    let proof = credentials
+        .apply_to_request(&mut request)
+        .expect("credentials");
     let address: SocketAddr = request
         .uri()
         .authority()
@@ -124,13 +244,15 @@ async fn shutdown_stops_accepting_drains_bounded_releases_port_and_removes_only_
         .parse()
         .expect("socket address");
     let stream = TcpStream::connect(address).await.expect("connect");
-    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
         .await
         .expect("authorized idle connection");
+    assert!(proof.verify(&response));
 
-    let started = Instant::now();
-    listener.shutdown().await.expect("bounded shutdown");
-    assert!(started.elapsed() < Duration::from_millis(500));
+    timeout(Duration::from_millis(500), listener.shutdown())
+        .await
+        .expect("shutdown obeyed its drain deadline")
+        .expect("bounded shutdown");
     assert_eq!(read_locator(&profile.profile).expect("locator state"), None);
     let rebound = TcpListener::bind(address).await.expect("listener released");
     drop(rebound);
@@ -162,14 +284,9 @@ async fn crash_leaves_stale_locator_that_next_owner_cleans_without_reusing_secre
         .expect("stale address");
     drop(crashed);
     timeout(Duration::from_millis(200), async {
-        loop {
-            match TcpStream::connect(stale_address).await {
-                Ok(stream) => {
-                    drop(stream);
-                    tokio::task::yield_now().await;
-                }
-                Err(_) => break,
-            }
+        while let Ok(stream) = TcpStream::connect(stale_address).await {
+            drop(stream);
+            tokio::task::yield_now().await;
         }
     })
     .await

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -111,6 +111,46 @@ impl ClusterBackend for PendingInitializeBackend {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ErrorInitializeFactory;
+
+struct ErrorInitializeBackend;
+
+impl NativeBackendFactory for ErrorInitializeFactory {
+    type Backend = ErrorInitializeBackend;
+
+    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+        ErrorInitializeBackend
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for ErrorInitializeBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        Err(BackendError::application(
+            "TEST_UNAVAILABLE",
+            "controlled initialize failure",
+            None,
+        ))
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult {
+            spec: None,
+            status: ClusterStatus::empty(),
+            at_cursor: None,
+        })
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn zero_capacity_or_deadline_is_rejected_before_profile_or_listener_creation() {
     let mut cases = Vec::new();
@@ -273,6 +313,42 @@ async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
         read_locator(&profile.profile).expect("locator removed"),
         None
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_initialize_error_preserves_incumbent_locator_and_prevents_second_owner() {
+    let profile = TempProfile::new("live-initialize-error");
+    let owner = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        ErrorInitializeFactory,
+        test_config(),
+    )
+    .await
+    .expect("start erroring incumbent");
+    let incumbent = owner.locator().clone();
+    let contender_factory = CountingFactory::default();
+
+    let contender = DaemonListener::start_with_config(
+        profile.profile.clone(),
+        contender_factory.clone(),
+        test_config(),
+    )
+    .await;
+    assert!(matches!(
+        contender,
+        Err(DaemonListenerError::LivenessIndeterminate)
+    ));
+    assert_eq!(
+        read_locator(&profile.profile).expect("preserved erroring incumbent locator"),
+        Some(incumbent.clone())
+    );
+    assert_eq!(contender_factory.created.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        probe_liveness(&incumbent, Duration::from_millis(250)).await,
+        LivenessOutcome::Indeterminate
+    );
+
+    owner.shutdown().await.expect("shutdown incumbent");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1000,7 +1076,7 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": "daemon-liveness",
-                "error": {"code": -32603, "message": "stale response"}
+                "error": {"code": -32603, "message": "backend unavailable"}
             })
             .to_string(),
             false,
@@ -1038,7 +1114,9 @@ async fn liveness_response_requires_exact_json_rpc_correlation_and_shape() {
     });
 
     for (name, _, expected) in &cases {
-        let expected = if *expected {
+        let expected = if *name == "error only" {
+            LivenessOutcome::Indeterminate
+        } else if *expected {
             LivenessOutcome::Alive
         } else {
             LivenessOutcome::DefinitelyStale
@@ -1199,7 +1277,7 @@ async fn shutdown_absolute_deadline_bounds_matching_cleanup_lock_and_reports_tim
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn connection_task_panic_releases_listener_and_shutdown_cleans_locator_with_task_error() {
+async fn connection_task_panic_releases_listener_and_cleans_locator_before_owner_shutdown() {
     let profile = TempProfile::new("connection-task-panic");
     let listener =
         DaemonListener::start_with_config(profile.profile.clone(), PanicFactory, test_config())
@@ -1250,6 +1328,16 @@ async fn connection_task_panic_releases_listener_and_shutdown_cleans_locator_wit
     })
     .await
     .expect("panicked accept loop released listener");
+    timeout(Duration::from_millis(300), async {
+        while read_locator(&profile.profile)
+            .expect("automatic panic cleanup state")
+            .is_some()
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("panicked accept loop removed its published locator");
 
     assert!(matches!(
         listener.shutdown().await,

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -1388,9 +1388,17 @@ async fn crash_leaves_stale_locator_that_next_owner_cleans_without_reusing_secre
     )
     .await
     .expect("clean stale crash locator");
-    assert_ne!(replacement.locator().endpoint, stale.endpoint);
     assert_ne!(replacement.locator().capability, stale.capability);
     assert_ne!(replacement.locator().daemon_nonce, stale.daemon_nonce);
+    let response = authenticated_initialize(replacement.locator()).await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        "openengine.cluster/v1"
+    );
+    assert_eq!(
+        probe_liveness(&stale, Duration::from_millis(250)).await,
+        LivenessOutcome::DefinitelyStale
+    );
     assert_eq!(
         read_locator(&profile.profile).expect("replacement locator"),
         Some(replacement.locator().clone())

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -1,7 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 #[path = "support/daemon.rs"]
 mod daemon_support;
@@ -9,8 +11,10 @@ mod daemon_support;
 use daemon_support::{
     CountingBackend, CountingFactory, TempProfile, authenticated_initialize, locator_credentials,
 };
-use openengine_cluster_protocol::{ClusterStatus, InitializeResult, ServerCapabilities};
-use openengine_cluster_server::ConnectionContext;
+use openengine_cluster_protocol::{
+    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, ServerCapabilities,
+};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::timeout;
@@ -50,6 +54,60 @@ impl NativeBackendFactory for PanicFactory {
 
     fn create(&self, _context: &ConnectionContext) -> Self::Backend {
         panic!("controlled connection factory panic")
+    }
+}
+
+#[derive(Clone, Default)]
+struct PendingInitializeFactory {
+    created: Arc<AtomicUsize>,
+    initialize_started: Arc<AtomicUsize>,
+    dropped: Arc<AtomicUsize>,
+}
+
+struct PendingInitializeBackend {
+    initialize_started: Arc<AtomicUsize>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl NativeBackendFactory for PendingInitializeFactory {
+    type Backend = PendingInitializeBackend;
+
+    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+        self.created.fetch_add(1, Ordering::SeqCst);
+        PendingInitializeBackend {
+            initialize_started: Arc::clone(&self.initialize_started),
+            dropped: Arc::clone(&self.dropped),
+        }
+    }
+}
+
+impl Drop for PendingInitializeBackend {
+    fn drop(&mut self) {
+        self.dropped.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for PendingInitializeBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        self.initialize_started.fetch_add(1, Ordering::SeqCst);
+        std::future::pending().await
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult {
+            spec: None,
+            status: ClusterStatus::empty(),
+            at_cursor: None,
+        })
     }
 }
 
@@ -712,6 +770,95 @@ async fn authenticated_liveness_releases_its_permit_at_server_timeout_without_cl
         .get_ref()
         .peer_addr()
         .expect("client websocket remains owned after server timeout");
+
+    drop(websocket);
+    listener.shutdown().await.expect("shutdown listener");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn liveness_deadline_cancels_pending_initialize_dispatch_without_response_or_leak() {
+    let profile = TempProfile::new("liveness-dispatch-timeout");
+    let config = ListenerConfig {
+        liveness_timeout: Duration::from_millis(300),
+        max_liveness_connections: 1,
+        ..test_config()
+    };
+    let factory = PendingInitializeFactory::default();
+    let listener =
+        DaemonListener::start_with_config(profile.profile.clone(), factory.clone(), config)
+            .await
+            .expect("start dispatch-timeout listener");
+    let locator = listener.locator().clone();
+    let credentials = locator_credentials(&locator);
+    let address: SocketAddr = locator
+        .endpoint
+        .strip_prefix("ws://")
+        .and_then(|endpoint| endpoint.strip_suffix(DAEMON_ROUTE))
+        .expect("dispatch-timeout endpoint")
+        .parse()
+        .expect("dispatch-timeout address");
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("liveness dispatch request");
+    let proof = credentials
+        .prepare_request(&mut request, ConnectionPurpose::Liveness)
+        .expect("liveness dispatch proof");
+    let stream = TcpStream::connect(address)
+        .await
+        .expect("liveness dispatch connection");
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authenticated liveness dispatch upgrade");
+    assert!(proof.verify(&response));
+    websocket
+        .send(Message::Text(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "pending-liveness",
+                "method": "initialize",
+                "params": {"protocolVersion": "openengine.cluster/v1"}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send valid pending initialize");
+    timeout(Duration::from_millis(200), async {
+        while factory.initialize_started.load(Ordering::SeqCst) != 1
+            || listener.active_liveness_connections() != 1
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("pending initialize dispatch started under liveness permit");
+
+    timeout(Duration::from_millis(500), async {
+        while listener.active_liveness_connections() != 0
+            || factory.dropped.load(Ordering::SeqCst) != 1
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("absolute liveness deadline cancelled dispatch and released backend");
+    assert_eq!(factory.created.load(Ordering::SeqCst), 1);
+    assert_eq!(factory.initialize_started.load(Ordering::SeqCst), 1);
+    assert_eq!(factory.dropped.load(Ordering::SeqCst), 1);
+    assert_eq!(listener.pending_handshakes(), 0);
+    assert_eq!(listener.active_sessions(), 0);
+
+    let ended = timeout(Duration::from_millis(200), websocket.next())
+        .await
+        .expect("timed-out liveness connection terminated");
+    if let Some(Ok(message)) = ended {
+        assert!(
+            !matches!(message, Message::Text(_)),
+            "cancelled liveness dispatch emitted a response"
+        );
+    }
 
     drop(websocket);
     listener.shutdown().await.expect("shutdown listener");

--- a/zeroshot-rust/tests/support/daemon.rs
+++ b/zeroshot-rust/tests/support/daemon.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use openengine_cluster_protocol::{
+    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, JSON_RPC_VERSION,
+    PROTOCOL_VERSION, ServerCapabilities,
+};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::Message;
+use zeroshot_engine::daemon_auth::DaemonCredentials;
+use zeroshot_engine::daemon_discovery::DaemonLocator;
+use zeroshot_engine::NativeBackendFactory;
+
+#[path = "temp_profile.rs"]
+mod temp_profile;
+pub use temp_profile::TempProfile;
+
+
+#[derive(Clone, Default)]
+pub struct CountingFactory {
+    pub created: Arc<AtomicUsize>,
+    pub initialized: Arc<AtomicUsize>,
+}
+
+pub struct CountingBackend {
+    initialized: Arc<AtomicUsize>,
+}
+
+impl NativeBackendFactory for CountingFactory {
+    type Backend = CountingBackend;
+
+    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+        self.created.fetch_add(1, Ordering::SeqCst);
+        CountingBackend {
+            initialized: Arc::clone(&self.initialized),
+        }
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for CountingBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        self.initialized.fetch_add(1, Ordering::SeqCst);
+        Ok(InitializeResult::new(
+            ServerCapabilities::default(),
+            ClusterStatus::empty(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        Ok(GetResult {
+            spec: None,
+            status: ClusterStatus::empty(),
+            at_cursor: None,
+        })
+    }
+}
+
+pub async fn authenticated_initialize(locator: &DaemonLocator) -> serde_json::Value {
+    let credentials = DaemonCredentials::from_locator(locator);
+    let mut request = locator
+        .endpoint
+        .as_str()
+        .into_client_request()
+        .expect("valid daemon endpoint");
+    credentials
+        .apply_to_request(&mut request)
+        .expect("valid daemon credentials");
+    let address = request
+        .uri()
+        .authority()
+        .expect("endpoint authority")
+        .as_str();
+    let stream = TcpStream::connect(address)
+        .await
+        .expect("daemon loopback connection");
+    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+        .await
+        .expect("authorized WebSocket handshake");
+    websocket
+        .send(Message::Text(
+            serde_json::json!({
+                "jsonrpc": JSON_RPC_VERSION,
+                "id": 1,
+                "method": "initialize",
+                "params": { "protocolVersion": PROTOCOL_VERSION }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send initialize");
+    loop {
+        let message = websocket
+            .next()
+            .await
+            .expect("initialize response")
+            .expect("valid initialize response frame");
+        if let Message::Text(text) = message {
+            return serde_json::from_str(text.as_ref()).expect("initialize JSON");
+        }
+    }
+}
+
+pub fn locator_credentials(locator: &DaemonLocator) -> DaemonCredentials {
+    DaemonCredentials::from_locator(locator)
+}

--- a/zeroshot-rust/tests/support/daemon.rs
+++ b/zeroshot-rust/tests/support/daemon.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
@@ -23,19 +24,22 @@ pub use temp_profile::TempProfile;
 pub struct CountingFactory {
     pub created: Arc<AtomicUsize>,
     pub initialized: Arc<AtomicUsize>,
+    pub identities: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 pub struct CountingBackend {
     initialized: Arc<AtomicUsize>,
+    identities: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl NativeBackendFactory for CountingFactory {
     type Backend = CountingBackend;
 
-    fn create(&self, _context: &ConnectionContext) -> Self::Backend {
+    fn create(&self) -> Self::Backend {
         self.created.fetch_add(1, Ordering::SeqCst);
         CountingBackend {
             initialized: Arc::clone(&self.initialized),
+            identities: Arc::clone(&self.identities),
         }
     }
 }
@@ -44,10 +48,17 @@ impl NativeBackendFactory for CountingFactory {
 impl ClusterBackend for CountingBackend {
     async fn initialize(
         &self,
-        _context: &ConnectionContext,
+        context: &ConnectionContext,
         _params: InitializeParams,
     ) -> Result<InitializeResult, BackendError> {
         self.initialized.fetch_add(1, Ordering::SeqCst);
+        self.identities
+            .lock()
+            .expect("identity recorder lock")
+            .push((
+                context.identity().principal().as_str().to_owned(),
+                context.identity().tenant().as_str().to_owned(),
+            ));
         Ok(InitializeResult::new(
             ServerCapabilities::default(),
             ClusterStatus::empty(),

--- a/zeroshot-rust/tests/support/daemon.rs
+++ b/zeroshot-rust/tests/support/daemon.rs
@@ -19,7 +19,6 @@ use zeroshot_engine::NativeBackendFactory;
 mod temp_profile;
 pub use temp_profile::TempProfile;
 
-
 #[derive(Clone, Default)]
 pub struct CountingFactory {
     pub created: Arc<AtomicUsize>,
@@ -75,7 +74,7 @@ pub async fn authenticated_initialize(locator: &DaemonLocator) -> serde_json::Va
         .as_str()
         .into_client_request()
         .expect("valid daemon endpoint");
-    credentials
+    let expectation = credentials
         .apply_to_request(&mut request)
         .expect("valid daemon credentials");
     let address = request
@@ -86,9 +85,13 @@ pub async fn authenticated_initialize(locator: &DaemonLocator) -> serde_json::Va
     let stream = TcpStream::connect(address)
         .await
         .expect("daemon loopback connection");
-    let (mut websocket, _) = tokio_tungstenite::client_async(request, stream)
+    let (mut websocket, response) = tokio_tungstenite::client_async(request, stream)
         .await
         .expect("authorized WebSocket handshake");
+    assert!(
+        expectation.verify(&response),
+        "daemon server possession proof"
+    );
     websocket
         .send(Message::Text(
             serde_json::json!({

--- a/zeroshot-rust/tests/support/temp_profile.rs
+++ b/zeroshot-rust/tests/support/temp_profile.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use zeroshot_engine::daemon_discovery::NativeProfile;
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
+
+pub struct TempProfile {
+    pub profile: NativeProfile,
+    root: PathBuf,
+}
+
+impl TempProfile {
+    pub fn new(label: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "zeroshot-daemon-{label}-{}-{}",
+            std::process::id(),
+            NEXT_TEMP.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        Self {
+            profile: NativeProfile::new(&root, format!("native-profile:{label}")),
+            root,
+        }
+    }
+}
+
+impl Drop for TempProfile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}

--- a/zeroshot-rust/tests/worker_catalog_architecture.rs
+++ b/zeroshot-rust/tests/worker_catalog_architecture.rs
@@ -7,11 +7,14 @@ use architecture_support::{product_package, product_root, read, relative_files, 
 
 const _: fn() -> String = architecture_support::runtime_source;
 const _: fn(&[&str]) -> String = architecture_support::rust_sources;
-const EXPECTED_TOP_LEVEL_SOURCE_ENTRIES: [&str; 21] = [
+const EXPECTED_TOP_LEVEL_SOURCE_ENTRIES: [&str; 24] = [
     "artifact_store",
     "artifact_store.rs",
     "cluster_ledger",
     "cluster_ledger.rs",
+    "daemon_auth.rs",
+    "daemon_discovery.rs",
+    "daemon_listener.rs",
     "execution",
     "execution.rs",
     "fault",


### PR DESCRIPTION
Closes #692

## Summary
- add owner-only, atomically published native-profile daemon locators with rotating 256-bit capabilities/nonces and short startup serialization
- add domain-separated mutual possession proofs for the exact local WebSocket route without transmitting the capability or nonce
- add one finite loopback listener with bounded pre-auth, ordinary-session, authenticated-liveness, handshake, transaction, drain, and shutdown ownership
- classify incumbent probes as `Alive`, `DefinitelyStale`, or `Indeterminate`; only definite stale state authorizes matching locator replacement
- make shutdown use one absolute deadline while releasing the listener and attempting matching-owner cleanup on success and task-error paths

## Decisions
- Authenticated `daemon/initialize` remains the sole positive liveness proof. Locator, PID, open-port, and timeout state do not prove a daemon.
- Ambiguous capacity/transport failures return `LivenessIndeterminate` and preserve the incumbent; they never authorize a split owner.
- Pre-auth/session/liveness resources are independently finite. Absolute availability under an unbounded sustained unauthenticated arrival stream is not claimed; a single TCP endpoint cannot classify a liveness request before consuming bounded pre-auth work.
- Initialize liveness reuses the authoritative protocol `InitializeResult`, dispatcher, connection context, and WebSocket host. No protocol schema or cluster/catalog/recovery surface was added.

## Verification
Two independent final verifiers passed every issue-owned and common gate.

- `cargo test -p zeroshot-rust --test daemon_discovery` — 7 passing
- `cargo test -p zeroshot-rust --test daemon_auth` — 4 passing
- `cargo test -p zeroshot-rust --test daemon_listener` — 17 passing
- `cargo test -p zeroshot-rust --test architecture` — 12 passing
- `npm run rust:check` — fmt/clippy clean; 548 workspace tests across 97 result groups
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint` — 0 errors
- `npm run test:unit` — 1,953 passing, 18 pending
- `opcore check --changed`

Causal regressions cover concurrent owners, crash/stale/indeterminate handoff, capability reflection/disclosure, wrong credential/profile/nonce/route/query, exact initialize response shape, atomic reader/rotation/removal, permissions/symlinks/hard links/oversize, every zero and positive deadline boundary, saturated pre-auth/session/liveness capacity, server-side handshake/liveness deadlines, controlled backend stalls/panics, socket release, and matching cleanup.