### PR TITLE
feat(cluster-protocol): define binding-injected connection identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,15 @@ Endpoint preflight rejects non-ws(s), userinfo, query, and fragment before netwo
 are never followed or downgraded. Keep `serve_websocket` plaintext/front-proxy terminated and keep
 TLS out of `zeroshot-rust`. Do not introduce native-tls: its Linux `openssl-sys` dependency breaks
 cross-compilation and static-musl builds.
+Connection identity is binding-injected and never wire-carried. Every accepted NDJSON or WebSocket
+binding resolves exactly one immutable `ConnectionIdentity` before decoding its first frame;
+principal and tenant are opaque typed IDs, expiry is required, and binding attributes remain opaque
+to the dispatcher. Check expiry at every request decode boundary before admission/backend work
+(`4401` for WebSocket; one terminal diagnostic then close for NDJSON). Protocol params named
+`principal`, `tenant`, or `expiresAt` remain strict unknown fields and must never alter context.
+Tenant partitioning is exclusively a backend decision: the dispatcher neither adds nor removes it.
+`ConnectionBinding` must preserve the host-supplied cancellation signal in the backend-visible
+context; identity resolution must not replace the host's connection/shutdown ownership.
 Each binding parses inbound JSON once into the duplicate-preserving connection frame. Preserve the
 legacy typed-request classification used for duplicate-ID and task-slot admission before the strict
 envelope outcome; malformed and wrong-version responses still cross that shared admission boundary.

