### PR TITLE
fix(release): stage complete Rust lock entry

### DIFF
--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -215,19 +215,20 @@ function escapeRegExp(value) {
 }
 
 function cargoLockPackages(cargoLock, packageName) {
-  const starts = [];
-  const marker = /^\[\[package\]\]\r?$/gm;
+  const tables = [];
+  const marker = /^\[{1,2}[^\r\n]+\]{1,2}\r?$/gm;
   for (let match = marker.exec(cargoLock); match; match = marker.exec(cargoLock)) {
-    starts.push(match.index);
+    tables.push({ header: match[0].trim(), start: match.index });
   }
-  return starts.flatMap((start, index) => {
-    const text = cargoLock.slice(start, starts[index + 1] ?? cargoLock.length);
+  return tables.flatMap((table, index) => {
+    if (table.header !== '[[package]]') return [];
+    const text = cargoLock.slice(table.start, tables[index + 1]?.start ?? cargoLock.length);
     const name = text.match(/^name = "([^"]+)"\r?$/m)?.[1];
     const version = text.match(/^version = "([^"]+)"\r?$/m)?.[1];
     if (name !== packageName || !version) return [];
     return [
       {
-        start,
+        start: table.start,
         text,
         version,
         source: text.match(/^source = "([^"]+)"\r?$/m)?.[1],

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -214,70 +214,121 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function lockedPackageMatch(cargoLock, packageName) {
-  return cargoLock.match(
-    new RegExp(
-      `\\[\\[package\\]\\]\\r?\\nname = "${escapeRegExp(packageName)}"\\r?\\nversion = "([^"]+)"[\\s\\S]*?(?=\\r?\\n\\[\\[package\\]\\]|$)`
-    )
-  );
-}
-
-function lockedPackageVersions(cargoLock, packageName) {
-  const versions = [];
-  const pattern = new RegExp(
-    `\\[\\[package\\]\\]\\r?\\nname = "${escapeRegExp(packageName)}"\\r?\\nversion = "([^"]+)"`,
-    'g'
-  );
-  for (let match = pattern.exec(cargoLock); match; match = pattern.exec(cargoLock)) {
-    versions.push(match[1]);
+function cargoLockPackages(cargoLock, packageName) {
+  const starts = [];
+  const marker = /^\[\[package\]\]\r?$/gm;
+  for (let match = marker.exec(cargoLock); match; match = marker.exec(cargoLock)) {
+    starts.push(match.index);
   }
-  return versions;
+  return starts.flatMap((start, index) => {
+    const text = cargoLock.slice(start, starts[index + 1] ?? cargoLock.length);
+    const name = text.match(/^name = "([^"]+)"\r?$/m)?.[1];
+    const version = text.match(/^version = "([^"]+)"\r?$/m)?.[1];
+    if (name !== packageName || !version) return [];
+    return [
+      {
+        start,
+        text,
+        version,
+        source: text.match(/^source = "([^"]+)"\r?$/m)?.[1],
+      },
+    ];
+  });
 }
 
-function workspaceDependencyVersion(workspaceCargoToml, dependencyName) {
+function workspaceLockPackage(cargoLock) {
+  const candidates = cargoLockPackages(cargoLock, 'zeroshot-rust').filter(
+    (candidate) => candidate.source === undefined
+  );
+  if (candidates.length !== 1) {
+    throw new Error(
+      'RUST_VERSION_STAGE_FAILED: Cargo.lock needs exactly one source-less zeroshot-rust package'
+    );
+  }
+  return candidates[0];
+}
+
+function workspaceDependencyRequirement(workspaceCargoToml, dependencyName) {
   const workspaceDependencies = workspaceCargoToml.match(
     /\[workspace\.dependencies\]([\s\S]*?)(?:\r?\n\[|$)/
   );
-  const version =
+  const requirement =
     workspaceDependencies &&
     workspaceDependencies[1].match(
       new RegExp(`^${escapeRegExp(dependencyName)}\\s*=\\s*"([^"]+)"\\s*$`, 'm')
     );
-  if (!version) {
+  if (!requirement || !/^(\^|=)?\d+\.\d+\.\d+$/.test(requirement[1])) {
     throw new Error(
-      `RUST_VERSION_STAGE_FAILED: workspace dependency ${dependencyName} needs an exact version`
+      `RUST_VERSION_STAGE_FAILED: workspace dependency ${dependencyName} has an unsupported version requirement`
     );
   }
-  return version[1];
+  return requirement[1];
 }
 
-function stagedLockDependencyVersions(workspaceCargoToml) {
-  return STAGED_LOCK_DEPENDENCIES.map((name) => ({
-    name,
-    version: workspaceDependencyVersion(workspaceCargoToml, name),
-  }));
+function parseCargoVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  return match ? match.slice(1).map(Number) : undefined;
+}
+
+function compareCargoVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function cargoRequirementMatches(requirement, version) {
+  const parsedVersion = parseCargoVersion(version);
+  const match = /^(\^|=)?(\d+)\.(\d+)\.(\d+)$/.exec(requirement);
+  if (!parsedVersion || !match) return false;
+  const lower = match.slice(2).map(Number);
+  if (match[1] === '=') return compareCargoVersions(parsedVersion, lower) === 0;
+  const upper =
+    lower[0] > 0
+      ? [lower[0] + 1, 0, 0]
+      : lower[1] > 0
+        ? [0, lower[1] + 1, 0]
+        : [0, 0, lower[2] + 1];
+  return (
+    compareCargoVersions(parsedVersion, lower) >= 0 &&
+    compareCargoVersions(parsedVersion, upper) < 0
+  );
+}
+
+function stagedLockDependencies(cargoLock, workspaceCargoToml) {
+  return STAGED_LOCK_DEPENDENCIES.map((name) => {
+    const requirement = workspaceDependencyRequirement(workspaceCargoToml, name);
+    const candidates = cargoLockPackages(cargoLock, name);
+    const satisfying = candidates.filter((candidate) =>
+      cargoRequirementMatches(requirement, candidate.version)
+    );
+    if (satisfying.length !== 1) {
+      const sourceAmbiguous =
+        satisfying.length > 1 &&
+        new Set(satisfying.map((candidate) => candidate.version)).size === 1;
+      throw new Error(
+        sourceAmbiguous
+          ? `RUST_VERSION_STAGE_FAILED: Cargo.lock ${name} ${satisfying[0].version} has ambiguous sources`
+          : `RUST_VERSION_STAGE_FAILED: Cargo.lock needs exactly one ${name} package satisfying ${requirement}`
+      );
+    }
+    const selected = satisfying[0];
+    return {
+      name,
+      requirement,
+      version: selected.version,
+      reference: candidates.length > 1 ? `${name} ${selected.version}` : name,
+    };
+  });
 }
 
 function stageCargoLock(cargoLock, version, workspaceCargoToml) {
-  const targetPackage = lockedPackageMatch(cargoLock, 'zeroshot-rust');
-  if (!targetPackage) {
-    throw new Error('RUST_VERSION_STAGE_FAILED: Cargo.lock has no zeroshot-rust package entry');
-  }
-  let stagedPackage = targetPackage[0].replace(
+  const targetPackage = workspaceLockPackage(cargoLock);
+  let stagedPackage = targetPackage.text.replace(
     /^(version = ")[^"]+(")$/m,
     `$1${version}$2`
   );
-  for (const dependency of stagedLockDependencyVersions(workspaceCargoToml)) {
-    const lockedVersions = lockedPackageVersions(cargoLock, dependency.name);
-    if (!lockedVersions.includes(dependency.version)) {
-      throw new Error(
-        `RUST_VERSION_STAGE_FAILED: Cargo.lock has no ${dependency.name} ${dependency.version} package`
-      );
-    }
-    const dependencyReference =
-      lockedVersions.length > 1
-        ? `${dependency.name} ${dependency.version}`
-        : dependency.name;
+  for (const dependency of stagedLockDependencies(cargoLock, workspaceCargoToml)) {
     const dependencyPattern = new RegExp(
       `^(\\s*")${escapeRegExp(dependency.name)}(?: [^"]+)?(",\\r?)$`,
       'm'
@@ -289,37 +340,29 @@ function stageCargoLock(cargoLock, version, workspaceCargoToml) {
     }
     stagedPackage = stagedPackage.replace(
       dependencyPattern,
-      `$1${dependencyReference}$2`
+      `$1${dependency.reference}$2`
     );
   }
   return (
-    cargoLock.slice(0, targetPackage.index) +
+    cargoLock.slice(0, targetPackage.start) +
     stagedPackage +
-    cargoLock.slice(targetPackage.index + targetPackage[0].length)
+    cargoLock.slice(targetPackage.start + targetPackage.text.length)
   );
 }
 
 function verifyStagedCargoLock(cargoLock, version, workspaceCargoToml) {
-  const targetPackage = lockedPackageMatch(cargoLock, 'zeroshot-rust');
-  if (!targetPackage || targetPackage[1] !== version) {
+  const targetPackage = workspaceLockPackage(cargoLock);
+  if (targetPackage.version !== version) {
     throw new Error(
-      `${VERSION_ERROR}: release tag version ${version} does not match Cargo.lock zeroshot-rust version ${targetPackage?.[1] || '(missing)'}`
+      `${VERSION_ERROR}: release tag version ${version} does not match Cargo.lock zeroshot-rust version ${targetPackage.version}`
     );
   }
-  for (const dependency of stagedLockDependencyVersions(workspaceCargoToml)) {
-    const lockedVersions = lockedPackageVersions(cargoLock, dependency.name);
-    const dependencyReference =
-      lockedVersions.length > 1
-        ? `${dependency.name} ${dependency.version}`
-        : dependency.name;
+  for (const dependency of stagedLockDependencies(cargoLock, workspaceCargoToml)) {
     const dependencyPattern = new RegExp(
-      `^\\s*"${escapeRegExp(dependencyReference)}",\\r?$`,
+      `^\\s*"${escapeRegExp(dependency.reference)}",\\r?$`,
       'm'
     );
-    if (
-      !lockedVersions.includes(dependency.version) ||
-      !dependencyPattern.test(targetPackage[0])
-    ) {
+    if (!dependencyPattern.test(targetPackage.text)) {
       throw new Error(
         `${VERSION_ERROR}: Cargo.lock zeroshot-rust dependency ${dependency.name} is not coupled to ${dependency.version}`
       );

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -208,10 +208,130 @@ function cargoVersion(cargoToml) {
   return version[1];
 }
 
+const STAGED_LOCK_DEPENDENCIES = Object.freeze(['windows-sys']);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function lockedPackageMatch(cargoLock, packageName) {
+  return cargoLock.match(
+    new RegExp(
+      `\\[\\[package\\]\\]\\r?\\nname = "${escapeRegExp(packageName)}"\\r?\\nversion = "([^"]+)"[\\s\\S]*?(?=\\r?\\n\\[\\[package\\]\\]|$)`
+    )
+  );
+}
+
+function lockedPackageVersions(cargoLock, packageName) {
+  const versions = [];
+  const pattern = new RegExp(
+    `\\[\\[package\\]\\]\\r?\\nname = "${escapeRegExp(packageName)}"\\r?\\nversion = "([^"]+)"`,
+    'g'
+  );
+  for (let match = pattern.exec(cargoLock); match; match = pattern.exec(cargoLock)) {
+    versions.push(match[1]);
+  }
+  return versions;
+}
+
+function workspaceDependencyVersion(workspaceCargoToml, dependencyName) {
+  const workspaceDependencies = workspaceCargoToml.match(
+    /\[workspace\.dependencies\]([\s\S]*?)(?:\r?\n\[|$)/
+  );
+  const version =
+    workspaceDependencies &&
+    workspaceDependencies[1].match(
+      new RegExp(`^${escapeRegExp(dependencyName)}\\s*=\\s*"([^"]+)"\\s*$`, 'm')
+    );
+  if (!version) {
+    throw new Error(
+      `RUST_VERSION_STAGE_FAILED: workspace dependency ${dependencyName} needs an exact version`
+    );
+  }
+  return version[1];
+}
+
+function stagedLockDependencyVersions(workspaceCargoToml) {
+  return STAGED_LOCK_DEPENDENCIES.map((name) => ({
+    name,
+    version: workspaceDependencyVersion(workspaceCargoToml, name),
+  }));
+}
+
+function stageCargoLock(cargoLock, version, workspaceCargoToml) {
+  const targetPackage = lockedPackageMatch(cargoLock, 'zeroshot-rust');
+  if (!targetPackage) {
+    throw new Error('RUST_VERSION_STAGE_FAILED: Cargo.lock has no zeroshot-rust package entry');
+  }
+  let stagedPackage = targetPackage[0].replace(
+    /^(version = ")[^"]+(")$/m,
+    `$1${version}$2`
+  );
+  for (const dependency of stagedLockDependencyVersions(workspaceCargoToml)) {
+    const lockedVersions = lockedPackageVersions(cargoLock, dependency.name);
+    if (!lockedVersions.includes(dependency.version)) {
+      throw new Error(
+        `RUST_VERSION_STAGE_FAILED: Cargo.lock has no ${dependency.name} ${dependency.version} package`
+      );
+    }
+    const dependencyReference =
+      lockedVersions.length > 1
+        ? `${dependency.name} ${dependency.version}`
+        : dependency.name;
+    const dependencyPattern = new RegExp(
+      `^(\\s*")${escapeRegExp(dependency.name)}(?: [^"]+)?(",\\r?)$`,
+      'm'
+    );
+    if (!dependencyPattern.test(stagedPackage)) {
+      throw new Error(
+        `RUST_VERSION_STAGE_FAILED: Cargo.lock zeroshot-rust entry has no ${dependency.name} dependency`
+      );
+    }
+    stagedPackage = stagedPackage.replace(
+      dependencyPattern,
+      `$1${dependencyReference}$2`
+    );
+  }
+  return (
+    cargoLock.slice(0, targetPackage.index) +
+    stagedPackage +
+    cargoLock.slice(targetPackage.index + targetPackage[0].length)
+  );
+}
+
+function verifyStagedCargoLock(cargoLock, version, workspaceCargoToml) {
+  const targetPackage = lockedPackageMatch(cargoLock, 'zeroshot-rust');
+  if (!targetPackage || targetPackage[1] !== version) {
+    throw new Error(
+      `${VERSION_ERROR}: release tag version ${version} does not match Cargo.lock zeroshot-rust version ${targetPackage?.[1] || '(missing)'}`
+    );
+  }
+  for (const dependency of stagedLockDependencyVersions(workspaceCargoToml)) {
+    const lockedVersions = lockedPackageVersions(cargoLock, dependency.name);
+    const dependencyReference =
+      lockedVersions.length > 1
+        ? `${dependency.name} ${dependency.version}`
+        : dependency.name;
+    const dependencyPattern = new RegExp(
+      `^\\s*"${escapeRegExp(dependencyReference)}",\\r?$`,
+      'm'
+    );
+    if (
+      !lockedVersions.includes(dependency.version) ||
+      !dependencyPattern.test(targetPackage[0])
+    ) {
+      throw new Error(
+        `${VERSION_ERROR}: Cargo.lock zeroshot-rust dependency ${dependency.name} is not coupled to ${dependency.version}`
+      );
+    }
+  }
+}
+
 function stageVersion(
   tag,
   cargoManifestPath = path.join(repositoryRoot, 'zeroshot-rust', 'Cargo.toml'),
-  cargoLockPath = path.join(repositoryRoot, 'Cargo.lock')
+  cargoLockPath = path.join(repositoryRoot, 'Cargo.lock'),
+  workspaceManifestPath = path.join(repositoryRoot, 'Cargo.toml')
 ) {
   const version = normalizeVersion(tag);
   const cargoToml = fs.readFileSync(cargoManifestPath, 'utf8');
@@ -225,26 +345,36 @@ function stageVersion(
   }
 
   const cargoLock = fs.readFileSync(cargoLockPath, 'utf8');
-  const lockPattern = /(\[\[package\]\]\r?\nname = "zeroshot-rust"\r?\nversion = ")[^"]+(")/;
-  if (!lockPattern.test(cargoLock)) {
-    throw new Error('RUST_VERSION_STAGE_FAILED: Cargo.lock has no zeroshot-rust package entry');
-  }
-  const stagedLock = cargoLock.replace(lockPattern, `$1${version}$2`);
+  const workspaceCargoToml = fs.readFileSync(workspaceManifestPath, 'utf8');
+  const stagedLock = stageCargoLock(cargoLock, version, workspaceCargoToml);
+  verifyStagedCargoLock(stagedLock, version, workspaceCargoToml);
   fs.writeFileSync(cargoManifestPath, stagedManifest);
   fs.writeFileSync(cargoLockPath, stagedLock);
   return { currentVersion, version };
 }
 
-function checkVersionCoupling(
-  tag,
-  cargoToml = fs.readFileSync(path.join(repositoryRoot, 'zeroshot-rust', 'Cargo.toml'), 'utf8')
-) {
+function checkVersionCoupling(tag, cargoToml, cargoLock, workspaceCargoToml) {
+  const useRepositoryFiles = cargoToml === undefined;
+  const manifest =
+    cargoToml ??
+    fs.readFileSync(path.join(repositoryRoot, 'zeroshot-rust', 'Cargo.toml'), 'utf8');
   const releaseVersion = normalizeVersion(tag);
-  const manifestVersion = cargoVersion(cargoToml);
+  const manifestVersion = cargoVersion(manifest);
   if (releaseVersion !== manifestVersion) {
     throw new Error(
       `${VERSION_ERROR}: release tag version ${releaseVersion} does not match zeroshot-rust/Cargo.toml version ${manifestVersion}`
     );
+  }
+  const lock =
+    cargoLock ??
+    (useRepositoryFiles
+      ? fs.readFileSync(path.join(repositoryRoot, 'Cargo.lock'), 'utf8')
+      : undefined);
+  if (lock !== undefined) {
+    const workspace =
+      workspaceCargoToml ??
+      fs.readFileSync(path.join(repositoryRoot, 'Cargo.toml'), 'utf8');
+    verifyStagedCargoLock(lock, releaseVersion, workspace);
   }
   return releaseVersion;
 }

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -34,7 +34,12 @@ function mutateWorkflowJob(source, jobName, mutateJob) {
 }
 
 function withRustStageFixture(
-  { requirement, lockedDependencies, includeRegistryNameCollision = false },
+  {
+    requirement,
+    lockedDependencies,
+    includeRegistryNameCollision = false,
+    trailingTables = [],
+  },
   assertion
 ) {
   const directory = temporaryDirectory();
@@ -76,6 +81,7 @@ function withRustStageFixture(
     ']',
     ''
   );
+  lockPackages.push(...trailingTables);
   fs.writeFileSync(lockPath, ['version = 4', '', ...lockPackages].join('\n'));
   try {
     return assertion({ lockPath, manifestPath, workspacePath });
@@ -270,6 +276,13 @@ describe('Rust release integration', function () {
           { version: '0.61.3', source: registry },
         ],
         includeRegistryNameCollision: true,
+        trailingTables: [
+          '[[patch.unused]]',
+          'name = "unused-windows-sys"',
+          'version = "0.1.0"',
+          'source = "git+https://example.invalid/unused?rev=fixture"',
+          '',
+        ],
       },
       ({ lockPath, manifestPath, workspacePath }) => {
         distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath);
@@ -279,6 +292,7 @@ describe('Rust release integration', function () {
           lock,
           /name = "zeroshot-rust"\nversion = "6\.10\.3"[\s\S]*"windows-sys 0\.61\.3"/
         );
+        assert.match(lock, /\[\[patch\.unused\]\][\s\S]*source = "git\+https:/);
       }
     );
     withRustStageFixture(
@@ -288,10 +302,12 @@ describe('Rust release integration', function () {
           { version: '0.61.2', source: registry },
           { version: '0.61.3', source: registry },
         ],
+        trailingTables: ['[metadata]', 'fixture = "preserved"', ''],
       },
       ({ lockPath, manifestPath, workspacePath }) => {
         distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath);
         assert.match(fs.readFileSync(lockPath, 'utf8'), /"windows-sys 0\.61\.2"/);
+        assert.match(fs.readFileSync(lockPath, 'utf8'), /\[metadata\]\nfixture = "preserved"/);
       }
     );
     withRustStageFixture(

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -123,28 +123,86 @@ describe('Rust release integration', function () {
     assert.strictEqual(distribution.checkVersionCoupling('v1.2.2', cargoToml), '1.2.2');
   });
 
-  it('stages the planned version in Cargo.toml and Cargo.lock before coupling', function () {
+  it('stages the planned version and target lock resolution before coupling', function () {
     const directory = temporaryDirectory();
-    const manifestPath = path.join(directory, 'Cargo.toml');
+    const packageDirectory = path.join(directory, 'zeroshot-rust');
+    const workspacePath = path.join(directory, 'Cargo.toml');
+    const manifestPath = path.join(packageDirectory, 'Cargo.toml');
     const lockPath = path.join(directory, 'Cargo.lock');
+    fs.mkdirSync(packageDirectory);
+    fs.writeFileSync(
+      workspacePath,
+      '[workspace]\nmembers = ["zeroshot-rust"]\n\n[workspace.dependencies]\nwindows-sys = "0.61.2"\n'
+    );
     fs.writeFileSync(
       manifestPath,
-      '[package]\nname = "zeroshot-rust"\nversion = "0.1.0"\nedition = "2024"\n'
+      '[package]\nname = "zeroshot-rust"\nversion = "0.1.0"\nedition = "2024"\n\n[target.\'cfg(windows)\'.dependencies]\nwindows-sys = { workspace = true }\n'
     );
     fs.writeFileSync(
       lockPath,
-      'version = 4\n\n[[package]]\nname = "zeroshot-rust"\nversion = "0.1.0"\n'
+      [
+        'version = 4',
+        '',
+        '[[package]]',
+        'name = "windows-sys"',
+        'version = "0.52.0"',
+        '',
+        '[[package]]',
+        'name = "windows-sys"',
+        'version = "0.61.2"',
+        '',
+        '[[package]]',
+        'name = "zeroshot-rust"',
+        'version = "0.1.0"',
+        'dependencies = [',
+        ' "windows-sys",',
+        ']',
+        '',
+      ].join('\n')
     );
     try {
-      assert.deepStrictEqual(distribution.stageVersion('v6.10.3', manifestPath, lockPath), {
-        currentVersion: '0.1.0',
-        version: '6.10.3',
-      });
+      assert.deepStrictEqual(
+        distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath),
+        {
+          currentVersion: '0.1.0',
+          version: '6.10.3',
+        }
+      );
       const stagedManifest = fs.readFileSync(manifestPath, 'utf8');
-      assert.strictEqual(distribution.checkVersionCoupling('v6.10.3', stagedManifest), '6.10.3');
+      const stagedLock = fs.readFileSync(lockPath, 'utf8');
+      const workspaceManifest = fs.readFileSync(workspacePath, 'utf8');
+      assert.strictEqual(
+        distribution.checkVersionCoupling(
+          'v6.10.3',
+          stagedManifest,
+          stagedLock,
+          workspaceManifest
+        ),
+        '6.10.3'
+      );
       assert.match(
-        fs.readFileSync(lockPath, 'utf8'),
-        /name = "zeroshot-rust"\nversion = "6\.10\.3"/
+        stagedLock,
+        /name = "zeroshot-rust"\nversion = "6\.10\.3"[\s\S]*"windows-sys 0\.61\.2"/
+      );
+      assert.throws(
+        () =>
+          distribution.checkVersionCoupling(
+            'v6.10.3',
+            stagedManifest,
+            stagedLock.replace('"windows-sys 0.61.2"', '"windows-sys"'),
+            workspaceManifest
+          ),
+        /RUST_VERSION_MISMATCH: Cargo\.lock zeroshot-rust dependency windows-sys/
+      );
+      assert.throws(
+        () =>
+          distribution.checkVersionCoupling(
+            'v6.10.3',
+            stagedManifest,
+            stagedLock.replace('version = "6.10.3"', 'version = "0.1.0"'),
+            workspaceManifest
+          ),
+        /RUST_VERSION_MISMATCH: release tag version 6\.10\.3.*Cargo\.lock.*0\.1\.0/
       );
     } finally {
       fs.rmSync(directory, { recursive: true, force: true });

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -33,6 +33,57 @@ function mutateWorkflowJob(source, jobName, mutateJob) {
   return JSON.stringify(document);
 }
 
+function withRustStageFixture(
+  { requirement, lockedDependencies, includeRegistryNameCollision = false },
+  assertion
+) {
+  const directory = temporaryDirectory();
+  const packageDirectory = path.join(directory, 'zeroshot-rust');
+  const workspacePath = path.join(directory, 'Cargo.toml');
+  const manifestPath = path.join(packageDirectory, 'Cargo.toml');
+  const lockPath = path.join(directory, 'Cargo.lock');
+  fs.mkdirSync(packageDirectory);
+  fs.writeFileSync(
+    workspacePath,
+    `[workspace]\nmembers = ["zeroshot-rust"]\n\n[workspace.dependencies]\nwindows-sys = "${requirement}"\n`
+  );
+  fs.writeFileSync(
+    manifestPath,
+    '[package]\nname = "zeroshot-rust"\nversion = "0.1.0"\nedition = "2024"\n\n[target.\'cfg(windows)\'.dependencies]\nwindows-sys = { workspace = true }\n'
+  );
+  const lockPackages = lockedDependencies.flatMap(({ version, source }) => [
+    '[[package]]',
+    'name = "windows-sys"',
+    `version = "${version}"`,
+    ...(source ? [`source = "${source}"`] : []),
+    '',
+  ]);
+  if (includeRegistryNameCollision) {
+    lockPackages.push(
+      '[[package]]',
+      'name = "zeroshot-rust"',
+      'version = "99.0.0"',
+      'source = "registry+https://github.com/rust-lang/crates.io-index"',
+      ''
+    );
+  }
+  lockPackages.push(
+    '[[package]]',
+    'name = "zeroshot-rust"',
+    'version = "0.1.0"',
+    'dependencies = [',
+    ' "windows-sys",',
+    ']',
+    ''
+  );
+  fs.writeFileSync(lockPath, ['version = 4', '', ...lockPackages].join('\n'));
+  try {
+    return assertion({ lockPath, manifestPath, workspacePath });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
 describe('Rust product distribution', function () {
   it('declares the complete native target and host matrix', function () {
     assert.deepStrictEqual(
@@ -207,6 +258,77 @@ describe('Rust release integration', function () {
     } finally {
       fs.rmSync(directory, { recursive: true, force: true });
     }
+  });
+
+  it('resolves supported Cargo requirements without collapsing lock identities', function () {
+    const registry = 'registry+https://github.com/rust-lang/crates.io-index';
+    withRustStageFixture(
+      {
+        requirement: '0.61.2',
+        lockedDependencies: [
+          { version: '0.52.0', source: registry },
+          { version: '0.61.3', source: registry },
+        ],
+        includeRegistryNameCollision: true,
+      },
+      ({ lockPath, manifestPath, workspacePath }) => {
+        distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath);
+        const lock = fs.readFileSync(lockPath, 'utf8');
+        assert.match(lock, /name = "zeroshot-rust"\nversion = "99\.0\.0"\nsource =/);
+        assert.match(
+          lock,
+          /name = "zeroshot-rust"\nversion = "6\.10\.3"[\s\S]*"windows-sys 0\.61\.3"/
+        );
+      }
+    );
+    withRustStageFixture(
+      {
+        requirement: '=0.61.2',
+        lockedDependencies: [
+          { version: '0.61.2', source: registry },
+          { version: '0.61.3', source: registry },
+        ],
+      },
+      ({ lockPath, manifestPath, workspacePath }) => {
+        distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath);
+        assert.match(fs.readFileSync(lockPath, 'utf8'), /"windows-sys 0\.61\.2"/);
+      }
+    );
+    withRustStageFixture(
+      {
+        requirement: '0.61.2',
+        lockedDependencies: [
+          { version: '0.61.2', source: registry },
+          { version: '0.61.3', source: registry },
+        ],
+      },
+      ({ lockPath, manifestPath, workspacePath }) => {
+        assert.throws(
+          () =>
+            distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath),
+          /needs exactly one windows-sys package satisfying 0\.61\.2/
+        );
+      }
+    );
+    withRustStageFixture(
+      {
+        requirement: '=0.61.2',
+        lockedDependencies: [
+          { version: '0.61.2', source: registry },
+          {
+            version: '0.61.2',
+            source: 'git+https://example.invalid/windows-rs?rev=fixture',
+          },
+        ],
+      },
+      ({ lockPath, manifestPath, workspacePath }) => {
+        assert.throws(
+          () =>
+            distribution.stageVersion('v6.10.3', manifestPath, lockPath, workspacePath),
+          /windows-sys 0\.61\.2 has ambiguous sources/
+        );
+      }
+    );
   });
 
   it('causally guards build, matrix, upload, publication, recovery, and shim integrity', function () {


### PR DESCRIPTION
## Summary

Stage every deterministic `zeroshot-rust` Cargo manifest/lock field needed by the release version before the existing multi-target `cargo build --locked` matrix runs, while preserving Cargo package and TOML table identity semantics.

## Failed-run evidence

Release run https://github.com/the-open-engine/zeroshot/actions/runs/30492851567 planned `v6.12.0`. All five `rust-binaries` jobs passed dependency installation, version staging, and coupling, then failed at **Build standalone Rust release binary** with `cannot update Cargo.lock because --locked was passed`.

Reproducing staging followed by full `cargo metadata --locked --offline` returned exit 101. Allowing Cargo to update only in a disposable worktree showed the exact non-version drift:

```diff
- "windows-sys",
+ "windows-sys 0.61.2",
```

Cargo.lock contains windows-sys 0.52.0 and 0.61.2, so the workspace package's target-specific dependency needs a qualified lock identity.

## Changes Made

- parse supported Cargo requirements: default/explicit caret `x.y.z`/`^x.y.z` and exact `=x.y.z`
- select one satisfying locked package identity, preserving compatible resolved updates rather than copying the literal requirement
- fail closed on unsupported/nonunique requirements and same-version source ambiguity
- select exactly one source-less workspace `zeroshot-rust` package despite registry/git name collisions
- bound each parsed package at the next column-zero TOML table/array-table header, so trailing `[[patch.unused]]` or `[metadata]` fields cannot be absorbed into the workspace package
- preserve indented dependency arrays and all unrelated bytes
- couple check-version to Cargo.toml plus the staged Cargo.lock version and resolved dependency reference
- cover compatible caret updates, exact requirements, nonunique/source-ambiguous candidates, root-name collisions, trailing array/single table headers, real bare-reference drift, and lock version coupling

The release retains `--locked`; staging runs no Cargo command and performs no network regeneration. Immutable checkout/ref/tag/recovery behavior and the five-target matrix are unchanged.

## Testing

- baseline staged `cargo metadata --locked --offline --format-version 1` — exit 101
- disposable unlocked offline resolution — identified only windows-sys qualification beyond staged versions
- `npx mocha tests/unit/rust-distribution.test.js` — 12 passing (514ms)
- post-fix staged `cargo metadata --locked --offline --format-version 1` — exit 0
- post-fix staged `cargo build --release --locked --offline -p zeroshot-rust --bin zeroshot-rust` — exit 0
- deterministic staged diff remains only both package versions plus `"windows-sys"` -> `"windows-sys 0.61.2"`
- `npm run rust:distribution:check` — `Rust distribution workflow declares 5 complete targets`
- `git diff --check` — clean

## Checklist

- [x] Focused tests pass
- [x] No release network regeneration
- [x] Documentation not needed
- [x] Follows commit guidelines