--- a/crates/openengine-cluster-server/src/identity.rs
+++ b/crates/openengine-cluster-server/src/identity.rs
@@ -1,0 +1,253 @@
+//! Binding-injected connection identity and acceptance-time resolution.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::admission::CancellationSignal;
+use crate::{ClusterBackend, ConnectionContext, Dispatcher};
+
+/// Opaque authenticated principal identifier supplied by a transport binding.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PrincipalId(Box<str>);
+
+impl PrincipalId {
+    #[must_use]
+    pub fn new(value: impl Into<Box<str>>) -> Self {
+        Self(value.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Opaque tenant identifier supplied by a transport binding.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TenantId(Box<str>);
+
+impl TenantId {
+    #[must_use]
+    pub fn new(value: impl Into<Box<str>>) -> Self {
+        Self(value.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Binding-specific attributes that are carried to a backend without interpretation by the
+/// dispatcher or protocol layer.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BindingAttributes(BTreeMap<String, String>);
+
+impl BindingAttributes {
+    #[must_use]
+    pub fn new(values: BTreeMap<String, String>) -> Self {
+        Self(values)
+    }
+
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.0.get(name).map(String::as_str)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.0
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+    }
+}
+
+/// Construction payload for an immutable [`ConnectionIdentity`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConnectionIdentityConfig {
+    pub principal: PrincipalId,
+    pub tenant: TenantId,
+    pub issued_at_ms: Option<u64>,
+    pub expires_at_ms: u64,
+    pub binding_attributes: BindingAttributes,
+}
+
+/// Authenticated identity fixed for the lifetime of one accepted connection.
+///
+/// This type deliberately has no serde implementation: it is injected by a binding and cannot be
+/// carried by a protocol request, response, or event.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConnectionIdentity {
+    principal: PrincipalId,
+    tenant: TenantId,
+    issued_at_ms: Option<u64>,
+    expires_at_ms: u64,
+    binding_attributes: BindingAttributes,
+}
+
+impl ConnectionIdentity {
+    #[must_use]
+    pub fn new(config: ConnectionIdentityConfig) -> Self {
+        Self {
+            principal: config.principal,
+            tenant: config.tenant,
+            issued_at_ms: config.issued_at_ms,
+            expires_at_ms: config.expires_at_ms,
+            binding_attributes: config.binding_attributes,
+        }
+    }
+
+    #[must_use]
+    pub fn principal(&self) -> &PrincipalId {
+        &self.principal
+    }
+
+    #[must_use]
+    pub fn tenant(&self) -> &TenantId {
+        &self.tenant
+    }
+
+    #[must_use]
+    pub fn issued_at_ms(&self) -> Option<u64> {
+        self.issued_at_ms
+    }
+
+    #[must_use]
+    pub fn expires_at_ms(&self) -> u64 {
+        self.expires_at_ms
+    }
+
+    #[must_use]
+    pub fn binding_attributes(&self) -> &BindingAttributes {
+        &self.binding_attributes
+    }
+
+    #[must_use]
+    pub fn is_expired_at(&self, now_ms: u64) -> bool {
+        now_ms >= self.expires_at_ms
+    }
+
+    pub(crate) fn local_default() -> Self {
+        Self::new(ConnectionIdentityConfig {
+            principal: PrincipalId::new("local"),
+            tenant: TenantId::new("local"),
+            issued_at_ms: None,
+            expires_at_ms: u64::MAX,
+            binding_attributes: BindingAttributes::default(),
+        })
+    }
+}
+
+/// Failure to resolve a connection identity before the binding reads its first frame.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error("{message}")]
+pub struct IdentityResolutionError {
+    message: String,
+}
+
+impl IdentityResolutionError {
+    #[must_use]
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Acceptance-time hook owned by a transport binding.
+#[async_trait]
+pub trait ConnectionIdentityResolver: Send + Sync + 'static {
+    async fn resolve(&self) -> Result<ConnectionIdentity, IdentityResolutionError>;
+}
+
+/// Resolver for hosts that already resolved identity synchronously while accepting the transport.
+#[derive(Clone, Debug)]
+pub struct StaticConnectionIdentityResolver {
+    identity: ConnectionIdentity,
+}
+
+impl StaticConnectionIdentityResolver {
+    #[must_use]
+    pub fn new(identity: ConnectionIdentity) -> Self {
+        Self { identity }
+    }
+}
+
+#[async_trait]
+impl ConnectionIdentityResolver for StaticConnectionIdentityResolver {
+    async fn resolve(&self) -> Result<ConnectionIdentity, IdentityResolutionError> {
+        Ok(self.identity.clone())
+    }
+}
+
+/// Millisecond clock observed at each inbound request decode boundary.
+pub trait ConnectionTimeSource: Send + Sync + 'static {
+    fn now_ms(&self) -> u64;
+}
+
+/// Wall-clock time source used by production bindings.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemConnectionTime;
+
+impl ConnectionTimeSource for SystemConnectionTime {
+    fn now_ms(&self) -> u64 {
+        let elapsed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default();
+        u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+    }
+}
+
+/// Backend and host-owned connection services consumed once by an accepted binding.
+pub struct ConnectionBinding<B, R, T> {
+    backend: Arc<B>,
+    identity_resolver: R,
+    time_source: T,
+    cancellation: CancellationSignal,
+}
+
+impl<B, R, T> ConnectionBinding<B, R, T> {
+    #[must_use]
+    pub fn new(
+        backend: Arc<B>,
+        identity_resolver: R,
+        time_source: T,
+        cancellation: CancellationSignal,
+    ) -> Self {
+        Self {
+            backend,
+            identity_resolver,
+            time_source,
+            cancellation,
+        }
+    }
+}
+
+pub(crate) struct ResolvedConnection<B, T> {
+    pub(crate) dispatcher: Dispatcher<B>,
+    pub(crate) time_source: T,
+}
+
+impl<B, R, T> ConnectionBinding<B, R, T>
+where
+    B: ClusterBackend,
+    R: ConnectionIdentityResolver,
+    T: ConnectionTimeSource,
+{
+    pub(crate) async fn resolve(self) -> io::Result<ResolvedConnection<B, T>> {
+        let identity = self
+            .identity_resolver
+            .resolve()
+            .await
+            .map_err(|error| io::Error::new(io::ErrorKind::PermissionDenied, error))?;
+        let context = ConnectionContext::new(identity, self.cancellation);
+        Ok(ResolvedConnection {
+            dispatcher: Dispatcher::from_shared(self.backend, context),
+            time_source: self.time_source,
+        })
+    }
+}

--- a/crates/openengine-cluster-server/src/lib.rs
+++ b/crates/openengine-cluster-server/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admission;
 pub mod agent_attach;
 pub mod graph_verifier;
+pub mod identity;
 pub mod lifecycle;
 pub mod logs;
 pub mod method_registry;
@@ -32,11 +33,36 @@ use thiserror::Error;
 use crate::agent_attach::{AgentAttachEventStream, AgentAttachHandle};
 use crate::logs::{LogEventStream, LogsHandle};
 use crate::watch::{WatchEventStream, WatchHandle};
+use crate::identity::ConnectionIdentity;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConnectionContext {
-    pub peer_label: Option<String>,
+    identity: ConnectionIdentity,
     pub cancellation: admission::CancellationSignal,
+}
+
+impl ConnectionContext {
+    #[must_use]
+    pub fn new(identity: ConnectionIdentity, cancellation: admission::CancellationSignal) -> Self {
+        Self {
+            identity,
+            cancellation,
+        }
+    }
+
+    #[must_use]
+    pub fn identity(&self) -> &ConnectionIdentity {
+        &self.identity
+    }
+}
+
+impl Default for ConnectionContext {
+    fn default() -> Self {
+        Self::new(
+            ConnectionIdentity::local_default(),
+            admission::CancellationSignal::default(),
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/openengine-cluster-server/src/stdio.rs
+++ b/crates/openengine-cluster-server/src/stdio.rs
@@ -13,6 +13,9 @@ use crate::connection::{
     ConnectionState, DecodedFrame, DecodedOutcome, DecodedRequest, DispatchCtx, RequestDispatch,
     RequestKind, ShutdownArgs,
 };
+use crate::identity::{
+    ConnectionBinding, ConnectionIdentityResolver, ConnectionTimeSource, ResolvedConnection,
+};
 use crate::{serialize_error, ClusterBackend, Dispatcher};
 
 /// Bounded NDJSON frame length. A line exceeding this (with no terminating newline found first)
@@ -39,18 +42,45 @@ where
     }
 }
 
-pub async fn serve_ndjson<B, R, W, E>(
-    dispatcher: Dispatcher<B>,
+/// The three byte streams owned by one NDJSON connection.
+pub struct NdjsonIo<R, W, E> {
     reader: R,
     writer: W,
-    mut diagnostics: E,
+    diagnostics: E,
+}
+
+impl<R, W, E> NdjsonIo<R, W, E> {
+    #[must_use]
+    pub fn new(reader: R, writer: W, diagnostics: E) -> Self {
+        Self {
+            reader,
+            writer,
+            diagnostics,
+        }
+    }
+}
+
+pub async fn serve_ndjson<B, R, W, E, I, T>(
+    binding: ConnectionBinding<B, I, T>,
+    io: NdjsonIo<R, W, E>,
 ) -> io::Result<()>
 where
     B: ClusterBackend,
     R: AsyncRead + Send + Unpin + 'static,
     W: AsyncWrite + Send + Unpin + 'static,
     E: AsyncWrite + Send + Unpin + 'static,
+    I: ConnectionIdentityResolver,
+    T: ConnectionTimeSource,
 {
+    let ResolvedConnection {
+        dispatcher,
+        time_source,
+    } = binding.resolve().await?;
+    let NdjsonIo {
+        reader,
+        writer,
+        mut diagnostics,
+    } = io;
     let (outbound_tx, outbound_rx) = mpsc::channel::<String>(OUTBOUND_QUEUE_CAPACITY);
     let writer_task = tokio::spawn(run_writer(writer, outbound_rx));
 
@@ -73,9 +103,23 @@ where
                 line = lines.next() => break line,
             }
         };
+        let Some(next_line) = next_line else {
+            break;
+        };
+        if dispatcher
+            .context()
+            .identity()
+            .is_expired_at(time_source.now_ms())
+        {
+            diagnostics
+                .write_all(b"cluster protocol connection identity expired\n")
+                .await?;
+            diagnostics.flush().await?;
+            break;
+        }
         let line = match next_line {
-            Some(Ok(line)) => line,
-            Some(Err(LinesCodecError::MaxLineLengthExceeded)) => {
+            Ok(line) => line,
+            Err(LinesCodecError::MaxLineLengthExceeded) => {
                 let _ = outbound_tx
                     .send(serialize_error(None, PARSE_ERROR, "Parse error", None))
                     .await;
@@ -89,14 +133,13 @@ where
                 lines = Framed::from_parts(lines.into_parts());
                 continue;
             }
-            Some(Err(LinesCodecError::Io(error))) => {
+            Err(LinesCodecError::Io(error)) => {
                 diagnostics
                     .write_all(format!("cluster protocol input error: {error}\n").as_bytes())
                     .await?;
                 diagnostics.flush().await?;
                 break;
             }
-            None => break,
         };
 
         let mut ctx = DispatchCtx {
@@ -169,15 +212,15 @@ async fn run_passthrough_request<B>(
     let _ = state.outbound_tx.send(response).await;
 }
 
-pub async fn serve_stdio<B>(dispatcher: Dispatcher<B>) -> io::Result<()>
+pub async fn serve_stdio<B, I, T>(binding: ConnectionBinding<B, I, T>) -> io::Result<()>
 where
     B: ClusterBackend,
+    I: ConnectionIdentityResolver,
+    T: ConnectionTimeSource,
 {
     serve_ndjson(
-        dispatcher,
-        tokio::io::stdin(),
-        tokio::io::stdout(),
-        tokio::io::stderr(),
+        binding,
+        NdjsonIo::new(tokio::io::stdin(), tokio::io::stdout(), tokio::io::stderr()),
     )
     .await
 }

--- a/crates/openengine-cluster-server/src/watch/fixtures.rs
+++ b/crates/openengine-cluster-server/src/watch/fixtures.rs
@@ -25,9 +25,34 @@ use super::{
     ResolvedSubscription, SubscribeRequest, WatchEventStream, WatchHandle,
 };
 use crate::admission::StoreError;
-use crate::stdio::serve_ndjson;
+use crate::identity::{
+    BindingAttributes, ConnectionBinding, ConnectionIdentity, ConnectionIdentityConfig,
+    PrincipalId, StaticConnectionIdentityResolver, SystemConnectionTime, TenantId,
+};
+use crate::stdio::{serve_ndjson, NdjsonIo};
 use crate::websocket::{serve_websocket, websocket_config};
-use crate::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
+use crate::{BackendError, ClusterBackend, ConnectionContext};
+
+fn fixture_binding<B>(
+    backend: B,
+) -> ConnectionBinding<B, StaticConnectionIdentityResolver, SystemConnectionTime>
+where
+    B: ClusterBackend,
+{
+    let identity = ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new("fixture-principal"),
+        tenant: TenantId::new("fixture-tenant"),
+        issued_at_ms: None,
+        expires_at_ms: u64::MAX,
+        binding_attributes: BindingAttributes::default(),
+    });
+    ConnectionBinding::new(
+        Arc::new(backend),
+        StaticConnectionIdentityResolver::new(identity),
+        SystemConnectionTime,
+        Default::default(),
+    )
+}
 
 /// Wires `backend` to a fresh [`serve_ndjson`] task over an in-memory duplex pipe pair, returning
 /// the pipe's client-facing write/read halves and the server task's join handle. Shared by this
@@ -39,12 +64,9 @@ where
 {
     let (client_write, server_read) = tokio::io::duplex(1 << 16);
     let (server_write, client_read) = tokio::io::duplex(1 << 16);
-    let dispatcher = Dispatcher::new(backend, ConnectionContext::default());
     let server = tokio::spawn(serve_ndjson(
-        dispatcher,
-        server_read,
-        server_write,
-        tokio::io::sink(),
+        fixture_binding(backend),
+        NdjsonIo::new(server_read, server_write, tokio::io::sink()),
     ));
     (client_write, client_read, server)
 }
@@ -73,12 +95,12 @@ where
     B: ClusterBackend,
 {
     let (client_io, server_io) = tokio::io::duplex(1 << 16);
-    let dispatcher = Dispatcher::new(backend, ConnectionContext::default());
+    let binding = fixture_binding(backend);
     let server = tokio::spawn(async move {
         let ws = tokio_tungstenite::accept_async_with_config(server_io, Some(websocket_config()))
             .await
             .expect("server handshake must succeed");
-        serve_websocket(dispatcher, ws).await
+        serve_websocket(binding, ws).await
     });
     let (client, _response) =
         tokio_tungstenite::client_async("ws://localhost/websocket", client_io)

--- a/crates/openengine-cluster-server/src/websocket.rs
+++ b/crates/openengine-cluster-server/src/websocket.rs
@@ -26,6 +26,9 @@ use crate::connection::{
     ConnectionSetup, ConnectionState, DecodedFrame, DecodedOutcome, DecodedRequest, DispatchCtx,
     RequestDispatch, RequestKind, ShutdownArgs,
 };
+use crate::identity::{
+    ConnectionBinding, ConnectionIdentityResolver, ConnectionTimeSource, ResolvedConnection,
+};
 use crate::{ClusterBackend, Dispatcher};
 
 /// Bounded WebSocket text-frame length: a text message whose UTF-8 byte length exceeds this
@@ -59,16 +62,23 @@ pub fn websocket_config() -> WebSocketConfig {
 /// Serves one already-handshaken WebSocket connection: demultiplexes unary requests and `watch`/
 /// `logs`/`agent/attach` subscriptions sharing this connection exactly like `stdio::serve_ndjson`,
 /// plus per-connection cooperative `$/cancelRequest`. Binary frames close with code 1003;
-/// oversized or capacity-rejected text frames close with code 1009. Never returns an `Err`:
-/// transport failures close the connection and this simply returns once torn down.
-pub async fn serve_websocket<B, S>(
-    dispatcher: Dispatcher<B>,
+/// oversized or capacity-rejected text frames close with code 1009, and an expired identity closes
+/// before text-frame decoding with code 4401. Identity-resolution failures are returned as I/O
+/// errors; transport failures after resolution tear down the connection and return `Ok`.
+pub async fn serve_websocket<B, S, I, T>(
+    binding: ConnectionBinding<B, I, T>,
     ws: WebSocketStream<S>,
 ) -> io::Result<()>
 where
     B: ClusterBackend,
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    I: ConnectionIdentityResolver,
+    T: ConnectionTimeSource,
 {
+    let ResolvedConnection {
+        dispatcher,
+        time_source,
+    } = binding.resolve().await?;
     let (sink, mut stream) = ws.split();
     let (outbound_tx, outbound_rx) = mpsc::channel::<String>(OUTBOUND_QUEUE_CAPACITY);
     let (close_tx, close_rx) = oneshot::channel::<CloseFrame>();
@@ -84,6 +94,19 @@ where
     let mut close_tx = Some(close_tx);
 
     while let Some(message) = next_incoming_message(&mut tasks, &mut stream, &mut close_tx).await {
+        if message.is_text()
+            && dispatcher
+                .context()
+                .identity()
+                .is_expired_at(time_source.now_ms())
+        {
+            signal_close(
+                &mut close_tx,
+                CloseCode::Library(4401),
+                "connection identity expired",
+            );
+            break;
+        }
         let mut ctx = WsCtx {
             dispatch: DispatchCtx {
                 dispatcher: &dispatcher,

--- a/crates/openengine-cluster-server/tests/connection_identity.rs
+++ b/crates/openengine-cluster-server/tests/connection_identity.rs
@@ -1,0 +1,292 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use openengine_cluster_protocol::{
+    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, ServerCapabilities,
+    INVALID_PARAMS,
+};
+use openengine_cluster_server::admission::CancellationSignal;
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionBinding, ConnectionIdentity, ConnectionIdentityConfig,
+    ConnectionIdentityResolver, ConnectionTimeSource, IdentityResolutionError, PrincipalId,
+    TenantId,
+};
+use openengine_cluster_server::stdio::{serve_ndjson, NdjsonIo};
+use openengine_cluster_server::websocket::{serve_websocket, websocket_config};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::Message;
+
+fn identity(expires_at_ms: u64) -> ConnectionIdentity {
+    let mut attributes = BTreeMap::new();
+    attributes.insert("transport".to_owned(), "fixture".to_owned());
+    ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new("principal-17"),
+        tenant: TenantId::new("tenant-blue"),
+        issued_at_ms: Some(10),
+        expires_at_ms,
+        binding_attributes: BindingAttributes::new(attributes),
+    })
+}
+
+#[derive(Clone)]
+struct CountingResolver {
+    identity: ConnectionIdentity,
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ConnectionIdentityResolver for CountingResolver {
+    async fn resolve(&self) -> Result<ConnectionIdentity, IdentityResolutionError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.identity.clone())
+    }
+}
+
+#[derive(Clone)]
+struct FixedTime(Arc<AtomicU64>);
+
+impl FixedTime {
+    fn new(now_ms: u64) -> Self {
+        Self(Arc::new(AtomicU64::new(now_ms)))
+    }
+}
+
+impl ConnectionTimeSource for FixedTime {
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Default)]
+struct RecordingBackend {
+    calls: AtomicUsize,
+    identities: Mutex<Vec<ConnectionIdentity>>,
+    cancellations: Mutex<Vec<bool>>,
+}
+
+impl RecordingBackend {
+    fn record(&self, context: &ConnectionContext) {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.identities.lock().push(context.identity().clone());
+        self.cancellations
+            .lock()
+            .push(context.cancellation.is_cancelled());
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for RecordingBackend {
+    async fn initialize(
+        &self,
+        context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        self.record(context);
+        Ok(InitializeResult::new(
+            ServerCapabilities::default(),
+            ClusterStatus::empty(),
+        ))
+    }
+
+    async fn get(
+        &self,
+        context: &ConnectionContext,
+        _params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        self.record(context);
+        Ok(GetResult::empty())
+    }
+}
+
+#[test]
+fn connection_identity_has_typed_read_only_shape() {
+    let identity = identity(50);
+    assert_eq!(identity.principal().as_str(), "principal-17");
+    assert_eq!(identity.tenant().as_str(), "tenant-blue");
+    assert_eq!(identity.issued_at_ms(), Some(10));
+    assert_eq!(identity.expires_at_ms(), 50);
+    assert_eq!(
+        identity.binding_attributes().get("transport"),
+        Some("fixture")
+    );
+    assert!(!identity.is_expired_at(49));
+    assert!(identity.is_expired_at(50));
+}
+
+#[tokio::test]
+async fn websocket_resolves_once_before_frames_and_keeps_identity_stable() {
+    let backend = Arc::new(RecordingBackend::default());
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
+    let resolver = CountingResolver {
+        identity: identity(100),
+        calls: Arc::clone(&resolver_calls),
+    };
+    let cancellation = CancellationSignal::default();
+    let binding = ConnectionBinding::new(
+        Arc::clone(&backend),
+        resolver,
+        FixedTime::new(99),
+        cancellation.clone(),
+    );
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    let server = tokio::spawn(async move {
+        let ws = tokio_tungstenite::accept_async_with_config(server_io, Some(websocket_config()))
+            .await
+            .unwrap();
+        serve_websocket(binding, ws).await
+    });
+    let (mut client, _) = tokio_tungstenite::client_async("ws://localhost/identity", client_io)
+        .await
+        .unwrap();
+
+    for id in [1, 2] {
+        client
+            .send(Message::Text(
+                json!({"jsonrpc":"2.0","id":id,"method":"get","params":{}})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        let response = client.next().await.unwrap().unwrap();
+        assert!(response.is_text());
+        if id == 1 {
+            cancellation.cancel();
+        }
+    }
+    assert_eq!(resolver_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        backend.identities.lock().as_slice(),
+        &[identity(100), identity(100)]
+    );
+    assert_eq!(backend.cancellations.lock().as_slice(), &[false, true]);
+
+    client.close(None).await.unwrap();
+    server.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn websocket_expiry_at_boundary_closes_4401_without_backend_calls() {
+    let backend = Arc::new(RecordingBackend::default());
+    let resolver_calls = Arc::new(AtomicUsize::new(0));
+    let binding = ConnectionBinding::new(
+        Arc::clone(&backend),
+        CountingResolver {
+            identity: identity(50),
+            calls: Arc::clone(&resolver_calls),
+        },
+        FixedTime::new(50),
+        Default::default(),
+    );
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    let server = tokio::spawn(async move {
+        let ws = tokio_tungstenite::accept_async_with_config(server_io, Some(websocket_config()))
+            .await
+            .unwrap();
+        serve_websocket(binding, ws).await
+    });
+    let (mut client, _) = tokio_tungstenite::client_async("ws://localhost/identity", client_io)
+        .await
+        .unwrap();
+    client
+        .send(Message::Text(
+            json!({"jsonrpc":"2.0","id":1,"method":"get","params":{}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+
+    let close = client.next().await.unwrap().unwrap();
+    let Message::Close(Some(frame)) = close else {
+        panic!("expired connection must receive a close frame");
+    };
+    assert_eq!(frame.code, CloseCode::Library(4401));
+    assert_eq!(resolver_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+    server.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn ndjson_expiry_emits_one_terminal_diagnostic_and_closes() {
+    let backend = Arc::new(RecordingBackend::default());
+    let binding = ConnectionBinding::new(
+        Arc::clone(&backend),
+        CountingResolver {
+            identity: identity(50),
+            calls: Arc::new(AtomicUsize::new(0)),
+        },
+        FixedTime::new(50),
+        Default::default(),
+    );
+    let (mut client_input, server_input) = tokio::io::duplex(1 << 16);
+    let (server_output, mut client_output) = tokio::io::duplex(1 << 16);
+    let (server_diagnostics, mut client_diagnostics) = tokio::io::duplex(1 << 16);
+    let server = tokio::spawn(serve_ndjson(
+        binding,
+        NdjsonIo::new(server_input, server_output, server_diagnostics),
+    ));
+    client_input
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"get\",\"params\":{}}\n")
+        .await
+        .unwrap();
+    server.await.unwrap().unwrap();
+
+    let mut diagnostics = String::new();
+    client_diagnostics
+        .read_to_string(&mut diagnostics)
+        .await
+        .unwrap();
+    assert_eq!(
+        diagnostics,
+        "cluster protocol connection identity expired\n"
+    );
+    let mut output = String::new();
+    client_output.read_to_string(&mut output).await.unwrap();
+    assert!(output.is_empty());
+    assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn identity_shaped_params_are_invalid_and_cannot_change_context() {
+    let expected_identity = identity(u64::MAX);
+    let backend = Arc::new(RecordingBackend::default());
+    let dispatcher = Dispatcher::from_shared(
+        Arc::clone(&backend),
+        ConnectionContext::new(expected_identity, Default::default()),
+    );
+
+    for (index, params) in [
+        json!({"principal":"attacker"}),
+        json!({"tenant":"other-tenant"}),
+        json!({"expiresAt":u64::MAX}),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let response: Value = serde_json::from_str(
+            &dispatcher
+                .dispatch(
+                    &json!({
+                        "jsonrpc":"2.0",
+                        "id":index as u64,
+                        "method":"get",
+                        "params":params
+                    })
+                    .to_string(),
+                )
+                .await,
+        )
+        .unwrap();
+        assert_eq!(response["error"]["code"], INVALID_PARAMS);
+    }
+    assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+}

--- a/crates/openengine-cluster-testkit/src/bin/openengine-cluster-stdio.rs
+++ b/crates/openengine-cluster-testkit/src/bin/openengine-cluster-stdio.rs
@@ -1,6 +1,11 @@
-use openengine_cluster_server::stdio::serve_stdio;
+use std::sync::Arc;
+
 use openengine_cluster_server::admission::AdmissionCoordinator;
-use openengine_cluster_server::{ConnectionContext, Dispatcher};
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionBinding, ConnectionIdentity, ConnectionIdentityConfig,
+    PrincipalId, StaticConnectionIdentityResolver, SystemConnectionTime, TenantId,
+};
+use openengine_cluster_server::stdio::serve_stdio;
 use openengine_cluster_testkit::admission::{
     compiled_from_graph_fixture, graph_fixture, InMemoryAdmissionStore, ScriptedOutcome,
     ScriptedVerifier,
@@ -18,8 +23,20 @@ async fn main() {
         ScriptedVerifier::new(outcomes),
         InMemoryAdmissionStore::default(),
     );
-    let dispatcher = Dispatcher::new(backend, ConnectionContext::default());
-    if let Err(error) = serve_stdio(dispatcher).await {
+    let identity = ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new("stdio-fixture"),
+        tenant: TenantId::new("stdio-fixture"),
+        issued_at_ms: None,
+        expires_at_ms: u64::MAX,
+        binding_attributes: BindingAttributes::default(),
+    });
+    let binding = ConnectionBinding::new(
+        Arc::new(backend),
+        StaticConnectionIdentityResolver::new(identity),
+        SystemConnectionTime,
+        Default::default(),
+    );
+    if let Err(error) = serve_stdio(binding).await {
         eprintln!("cluster protocol stdio server failed: {error}");
         std::process::exit(1);
     }

--- a/crates/openengine-cluster-testkit/src/conformance/runner.rs
+++ b/crates/openengine-cluster-testkit/src/conformance/runner.rs
@@ -8,6 +8,9 @@ use openengine_cluster_protocol::{
     AgentAttachParams, ExecutionRef, GetResult, InitializeResult, LogsParams, WatchParams,
     NOT_FOUND,
 };
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionIdentity, ConnectionIdentityConfig, PrincipalId, TenantId,
+};
 use openengine_cluster_server::{ClusterBackend, ConnectionContext, Dispatcher};
 use serde_json::Value;
 
@@ -207,10 +210,16 @@ where
         .await
         .map_err(|error| format!("create failed: {error}"))?;
     let backend = Arc::new(backend);
-    let context = ConnectionContext {
-        peer_label: Some(format!("portable-conformance:{ordinal}")),
-        ..ConnectionContext::default()
-    };
+    let context = ConnectionContext::new(
+        ConnectionIdentity::new(ConnectionIdentityConfig {
+            principal: PrincipalId::new(format!("portable-conformance:{ordinal}")),
+            tenant: TenantId::new(format!("portable-conformance:{ordinal}")),
+            issued_at_ms: None,
+            expires_at_ms: u64::MAX,
+            binding_attributes: BindingAttributes::default(),
+        }),
+        Default::default(),
+    );
     let dispatcher = Dispatcher::from_shared(Arc::clone(&backend), context);
     let exercise = exercise(&dispatcher, registration, case).await;
     drop(dispatcher);

--- a/crates/openengine-cluster-testkit/tests/admission.rs
+++ b/crates/openengine-cluster-testkit/tests/admission.rs
@@ -386,10 +386,10 @@ async fn idempotency_and_cancellation_before_create_has_zero_effects() {
     let cancellation = CancellationSignal::default();
     let dispatcher = Dispatcher::new(
         backend,
-        ConnectionContext {
-            peer_label: None,
-            cancellation: cancellation.clone(),
-        },
+        ConnectionContext::new(
+            ConnectionContext::default().identity().clone(),
+            cancellation.clone(),
+        ),
     );
     let cancelled_client = Arc::new(ClusterClient::new(InProcessTransport::new(dispatcher)));
     let task_client = Arc::clone(&cancelled_client);
@@ -427,10 +427,10 @@ async fn idempotency_and_cancellation_restores_existing_run_and_replays_after_co
     let update_client = Arc::new(ClusterClient::new(InProcessTransport::new(
         Dispatcher::new(
             backend,
-            ConnectionContext {
-                peer_label: None,
-                cancellation: cancellation.clone(),
-            },
+            ConnectionContext::new(
+                ConnectionContext::default().identity().clone(),
+                cancellation.clone(),
+            ),
         ),
     )));
     let update_task_client = Arc::clone(&update_client);
@@ -453,10 +453,10 @@ async fn idempotency_and_cancellation_restores_existing_run_and_replays_after_co
     already_cancelled.cancel();
     let replay_client = ClusterClient::new(InProcessTransport::new(Dispatcher::new(
         replay_backend,
-        ConnectionContext {
-            peer_label: None,
-            cancellation: already_cancelled,
-        },
+        ConnectionContext::new(
+            ConnectionContext::default().identity().clone(),
+            already_cancelled,
+        ),
     )));
     let recovered = replay_client
         .apply(committed(graph, json!(1), 0, "stable-key"))

--- a/crates/openengine-cluster-testkit/tests/external-backend-fixture/src/lib.rs
+++ b/crates/openengine-cluster-testkit/tests/external-backend-fixture/src/lib.rs
@@ -42,9 +42,10 @@ mod tests {
             _params: InitializeParams,
         ) -> Result<InitializeResult, BackendError> {
             if !context
-                .peer_label
-                .as_deref()
-                .is_some_and(|label| label.starts_with("portable-conformance:"))
+                .identity()
+                .tenant()
+                .as_str()
+                .starts_with("portable-conformance:")
             {
                 return Err(BackendError::new(
                     "CONTEXT_NOT_ISOLATED",
@@ -67,7 +68,12 @@ mod tests {
             context: &ConnectionContext,
             _params: GetParams,
         ) -> Result<GetResult, BackendError> {
-            if context.peer_label.is_none() {
+            if !context
+                .identity()
+                .tenant()
+                .as_str()
+                .starts_with("portable-conformance:")
+            {
                 return Err(BackendError::new(
                     "CONTEXT_NOT_ISOLATED",
                     "runner context was missing",

--- a/crates/openengine-cluster-testkit/tests/external_backend_conformance.rs
+++ b/crates/openengine-cluster-testkit/tests/external_backend_conformance.rs
@@ -43,7 +43,12 @@ impl ClusterBackend for OptionalCapabilityBackend {
         context: &ConnectionContext,
         _params: InitializeParams,
     ) -> Result<InitializeResult, BackendError> {
-        if context.peer_label.is_none() {
+        if !context
+            .identity()
+            .tenant()
+            .as_str()
+            .starts_with("portable-conformance:")
+        {
             return Err(BackendError::new(
                 "CONTEXT_NOT_ISOLATED",
                 "runner context was missing",
@@ -60,7 +65,12 @@ impl ClusterBackend for OptionalCapabilityBackend {
         context: &ConnectionContext,
         _params: GetParams,
     ) -> Result<GetResult, BackendError> {
-        if context.peer_label.is_none() {
+        if !context
+            .identity()
+            .tenant()
+            .as_str()
+            .starts_with("portable-conformance:")
+        {
             return Err(BackendError::new(
                 "CONTEXT_NOT_ISOLATED",
                 "runner context was missing",

--- a/crates/openengine-cluster-testkit/tests/protocol_websocket.rs
+++ b/crates/openengine-cluster-testkit/tests/protocol_websocket.rs
@@ -2,18 +2,25 @@
 //! watch transcript (cursor progression and event algebra) as the in-process `Dispatcher::watch`
 //! passthrough from #647 and the NDJSON binding from #745 (see `protocol_ndjson.rs`), while
 //! sharing its connection with ordinary unary traffic and honoring `subscription/cancel`. Also
-//! proves two independently-authorized WebSocket connections sharing one backend (AC3) preserve
-//! CAS/idempotency and cannot observe each other's injected `ConnectionContext`, since
-//! `ConnectionContext` is constructed once per connection and never derived from protocol params.
+//! proves independently accepted WebSocket connections receive stable injected identities while
+//! tenant sharing or isolation remains exactly the shared backend's decision.
 
+use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Duration;
 
 use openengine_cluster_client::{ClusterClient, WatchSubscriptionClient, WebSocketTransport};
-use openengine_cluster_protocol::{GetParams, StopMode, WatchParams};
+use openengine_cluster_protocol::{
+    ApplyParams, ApplyResult, GetParams, GetResult, InitializeParams, InitializeResult, StopMode,
+    WatchParams,
+};
 use openengine_cluster_server::admission::AdmissionCoordinator;
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionBinding, ConnectionIdentity, ConnectionIdentityConfig,
+    PrincipalId, StaticConnectionIdentityResolver, SystemConnectionTime, TenantId,
+};
 use openengine_cluster_server::watch::fixtures::{await_websocket_shutdown, spawn_websocket};
-use openengine_cluster_server::{ClusterBackend, ConnectionContext, Dispatcher};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
 use openengine_cluster_testkit::admission::{
     compiled_from_graph_fixture, graph_fixture, InMemoryAdmissionStore, ScriptedOutcome,
     ScriptedVerifier,
@@ -90,15 +97,11 @@ async fn websocket_watch_transcript_matches_in_process_and_shares_its_connection
     await_websocket_shutdown(server).await;
 }
 
-/// Wires `backend` to a fresh [`openengine_cluster_server::websocket::serve_websocket`] task over
-/// an in-memory duplex pipe pair, injecting `peer_label` into that connection's
-/// [`ConnectionContext`] -- unlike [`spawn_websocket`], which always uses
-/// [`Dispatcher::new`]/[`ConnectionContext::default`], this uses
-/// [`Dispatcher::from_shared`] so multiple independently-authorized connections can share one
-/// backend, exactly as AC3 requires.
+/// Wires a shared backend to one accepted WebSocket connection. The binding resolves the supplied
+/// tenant exactly once before it decodes a frame; sharing or partitioning remains backend-owned.
 async fn spawn_websocket_with_shared_backend<B>(
     backend: Arc<B>,
-    peer_label: &str,
+    tenant: &str,
 ) -> (
     tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>,
     tokio::task::JoinHandle<std::io::Result<()>>,
@@ -107,12 +110,18 @@ where
     B: ClusterBackend,
 {
     let (client_io, server_io) = tokio::io::duplex(1 << 16);
-    let dispatcher = Dispatcher::from_shared(
+    let identity = ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new(format!("principal-for-{tenant}")),
+        tenant: TenantId::new(tenant.to_owned()),
+        issued_at_ms: Some(1),
+        expires_at_ms: u64::MAX,
+        binding_attributes: BindingAttributes::default(),
+    });
+    let binding = ConnectionBinding::new(
         backend,
-        ConnectionContext {
-            peer_label: Some(peer_label.to_owned()),
-            ..ConnectionContext::default()
-        },
+        StaticConnectionIdentityResolver::new(identity),
+        SystemConnectionTime,
+        Default::default(),
     );
     let server = tokio::spawn(async move {
         let ws = tokio_tungstenite::accept_async_with_config(
@@ -121,7 +130,7 @@ where
         )
         .await
         .expect("server handshake must succeed");
-        openengine_cluster_server::websocket::serve_websocket(dispatcher, ws).await
+        openengine_cluster_server::websocket::serve_websocket(binding, ws).await
     });
     let (client, _response) =
         tokio_tungstenite::client_async("ws://localhost/websocket", client_io)
@@ -131,8 +140,7 @@ where
 }
 
 #[tokio::test]
-async fn two_websocket_connections_share_one_backend_with_isolated_context_and_shared_idempotency()
-{
+async fn same_tenant_connections_share_backend_cas_and_idempotency() {
     let graph = graph_fixture("worker", serde_json::json!({"kind":"null"}));
     let verifier = Arc::new(ScriptedVerifier::new(vec![ScriptedOutcome::approve(
         compiled_from_graph_fixture(&graph),
@@ -142,9 +150,9 @@ async fn two_websocket_connections_share_one_backend_with_isolated_context_and_s
     let backend = Arc::new(AdmissionCoordinator::from_shared(verifier, store));
 
     let (conn_a, server_a) =
-        spawn_websocket_with_shared_backend(Arc::clone(&backend), "connection-a").await;
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-shared").await;
     let (conn_b, server_b) =
-        spawn_websocket_with_shared_backend(Arc::clone(&backend), "connection-b").await;
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-shared").await;
 
     let transport_a = WebSocketTransport::new(conn_a);
     let transport_b = WebSocketTransport::new(conn_b);
@@ -166,9 +174,7 @@ async fn two_websocket_connections_share_one_backend_with_isolated_context_and_s
         .unwrap();
     assert!(!apply_a.deduped);
 
-    // AC3: connection B replays the exact same idempotency key/params and dedups against A's
-    // commit, proving CAS/idempotency state is shared across independently-authorized connections
-    // on one backend rather than partitioned per connection.
+    // The backend shares one CAS/idempotency domain for this tenant across both connections.
     let apply_b = client_b
         .apply(committed(
             graph.clone(),
@@ -182,13 +188,164 @@ async fn two_websocket_connections_share_one_backend_with_isolated_context_and_s
     assert_eq!(apply_b.generation, apply_a.generation);
     assert_eq!(apply_b.run_id, apply_a.run_id);
 
-    // AC3: both connections observe the same committed spec via `get`, independent of which
-    // connection created it -- `ConnectionContext` carries no route/tenant field that could
-    // partition visibility between them.
+    // Identity is stable per connection, while state ownership remains with the shared backend.
     let get_a = client_a.get(GetParams::default()).await.unwrap();
     let get_b = client_b.get(GetParams::default()).await.unwrap();
     assert_eq!(get_a.spec, Some(graph.clone()));
     assert_eq!(get_a, get_b);
+
+    drop(transport_a);
+    drop(transport_b);
+    await_websocket_shutdown(server_a).await;
+    await_websocket_shutdown(server_b).await;
+}
+
+type FixtureCoordinator = AdmissionCoordinator<ScriptedVerifier, InMemoryAdmissionStore>;
+
+struct TenantPartitioningBackend {
+    tenant_a: FixtureCoordinator,
+    tenant_b: FixtureCoordinator,
+}
+
+impl TenantPartitioningBackend {
+    fn select(&self, context: &ConnectionContext) -> &FixtureCoordinator {
+        match context.identity().tenant().as_str() {
+            "tenant-a" => &self.tenant_a,
+            "tenant-b" => &self.tenant_b,
+            tenant => panic!("unexpected fixture tenant {tenant}"),
+        }
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for TenantPartitioningBackend {
+    async fn initialize(
+        &self,
+        context: &ConnectionContext,
+        params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        self.select(context).initialize(context, params).await
+    }
+
+    async fn apply(
+        &self,
+        context: &ConnectionContext,
+        params: ApplyParams,
+    ) -> Result<ApplyResult, BackendError> {
+        self.select(context).apply(context, params).await
+    }
+
+    async fn get(
+        &self,
+        context: &ConnectionContext,
+        params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        self.select(context).get(context, params).await
+    }
+}
+
+#[tokio::test]
+async fn distinct_tenants_share_state_when_backend_does_not_partition() {
+    let graph = graph_fixture("worker", serde_json::json!({"kind":"null"}));
+    let verifier = Arc::new(ScriptedVerifier::new(vec![ScriptedOutcome::approve(
+        compiled_from_graph_fixture(&graph),
+        vec![],
+    )]));
+    let store = Arc::new(InMemoryAdmissionStore::default());
+    let backend = Arc::new(AdmissionCoordinator::from_shared(verifier, store));
+    let (conn_a, server_a) =
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-a").await;
+    let (conn_b, server_b) =
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-b").await;
+    let transport_a = WebSocketTransport::new(conn_a);
+    let transport_b = WebSocketTransport::new(conn_b);
+    let client_a = ClusterClient::new(&transport_a);
+    let client_b = ClusterClient::new(&transport_b);
+    client_a.initialize().await.unwrap();
+    client_b.initialize().await.unwrap();
+
+    let first = client_a
+        .apply(committed(
+            graph.clone(),
+            Value::Null,
+            0,
+            "non-partitioning-key",
+        ))
+        .await
+        .unwrap();
+    let second = client_b
+        .apply(committed(
+            graph.clone(),
+            Value::Null,
+            0,
+            "non-partitioning-key",
+        ))
+        .await
+        .unwrap();
+    assert!(!first.deduped);
+    assert!(second.deduped);
+    assert_eq!(
+        client_b.get(GetParams::default()).await.unwrap().spec,
+        Some(graph)
+    );
+
+    drop(transport_a);
+    drop(transport_b);
+    await_websocket_shutdown(server_a).await;
+    await_websocket_shutdown(server_b).await;
+}
+
+#[tokio::test]
+async fn distinct_tenants_are_isolated_only_when_backend_partitions() {
+    let graph_a = graph_fixture("worker-a", serde_json::json!({"kind":"null"}));
+    let graph_b = graph_fixture("worker-b", serde_json::json!({"kind":"null"}));
+    let backend = Arc::new(TenantPartitioningBackend {
+        tenant_a: AdmissionCoordinator::new(
+            ScriptedVerifier::new(vec![ScriptedOutcome::approve(
+                compiled_from_graph_fixture(&graph_a),
+                vec![],
+            )]),
+            InMemoryAdmissionStore::default(),
+        ),
+        tenant_b: AdmissionCoordinator::new(
+            ScriptedVerifier::new(vec![ScriptedOutcome::approve(
+                compiled_from_graph_fixture(&graph_b),
+                vec![],
+            )]),
+            InMemoryAdmissionStore::default(),
+        ),
+    });
+    let (conn_a, server_a) =
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-a").await;
+    let (conn_b, server_b) =
+        spawn_websocket_with_shared_backend(Arc::clone(&backend), "tenant-b").await;
+    let transport_a = WebSocketTransport::new(conn_a);
+    let transport_b = WebSocketTransport::new(conn_b);
+    let client_a = ClusterClient::new(&transport_a);
+    let client_b = ClusterClient::new(&transport_b);
+    client_a.initialize().await.unwrap();
+    client_b.initialize().await.unwrap();
+
+    let first = client_a
+        .apply(committed(graph_a.clone(), Value::Null, 0, "same-key"))
+        .await
+        .unwrap();
+    assert!(!first.deduped);
+    assert_eq!(client_b.get(GetParams::default()).await.unwrap().spec, None);
+
+    let second = client_b
+        .apply(committed(graph_b.clone(), Value::Null, 0, "same-key"))
+        .await
+        .unwrap();
+    assert!(!second.deduped);
+    assert_eq!(
+        client_a.get(GetParams::default()).await.unwrap().spec,
+        Some(graph_a)
+    );
+    assert_eq!(
+        client_b.get(GetParams::default()).await.unwrap().spec,
+        Some(graph_b)
+    );
 
     drop(transport_a);
     drop(transport_b);

--- a/docs/openengine-cluster-protocol/v1/data-plane.md
+++ b/docs/openengine-cluster-protocol/v1/data-plane.md
@@ -36,13 +36,19 @@ instead, exactly as over NDJSON.
 
 ## Connection isolation over a shared backend
 
-One backend instance can be shared by multiple independently authorized WebSocket connections. Each
-connection is constructed with its own injected `ConnectionContext`; the wire protocol carries no
-auth, tenant, or route field, and no protocol parameter is ever interpreted as one -- that
-identity/authorization decision is made once, by whatever hosts this binding, at connection
-acceptance time, not by anything this crate parses from a request. CAS and idempotency guarantees
-are enforced by the shared backend itself, so two connections against one backend cannot double
-commit or observe effects attributable to another connection's context.
+One backend instance can be shared by multiple independently accepted WebSocket connections. At
+acceptance, the binding invokes its host-owned identity resolver exactly once, before decoding the
+first frame, and constructs an immutable `ConnectionContext` containing the resulting typed
+`ConnectionIdentity`: opaque principal and tenant identifiers, optional issuance time, required
+hard expiry, and binding-specific opaque attributes. Identity has no serde/wire representation.
+`principal`, `tenant`, and `expiresAt` keys in protocol params are ordinary unknown fields and fail
+typed parameter decoding with `INVALID_PARAMS`; they never change the connection identity.
+
+The binding checks expiry at every inbound request decode boundary. A frame observed at or after
+`expires_at_ms` reaches neither admission nor the backend: WebSocket closes with application code
+`4401`, while NDJSON writes one terminal diagnostic and closes. The dispatcher never partitions
+state. Connections with the same or distinct tenants observe exactly the sharing or isolation
+chosen by the backend that receives their read-only contexts.
 
 ## Capsule data-plane placement
 
@@ -53,16 +59,17 @@ upstream of an accepted connection is owned by whatever hosts that capsule, not 
 - provisioning or scheduling the capsule itself;
 - TLS termination (this binding speaks plain WebSocket text frames; TLS, if any, terminates in
   front of it);
-- resolving tenancy, routing, or authentication/authorization for a connection before it reaches
-  `serve_websocket`;
+- resolving the principal, tenant, expiry, and opaque binding attributes supplied to the
+  connection's identity resolver;
 - billing and usage metering;
 - workspace or secret storage/services;
 - artifact bytes (this protocol carries status, events, and control -- never artifact payloads);
 - issuing or validating the token/credential that authorized the connection.
 
-A hosting process is expected to accept the raw connection, resolve and inject that connection's
-`ConnectionContext`, and hand the rest to `serve_websocket`; this document defines only what happens
-from that handoff onward.
+A hosting process accepts the raw connection and supplies `ConnectionBinding` with its shared
+backend, identity resolver, time source, and connection cancellation signal. `serve_websocket`
+preserves that cancellation handle while resolving identity and constructing the context before
+reading frames; this document defines only what happens from that handoff onward.
 
 ## Client dialing and TLS
 

--- a/zeroshot-rust/tests/backend_boundary.rs
+++ b/zeroshot-rust/tests/backend_boundary.rs
@@ -3,6 +3,9 @@ use openengine_cluster_protocol::{
     ClusterStatus, Cursor, GetParams, GetResult, InitializeParams, InitializeResult,
     ServerCapabilities, APPLICATION_ERROR, INVALID_PHASE, PROTOCOL_VERSION,
 };
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionIdentity, ConnectionIdentityConfig, PrincipalId, TenantId,
+};
 use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
 use serde_json::{json, Value};
 use zeroshot_engine::{dispatcher_for_route, NativeBackendFactory, ProductionNativeBackendFactory};
@@ -124,10 +127,7 @@ impl NativeBackendFactory for FakeFactory {
 
     fn create(&self, context: &ConnectionContext) -> Self::Backend {
         FakeBackend {
-            route: context
-                .peer_label
-                .clone()
-                .expect("test route must identify its isolated cluster"),
+            route: context.identity().tenant().as_str().to_owned(),
         }
     }
 }
@@ -160,10 +160,16 @@ impl ClusterBackend for FakeBackend {
 
 #[tokio::test]
 async fn factory_injection_composes_the_selected_backend_with_its_route() {
-    let context = ConnectionContext {
-        peer_label: Some("cluster-route-7".to_owned()),
-        ..ConnectionContext::default()
-    };
+    let context = ConnectionContext::new(
+        ConnectionIdentity::new(ConnectionIdentityConfig {
+            principal: PrincipalId::new("principal-7"),
+            tenant: TenantId::new("cluster-route-7"),
+            issued_at_ms: Some(1),
+            expires_at_ms: u64::MAX,
+            binding_attributes: BindingAttributes::default(),
+        }),
+        Default::default(),
+    );
     let dispatcher = dispatcher_for_route(&FakeFactory, context);
     let response: Value = serde_json::from_str(
         &dispatcher


### PR DESCRIPTION
Closes #831

## Decision
Make connection identity an immutable, non-serializable server type resolved by each binding exactly once before its first frame. `ConnectionBinding` also carries the host-owned cancellation signal unchanged, preserving the pre-existing backend cancellation seam while moving context construction into the binding.

Expiry is evaluated at each inbound decode boundary with `now_ms >= expires_at_ms`. Expired WebSocket connections close with 4401; expired NDJSON connections emit one terminal diagnostic and close before admission or backend dispatch.

## Changes
- replaces `peer_label` with typed `PrincipalId`, `TenantId`, `ConnectionIdentity`, optional issuance, required expiry, and opaque binding attributes
- adds async identity resolution, static resolver, injectable time source, and binding-owned context construction
- updates NDJSON and WebSocket entry points to resolve before input and enforce hard expiry
- keeps identity absent from protocol types/artifacts and proves caller-supplied `principal`, `tenant`, and `expiresAt` are ordinary invalid params
- proves caller cancellation identity is preserved across the binding seam
- reconciles shared-backend testkit coverage for same-tenant sharing, non-partitioning cross-tenant sharing, and backend-selected tenant isolation
- migrates native backend route derivation from the free-form label to the typed tenant
- documents the binding/dispatcher/backend ownership boundary in `AGENTS.md` and the data-plane contract

## Review loop
An independent reviewer found that the first implementation created a fresh cancellation signal inside `ConnectionBinding::resolve`, removing the host's prior handle. Fixed by requiring a caller-supplied signal and adding a mutation-sensitive observation test. Two independent final verifier runs returned zero findings.

## Verification
- `cargo test -p openengine-cluster-server --test connection_identity` — 5 passed
- `cargo test -p openengine-cluster-server --test websocket` — 13 passed
- `cargo test -p openengine-cluster-testkit --test protocol_websocket` — 4 passed
- `cargo test -p zeroshot-rust --test backend_boundary` — 3 passed
- `npm run rust:check` — fmt, clippy -D warnings, workspace tests passed
- `npm run protocol:check` — byte-clean
- `npm run typecheck` — passed
- `npm run lint` — passed with 224 pre-existing warnings
- `npm run test:unit` — 2,113 passed, 18 pending
- `opcore check --changed` — 25 checks passed, 0 findings
- independent final verifier A reran focused targets, Rust, and protocol gates: zero findings
- independent final verifier B reran focused targets, TypeScript/lint/unit/Opcore plus Rust/protocol checks: zero findings