### PR TITLE
feat(zeroshot-rust): add durable workspace leases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Local runtime + drivers      | `zeroshot-rust/src/execution/{local,driver}.rs`                         |
 | Local process runner         | `zeroshot-rust/src/execution/process.rs`                                |
 | Fair scheduler               | `zeroshot-rust/src/scheduler.rs`                                        |
+| Durable workspace leases     | `zeroshot-rust/src/workspace_lease.rs`, `workspace_lease/`              |
+| Workspace lease stores       | `zeroshot-rust/src/workspace_lease/store/{fake,sqlite}.rs`              |
+| Workspace resource adapters  | `zeroshot-rust/src/workspace_lease/{resource,adapters,borrowed}.rs`     |
 | Native safe faults           | `zeroshot-rust/src/fault.rs`                                            |
 | Native fault taxonomy        | `zeroshot-rust/src/fault/taxonomy.rs`                                   |
 | Native diagnostic redaction  | `zeroshot-rust/src/fault/redaction.rs`                                  |
@@ -220,6 +223,37 @@ spawn, stdout and diagnostics stay bounded, and close/release owns termination a
 once. Provider framing and candidate decoding remain in the provider drivers.
 Windows children stay suspended until assignment to their kill-on-close Job Object; never reopen
 the pre-assignment execution window.
+`WorkspaceLeaseManager` is the engine-private durable authority for borrowed, worktree, and Docker
+workspace preparation and cleanup. It persists the deterministic `WorkspaceLeaseId`, owner fence,
+stable mode inputs, and `CreatePending` before effects; uncertain create/cleanup advances only from
+authoritative `WorkspaceResourcePort` inspection through owner-fenced store CAS. A matching owned
+resource may move directly from `CreatePending` to `CleanupRequired`, allowing correct-owner cleanup
+to remain retryable without a separate restart call. Production lease state uses the Linux-only
+`SqliteWorkspaceLeaseStore`; other targets fail closed before opening or creating a database. The
+store canonicalizes relative/symlink spellings to one database, rejects multiple hard links, and
+revalidates both the pinned file and canonical pathname identity. Its operation fence is a global
+OS lock on an independently opened, identity-checked descriptor for that sole database inode;
+replaceable companion pathnames are never lock authority. Every rusqlite connection opens through
+the retained `/proc/self/fd` path for that verified database descriptor, then revalidates both the
+descriptor and canonical pathname before any application pragma/query; path races may fail closed
+before rows or effects and must be cleanly retryable. The fence serializes authoritative absence
+through the following effect across store instances and processes. Lease IDs reuse `ResourceId`;
+execution isolation adds the already-committed `ExecutionId` and never creates a second scheduling
+identity. Borrowed roots are never owned or deleted. Fingerprinting opens the canonical root once
+with no-follow semantics, traverses descendants descriptor-relatively, hashes collision-free
+platform path bytes, and revalidates every named descriptor identity. Owned roots require Linux
+descriptor-relative filesystem support, are fixed beneath a canonical private
+`<product-root>/zeroshot/workspaces` base, and must already satisfy owner-only permissions; never
+chmod an arbitrary supplied root. Each worktree uses a lease-owned container with a stable
+lease/owner marker and an inner source directory, so partial scaffolding remains `CleanupRequired`
+without contaminating source contents. Worktree cleanup quarantines and identity-checks named
+children before removal; substitutions are preserved as mismatches. Worktree source delivery and
+all worktree/Docker inspect, create, and cleanup effects receive pinned directory capabilities
+rather than mutable host pathnames. Docker mount handles are atomically created/opened relative to
+that pinned base with no-follow semantics. Docker socket handles and socket/symlink targets are
+denied.
+Persisted lease values contain no credentials, runtime IDs, arbitrary handles,
+or host paths. Cleanup state never mutates graph outcomes.
 Native engine faults must be constructed only by `FaultFactory` from closed `ModuleEvidence`.
 Decoded faults must match the canonical semantics derived from their required primary source frame.
 Raw diagnostic values are replaced wholesale with typed markers and remain ephemeral; never put

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,14 +244,20 @@ with no-follow semantics, traverses descendants descriptor-relatively, hashes co
 platform path bytes, and revalidates every named descriptor identity. Owned roots require Linux
 descriptor-relative filesystem support, are fixed beneath a canonical private
 `<product-root>/zeroshot/workspaces` base, and must already satisfy owner-only permissions; never
-chmod an arbitrary supplied root. Each worktree uses a lease-owned container with a stable
-lease/owner marker and an inner source directory, so partial scaffolding remains `CleanupRequired`
-without contaminating source contents. Worktree cleanup quarantines and identity-checks named
-children before removal; substitutions are preserved as mismatches. Worktree source delivery and
-all worktree/Docker inspect, create, and cleanup effects receive pinned directory capabilities
-rather than mutable host pathnames. Docker mount handles are atomically created/opened relative to
-that pinned base with no-follow semantics. Docker socket handles and socket/symlink targets are
-denied.
+chmod an arbitrary supplied root. Each worktree creates a complete, synced lease/owner marker in a
+private staging container before atomically publishing its inner source directory. Abandoned
+staging and deterministic inner/public/staging cleanup quarantines are authoritative recovery
+states: restart finishes correct-owner scaffolding removal through identity-checked quarantine
+names, while conflicting names, content, or identities are preserved as mismatches. Linux has no
+identity-conditional directory unlink, so the final name-based `unlinkat` relies on the private
+0700 product root and lease operation fence for supported manager writers; uncooperative
+same-UID namespace mutation is outside the local adapter trust boundary and requires process/UID
+isolation or a broker. Keep the immediate name/inode recheck so cooperative and recovery races fail
+closed. Worktree effects receive non-cloneable, non-serializable scoped operations backed by pinned
+directory descriptors; never expose a host pathname, descriptor number, or retained handle to
+source materialization. Docker effects receive pinned mount descriptors rather than mutable host
+pathnames. Docker mount handles are atomically created/opened relative to that pinned base with
+no-follow semantics. Docker socket handles and socket/symlink targets are denied.
 Persisted lease values contain no credentials, runtime IDs, arbitrary handles,
 or host paths. Cleanup state never mutates graph outcomes.
 Native engine faults must be constructed only by `FaultFactory` from closed `ModuleEvidence`.

--- a/docs/v2/parity-matrix.md
+++ b/docs/v2/parity-matrix.md
@@ -1,0 +1,7 @@
+# Zeroshot 2 parity matrix
+
+## 9. Intentional replacements
+
+| Node behavior | Native Rust status | Replacement contract | Authority |
+| --- | --- | --- | --- |
+| Docker isolation implicitly mounts the user's home directory, Docker socket, and broad host paths | `replaced` | Durable Docker workspace leases mount only deterministic handles beneath the native product's Docker root; home, the Docker socket, filesystem roots, and broad host paths are denied by default. This is an intentional security-breaking replacement, not Node-compatible behavior. | #677 |

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod required_proof;
 pub mod scheduler;
 pub mod source_code_provider;
 pub mod worker_catalog;
+pub mod workspace_lease;
 
 use async_trait::async_trait;
 use openengine_cluster_protocol::{

--- a/zeroshot-rust/src/source_code_provider.rs
+++ b/zeroshot-rust/src/source_code_provider.rs
@@ -54,14 +54,40 @@
 //! IssueProviderRegistry::new().lookup(&source).unwrap();
 //! ```
 //!
-//! A materialization destination is deliberately ephemeral and cannot be serialized:
+//! A materialization destination cannot be minted, cloned, serialized, or retained beyond its
+//! invocation by safe downstream code:
 //!
 //! ```compile_fail
 //! use zeroshot_engine::source_code_provider::SourceMaterializationDestination;
 //!
-//! let mut destination = ();
-//! let destination = SourceMaterializationDestination::new(&mut destination);
-//! serde_json::to_string(&destination).unwrap();
+//! let target = ();
+//! let destination = SourceMaterializationDestination::new(&target);
+//! ```
+//!
+//! ```compile_fail
+//! use zeroshot_engine::source_code_provider::SourceMaterializationDestination;
+//!
+//! fn clone_capability(destination: SourceMaterializationDestination<'_>) {
+//!     let _escaped = destination.clone();
+//! }
+//! ```
+//!
+//! ```compile_fail
+//! use zeroshot_engine::source_code_provider::SourceMaterializationDestination;
+//!
+//! fn serialize_capability(destination: SourceMaterializationDestination<'_>) {
+//!     serde_json::to_string(&destination).unwrap();
+//! }
+//! ```
+//!
+//! ```compile_fail
+//! use zeroshot_engine::source_code_provider::SourceMaterializationDestination;
+//!
+//! fn retain<'a>(
+//!     destination: SourceMaterializationDestination<'a>,
+//! ) -> SourceMaterializationDestination<'static> {
+//!     destination
+//! }
 //! ```
 //!
 //! A verified workspace capability cannot be minted, serialized, or cloned by safe downstream

--- a/zeroshot-rust/src/source_code_provider/repository.rs
+++ b/zeroshot-rust/src/source_code_provider/repository.rs
@@ -181,17 +181,91 @@ impl SourceMaterializeRequest {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, thiserror::Error, PartialEq)]
+#[error("source materialization destination operation failed")]
+pub struct SourceMaterializationError;
+
+pub(crate) trait SourceMaterializationTarget: Send + Sync {
+    fn is_available(&self) -> bool;
+    fn remove_file(&self, name: &str) -> Result<(), SourceMaterializationError>;
+    fn write_file(&self, name: &str, contents: &[u8]) -> Result<(), SourceMaterializationError>;
+}
+
+/// Scoped authority for materializing source into an engine-selected destination.
+///
+/// The private target is borrowed for the invocation and exposes only bounded operations. Safe
+/// downstream code cannot construct, clone, serialize, copy, or retain its directory authority.
 pub struct SourceMaterializationDestination<'a> {
-    handle: &'a mut (dyn Any + Send),
+    target: &'a dyn SourceMaterializationTarget,
 }
 
 impl<'a> SourceMaterializationDestination<'a> {
-    pub fn new<T: Any + Send>(handle: &'a mut T) -> Self {
-        Self { handle }
+    pub(crate) fn new(target: &'a dyn SourceMaterializationTarget) -> Self {
+        Self { target }
     }
 
-    pub fn downcast_mut<T: Any + Send>(&mut self) -> Option<&mut T> {
-        self.handle.downcast_mut::<T>()
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        self.target.is_available()
+    }
+
+    pub fn write_file(
+        &self,
+        name: &str,
+        contents: &[u8],
+    ) -> Result<(), SourceMaterializationError> {
+        self.target.write_file(name, contents)
+    }
+}
+
+/// Engine-owned in-memory target for exercising provider contracts without exposing path or file
+/// descriptor authority.
+///
+/// This harness exists only for external contract tests. Production code must receive destinations
+/// from the workspace adapter.
+#[doc(hidden)]
+pub struct SourceMaterializationContractHarness {
+    writes: std::sync::atomic::AtomicUsize,
+}
+
+impl SourceMaterializationContractHarness {
+    /// Constructs the external provider-contract harness.
+    ///
+    /// # Safety
+    ///
+    /// The caller must use this harness only to test a provider contract and must not substitute it
+    /// for workspace preparation in production.
+    #[must_use]
+    pub const unsafe fn new() -> Self {
+        Self {
+            writes: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    #[must_use]
+    pub fn destination(&self) -> SourceMaterializationDestination<'_> {
+        SourceMaterializationDestination::new(self)
+    }
+
+    #[must_use]
+    pub fn write_count(&self) -> usize {
+        self.writes.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl SourceMaterializationTarget for SourceMaterializationContractHarness {
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    fn remove_file(&self, _name: &str) -> Result<(), SourceMaterializationError> {
+        Err(SourceMaterializationError)
+    }
+
+    fn write_file(&self, _name: &str, _contents: &[u8]) -> Result<(), SourceMaterializationError> {
+        self.writes
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
     }
 }
 /// Ephemeral proof that a previously verified workspace is the mutation target.

--- a/zeroshot-rust/src/workspace_lease.rs
+++ b/zeroshot-rust/src/workspace_lease.rs
@@ -1,0 +1,84 @@
+//! Durable, owner-fenced workspace lifecycle.
+//!
+//! Stable lease intent is stored before local effects. `CreatePending` and
+//! `CleanupRequired` are deliberately uncertain states and can advance only from an
+//! authoritative resource inspection. The module does not select credentials, mutate graph
+//! outcomes, expose deletion, or implement a remote workspace service.
+
+use std::fmt;
+
+mod adapters;
+mod borrowed;
+mod manager;
+mod resource;
+mod store;
+mod types;
+
+pub use adapters::{
+    BorrowedWorkspaceAdapter, DockerResourceRequest, DockerWorkspaceAdapter,
+    DockerWorkspaceEffects, WorkspaceResourceRouter, WorktreeResourceRequest,
+    WorktreeWorkspaceAdapter, WorktreeWorkspaceEffects,
+};
+pub use borrowed::{BorrowedWorkspaceFingerprintPort, FilesystemBorrowedWorkspaceFingerprint};
+pub use manager::{WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest};
+pub use resource::{WorkspaceResourceObservation, WorkspaceResourcePort};
+pub use store::{
+    sqlite::{SqliteWorkspaceLeaseHooks, SqliteWorkspaceLeaseStore},
+    CreateLeaseOutcome, WorkspaceLeaseOperationGuard, WorkspaceLeaseStore,
+    WorkspaceLeaseTransition,
+};
+pub use types::{
+    BorrowedWorkspace, CanonicalWorkspaceRoot, DockerImageDigest, DockerMount, DockerMountHandleId,
+    DockerResourceId, DockerWorkspace, PrepareWorkspaceRequest, WorkspaceFingerprint,
+    WorkspaceIsolation, WorkspaceLeaseId, WorkspaceLeaseKey, WorkspaceLeaseRecord,
+    WorkspaceLeaseState, WorkspaceMaterializationId, WorkspaceMode, WorkspaceName,
+    WorkspaceProductRoots, WorkspaceProfile, WorktreeWorkspace,
+};
+
+pub mod fake {
+    pub use super::resource::fake::{FakeEffectFailure, FakeResourceAction, FakeWorkspaceResourcePort};
+    pub use super::store::fake::FakeWorkspaceLeaseStore;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceLeaseErrorKind {
+    InvalidInput,
+    NotFound,
+    OwnerMismatch,
+    ResourceMismatch,
+    Conflict,
+    StoreUnavailable,
+    ResourceUnavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceLeaseError {
+    pub(crate) kind: WorkspaceLeaseErrorKind,
+    pub(crate) message: String,
+}
+
+impl WorkspaceLeaseError {
+    pub(crate) fn new(kind: WorkspaceLeaseErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn invalid(message: impl Into<String>) -> Self {
+        Self::new(WorkspaceLeaseErrorKind::InvalidInput, message)
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> WorkspaceLeaseErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for WorkspaceLeaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for WorkspaceLeaseError {}

--- a/zeroshot-rust/src/workspace_lease.rs
+++ b/zeroshot-rust/src/workspace_lease.rs
@@ -19,7 +19,10 @@ pub use adapters::{
     DockerWorkspaceEffects, WorkspaceResourceRouter, WorktreeResourceRequest,
     WorktreeWorkspaceAdapter, WorktreeWorkspaceEffects,
 };
-pub use borrowed::{BorrowedWorkspaceFingerprintPort, FilesystemBorrowedWorkspaceFingerprint};
+pub use borrowed::{
+    BorrowedWorkspaceFingerprintPort, FilesystemBorrowedWorkspaceFingerprint,
+    FilesystemBorrowedWorkspaceFingerprintHooks,
+};
 pub use manager::{WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest};
 pub use resource::{WorkspaceResourceObservation, WorkspaceResourcePort};
 pub use store::{
@@ -32,7 +35,7 @@ pub use types::{
     DockerResourceId, DockerWorkspace, PrepareWorkspaceRequest, WorkspaceFingerprint,
     WorkspaceIsolation, WorkspaceLeaseId, WorkspaceLeaseKey, WorkspaceLeaseRecord,
     WorkspaceLeaseState, WorkspaceMaterializationId, WorkspaceMode, WorkspaceName,
-    WorkspaceProductRoots, WorkspaceProfile, WorktreeWorkspace,
+    WorkspaceProductRootHooks, WorkspaceProductRoots, WorkspaceProfile, WorktreeWorkspace,
 };
 
 pub mod fake {

--- a/zeroshot-rust/src/workspace_lease/adapters.rs
+++ b/zeroshot-rust/src/workspace_lease/adapters.rs
@@ -2,7 +2,9 @@ use std::fs::File;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use crate::source_code_provider::SourceMaterializationDestination;
+use crate::source_code_provider::{
+    SourceMaterializationDestination, SourceMaterializationError, SourceMaterializationTarget,
+};
 use super::borrowed::{BorrowedWorkspaceFingerprintPort, FilesystemBorrowedWorkspaceFingerprint};
 
 use super::{
@@ -76,7 +78,7 @@ impl BorrowedWorkspaceAdapter {
 
 impl Default for BorrowedWorkspaceAdapter {
     fn default() -> Self {
-        Self::new(Arc::new(FilesystemBorrowedWorkspaceFingerprint))
+        Self::new(Arc::new(FilesystemBorrowedWorkspaceFingerprint::default()))
     }
 }
 
@@ -128,7 +130,46 @@ impl WorkspaceResourcePort for BorrowedWorkspaceAdapter {
 pub struct WorktreeResourceRequest<'a> {
     pub lease: &'a WorkspaceLeaseRecord,
     pub mode: &'a WorktreeWorkspace,
-    pub root_directory: Arc<File>,
+    target: &'a dyn SourceMaterializationTarget,
+}
+
+impl WorktreeResourceRequest<'_> {
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        self.target.is_available()
+    }
+
+    pub fn remove_file(&self, name: &str) -> Result<(), SourceMaterializationError> {
+        self.target.remove_file(name)
+    }
+
+    pub fn write_file(
+        &self,
+        name: &str,
+        contents: &[u8],
+    ) -> Result<(), SourceMaterializationError> {
+        self.target.write_file(name, contents)
+    }
+}
+
+struct PinnedMaterializationTarget<'a> {
+    directory: &'a File,
+}
+
+impl SourceMaterializationTarget for PinnedMaterializationTarget<'_> {
+    fn is_available(&self) -> bool {
+        self.directory
+            .metadata()
+            .is_ok_and(|metadata| metadata.is_dir())
+    }
+
+    fn remove_file(&self, name: &str) -> Result<(), SourceMaterializationError> {
+        remove_materialized_file(self.directory, name)
+    }
+
+    fn write_file(&self, name: &str, contents: &[u8]) -> Result<(), SourceMaterializationError> {
+        write_materialized_file(self.directory, name, contents)
+    }
 }
 
 #[async_trait]
@@ -172,21 +213,21 @@ impl WorkspaceResourcePort for WorktreeWorkspaceAdapter {
         let WorkspaceMode::Worktree(mode) = &lease.mode else {
             return Err(wrong_mode());
         };
-        let Some(root_directory) = self.roots.inspect_worktree(&mode.name)? else {
+        let Some(root_directory) = self.roots.inspect_worktree(&mode.name, lease)? else {
             return Ok(WorkspaceResourceObservation::Absent);
         };
-        if !self.roots.worktree_owned_by(&root_directory, lease)? {
-            return Ok(WorkspaceResourceObservation::Mismatch);
-        }
-        let Some(workspace) = root_directory.workspace() else {
+        let Some(workspace) = root_directory.workspace_for_inspect_effect() else {
             return Ok(WorkspaceResourceObservation::CleanupRequired);
+        };
+        let target = PinnedMaterializationTarget {
+            directory: workspace.as_ref(),
         };
         let observation = self
             .effects
             .inspect(WorktreeResourceRequest {
                 lease,
                 mode,
-                root_directory: workspace.clone(),
+                target: &target,
             })
             .await?;
         Ok(match observation {
@@ -200,42 +241,42 @@ impl WorkspaceResourcePort for WorktreeWorkspaceAdapter {
             return Err(wrong_mode());
         };
         let root_directory = self.roots.create_worktree(&mode.name, lease)?;
-        let mut destination_root = self.roots.worktree_destination(&root_directory)?;
-        let request = WorktreeResourceRequest {
-            lease,
-            mode,
-            root_directory: root_directory
-                .workspace()
-                .expect("created worktree has a workspace directory")
-                .clone(),
+        let workspace = root_directory
+            .workspace_for_create_effect()
+            .expect("created worktree has a private source staging directory");
+        let target = PinnedMaterializationTarget {
+            directory: workspace.as_ref(),
         };
         self.effects
             .create(
-                request,
-                SourceMaterializationDestination::new(&mut destination_root),
+                WorktreeResourceRequest {
+                    lease,
+                    mode,
+                    target: &target,
+                },
+                SourceMaterializationDestination::new(&target),
             )
-            .await
+            .await?;
+        self.roots
+            .publish_worktree(&mode.name, &root_directory, lease)
     }
 
     async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
         let WorkspaceMode::Worktree(mode) = &lease.mode else {
             return Err(wrong_mode());
         };
-        let Some(root_directory) = self.roots.inspect_worktree(&mode.name)? else {
+        let Some(root_directory) = self.roots.inspect_worktree(&mode.name, lease)? else {
             return Ok(());
         };
-        if !self.roots.worktree_owned_by(&root_directory, lease)? {
-            return Err(WorkspaceLeaseError::new(
-                WorkspaceLeaseErrorKind::ResourceMismatch,
-                "workspace worktree owner marker changed before cleanup",
-            ));
-        }
-        if let Some(workspace) = root_directory.workspace() {
+        if let Some(workspace) = root_directory.workspace_for_cleanup_effect() {
+            let target = PinnedMaterializationTarget {
+                directory: workspace.as_ref(),
+            };
             self.effects
                 .cleanup(WorktreeResourceRequest {
                     lease,
                     mode,
-                    root_directory: workspace.clone(),
+                    target: &target,
                 })
                 .await?;
         }
@@ -316,6 +357,78 @@ impl WorkspaceResourcePort for DockerWorkspaceAdapter {
             })
             .await
     }
+}
+
+#[cfg(target_os = "linux")]
+fn write_materialized_file(
+    directory: &File,
+    name: &str,
+    contents: &[u8],
+) -> Result<(), SourceMaterializationError> {
+    use std::io::Write;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = materialized_name(name)?;
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(SourceMaterializationError);
+    }
+    let mut file = unsafe { File::from_raw_fd(descriptor) };
+    file.write_all(contents)
+        .and_then(|()| file.sync_all())
+        .and_then(|()| directory.sync_all())
+        .map_err(|_| SourceMaterializationError)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn write_materialized_file(
+    _directory: &File,
+    _name: &str,
+    _contents: &[u8],
+) -> Result<(), SourceMaterializationError> {
+    Err(SourceMaterializationError)
+}
+
+#[cfg(target_os = "linux")]
+fn remove_materialized_file(
+    directory: &File,
+    name: &str,
+) -> Result<(), SourceMaterializationError> {
+    use std::os::fd::AsRawFd;
+
+    let name = materialized_name(name)?;
+    if unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) } != 0 {
+        return Err(SourceMaterializationError);
+    }
+    directory.sync_all().map_err(|_| SourceMaterializationError)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_materialized_file(
+    _directory: &File,
+    _name: &str,
+) -> Result<(), SourceMaterializationError> {
+    Err(SourceMaterializationError)
+}
+
+#[cfg(target_os = "linux")]
+fn materialized_name(name: &str) -> Result<std::ffi::CString, SourceMaterializationError> {
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.len() > 255
+        || name.as_bytes().contains(&b'/')
+    {
+        return Err(SourceMaterializationError);
+    }
+    std::ffi::CString::new(name).map_err(|_| SourceMaterializationError)
 }
 
 fn wrong_mode() -> WorkspaceLeaseError {

--- a/zeroshot-rust/src/workspace_lease/adapters.rs
+++ b/zeroshot-rust/src/workspace_lease/adapters.rs
@@ -1,0 +1,326 @@
+use std::fs::File;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use crate::source_code_provider::SourceMaterializationDestination;
+use super::borrowed::{BorrowedWorkspaceFingerprintPort, FilesystemBorrowedWorkspaceFingerprint};
+
+use super::{
+    WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseRecord, WorkspaceMode,
+    WorkspaceResourceObservation, WorkspaceResourcePort,
+};
+
+use super::{DockerMount, WorkspaceProductRoots, WorktreeWorkspace};
+
+/// Routes the three closed workspace modes to independently injectable local adapters.
+#[derive(Clone)]
+pub struct WorkspaceResourceRouter {
+    borrowed: Arc<dyn WorkspaceResourcePort>,
+    worktree: Arc<dyn WorkspaceResourcePort>,
+    docker: Arc<dyn WorkspaceResourcePort>,
+}
+
+impl WorkspaceResourceRouter {
+    #[must_use]
+    pub fn new(
+        borrowed: Arc<dyn WorkspaceResourcePort>,
+        worktree: Arc<dyn WorkspaceResourcePort>,
+        docker: Arc<dyn WorkspaceResourcePort>,
+    ) -> Self {
+        Self {
+            borrowed,
+            worktree,
+            docker,
+        }
+    }
+
+    fn port(&self, lease: &WorkspaceLeaseRecord) -> &dyn WorkspaceResourcePort {
+        match lease.mode {
+            WorkspaceMode::Borrowed(_) => self.borrowed.as_ref(),
+            WorkspaceMode::Worktree(_) => self.worktree.as_ref(),
+            WorkspaceMode::Docker(_) => self.docker.as_ref(),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for WorkspaceResourceRouter {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        self.port(lease).inspect(lease).await
+    }
+
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.port(lease).create(lease).await
+    }
+
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.port(lease).cleanup(lease).await
+    }
+}
+
+/// Production borrowed-mode adapter. It verifies canonical root and exact content fingerprint.
+#[derive(Clone)]
+pub struct BorrowedWorkspaceAdapter {
+    fingerprints: Arc<dyn BorrowedWorkspaceFingerprintPort>,
+}
+
+impl BorrowedWorkspaceAdapter {
+    #[must_use]
+    pub fn new(fingerprints: Arc<dyn BorrowedWorkspaceFingerprintPort>) -> Self {
+        Self { fingerprints }
+    }
+}
+
+impl Default for BorrowedWorkspaceAdapter {
+    fn default() -> Self {
+        Self::new(Arc::new(FilesystemBorrowedWorkspaceFingerprint))
+    }
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for BorrowedWorkspaceAdapter {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        let WorkspaceMode::Borrowed(borrowed) = &lease.mode else {
+            return Err(wrong_mode());
+        };
+        let root = borrowed.canonical_root.as_path();
+        if !root.exists() {
+            return Ok(WorkspaceResourceObservation::Absent);
+        }
+        let canonical = std::fs::canonicalize(root).map_err(|_| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceUnavailable,
+                "borrowed workspace root could not be authoritatively inspected",
+            )
+        })?;
+        if canonical != root {
+            return Ok(WorkspaceResourceObservation::Mismatch);
+        }
+        let fingerprint = self.fingerprints.fingerprint(root)?;
+        if fingerprint == borrowed.fingerprint {
+            Ok(WorkspaceResourceObservation::Matching)
+        } else {
+            Ok(WorkspaceResourceObservation::Mismatch)
+        }
+    }
+
+    async fn create(&self, _lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::Conflict,
+            "borrowed workspaces cannot be created",
+        ))
+    }
+
+    async fn cleanup(&self, _lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::Conflict,
+            "borrowed workspaces cannot be deleted",
+        ))
+    }
+}
+
+pub struct WorktreeResourceRequest<'a> {
+    pub lease: &'a WorkspaceLeaseRecord,
+    pub mode: &'a WorktreeWorkspace,
+    pub root_directory: Arc<File>,
+}
+
+#[async_trait]
+pub trait WorktreeWorkspaceEffects: Send + Sync {
+    async fn inspect(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError>;
+
+    async fn create(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+        destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError>;
+
+    async fn cleanup(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError>;
+}
+
+#[derive(Clone)]
+pub struct WorktreeWorkspaceAdapter {
+    roots: WorkspaceProductRoots,
+    effects: Arc<dyn WorktreeWorkspaceEffects>,
+}
+
+impl WorktreeWorkspaceAdapter {
+    #[must_use]
+    pub fn new(roots: WorkspaceProductRoots, effects: Arc<dyn WorktreeWorkspaceEffects>) -> Self {
+        Self { roots, effects }
+    }
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for WorktreeWorkspaceAdapter {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        let WorkspaceMode::Worktree(mode) = &lease.mode else {
+            return Err(wrong_mode());
+        };
+        let Some(root_directory) = self.roots.inspect_worktree(&mode.name)? else {
+            return Ok(WorkspaceResourceObservation::Absent);
+        };
+        if !self.roots.worktree_owned_by(&root_directory, lease)? {
+            return Ok(WorkspaceResourceObservation::Mismatch);
+        }
+        let Some(workspace) = root_directory.workspace() else {
+            return Ok(WorkspaceResourceObservation::CleanupRequired);
+        };
+        let observation = self
+            .effects
+            .inspect(WorktreeResourceRequest {
+                lease,
+                mode,
+                root_directory: workspace.clone(),
+            })
+            .await?;
+        Ok(match observation {
+            WorkspaceResourceObservation::Absent => WorkspaceResourceObservation::CleanupRequired,
+            observation => observation,
+        })
+    }
+
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        let WorkspaceMode::Worktree(mode) = &lease.mode else {
+            return Err(wrong_mode());
+        };
+        let root_directory = self.roots.create_worktree(&mode.name, lease)?;
+        let mut destination_root = self.roots.worktree_destination(&root_directory)?;
+        let request = WorktreeResourceRequest {
+            lease,
+            mode,
+            root_directory: root_directory
+                .workspace()
+                .expect("created worktree has a workspace directory")
+                .clone(),
+        };
+        self.effects
+            .create(
+                request,
+                SourceMaterializationDestination::new(&mut destination_root),
+            )
+            .await
+    }
+
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        let WorkspaceMode::Worktree(mode) = &lease.mode else {
+            return Err(wrong_mode());
+        };
+        let Some(root_directory) = self.roots.inspect_worktree(&mode.name)? else {
+            return Ok(());
+        };
+        if !self.roots.worktree_owned_by(&root_directory, lease)? {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceMismatch,
+                "workspace worktree owner marker changed before cleanup",
+            ));
+        }
+        if let Some(workspace) = root_directory.workspace() {
+            self.effects
+                .cleanup(WorktreeResourceRequest {
+                    lease,
+                    mode,
+                    root_directory: workspace.clone(),
+                })
+                .await?;
+        }
+        self.roots
+            .remove_worktree(&mode.name, &root_directory, lease)
+    }
+}
+
+pub struct DockerResourceRequest<'a> {
+    pub lease: &'a WorkspaceLeaseRecord,
+    pub mounts: &'a [DockerMount],
+}
+
+#[async_trait]
+pub trait DockerWorkspaceEffects: Send + Sync {
+    async fn inspect(
+        &self,
+        request: DockerResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError>;
+    async fn create(&self, request: DockerResourceRequest<'_>) -> Result<(), WorkspaceLeaseError>;
+    async fn cleanup(&self, request: DockerResourceRequest<'_>) -> Result<(), WorkspaceLeaseError>;
+}
+
+#[derive(Clone)]
+pub struct DockerWorkspaceAdapter {
+    roots: WorkspaceProductRoots,
+    effects: Arc<dyn DockerWorkspaceEffects>,
+}
+
+impl DockerWorkspaceAdapter {
+    #[must_use]
+    pub fn new(roots: WorkspaceProductRoots, effects: Arc<dyn DockerWorkspaceEffects>) -> Self {
+        Self { roots, effects }
+    }
+
+    fn mounts(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<Vec<DockerMount>, WorkspaceLeaseError> {
+        let WorkspaceMode::Docker(mode) = &lease.mode else {
+            return Err(wrong_mode());
+        };
+        self.roots.default_docker_mounts(mode)
+    }
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for DockerWorkspaceAdapter {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        let mounts = self.mounts(lease)?;
+        self.effects
+            .inspect(DockerResourceRequest {
+                lease,
+                mounts: &mounts,
+            })
+            .await
+    }
+
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        let mounts = self.mounts(lease)?;
+        self.effects
+            .create(DockerResourceRequest {
+                lease,
+                mounts: &mounts,
+            })
+            .await
+    }
+
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        let mounts = self.mounts(lease)?;
+        self.effects
+            .cleanup(DockerResourceRequest {
+                lease,
+                mounts: &mounts,
+            })
+            .await
+    }
+}
+
+fn wrong_mode() -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(
+        WorkspaceLeaseErrorKind::InvalidInput,
+        "workspace adapter received the wrong mode",
+    )
+}

--- a/zeroshot-rust/src/workspace_lease/borrowed.rs
+++ b/zeroshot-rust/src/workspace_lease/borrowed.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 
@@ -11,8 +12,22 @@ pub trait BorrowedWorkspaceFingerprintPort: Send + Sync {
     fn fingerprint(&self, root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError>;
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct FilesystemBorrowedWorkspaceFingerprint;
+#[derive(Clone, Default)]
+pub struct FilesystemBorrowedWorkspaceFingerprintHooks {
+    pub before_root_revalidation: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+#[derive(Clone, Default)]
+pub struct FilesystemBorrowedWorkspaceFingerprint {
+    hooks: FilesystemBorrowedWorkspaceFingerprintHooks,
+}
+
+impl FilesystemBorrowedWorkspaceFingerprint {
+    #[must_use]
+    pub fn new_with_hooks(hooks: FilesystemBorrowedWorkspaceFingerprintHooks) -> Self {
+        Self { hooks }
+    }
+}
 
 impl BorrowedWorkspaceFingerprintPort for FilesystemBorrowedWorkspaceFingerprint {
     fn fingerprint(&self, root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
@@ -25,7 +40,7 @@ impl BorrowedWorkspaceFingerprintPort for FilesystemBorrowedWorkspaceFingerprint
         }
         #[cfg(target_os = "linux")]
         {
-            fingerprint_linux(root)
+            fingerprint_linux(root, &self.hooks)
         }
     }
 }
@@ -38,7 +53,10 @@ struct FingerprintBounds {
 }
 
 #[cfg(target_os = "linux")]
-fn fingerprint_linux(root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
+fn fingerprint_linux(
+    root: &Path,
+    hooks: &FilesystemBorrowedWorkspaceFingerprintHooks,
+) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
     let directory = open_directory_no_follow(root)?;
     let identity = file_identity(&directory)?;
     verify_canonical_directory(root, identity)?;
@@ -48,6 +66,9 @@ fn fingerprint_linux(root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLease
     digest.update(b"unix-path-bytes\0");
     let mut bounds = FingerprintBounds::default();
     fingerprint_directory(&directory, Path::new(""), &mut digest, &mut bounds)?;
+    if let Some(hook) = &hooks.before_root_revalidation {
+        hook();
+    }
     verify_canonical_directory(root, identity)?;
     WorkspaceFingerprint::new(format!("{:x}", digest.finalize()))
 }

--- a/zeroshot-rust/src/workspace_lease/borrowed.rs
+++ b/zeroshot-rust/src/workspace_lease/borrowed.rs
@@ -1,0 +1,236 @@
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use super::{WorkspaceFingerprint, WorkspaceLeaseError, WorkspaceLeaseErrorKind};
+
+const MAX_BORROWED_ENTRIES: usize = 10_000;
+const MAX_BORROWED_BYTES: u64 = 64 * 1024 * 1024;
+
+pub trait BorrowedWorkspaceFingerprintPort: Send + Sync {
+    fn fingerprint(&self, root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FilesystemBorrowedWorkspaceFingerprint;
+
+impl BorrowedWorkspaceFingerprintPort for FilesystemBorrowedWorkspaceFingerprint {
+    fn fingerprint(&self, root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = root;
+            return Err(fingerprint_error(
+                "borrowed workspace fingerprinting requires Linux descriptor-relative traversal",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            fingerprint_linux(root)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct FingerprintBounds {
+    entries: usize,
+    bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn fingerprint_linux(root: &Path) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
+    let directory = open_directory_no_follow(root)?;
+    let identity = file_identity(&directory)?;
+    verify_canonical_directory(root, identity)?;
+
+    let mut digest = Sha256::new();
+    digest.update(b"zeroshot.borrowed-workspace/v2\0");
+    digest.update(b"unix-path-bytes\0");
+    let mut bounds = FingerprintBounds::default();
+    fingerprint_directory(&directory, Path::new(""), &mut digest, &mut bounds)?;
+    verify_canonical_directory(root, identity)?;
+    WorkspaceFingerprint::new(format!("{:x}", digest.finalize()))
+}
+
+#[cfg(target_os = "linux")]
+fn fingerprint_directory(
+    directory: &std::fs::File,
+    relative: &Path,
+    digest: &mut Sha256,
+    bounds: &mut FingerprintBounds,
+) -> Result<(), WorkspaceLeaseError> {
+    let descriptor = descriptor_path(directory);
+    let mut entries = std::fs::read_dir(&descriptor)
+        .map_err(|_| fingerprint_error("borrowed workspace directory changed"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| fingerprint_error("borrowed workspace directory changed"))?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        bounds.entries = bounds
+            .entries
+            .checked_add(1)
+            .ok_or_else(|| fingerprint_error("borrowed workspace entry count overflowed"))?;
+        if bounds.entries > MAX_BORROWED_ENTRIES {
+            return Err(fingerprint_error("borrowed workspace has too many entries"));
+        }
+        let name = entry.file_name();
+        let child_relative = relative.join(&name);
+        let child_path = descriptor.join(&name);
+        let metadata = std::fs::symlink_metadata(&child_path)
+            .map_err(|_| fingerprint_error("borrowed workspace entry changed"))?;
+        if metadata.file_type().is_symlink() {
+            return Err(fingerprint_error(
+                "borrowed workspace fingerprints do not follow symbolic links",
+            ));
+        }
+        if metadata.is_dir() {
+            let child = open_directory_no_follow(&child_path)?;
+            let identity = file_identity(&child)?;
+            verify_path_identity(&child_path, identity)?;
+            digest.update(b"d\0");
+            hash_path(digest, &child_relative);
+            fingerprint_directory(&child, &child_relative, digest, bounds)?;
+            verify_path_identity(&child_path, identity)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            return Err(fingerprint_error(
+                "borrowed workspace contains an unsupported entry",
+            ));
+        }
+        fingerprint_file(&child_path, &child_relative, digest, bounds)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn fingerprint_file(
+    path: &Path,
+    relative: &Path,
+    digest: &mut Sha256,
+    bounds: &mut FingerprintBounds,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::io::Read;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let mut file = options
+        .open(path)
+        .map_err(|_| fingerprint_error("borrowed workspace file changed"))?;
+    let before = file
+        .metadata()
+        .map_err(|_| fingerprint_error("borrowed workspace file changed"))?;
+    if !before.is_file() {
+        return Err(fingerprint_error(
+            "borrowed workspace contains an unsupported entry",
+        ));
+    }
+    bounds.bytes = bounds
+        .bytes
+        .checked_add(before.len())
+        .ok_or_else(|| fingerprint_error("borrowed workspace size overflowed"))?;
+    if bounds.bytes > MAX_BORROWED_BYTES {
+        return Err(fingerprint_error(
+            "borrowed workspace is too large to inspect",
+        ));
+    }
+    digest.update(b"f\0");
+    hash_path(digest, relative);
+    digest.update(before.len().to_be_bytes());
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|_| fingerprint_error("borrowed workspace file changed"))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    let after = file
+        .metadata()
+        .map_err(|_| fingerprint_error("borrowed workspace file changed"))?;
+    if file_identity_from_metadata(&before) != file_identity_from_metadata(&after)
+        || before.len() != after.len()
+    {
+        return Err(fingerprint_error("borrowed workspace file changed"));
+    }
+    verify_path_identity(path, file_identity_from_metadata(&after))
+}
+
+#[cfg(target_os = "linux")]
+fn open_directory_no_follow(path: &Path) -> Result<std::fs::File, WorkspaceLeaseError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    options
+        .open(path)
+        .map_err(|_| fingerprint_error("borrowed workspace directory changed"))
+}
+
+#[cfg(target_os = "linux")]
+fn verify_canonical_directory(
+    path: &Path,
+    expected: (u64, u64),
+) -> Result<(), WorkspaceLeaseError> {
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|_| fingerprint_error("borrowed workspace canonical root changed"))?;
+    if canonical != path {
+        return Err(fingerprint_error(
+            "borrowed workspace root is not canonical",
+        ));
+    }
+    verify_path_identity(path, expected)
+}
+
+#[cfg(target_os = "linux")]
+fn verify_path_identity(path: &Path, expected: (u64, u64)) -> Result<(), WorkspaceLeaseError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|_| fingerprint_error("borrowed workspace entry changed"))?;
+    if metadata.file_type().is_symlink() || file_identity_from_metadata(&metadata) != expected {
+        return Err(fingerprint_error("borrowed workspace entry changed"));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn file_identity(file: &std::fs::File) -> Result<(u64, u64), WorkspaceLeaseError> {
+    let metadata = file
+        .metadata()
+        .map_err(|_| fingerprint_error("borrowed workspace entry changed"))?;
+    Ok(file_identity_from_metadata(&metadata))
+}
+
+#[cfg(target_os = "linux")]
+fn file_identity_from_metadata(metadata: &std::fs::Metadata) -> (u64, u64) {
+    use std::os::unix::fs::MetadataExt;
+
+    (metadata.dev(), metadata.ino())
+}
+
+#[cfg(target_os = "linux")]
+fn descriptor_path(file: &std::fs::File) -> std::path::PathBuf {
+    use std::os::fd::AsRawFd;
+
+    std::path::PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()))
+}
+
+#[cfg(target_os = "linux")]
+fn hash_path(digest: &mut Sha256, path: &Path) {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bytes = path.as_os_str().as_bytes();
+    digest.update(u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_be_bytes());
+    digest.update(bytes);
+}
+
+fn fingerprint_error(message: &'static str) -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(WorkspaceLeaseErrorKind::ResourceUnavailable, message)
+}

--- a/zeroshot-rust/src/workspace_lease/manager.rs
+++ b/zeroshot-rust/src/workspace_lease/manager.rs
@@ -58,7 +58,7 @@ impl WorkspaceLeaseManager {
         self.prepare_record(record).await
     }
 
-    /// Restart recovery is inspect-only: it never invents absence or repeats an effect.
+    /// Restart reconciles durable intent and finishes recognized owner-fenced recovery scaffolding.
     pub async fn restart(
         &self,
         request: WorkspaceLeaseOwnerRequest,
@@ -69,7 +69,23 @@ impl WorkspaceLeaseManager {
             .store
             .acquire_operation(&request.id, &request.owner)
             .await?;
-        self.inspect_unlocked(&request).await
+        let mut record = self.load_owned(&request).await?;
+        if record.state == WorkspaceLeaseState::Cleaned {
+            return self.reconcile_cleaned(record).await;
+        }
+        if matches!(record.mode, super::WorkspaceMode::Borrowed(_)) {
+            return self.inspect_borrowed(record).await;
+        }
+        let observation = self.resources.inspect(&record).await?;
+        if observation == WorkspaceResourceObservation::CleanupRequired {
+            if record.state != WorkspaceLeaseState::CleanupRequired {
+                record = self
+                    .transition(&record, WorkspaceLeaseState::CleanupRequired)
+                    .await?;
+            }
+            return self.cleanup_owned(record).await;
+        }
+        self.reconcile_owned_inspection(record, observation).await
     }
 
     /// Authoritatively reconciles durable state without performing create or cleanup.
@@ -98,6 +114,14 @@ impl WorkspaceLeaseManager {
             return self.inspect_borrowed(record).await;
         }
         let observation = self.resources.inspect(&record).await?;
+        self.reconcile_owned_inspection(record, observation).await
+    }
+
+    async fn reconcile_owned_inspection(
+        &self,
+        record: WorkspaceLeaseRecord,
+        observation: WorkspaceResourceObservation,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
         match (record.state, observation) {
             (WorkspaceLeaseState::CreatePending, WorkspaceResourceObservation::Matching) => {
                 self.transition(&record, WorkspaceLeaseState::Ready).await

--- a/zeroshot-rust/src/workspace_lease/manager.rs
+++ b/zeroshot-rust/src/workspace_lease/manager.rs
@@ -1,0 +1,383 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::cluster_ledger::OwnerId;
+
+use super::resource::{WorkspaceResourceObservation, WorkspaceResourcePort};
+use super::store::{CreateLeaseOutcome, WorkspaceLeaseStore, WorkspaceLeaseTransition};
+use super::{
+    PrepareWorkspaceRequest, WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId,
+    WorkspaceLeaseRecord, WorkspaceLeaseState,
+};
+
+#[derive(Clone, Debug)]
+pub struct WorkspaceLeaseOwnerRequest {
+    pub id: WorkspaceLeaseId,
+    pub owner: OwnerId,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceLeaseManager {
+    store: Arc<dyn WorkspaceLeaseStore>,
+    resources: Arc<dyn WorkspaceResourcePort>,
+    operations: Arc<Mutex<BTreeMap<WorkspaceLeaseId, Arc<AsyncMutex<()>>>>>,
+}
+
+impl WorkspaceLeaseManager {
+    #[must_use]
+    pub fn new(
+        store: Arc<dyn WorkspaceLeaseStore>,
+        resources: Arc<dyn WorkspaceResourcePort>,
+    ) -> Self {
+        Self {
+            store,
+            resources,
+            operations: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Commits stable intent and owner before any create effect.
+    pub async fn prepare(
+        &self,
+        request: PrepareWorkspaceRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let operation = self.operation_lock(&id);
+        let _operation = operation.lock().await;
+        let _store_operation = self.store.acquire_operation(&id, &request.owner).await?;
+        let pending = WorkspaceLeaseRecord::pending(&request);
+        let record = match self.store.create_pending(pending.clone()).await? {
+            CreateLeaseOutcome::Created(record) => record,
+            CreateLeaseOutcome::Existing(record) => {
+                validate_same_intent(&record, &pending)?;
+                record
+            }
+        };
+        self.prepare_record(record).await
+    }
+
+    /// Restart recovery is inspect-only: it never invents absence or repeats an effect.
+    pub async fn restart(
+        &self,
+        request: WorkspaceLeaseOwnerRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let operation = self.operation_lock(&request.id);
+        let _operation = operation.lock().await;
+        let _store_operation = self
+            .store
+            .acquire_operation(&request.id, &request.owner)
+            .await?;
+        self.inspect_unlocked(&request).await
+    }
+
+    /// Authoritatively reconciles durable state without performing create or cleanup.
+    pub async fn inspect(
+        &self,
+        request: WorkspaceLeaseOwnerRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let operation = self.operation_lock(&request.id);
+        let _operation = operation.lock().await;
+        let _store_operation = self
+            .store
+            .acquire_operation(&request.id, &request.owner)
+            .await?;
+        self.inspect_unlocked(&request).await
+    }
+
+    async fn inspect_unlocked(
+        &self,
+        request: &WorkspaceLeaseOwnerRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let record = self.load_owned(request).await?;
+        if record.state == WorkspaceLeaseState::Cleaned {
+            return Ok(record);
+        }
+        if matches!(record.mode, super::WorkspaceMode::Borrowed(_)) {
+            return self.inspect_borrowed(record).await;
+        }
+        let observation = self.resources.inspect(&record).await?;
+        match (record.state, observation) {
+            (WorkspaceLeaseState::CreatePending, WorkspaceResourceObservation::Matching) => {
+                self.transition(&record, WorkspaceLeaseState::Ready).await
+            }
+            (WorkspaceLeaseState::CreatePending, WorkspaceResourceObservation::CleanupRequired) => {
+                self.transition(&record, WorkspaceLeaseState::CleanupRequired)
+                    .await
+            }
+            (WorkspaceLeaseState::Ready, WorkspaceResourceObservation::CleanupRequired) => {
+                Err(WorkspaceLeaseError::new(
+                    WorkspaceLeaseErrorKind::ResourceUnavailable,
+                    "ready workspace has only partial owned scaffolding",
+                ))
+            }
+            (WorkspaceLeaseState::CleanupRequired, WorkspaceResourceObservation::Absent) => {
+                self.transition(&record, WorkspaceLeaseState::Cleaned).await
+            }
+            (WorkspaceLeaseState::Ready, WorkspaceResourceObservation::Absent) => {
+                Err(WorkspaceLeaseError::new(
+                    WorkspaceLeaseErrorKind::ResourceUnavailable,
+                    "ready workspace resource is absent",
+                ))
+            }
+            (_, WorkspaceResourceObservation::CleanupRequired) => Ok(record),
+            (_, WorkspaceResourceObservation::Mismatch) => Err(resource_mismatch()),
+            _ => Ok(record),
+        }
+    }
+
+    /// Cleanup is owner-fenced. Borrowed cleanup is a durable no-op and never calls delete.
+    pub async fn cleanup(
+        &self,
+        request: WorkspaceLeaseOwnerRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let operation = self.operation_lock(&request.id);
+        let _operation = operation.lock().await;
+        let _store_operation = self
+            .store
+            .acquire_operation(&request.id, &request.owner)
+            .await?;
+        let mut record = self.load_owned(&request).await?;
+        if record.state == WorkspaceLeaseState::Cleaned {
+            return self.reconcile_cleaned(record).await;
+        }
+        if matches!(record.mode, super::WorkspaceMode::Borrowed(_)) {
+            return self.transition(&record, WorkspaceLeaseState::Cleaned).await;
+        }
+
+        if record.state != WorkspaceLeaseState::CleanupRequired {
+            let observation = self.resources.inspect(&record).await?;
+            match observation {
+                WorkspaceResourceObservation::Mismatch => return Err(resource_mismatch()),
+                WorkspaceResourceObservation::Absent => {
+                    return self.transition(&record, WorkspaceLeaseState::Cleaned).await;
+                }
+                WorkspaceResourceObservation::Matching
+                | WorkspaceResourceObservation::CleanupRequired => {
+                    record = self
+                        .transition(&record, WorkspaceLeaseState::CleanupRequired)
+                        .await?;
+                }
+            }
+        }
+        self.cleanup_owned(record).await
+    }
+
+    async fn prepare_record(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        match record.state {
+            WorkspaceLeaseState::Cleaned => Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "cleaned workspace lease cannot be prepared again",
+            )),
+            WorkspaceLeaseState::CleanupRequired => Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace cleanup is already required",
+            )),
+            WorkspaceLeaseState::Ready => match self.resources.inspect(&record).await? {
+                WorkspaceResourceObservation::Matching => Ok(record),
+                WorkspaceResourceObservation::Absent => Err(WorkspaceLeaseError::new(
+                    WorkspaceLeaseErrorKind::ResourceUnavailable,
+                    "ready workspace resource is absent",
+                )),
+                WorkspaceResourceObservation::CleanupRequired => Err(WorkspaceLeaseError::new(
+                    WorkspaceLeaseErrorKind::ResourceUnavailable,
+                    "ready workspace has only partial owned scaffolding",
+                )),
+                WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+            },
+            WorkspaceLeaseState::CreatePending => self.prepare_pending(record).await,
+        }
+    }
+
+    async fn prepare_pending(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        match self.resources.inspect(&record).await? {
+            WorkspaceResourceObservation::Matching => {
+                self.transition(&record, WorkspaceLeaseState::Ready).await
+            }
+            WorkspaceResourceObservation::CleanupRequired => {
+                self.transition(&record, WorkspaceLeaseState::CleanupRequired)
+                    .await
+            }
+            WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+            WorkspaceResourceObservation::Absent => {
+                if matches!(record.mode, super::WorkspaceMode::Borrowed(_)) {
+                    return Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::NotFound,
+                        "borrowed workspace root is absent",
+                    ));
+                }
+                self.resources.create(&record).await?;
+                match self.resources.inspect(&record).await? {
+                    WorkspaceResourceObservation::Matching => {
+                        self.transition(&record, WorkspaceLeaseState::Ready).await
+                    }
+                    WorkspaceResourceObservation::Absent => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "workspace create completed without an authoritative resource",
+                    )),
+                    WorkspaceResourceObservation::CleanupRequired => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "workspace create left partial owned scaffolding",
+                    )),
+                    WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+                }
+            }
+        }
+    }
+
+    async fn inspect_borrowed(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        match self.resources.inspect(&record).await? {
+            WorkspaceResourceObservation::Matching => {
+                if record.state == WorkspaceLeaseState::CreatePending {
+                    self.transition(&record, WorkspaceLeaseState::Ready).await
+                } else {
+                    Ok(record)
+                }
+            }
+            WorkspaceResourceObservation::Absent => Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::NotFound,
+                "borrowed workspace root is absent",
+            )),
+            WorkspaceResourceObservation::CleanupRequired => Err(resource_mismatch()),
+            WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+        }
+    }
+
+    async fn cleanup_owned(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        match self.resources.inspect(&record).await? {
+            WorkspaceResourceObservation::Absent => {
+                self.transition(&record, WorkspaceLeaseState::Cleaned).await
+            }
+            WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+            WorkspaceResourceObservation::Matching
+            | WorkspaceResourceObservation::CleanupRequired => {
+                self.resources.cleanup(&record).await?;
+                match self.resources.inspect(&record).await? {
+                    WorkspaceResourceObservation::Absent => {
+                        self.transition(&record, WorkspaceLeaseState::Cleaned).await
+                    }
+                    WorkspaceResourceObservation::Matching => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "workspace cleanup did not remove the resource",
+                    )),
+                    WorkspaceResourceObservation::CleanupRequired => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "workspace cleanup left partial owned scaffolding",
+                    )),
+                    WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+                }
+            }
+        }
+    }
+
+    async fn load_owned(
+        &self,
+        request: &WorkspaceLeaseOwnerRequest,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let record = self.store.load(&request.id).await?.ok_or_else(|| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::NotFound,
+                "workspace lease does not exist",
+            )
+        })?;
+        if record.owner != request.owner {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::OwnerMismatch,
+                "workspace lease owner fence mismatch",
+            ));
+        }
+        Ok(record)
+    }
+
+    async fn transition(
+        &self,
+        current: &WorkspaceLeaseRecord,
+        next_state: WorkspaceLeaseState,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        self.store
+            .transition(WorkspaceLeaseTransition {
+                id: current.id.clone(),
+                owner: current.owner.clone(),
+                expected_revision: current.revision,
+                expected_state: current.state,
+                next_state,
+            })
+            .await
+    }
+    async fn reconcile_cleaned(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        if matches!(record.mode, super::WorkspaceMode::Borrowed(_)) {
+            return Ok(record);
+        }
+        match self.resources.inspect(&record).await? {
+            WorkspaceResourceObservation::Absent => Ok(record),
+            WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+            WorkspaceResourceObservation::Matching
+            | WorkspaceResourceObservation::CleanupRequired => {
+                self.resources.cleanup(&record).await?;
+                match self.resources.inspect(&record).await? {
+                    WorkspaceResourceObservation::Absent => Ok(record),
+                    WorkspaceResourceObservation::Matching => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "cleaned workspace orphan cleanup did not remove the resource",
+                    )),
+                    WorkspaceResourceObservation::CleanupRequired => Err(WorkspaceLeaseError::new(
+                        WorkspaceLeaseErrorKind::ResourceUnavailable,
+                        "cleaned workspace orphan cleanup left partial owned scaffolding",
+                    )),
+                    WorkspaceResourceObservation::Mismatch => Err(resource_mismatch()),
+                }
+            }
+        }
+    }
+
+    fn operation_lock(&self, id: &WorkspaceLeaseId) -> Arc<AsyncMutex<()>> {
+        self.operations
+            .lock()
+            .expect("workspace operation map mutex")
+            .entry(id.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}
+
+fn validate_same_intent(
+    existing: &WorkspaceLeaseRecord,
+    requested: &WorkspaceLeaseRecord,
+) -> Result<(), WorkspaceLeaseError> {
+    if existing.owner != requested.owner {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::OwnerMismatch,
+            "workspace lease owner fence mismatch",
+        ));
+    }
+    if existing.id != requested.id
+        || existing.mode != requested.mode
+        || existing.access_mode != requested.access_mode
+    {
+        return Err(resource_mismatch());
+    }
+    Ok(())
+}
+
+fn resource_mismatch() -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(
+        WorkspaceLeaseErrorKind::ResourceMismatch,
+        "workspace resource identity or owner does not match durable intent",
+    )
+}

--- a/zeroshot-rust/src/workspace_lease/resource.rs
+++ b/zeroshot-rust/src/workspace_lease/resource.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+
+use super::{WorkspaceLeaseError, WorkspaceLeaseRecord};
+
+pub mod fake;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceResourceObservation {
+    Absent,
+    /// Deterministic owned scaffolding exists, but delegated materialization is absent.
+    CleanupRequired,
+    Matching,
+    Mismatch,
+}
+
+#[async_trait]
+pub trait WorkspaceResourcePort: Send + Sync {
+    /// Authoritative inspection must compare all persisted stable identity and the owner fence.
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError>;
+
+    /// Called only after an authoritative `Absent` observation for an owned workspace.
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError>;
+
+    /// Called only for an authoritatively matching owned workspace.
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError>;
+}

--- a/zeroshot-rust/src/workspace_lease/resource/fake.rs
+++ b/zeroshot-rust/src/workspace_lease/resource/fake.rs
@@ -1,0 +1,162 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use super::{WorkspaceResourceObservation, WorkspaceResourcePort};
+use crate::workspace_lease::{
+    WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId, WorkspaceLeaseRecord,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FakeEffectFailure {
+    BeforeEffect,
+    AfterEffect,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FakeResourceAction {
+    Inspect,
+    Create,
+    Cleanup,
+}
+
+#[derive(Default)]
+pub struct FakeWorkspaceResourcePort {
+    resources: Mutex<BTreeMap<WorkspaceLeaseId, WorkspaceLeaseRecord>>,
+    actions: Mutex<Vec<(WorkspaceLeaseId, FakeResourceAction)>>,
+    create_failure: Mutex<Option<FakeEffectFailure>>,
+    cleanup_failure: Mutex<Option<FakeEffectFailure>>,
+    inspect_failure: Mutex<bool>,
+}
+
+impl FakeWorkspaceResourcePort {
+    pub fn seed(&self, lease: WorkspaceLeaseRecord) {
+        self.resources
+            .lock()
+            .expect("fake resource mutex")
+            .insert(lease.id.clone(), lease);
+    }
+
+    pub fn remove(&self, id: &WorkspaceLeaseId) {
+        self.resources
+            .lock()
+            .expect("fake resource mutex")
+            .remove(id);
+    }
+
+    pub fn fail_next_create(&self, failure: FakeEffectFailure) {
+        *self.create_failure.lock().expect("fake resource mutex") = Some(failure);
+    }
+
+    pub fn fail_next_cleanup(&self, failure: FakeEffectFailure) {
+        *self.cleanup_failure.lock().expect("fake resource mutex") = Some(failure);
+    }
+
+    pub fn fail_next_inspect(&self) {
+        *self.inspect_failure.lock().expect("fake resource mutex") = true;
+    }
+
+    #[must_use]
+    pub fn actions(&self) -> Vec<(WorkspaceLeaseId, FakeResourceAction)> {
+        self.actions.lock().expect("fake resource mutex").clone()
+    }
+
+    #[must_use]
+    pub fn contains(&self, id: &WorkspaceLeaseId) -> bool {
+        self.resources
+            .lock()
+            .expect("fake resource mutex")
+            .contains_key(id)
+    }
+
+    fn record(&self, id: &WorkspaceLeaseId, action: FakeResourceAction) {
+        self.actions
+            .lock()
+            .expect("fake resource mutex")
+            .push((id.clone(), action));
+    }
+
+    fn effect_error(operation: &'static str) -> WorkspaceLeaseError {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            format!("workspace {operation} outcome is uncertain"),
+        )
+    }
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for FakeWorkspaceResourcePort {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        self.record(&lease.id, FakeResourceAction::Inspect);
+        if std::mem::take(&mut *self.inspect_failure.lock().expect("fake resource mutex")) {
+            return Err(Self::effect_error("inspection"));
+        }
+        Ok(
+            match self
+                .resources
+                .lock()
+                .expect("fake resource mutex")
+                .get(&lease.id)
+            {
+                None => WorkspaceResourceObservation::Absent,
+                Some(found)
+                    if found.owner == lease.owner
+                        && found.mode == lease.mode
+                        && found.access_mode == lease.access_mode =>
+                {
+                    WorkspaceResourceObservation::Matching
+                }
+                Some(_) => WorkspaceResourceObservation::Mismatch,
+            },
+        )
+    }
+
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.record(&lease.id, FakeResourceAction::Create);
+        let failure = self
+            .create_failure
+            .lock()
+            .expect("fake resource mutex")
+            .take();
+        if failure == Some(FakeEffectFailure::BeforeEffect) {
+            return Err(Self::effect_error("create"));
+        }
+        let mut resources = self.resources.lock().expect("fake resource mutex");
+        if resources.contains_key(&lease.id) {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceMismatch,
+                "workspace create found an existing resource",
+            ));
+        }
+        resources.insert(lease.id.clone(), lease.clone());
+        drop(resources);
+        if failure == Some(FakeEffectFailure::AfterEffect) {
+            return Err(Self::effect_error("create"));
+        }
+        Ok(())
+    }
+
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.record(&lease.id, FakeResourceAction::Cleanup);
+        let failure = self
+            .cleanup_failure
+            .lock()
+            .expect("fake resource mutex")
+            .take();
+        if failure == Some(FakeEffectFailure::BeforeEffect) {
+            return Err(Self::effect_error("cleanup"));
+        }
+        self.resources
+            .lock()
+            .expect("fake resource mutex")
+            .remove(&lease.id);
+        if failure == Some(FakeEffectFailure::AfterEffect) {
+            return Err(Self::effect_error("cleanup"));
+        }
+        Ok(())
+    }
+}

--- a/zeroshot-rust/src/workspace_lease/store.rs
+++ b/zeroshot-rust/src/workspace_lease/store.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+
+use super::{WorkspaceLeaseError, WorkspaceLeaseId, WorkspaceLeaseRecord, WorkspaceLeaseState};
+use crate::cluster_ledger::OwnerId;
+
+pub mod fake;
+pub mod sqlite;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CreateLeaseOutcome {
+    Created(WorkspaceLeaseRecord),
+    Existing(WorkspaceLeaseRecord),
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkspaceLeaseTransition {
+    pub id: WorkspaceLeaseId,
+    pub owner: OwnerId,
+    pub expected_revision: u64,
+    pub expected_state: WorkspaceLeaseState,
+    pub next_state: WorkspaceLeaseState,
+}
+
+pub trait WorkspaceLeaseOperationGuard: Send {}
+
+#[async_trait]
+pub trait WorkspaceLeaseStore: Send + Sync {
+    /// Serializes absence inspection and its following effect across store instances/processes.
+    async fn acquire_operation(
+        &self,
+        id: &WorkspaceLeaseId,
+        owner: &OwnerId,
+    ) -> Result<Box<dyn WorkspaceLeaseOperationGuard>, WorkspaceLeaseError>;
+
+    async fn load(
+        &self,
+        id: &WorkspaceLeaseId,
+    ) -> Result<Option<WorkspaceLeaseRecord>, WorkspaceLeaseError>;
+
+    /// Atomically persists the owner fence, stable mode inputs, and `CreatePending` before effects.
+    async fn create_pending(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<CreateLeaseOutcome, WorkspaceLeaseError>;
+
+    /// Owner-fenced compare-and-set. Implementations must not partially apply a transition.
+    async fn transition(
+        &self,
+        request: WorkspaceLeaseTransition,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError>;
+}

--- a/zeroshot-rust/src/workspace_lease/store/fake.rs
+++ b/zeroshot-rust/src/workspace_lease/store/fake.rs
@@ -1,0 +1,164 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use super::{
+    CreateLeaseOutcome, WorkspaceLeaseOperationGuard, WorkspaceLeaseStore, WorkspaceLeaseTransition,
+};
+use crate::workspace_lease::{
+    WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId, WorkspaceLeaseRecord,
+    WorkspaceLeaseState,
+};
+#[derive(Default)]
+pub struct FakeWorkspaceLeaseStore {
+    records: Mutex<BTreeMap<WorkspaceLeaseId, WorkspaceLeaseRecord>>,
+    fail_next: Mutex<bool>,
+    operations: Mutex<BTreeMap<WorkspaceLeaseId, Arc<AsyncMutex<()>>>>,
+}
+
+impl FakeWorkspaceLeaseStore {
+    pub fn fail_next(&self) {
+        *self.fail_next.lock().expect("fake store mutex") = true;
+    }
+
+    #[must_use]
+    pub fn record(&self, id: &WorkspaceLeaseId) -> Option<WorkspaceLeaseRecord> {
+        self.records
+            .lock()
+            .expect("fake store mutex")
+            .get(id)
+            .cloned()
+    }
+
+    fn check_failure(&self) -> Result<(), WorkspaceLeaseError> {
+        let mut fail = self.fail_next.lock().expect("fake store mutex");
+        if std::mem::take(&mut *fail) {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::StoreUnavailable,
+                "workspace lease store unavailable",
+            ));
+        }
+        Ok(())
+    }
+}
+
+struct FakeOperationGuard {
+    _guard: OwnedMutexGuard<()>,
+}
+
+impl WorkspaceLeaseOperationGuard for FakeOperationGuard {}
+
+#[async_trait]
+impl WorkspaceLeaseStore for FakeWorkspaceLeaseStore {
+    async fn acquire_operation(
+        &self,
+        id: &WorkspaceLeaseId,
+        _owner: &crate::cluster_ledger::OwnerId,
+    ) -> Result<Box<dyn WorkspaceLeaseOperationGuard>, WorkspaceLeaseError> {
+        let operation = self
+            .operations
+            .lock()
+            .expect("fake store operation mutex")
+            .entry(id.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone();
+        Ok(Box::new(FakeOperationGuard {
+            _guard: operation.lock_owned().await,
+        }))
+    }
+
+    async fn load(
+        &self,
+        id: &WorkspaceLeaseId,
+    ) -> Result<Option<WorkspaceLeaseRecord>, WorkspaceLeaseError> {
+        self.check_failure()?;
+        Ok(self
+            .records
+            .lock()
+            .expect("fake store mutex")
+            .get(id)
+            .cloned())
+    }
+
+    async fn create_pending(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<CreateLeaseOutcome, WorkspaceLeaseError> {
+        self.check_failure()?;
+        if record.state != WorkspaceLeaseState::CreatePending || record.revision != 0 {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::InvalidInput,
+                "new workspace lease must start at revision zero in CreatePending",
+            ));
+        }
+        let mut records = self.records.lock().expect("fake store mutex");
+        if let Some(existing) = records.get(&record.id) {
+            return Ok(CreateLeaseOutcome::Existing(existing.clone()));
+        }
+        records.insert(record.id.clone(), record.clone());
+        Ok(CreateLeaseOutcome::Created(record))
+    }
+
+    async fn transition(
+        &self,
+        request: WorkspaceLeaseTransition,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        self.check_failure()?;
+        let mut records = self.records.lock().expect("fake store mutex");
+        let current = records.get_mut(&request.id).ok_or_else(|| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::NotFound,
+                "workspace lease does not exist",
+            )
+        })?;
+        if current.owner != request.owner {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::OwnerMismatch,
+                "workspace lease owner fence mismatch",
+            ));
+        }
+        if current.revision != request.expected_revision || current.state != request.expected_state
+        {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace lease transition lost a compare-and-set race",
+            ));
+        }
+        let legal = matches!(
+            (current.state, request.next_state),
+            (
+                WorkspaceLeaseState::CreatePending,
+                WorkspaceLeaseState::Ready
+            ) | (
+                WorkspaceLeaseState::CreatePending,
+                WorkspaceLeaseState::CleanupRequired
+            ) | (
+                WorkspaceLeaseState::CreatePending,
+                WorkspaceLeaseState::Cleaned
+            ) | (
+                WorkspaceLeaseState::Ready,
+                WorkspaceLeaseState::CleanupRequired
+            ) | (WorkspaceLeaseState::Ready, WorkspaceLeaseState::Cleaned)
+                | (
+                    WorkspaceLeaseState::CleanupRequired,
+                    WorkspaceLeaseState::Cleaned
+                )
+        );
+        if !legal {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "illegal workspace lease state transition",
+            ));
+        }
+        current.revision = current.revision.checked_add(1).ok_or_else(|| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace lease revision overflow",
+            )
+        })?;
+        current.state = request.next_state;
+        Ok(current.clone())
+    }
+}

--- a/zeroshot-rust/src/workspace_lease/store/sqlite.rs
+++ b/zeroshot-rust/src/workspace_lease/store/sqlite.rs
@@ -1,0 +1,505 @@
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use fs2::FileExt;
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+
+use super::{
+    CreateLeaseOutcome, WorkspaceLeaseOperationGuard, WorkspaceLeaseStore, WorkspaceLeaseTransition,
+};
+use crate::workspace_lease::{
+    WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId, WorkspaceLeaseRecord,
+    WorkspaceLeaseState,
+};
+
+const MAX_RECORD_BYTES: usize = 65_536;
+const APPLICATION_ID: i32 = 0x5a_57_4c_53;
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DatabaseIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(not(target_os = "linux"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DatabaseIdentity;
+/// Ephemeral observers for deterministic filesystem-boundary verification.
+#[derive(Clone, Default)]
+pub struct SqliteWorkspaceLeaseHooks {
+    pub lock_contention: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub before_connection_open: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub after_connection_open: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub after_operation_lock: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+pub struct SqliteWorkspaceLeaseStore {
+    path: PathBuf,
+    identity: DatabaseIdentity,
+    writer: Mutex<()>,
+    hooks: SqliteWorkspaceLeaseHooks,
+}
+
+impl SqliteWorkspaceLeaseStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, WorkspaceLeaseError> {
+        Self::open_inner(path.as_ref(), SqliteWorkspaceLeaseHooks::default())
+    }
+
+    /// Opens a store with ephemeral filesystem-boundary observers.
+    pub fn open_with_hooks(
+        path: impl AsRef<Path>,
+        hooks: SqliteWorkspaceLeaseHooks,
+    ) -> Result<Self, WorkspaceLeaseError> {
+        Self::open_inner(path.as_ref(), hooks)
+    }
+
+    fn open_inner(
+        requested_path: &Path,
+        hooks: SqliteWorkspaceLeaseHooks,
+    ) -> Result<Self, WorkspaceLeaseError> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (requested_path, hooks);
+            Err(store_error(
+                "SQLite workspace leases require Linux descriptor-backed file identity",
+            ))
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let requested_parent = requested_path
+                .parent()
+                .ok_or_else(|| store_error("lease store path has no parent"))?;
+            fs::create_dir_all(requested_parent)
+                .map_err(|_| store_error("lease store directory unavailable"))?;
+            let path = match fs::canonicalize(requested_path) {
+                Ok(path) => path,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    create_private_file(requested_path)?;
+                    fs::canonicalize(requested_path)
+                        .map_err(|_| store_error("lease store identity unavailable"))?
+                }
+                Err(_) => return Err(store_error("lease store identity unavailable")),
+            };
+            create_private_file(&path)?;
+            let identity = database_identity(&path)?;
+            let store = Self {
+                path,
+                identity,
+                writer: Mutex::new(()),
+                hooks,
+            };
+            let connection = store.connect()?;
+            connection
+                .execute_batch(&format!(
+                    "PRAGMA application_id = {APPLICATION_ID};
+                     PRAGMA user_version = 1;
+                     PRAGMA journal_mode = WAL;
+                     PRAGMA synchronous = FULL;
+                     CREATE TABLE IF NOT EXISTS workspace_leases (
+                         lease_id TEXT PRIMARY KEY NOT NULL,
+                         owner_id TEXT NOT NULL,
+                         state TEXT NOT NULL,
+                         revision INTEGER NOT NULL CHECK (revision >= 0),
+                         record BLOB NOT NULL
+                     ) STRICT;"
+                ))
+                .map_err(|_| store_error("lease store schema unavailable"))?;
+            Ok(store)
+        }
+    }
+
+    fn connect(&self) -> Result<Connection, WorkspaceLeaseError> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(store_error(
+                "SQLite workspace leases require Linux descriptor-backed file identity",
+            ))
+        }
+        #[cfg(target_os = "linux")]
+        {
+            validate_database_identity(&self.path, self.identity)?;
+            let file = open_existing_database(&self.path)?;
+            validate_file_identity(&file, self.identity)?;
+            if let Some(hook) = &self.hooks.before_connection_open {
+                hook();
+            }
+            let connection = Connection::open(descriptor_path(&file))
+                .map_err(|_| store_error("lease store database unavailable"))?;
+            if let Some(hook) = &self.hooks.after_connection_open {
+                hook();
+            }
+            validate_file_identity(&file, self.identity)?;
+            validate_database_identity(&self.path, self.identity)?;
+            let application_id: i32 = connection
+                .pragma_query_value(None, "application_id", |row| row.get(0))
+                .map_err(|_| store_error("lease store identity unavailable"))?;
+            if application_id != 0 && application_id != APPLICATION_ID {
+                return Err(store_error("lease store identity mismatch"));
+            }
+            connection
+                .busy_timeout(std::time::Duration::from_secs(5))
+                .map_err(|_| store_error("lease store busy timeout unavailable"))?;
+            Ok(connection)
+        }
+    }
+}
+
+struct SqliteOperationGuard {
+    file: File,
+}
+
+impl WorkspaceLeaseOperationGuard for SqliteOperationGuard {}
+
+impl Drop for SqliteOperationGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[async_trait]
+impl WorkspaceLeaseStore for SqliteWorkspaceLeaseStore {
+    async fn acquire_operation(
+        &self,
+        _id: &WorkspaceLeaseId,
+        _owner: &crate::cluster_ledger::OwnerId,
+    ) -> Result<Box<dyn WorkspaceLeaseOperationGuard>, WorkspaceLeaseError> {
+        validate_database_identity(&self.path, self.identity)?;
+        let file = open_existing_database(&self.path)?;
+        validate_file_identity(&file, self.identity)?;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    if let Some(hook) = &self.hooks.after_operation_lock {
+                        hook();
+                    }
+                    validate_database_identity(&self.path, self.identity)?;
+                    return Ok(Box::new(SqliteOperationGuard { file }));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if let Some(hook) = &self.hooks.lock_contention {
+                        hook();
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+                Err(_) => return Err(store_error("lease operation lock unavailable")),
+            }
+        }
+    }
+
+    async fn load(
+        &self,
+        id: &WorkspaceLeaseId,
+    ) -> Result<Option<WorkspaceLeaseRecord>, WorkspaceLeaseError> {
+        let connection = self.connect()?;
+        load_record(&connection, id)
+    }
+
+    async fn create_pending(
+        &self,
+        record: WorkspaceLeaseRecord,
+    ) -> Result<CreateLeaseOutcome, WorkspaceLeaseError> {
+        validate_new_record(&record)?;
+        let bytes = encode_record(&record)?;
+        let _writer = self.writer.lock().expect("workspace lease writer mutex");
+        let mut connection = self.connect()?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|_| store_error("lease store transaction unavailable"))?;
+        let inserted = transaction
+            .execute(
+                "INSERT OR IGNORE INTO workspace_leases
+                 (lease_id, owner_id, state, revision, record) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    record.id.resource_id().as_str(),
+                    record.owner.as_str(),
+                    state_name(record.state),
+                    to_sql_revision(record.revision)?,
+                    bytes
+                ],
+            )
+            .map_err(|_| store_error("lease intent could not be committed"))?;
+        let outcome = if inserted == 1 {
+            CreateLeaseOutcome::Created(record)
+        } else {
+            CreateLeaseOutcome::Existing(
+                load_record(&transaction, &record.id)?
+                    .ok_or_else(|| store_error("existing lease disappeared"))?,
+            )
+        };
+        transaction
+            .commit()
+            .map_err(|_| store_error("lease intent commit failed"))?;
+        Ok(outcome)
+    }
+
+    async fn transition(
+        &self,
+        request: WorkspaceLeaseTransition,
+    ) -> Result<WorkspaceLeaseRecord, WorkspaceLeaseError> {
+        let _writer = self.writer.lock().expect("workspace lease writer mutex");
+        let mut connection = self.connect()?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|_| store_error("lease store transaction unavailable"))?;
+        let mut current = load_record(&transaction, &request.id)?.ok_or_else(|| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::NotFound,
+                "workspace lease does not exist",
+            )
+        })?;
+        if current.owner != request.owner {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::OwnerMismatch,
+                "workspace lease owner fence mismatch",
+            ));
+        }
+        if current.revision != request.expected_revision || current.state != request.expected_state
+        {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace lease transition lost a compare-and-set race",
+            ));
+        }
+        if !legal_transition(current.state, request.next_state) {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "illegal workspace lease state transition",
+            ));
+        }
+        current.revision = current.revision.checked_add(1).ok_or_else(|| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace lease revision overflow",
+            )
+        })?;
+        current.state = request.next_state;
+        let bytes = encode_record(&current)?;
+        let changed = transaction
+            .execute(
+                "UPDATE workspace_leases SET state = ?1, revision = ?2, record = ?3
+                 WHERE lease_id = ?4 AND owner_id = ?5 AND state = ?6 AND revision = ?7",
+                params![
+                    state_name(current.state),
+                    to_sql_revision(current.revision)?,
+                    bytes,
+                    current.id.resource_id().as_str(),
+                    current.owner.as_str(),
+                    state_name(request.expected_state),
+                    to_sql_revision(request.expected_revision)?
+                ],
+            )
+            .map_err(|_| store_error("lease transition failed"))?;
+        if changed != 1 {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::Conflict,
+                "workspace lease transition lost a compare-and-set race",
+            ));
+        }
+        transaction
+            .commit()
+            .map_err(|_| store_error("lease transition commit failed"))?;
+        Ok(current)
+    }
+}
+
+fn load_record(
+    connection: &Connection,
+    id: &WorkspaceLeaseId,
+) -> Result<Option<WorkspaceLeaseRecord>, WorkspaceLeaseError> {
+    let row = connection
+        .query_row(
+            "SELECT owner_id, state, revision, record FROM workspace_leases WHERE lease_id = ?1",
+            [id.resource_id().as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|_| store_error("lease record unavailable"))?;
+    let Some((owner, state, revision, bytes)) = row else {
+        return Ok(None);
+    };
+    if bytes.len() > MAX_RECORD_BYTES {
+        return Err(store_error("lease record exceeds its bound"));
+    }
+    let record: WorkspaceLeaseRecord =
+        serde_json::from_slice(&bytes).map_err(|_| store_error("lease record is corrupt"))?;
+    let revision = u64::try_from(revision).map_err(|_| store_error("lease revision is corrupt"))?;
+    if &record.id != id
+        || record.owner.as_str() != owner
+        || state_name(record.state) != state
+        || record.revision != revision
+    {
+        return Err(store_error("lease record identity is corrupt"));
+    }
+    Ok(Some(record))
+}
+
+fn encode_record(record: &WorkspaceLeaseRecord) -> Result<Vec<u8>, WorkspaceLeaseError> {
+    let bytes =
+        serde_json::to_vec(record).map_err(|_| store_error("lease record encoding failed"))?;
+    if bytes.len() > MAX_RECORD_BYTES {
+        return Err(store_error("lease record exceeds its bound"));
+    }
+    Ok(bytes)
+}
+
+fn validate_new_record(record: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+    if record.state != WorkspaceLeaseState::CreatePending || record.revision != 0 {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::InvalidInput,
+            "new workspace lease must start at revision zero in CreatePending",
+        ));
+    }
+    Ok(())
+}
+
+fn legal_transition(current: WorkspaceLeaseState, next: WorkspaceLeaseState) -> bool {
+    matches!(
+        (current, next),
+        (
+            WorkspaceLeaseState::CreatePending,
+            WorkspaceLeaseState::Ready
+        ) | (
+            WorkspaceLeaseState::CreatePending,
+            WorkspaceLeaseState::CleanupRequired
+        ) | (
+            WorkspaceLeaseState::CreatePending,
+            WorkspaceLeaseState::Cleaned
+        ) | (
+            WorkspaceLeaseState::Ready,
+            WorkspaceLeaseState::CleanupRequired
+        ) | (WorkspaceLeaseState::Ready, WorkspaceLeaseState::Cleaned)
+            | (
+                WorkspaceLeaseState::CleanupRequired,
+                WorkspaceLeaseState::Cleaned
+            )
+    )
+}
+
+fn state_name(state: WorkspaceLeaseState) -> &'static str {
+    match state {
+        WorkspaceLeaseState::CreatePending => "create_pending",
+        WorkspaceLeaseState::Ready => "ready",
+        WorkspaceLeaseState::CleanupRequired => "cleanup_required",
+        WorkspaceLeaseState::Cleaned => "cleaned",
+    }
+}
+
+fn to_sql_revision(revision: u64) -> Result<i64, WorkspaceLeaseError> {
+    i64::try_from(revision).map_err(|_| store_error("lease revision exceeds SQLite range"))
+}
+
+#[cfg(target_os = "linux")]
+fn database_identity(path: &Path) -> Result<DatabaseIdentity, WorkspaceLeaseError> {
+    identity_from_metadata(
+        fs::metadata(path).map_err(|_| store_error("lease store identity unavailable"))?,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn identity_from_metadata(metadata: fs::Metadata) -> Result<DatabaseIdentity, WorkspaceLeaseError> {
+    use std::os::unix::fs::MetadataExt;
+
+    if metadata.nlink() != 1 {
+        return Err(store_error(
+            "lease store database must have exactly one filesystem link",
+        ));
+    }
+    Ok(DatabaseIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn database_identity(path: &Path) -> Result<DatabaseIdentity, WorkspaceLeaseError> {
+    fs::metadata(path).map_err(|_| store_error("lease store identity unavailable"))?;
+    Ok(DatabaseIdentity)
+}
+
+#[cfg(target_os = "linux")]
+fn validate_file_identity(
+    file: &File,
+    expected: DatabaseIdentity,
+) -> Result<(), WorkspaceLeaseError> {
+    let current = identity_from_metadata(
+        file.metadata()
+            .map_err(|_| store_error("lease store identity unavailable"))?,
+    )?;
+    if current != expected {
+        return Err(store_error("lease store database identity changed"));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn validate_file_identity(
+    file: &File,
+    _expected: DatabaseIdentity,
+) -> Result<(), WorkspaceLeaseError> {
+    file.metadata()
+        .map_err(|_| store_error("lease store identity unavailable"))?;
+    Ok(())
+}
+
+fn validate_database_identity(
+    path: &Path,
+    expected: DatabaseIdentity,
+) -> Result<(), WorkspaceLeaseError> {
+    if database_identity(path)? != expected {
+        return Err(store_error("lease store database identity changed"));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn descriptor_path(file: &File) -> PathBuf {
+    use std::os::fd::AsRawFd;
+
+    PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()))
+}
+
+fn store_error(message: &'static str) -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(WorkspaceLeaseErrorKind::StoreUnavailable, message)
+}
+
+fn create_private_file(path: &Path) -> Result<(), WorkspaceLeaseError> {
+    open_private_file(path).map(|_| ())
+}
+
+fn open_private_file(path: &Path) -> Result<File, WorkspaceLeaseError> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    options
+        .open(path)
+        .map_err(|_| store_error("lease store file unavailable"))
+}
+
+fn open_existing_database(path: &Path) -> Result<File, WorkspaceLeaseError> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    options
+        .open(path)
+        .map_err(|_| store_error("lease store file unavailable"))
+}

--- a/zeroshot-rust/src/workspace_lease/types.rs
+++ b/zeroshot-rust/src/workspace_lease/types.rs
@@ -389,7 +389,12 @@ impl DockerWorkspace {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+#[serde(
+    rename_all = "snake_case",
+    tag = "kind",
+    content = "value",
+    deny_unknown_fields
+)]
 pub enum WorkspaceMode {
     Borrowed(BorrowedWorkspace),
     Worktree(WorktreeWorkspace),
@@ -441,44 +446,111 @@ pub struct PrepareWorkspaceRequest {
     pub mode: WorkspaceMode,
 }
 
+#[derive(Clone, Default)]
+pub struct WorkspaceProductRootHooks {
+    pub after_base_open: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub fail_after_staging_directory: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_owner_marker_create: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_owner_marker_sync: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_inner_quarantine: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_staging_quarantine: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_outer_quarantine: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    pub fail_after_owner_marker_removal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+}
+
 #[derive(Clone)]
 pub struct WorkspaceProductRoots {
     worktree_directory: Arc<File>,
     docker_mount_directory: Arc<File>,
+    hooks: WorkspaceProductRootHooks,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum WorktreeContainerLocation {
+    Public,
+    Staging,
+    PublicQuarantine,
+    StagingQuarantine,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum WorktreeWorkspaceLocation {
+    Public,
+    Staging,
+    PublicQuarantine,
+    StagingQuarantine,
 }
 
 #[derive(Clone)]
 pub(crate) struct PinnedWorktree {
     container: Arc<File>,
+    container_location: WorktreeContainerLocation,
     workspace: Option<Arc<File>>,
+    workspace_location: Option<WorktreeWorkspaceLocation>,
+}
+
+struct FinishContainerQuarantineRequest<'a> {
+    parent: &'a File,
+    child: &'a str,
+    expected: &'a File,
+    lease: &'a WorkspaceLeaseRecord,
+    fail_after_owner_marker_removal: &'a Option<Arc<dyn Fn() -> bool + Send + Sync>>,
 }
 
 impl PinnedWorktree {
     pub(crate) fn workspace(&self) -> Option<&Arc<File>> {
         self.workspace.as_ref()
     }
+
+    pub(crate) fn workspace_for_inspect_effect(&self) -> Option<&Arc<File>> {
+        (self.container_location == WorktreeContainerLocation::Public
+            && self.workspace_location == Some(WorktreeWorkspaceLocation::Public))
+        .then_some(())
+        .and(self.workspace.as_ref())
+    }
+
+    pub(crate) fn workspace_for_create_effect(&self) -> Option<&Arc<File>> {
+        (self.container_location == WorktreeContainerLocation::Staging
+            && self.workspace_location == Some(WorktreeWorkspaceLocation::Staging))
+        .then_some(())
+        .and(self.workspace.as_ref())
+    }
+
+    pub(crate) fn workspace_for_cleanup_effect(&self) -> Option<&Arc<File>> {
+        matches!(
+            self.workspace_location,
+            Some(WorktreeWorkspaceLocation::Public | WorktreeWorkspaceLocation::Staging)
+        )
+        .then_some(())
+        .and(self.workspace.as_ref())
+    }
 }
 
 impl WorkspaceProductRoots {
     pub fn new(base: CanonicalWorkspaceRoot) -> Result<Self, WorkspaceLeaseError> {
+        Self::new_with_hooks(base, WorkspaceProductRootHooks::default())
+    }
+
+    pub fn new_with_hooks(
+        base: CanonicalWorkspaceRoot,
+        hooks: WorkspaceProductRootHooks,
+    ) -> Result<Self, WorkspaceLeaseError> {
         #[cfg(not(target_os = "linux"))]
         {
-            let _ = base;
+            let _ = (base, hooks);
             return Err(WorkspaceLeaseError::invalid(
                 "owned workspace roots require Linux descriptor-relative filesystem support",
             ));
         }
         #[cfg(target_os = "linux")]
         {
-            let base_path = base.as_path();
-            validate_private_product_base(base_path)?;
-            let base_directory = open_directory_no_follow(base_path)?;
-            validate_private_product_base_descriptor(&base_directory)?;
+            let base_directory = open_validated_product_base(base.as_path(), &hooks)?;
             let worktree_directory = open_pinned_product_child(&base_directory, "worktrees")?;
             let docker_mount_directory = open_pinned_product_child(&base_directory, "mounts")?;
             Ok(Self {
                 worktree_directory: Arc::new(worktree_directory),
                 docker_mount_directory: Arc::new(docker_mount_directory),
+                hooks,
             })
         }
     }
@@ -486,16 +558,119 @@ impl WorkspaceProductRoots {
     pub(crate) fn inspect_worktree(
         &self,
         name: &WorkspaceName,
+        lease: &WorkspaceLeaseRecord,
     ) -> Result<Option<PinnedWorktree>, WorkspaceLeaseError> {
-        let Some(container) =
-            open_existing_pinned_product_child(&self.worktree_directory, name.as_str())?
-        else {
+        let staging_name = worktree_staging_name(name);
+        let quarantine_name = cleanup_name(name.as_str());
+        let staging_quarantine_name = cleanup_name(&staging_name);
+        let public = inspect_recognized_worktree_child(&self.worktree_directory, name.as_str())?;
+        let staging = inspect_recognized_worktree_child(&self.worktree_directory, &staging_name)?;
+        let quarantine =
+            inspect_recognized_worktree_child(&self.worktree_directory, &quarantine_name)?;
+        let staging_quarantine =
+            inspect_recognized_worktree_child(&self.worktree_directory, &staging_quarantine_name)?;
+        let present = usize::from(public.is_some())
+            + usize::from(staging.is_some())
+            + usize::from(quarantine.is_some())
+            + usize::from(staging_quarantine.is_some());
+        if present > 1 {
+            return Err(worktree_mismatch(
+                "workspace public, staging, and quarantine names conflict",
+            ));
+        }
+        let (container, container_location, owner_status) = if let Some(container) = public {
+            let owner_status = worktree_owner_status(&container, lease)?;
+            if owner_status != WorktreeOwnerStatus::Matching {
+                return Err(worktree_mismatch(
+                    "workspace worktree owner marker does not match durable intent",
+                ));
+            }
+            (container, WorktreeContainerLocation::Public, owner_status)
+        } else if let Some(container) = staging {
+            let owner_status = worktree_owner_status(&container, lease)?;
+            if owner_status == WorktreeOwnerStatus::Foreign {
+                return Err(worktree_mismatch(
+                    "workspace staging owner marker does not match durable intent",
+                ));
+            }
+            (container, WorktreeContainerLocation::Staging, owner_status)
+        } else if let Some(container) = quarantine {
+            let owner_status = worktree_owner_status(&container, lease)?;
+            if owner_status == WorktreeOwnerStatus::Foreign {
+                return Err(worktree_mismatch(
+                    "workspace quarantine owner marker does not match durable intent",
+                ));
+            }
+            (
+                container,
+                WorktreeContainerLocation::PublicQuarantine,
+                owner_status,
+            )
+        } else if let Some(container) = staging_quarantine {
+            let owner_status = worktree_owner_status(&container, lease)?;
+            if owner_status == WorktreeOwnerStatus::Foreign {
+                return Err(worktree_mismatch(
+                    "workspace staging quarantine owner marker does not match durable intent",
+                ));
+            }
+            (
+                container,
+                WorktreeContainerLocation::StagingQuarantine,
+                owner_status,
+            )
+        } else {
             return Ok(None);
         };
-        let workspace = open_existing_pinned_product_child(&container, "workspace")?;
+        validate_worktree_container_shape(&container, container_location, owner_status)?;
+
+        let workspace_name = "workspace";
+        let workspace_staging_name = workspace_staging_name();
+        let workspace_quarantine_name = cleanup_name(workspace_name);
+        let workspace_staging_quarantine_name = cleanup_name(workspace_staging_name);
+        let workspace = inspect_recognized_worktree_child(&container, workspace_name)?;
+        let workspace_staging =
+            inspect_recognized_worktree_child(&container, workspace_staging_name)?;
+        let workspace_quarantine =
+            inspect_recognized_worktree_child(&container, &workspace_quarantine_name)?;
+        let workspace_staging_quarantine =
+            inspect_recognized_worktree_child(&container, &workspace_staging_quarantine_name)?;
+        let present = usize::from(workspace.is_some())
+            + usize::from(workspace_staging.is_some())
+            + usize::from(workspace_quarantine.is_some())
+            + usize::from(workspace_staging_quarantine.is_some());
+        if present > 1 {
+            return Err(worktree_mismatch(
+                "workspace child and recovery names conflict",
+            ));
+        }
+        let (workspace, workspace_location) = if let Some(workspace) = workspace {
+            (
+                Some(Arc::new(workspace)),
+                Some(WorktreeWorkspaceLocation::Public),
+            )
+        } else if let Some(workspace) = workspace_staging {
+            (
+                Some(Arc::new(workspace)),
+                Some(WorktreeWorkspaceLocation::Staging),
+            )
+        } else if let Some(workspace) = workspace_quarantine {
+            (
+                Some(Arc::new(workspace)),
+                Some(WorktreeWorkspaceLocation::PublicQuarantine),
+            )
+        } else if let Some(workspace) = workspace_staging_quarantine {
+            (
+                Some(Arc::new(workspace)),
+                Some(WorktreeWorkspaceLocation::StagingQuarantine),
+            )
+        } else {
+            (None, None)
+        };
         Ok(Some(PinnedWorktree {
             container: Arc::new(container),
-            workspace: workspace.map(Arc::new),
+            container_location,
+            workspace,
+            workspace_location,
         }))
     }
 
@@ -504,21 +679,131 @@ impl WorkspaceProductRoots {
         name: &WorkspaceName,
         lease: &WorkspaceLeaseRecord,
     ) -> Result<PinnedWorktree, WorkspaceLeaseError> {
-        let (container, created) =
-            open_pinned_product_child_with_status(&self.worktree_directory, name.as_str())?;
-        if created {
-            set_worktree_owner(&container, lease)?;
-        } else if !worktree_owner_matches(&container, lease)? {
-            return Err(WorkspaceLeaseError::new(
-                WorkspaceLeaseErrorKind::ResourceMismatch,
-                "workspace worktree owner marker does not match durable intent",
+        let staging_name = worktree_staging_name(name);
+        if inspect_recognized_worktree_child(&self.worktree_directory, name.as_str())?.is_some()
+            || inspect_recognized_worktree_child(
+                &self.worktree_directory,
+                &cleanup_name(name.as_str()),
+            )?
+            .is_some()
+            || inspect_recognized_worktree_child(
+                &self.worktree_directory,
+                &cleanup_name(&staging_name),
+            )?
+            .is_some()
+        {
+            return Err(worktree_mismatch(
+                "workspace public or quarantine name appeared before create",
             ));
         }
-        let workspace = open_pinned_product_child(&container, "workspace")?;
+        let (staging, created) =
+            open_pinned_product_child_with_status(&self.worktree_directory, &staging_name)?;
+        if created && hook_fails(&self.hooks.fail_after_staging_directory) {
+            return Err(injected_root_failure(
+                "workspace staging interrupted after directory creation",
+            ));
+        }
+        let owner_status = worktree_owner_status(&staging, lease)?;
+        match owner_status {
+            WorktreeOwnerStatus::Matching => {}
+            WorktreeOwnerStatus::Recoverable => {
+                remove_worktree_owner_if_present(&staging)?;
+                set_worktree_owner(&staging, lease, &self.hooks.fail_after_owner_marker_create)?;
+            }
+            WorktreeOwnerStatus::Foreign => {
+                return Err(worktree_mismatch(
+                    "workspace staging owner marker does not match durable intent",
+                ));
+            }
+        }
+        staging.sync_all().map_err(|_| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceUnavailable,
+                "workspace staging directory could not be synchronized",
+            )
+        })?;
+        validate_worktree_container_shape(
+            &staging,
+            WorktreeContainerLocation::Staging,
+            WorktreeOwnerStatus::Matching,
+        )?;
+        if hook_fails(&self.hooks.fail_after_owner_marker_sync) {
+            return Err(injected_root_failure(
+                "workspace staging interrupted after owner marker synchronization",
+            ));
+        }
+        let workspace = open_pinned_product_child(&staging, workspace_staging_name())?;
         Ok(PinnedWorktree {
-            container: Arc::new(container),
+            container: Arc::new(staging),
+            container_location: WorktreeContainerLocation::Staging,
             workspace: Some(Arc::new(workspace)),
+            workspace_location: Some(WorktreeWorkspaceLocation::Staging),
         })
+    }
+
+    pub(crate) fn publish_worktree(
+        &self,
+        name: &WorkspaceName,
+        worktree: &PinnedWorktree,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<(), WorkspaceLeaseError> {
+        if worktree.container_location != WorktreeContainerLocation::Staging
+            || worktree.workspace_location != Some(WorktreeWorkspaceLocation::Staging)
+            || !named_child_matches(
+                &self.worktree_directory,
+                &worktree_staging_name(name),
+                &worktree.container,
+            )?
+        {
+            return Err(worktree_mismatch(
+                "workspace staging identity changed before publication",
+            ));
+        }
+        let workspace = worktree
+            .workspace()
+            .ok_or_else(|| worktree_mismatch("workspace source staging is absent"))?;
+        if !named_child_matches(&worktree.container, workspace_staging_name(), workspace)? {
+            return Err(worktree_mismatch(
+                "workspace source staging identity changed before publication",
+            ));
+        }
+        if worktree_owner_status(&worktree.container, lease)? != WorktreeOwnerStatus::Matching {
+            return Err(worktree_mismatch(
+                "workspace staging owner marker changed before publication",
+            ));
+        }
+        validate_worktree_container_shape(
+            &worktree.container,
+            WorktreeContainerLocation::Staging,
+            WorktreeOwnerStatus::Matching,
+        )?;
+        rename_product_child(&worktree.container, workspace_staging_name(), "workspace")?;
+        worktree.container.sync_all().map_err(|_| {
+            injected_root_failure("workspace source publication could not be synchronized")
+        })?;
+        rename_product_child(
+            &self.worktree_directory,
+            &worktree_staging_name(name),
+            name.as_str(),
+        )?;
+        self.worktree_directory.sync_all().map_err(|_| {
+            injected_root_failure("workspace worktree publication could not be synchronized")
+        })?;
+        let published =
+            open_existing_pinned_product_child(&self.worktree_directory, name.as_str())?
+                .ok_or_else(|| {
+                    injected_root_failure("workspace worktree publication disappeared")
+                })?;
+        if !named_child_matches(&published, "workspace", workspace)?
+            || worktree_owner_status(&published, lease)? != WorktreeOwnerStatus::Matching
+        {
+            return Err(worktree_mismatch("published workspace identity changed"));
+        }
+        validate_worktree_container_shape(
+            &published,
+            WorktreeContainerLocation::Public,
+            WorktreeOwnerStatus::Matching,
+        )
     }
 
     pub(crate) fn remove_worktree(
@@ -527,38 +812,92 @@ impl WorkspaceProductRoots {
         worktree: &PinnedWorktree,
         lease: &WorkspaceLeaseRecord,
     ) -> Result<(), WorkspaceLeaseError> {
-        if let Some(workspace) = worktree.workspace() {
-            remove_pinned_product_child(&worktree.container, "workspace", workspace)?;
+        if let (Some(workspace), Some(location)) =
+            (worktree.workspace(), worktree.workspace_location)
+        {
+            match location {
+                WorktreeWorkspaceLocation::Public => quarantine_and_remove_product_child(
+                    &worktree.container,
+                    "workspace",
+                    workspace,
+                    &self.hooks.fail_after_inner_quarantine,
+                )?,
+                WorktreeWorkspaceLocation::Staging => quarantine_and_remove_product_child(
+                    &worktree.container,
+                    workspace_staging_name(),
+                    workspace,
+                    &self.hooks.fail_after_inner_quarantine,
+                )?,
+                WorktreeWorkspaceLocation::PublicQuarantine => {
+                    remove_quarantined_product_child(&worktree.container, "workspace", workspace)?
+                }
+                WorktreeWorkspaceLocation::StagingQuarantine => remove_quarantined_product_child(
+                    &worktree.container,
+                    workspace_staging_name(),
+                    workspace,
+                )?,
+            }
         }
-        remove_worktree_owner(&worktree.container)?;
-        if let Err(error) = remove_pinned_product_child(
-            &self.worktree_directory,
-            name.as_str(),
-            &worktree.container,
-        ) {
-            let _ = set_worktree_owner(&worktree.container, lease);
-            return Err(error);
+        match worktree.container_location {
+            WorktreeContainerLocation::Public => {
+                quarantine_product_child(
+                    &self.worktree_directory,
+                    name.as_str(),
+                    &worktree.container,
+                )?;
+                if hook_fails(&self.hooks.fail_after_outer_quarantine) {
+                    return Err(injected_root_failure(
+                        "workspace cleanup interrupted after outer quarantine",
+                    ));
+                }
+                finish_container_quarantine(FinishContainerQuarantineRequest {
+                    parent: &self.worktree_directory,
+                    child: name.as_str(),
+                    expected: &worktree.container,
+                    lease,
+                    fail_after_owner_marker_removal: &self.hooks.fail_after_owner_marker_removal,
+                })
+            }
+            WorktreeContainerLocation::Staging => {
+                let staging_name = worktree_staging_name(name);
+                quarantine_product_child(
+                    &self.worktree_directory,
+                    &staging_name,
+                    &worktree.container,
+                )?;
+                if hook_fails(&self.hooks.fail_after_staging_quarantine) {
+                    return Err(injected_root_failure(
+                        "workspace staging cleanup interrupted after quarantine",
+                    ));
+                }
+                finish_container_quarantine(FinishContainerQuarantineRequest {
+                    parent: &self.worktree_directory,
+                    child: &staging_name,
+                    expected: &worktree.container,
+                    lease,
+                    fail_after_owner_marker_removal: &self.hooks.fail_after_owner_marker_removal,
+                })
+            }
+            WorktreeContainerLocation::PublicQuarantine => {
+                finish_container_quarantine(FinishContainerQuarantineRequest {
+                    parent: &self.worktree_directory,
+                    child: name.as_str(),
+                    expected: &worktree.container,
+                    lease,
+                    fail_after_owner_marker_removal: &self.hooks.fail_after_owner_marker_removal,
+                })
+            }
+            WorktreeContainerLocation::StagingQuarantine => {
+                let staging_name = worktree_staging_name(name);
+                finish_container_quarantine(FinishContainerQuarantineRequest {
+                    parent: &self.worktree_directory,
+                    child: &staging_name,
+                    expected: &worktree.container,
+                    lease,
+                    fail_after_owner_marker_removal: &self.hooks.fail_after_owner_marker_removal,
+                })
+            }
         }
-        Ok(())
-    }
-
-    pub(crate) fn worktree_owned_by(
-        &self,
-        worktree: &PinnedWorktree,
-        lease: &WorkspaceLeaseRecord,
-    ) -> Result<bool, WorkspaceLeaseError> {
-        worktree_owner_matches(&worktree.container, lease)
-    }
-
-    pub(crate) fn worktree_destination(
-        &self,
-        worktree: &PinnedWorktree,
-    ) -> Result<PathBuf, WorkspaceLeaseError> {
-        descriptor_path(
-            worktree
-                .workspace()
-                .ok_or_else(|| WorkspaceLeaseError::invalid("workspace root is absent"))?,
-        )
     }
 
     fn docker_mount(
@@ -613,7 +952,12 @@ impl DockerMount {
 }
 
 #[cfg(target_os = "linux")]
-fn validate_private_product_base(path: &Path) -> Result<(), WorkspaceLeaseError> {
+fn open_validated_product_base(
+    path: &Path,
+    hooks: &WorkspaceProductRootHooks,
+) -> Result<File, WorkspaceLeaseError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
     let canonical = fs::canonicalize(path).map_err(|_| {
         WorkspaceLeaseError::new(
             WorkspaceLeaseErrorKind::ResourceUnavailable,
@@ -630,42 +974,46 @@ fn validate_private_product_base(path: &Path) -> Result<(), WorkspaceLeaseError>
         ));
     }
     let directory = open_directory_no_follow(path)?;
-    validate_private_product_base_descriptor(&directory)
-}
-
-#[cfg(target_os = "linux")]
-fn validate_private_product_base_descriptor(directory: &File) -> Result<(), WorkspaceLeaseError> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-
-    let metadata = directory.metadata().map_err(|_| {
+    let descriptor_metadata = directory.metadata().map_err(|_| {
         WorkspaceLeaseError::new(
             WorkspaceLeaseErrorKind::ResourceUnavailable,
             "workspace product base could not be inspected",
         )
     })?;
-    if !metadata.is_dir()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.permissions().mode() & 0o777 != 0o700
+    if let Some(hook) = &hooks.after_base_open {
+        hook();
+    }
+    let canonical_after = fs::canonicalize(path).map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product base identity changed",
+        )
+    })?;
+    let path_metadata = fs::symlink_metadata(path).map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product base identity changed",
+        )
+    })?;
+    if canonical_after != path
+        || path_metadata.file_type().is_symlink()
+        || path_metadata.dev() != descriptor_metadata.dev()
+        || path_metadata.ino() != descriptor_metadata.ino()
+    {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceMismatch,
+            "workspace product base changed during validation",
+        ));
+    }
+    if !descriptor_metadata.is_dir()
+        || descriptor_metadata.uid() != unsafe { libc::geteuid() }
+        || descriptor_metadata.permissions().mode() & 0o777 != 0o700
     {
         return Err(WorkspaceLeaseError::invalid(
             "workspace product base must be an owned private directory",
         ));
     }
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn validate_private_product_base(_path: &Path) -> Result<(), WorkspaceLeaseError> {
-    Err(WorkspaceLeaseError::invalid(
-        "owned workspace roots require Linux descriptor-relative filesystem support",
-    ))
-}
-
-#[cfg(not(target_os = "linux"))]
-fn validate_private_product_base_descriptor(_directory: &File) -> Result<(), WorkspaceLeaseError> {
-    Err(WorkspaceLeaseError::invalid(
-        "owned workspace roots require Linux descriptor-relative filesystem support",
-    ))
+    Ok(directory)
 }
 
 #[cfg(target_os = "linux")]
@@ -764,15 +1112,15 @@ fn open_pinned_product_child_with_status(
     ))
 }
 
-#[cfg(not(target_os = "linux"))]
-fn open_pinned_product_child(_parent: &File, _child: &str) -> Result<File, WorkspaceLeaseError> {
-    Err(WorkspaceLeaseError::invalid(
-        "owned workspace roots require Linux descriptor-relative filesystem support",
-    ))
-}
-
 #[cfg(target_os = "linux")]
 const WORKTREE_OWNER_MARKER: &str = ".zeroshot-owner";
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum WorktreeOwnerStatus {
+    Matching,
+    Recoverable,
+    Foreign,
+}
 
 #[cfg(target_os = "linux")]
 fn worktree_owner_bytes(lease: &WorkspaceLeaseRecord) -> Vec<u8> {
@@ -788,6 +1136,7 @@ fn worktree_owner_bytes(lease: &WorkspaceLeaseRecord) -> Vec<u8> {
 fn set_worktree_owner(
     directory: &File,
     lease: &WorkspaceLeaseRecord,
+    fail_after_create: &Option<Arc<dyn Fn() -> bool + Send + Sync>>,
 ) -> Result<(), WorkspaceLeaseError> {
     use std::ffi::CString;
     use std::io::Write;
@@ -803,26 +1152,27 @@ fn set_worktree_owner(
         )
     };
     if descriptor < 0 {
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace owner marker could not be persisted",
+        return Err(injected_root_failure(
+            "workspace owner marker could not be created",
         ));
     }
     let mut file = unsafe { File::from_raw_fd(descriptor) };
+    if hook_fails(fail_after_create) {
+        return Err(injected_root_failure(
+            "workspace owner marker persistence was interrupted",
+        ));
+    }
     file.write_all(&worktree_owner_bytes(lease))
         .and_then(|()| file.sync_all())
-        .map_err(|_| {
-            WorkspaceLeaseError::new(
-                WorkspaceLeaseErrorKind::ResourceUnavailable,
-                "workspace owner marker could not be persisted",
-            )
-        })
+        .and_then(|()| directory.sync_all())
+        .map_err(|_| injected_root_failure("workspace owner marker could not be persisted"))
 }
 
 #[cfg(not(target_os = "linux"))]
 fn set_worktree_owner(
     _directory: &File,
     _lease: &WorkspaceLeaseRecord,
+    _fail_after_create: &Option<Arc<dyn Fn() -> bool + Send + Sync>>,
 ) -> Result<(), WorkspaceLeaseError> {
     Err(WorkspaceLeaseError::invalid(
         "owned workspace roots require Linux descriptor-relative filesystem support",
@@ -830,10 +1180,7 @@ fn set_worktree_owner(
 }
 
 #[cfg(target_os = "linux")]
-fn worktree_owner_matches(
-    directory: &File,
-    lease: &WorkspaceLeaseRecord,
-) -> Result<bool, WorkspaceLeaseError> {
+fn read_worktree_owner(directory: &File) -> Result<Option<Vec<u8>>, WorkspaceLeaseError> {
     use std::ffi::CString;
     use std::io::Read;
     use std::os::fd::{AsRawFd, FromRawFd};
@@ -849,54 +1196,173 @@ fn worktree_owner_matches(
     if descriptor < 0 {
         let error = std::io::Error::last_os_error();
         if error.kind() == std::io::ErrorKind::NotFound {
-            return Ok(false);
+            return Ok(None);
         }
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
+        return Err(injected_root_failure(
             "workspace owner marker could not be inspected",
         ));
     }
     let file = unsafe { File::from_raw_fd(descriptor) };
     let mut value = Vec::new();
-    file.take(1025).read_to_end(&mut value).map_err(|_| {
-        WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace owner marker could not be inspected",
-        )
-    })?;
-    Ok(value.len() <= 1024 && value == worktree_owner_bytes(lease))
+    file.take(1025)
+        .read_to_end(&mut value)
+        .map_err(|_| injected_root_failure("workspace owner marker could not be inspected"))?;
+    Ok(Some(value))
+}
+
+#[cfg(target_os = "linux")]
+fn worktree_owner_status(
+    directory: &File,
+    lease: &WorkspaceLeaseRecord,
+) -> Result<WorktreeOwnerStatus, WorkspaceLeaseError> {
+    let expected = worktree_owner_bytes(lease);
+    let marker = read_worktree_owner(directory)?;
+    if marker.as_deref() == Some(expected.as_slice()) {
+        return Ok(WorktreeOwnerStatus::Matching);
+    }
+    let descriptor = descriptor_path(directory)?;
+    let mut names = fs::read_dir(descriptor)
+        .map_err(|_| injected_root_failure("workspace scaffold could not be inspected"))?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| injected_root_failure("workspace scaffold could not be inspected"))?;
+    names.sort();
+    let only_recoverable_marker = names.is_empty()
+        || (names == [std::ffi::OsString::from(WORKTREE_OWNER_MARKER)]
+            && marker
+                .as_ref()
+                .is_some_and(|value| expected.starts_with(value)));
+    Ok(if only_recoverable_marker {
+        WorktreeOwnerStatus::Recoverable
+    } else {
+        WorktreeOwnerStatus::Foreign
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
-fn worktree_owner_matches(
+fn worktree_owner_status(
     _directory: &File,
     _lease: &WorkspaceLeaseRecord,
-) -> Result<bool, WorkspaceLeaseError> {
+) -> Result<WorktreeOwnerStatus, WorkspaceLeaseError> {
     Err(WorkspaceLeaseError::invalid(
         "owned workspace roots require Linux descriptor-relative filesystem support",
     ))
 }
 
 #[cfg(target_os = "linux")]
-fn remove_worktree_owner(directory: &File) -> Result<(), WorkspaceLeaseError> {
+fn remove_worktree_owner_if_present(directory: &File) -> Result<(), WorkspaceLeaseError> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
     let marker = CString::new(WORKTREE_OWNER_MARKER).expect("static marker contains no NUL");
     if unsafe { libc::unlinkat(directory.as_raw_fd(), marker.as_ptr(), 0) } != 0 {
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace owner marker could not be removed",
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::NotFound {
+            return Err(injected_root_failure(
+                "workspace owner marker could not be removed",
+            ));
+        }
+    }
+    directory
+        .sync_all()
+        .map_err(|_| injected_root_failure("workspace owner removal could not be synchronized"))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_worktree_owner_if_present(_directory: &File) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+fn worktree_staging_name(name: &WorkspaceName) -> String {
+    format!(".{}.create-pending", name.as_str())
+}
+
+fn workspace_staging_name() -> &'static str {
+    ".workspace.create-pending"
+}
+
+fn cleanup_name(child: &str) -> String {
+    format!(".{child}.cleanup")
+}
+
+#[cfg(target_os = "linux")]
+fn validate_worktree_container_shape(
+    directory: &File,
+    location: WorktreeContainerLocation,
+    owner_status: WorktreeOwnerStatus,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::ffi::OsStr;
+
+    if owner_status == WorktreeOwnerStatus::Foreign
+        || (location == WorktreeContainerLocation::Public
+            && owner_status != WorktreeOwnerStatus::Matching)
+    {
+        return Err(worktree_mismatch(
+            "workspace container owner marker does not match durable intent",
         ));
+    }
+    let descriptor = descriptor_path(directory)?;
+    for entry in fs::read_dir(descriptor)
+        .map_err(|_| injected_root_failure("workspace container could not be inspected"))?
+    {
+        let name = entry
+            .map_err(|_| injected_root_failure("workspace container could not be inspected"))?
+            .file_name();
+        let recognized = name == OsStr::new(WORKTREE_OWNER_MARKER)
+            || match location {
+                WorktreeContainerLocation::Public => {
+                    name == OsStr::new("workspace")
+                        || name == OsStr::new(&cleanup_name("workspace"))
+                }
+                WorktreeContainerLocation::Staging => {
+                    name == OsStr::new("workspace")
+                        || name == OsStr::new(workspace_staging_name())
+                        || name == OsStr::new(&cleanup_name("workspace"))
+                        || name == OsStr::new(&cleanup_name(workspace_staging_name()))
+                }
+                WorktreeContainerLocation::PublicQuarantine
+                | WorktreeContainerLocation::StagingQuarantine => false,
+            };
+        if !recognized {
+            return Err(worktree_mismatch(
+                "workspace container contains conflicting content",
+            ));
+        }
     }
     Ok(())
 }
 
 #[cfg(not(target_os = "linux"))]
-fn remove_worktree_owner(_directory: &File) -> Result<(), WorkspaceLeaseError> {
+fn validate_worktree_container_shape(
+    _directory: &File,
+    _location: WorktreeContainerLocation,
+    _owner_status: WorktreeOwnerStatus,
+) -> Result<(), WorkspaceLeaseError> {
     Err(WorkspaceLeaseError::invalid(
         "owned workspace roots require Linux descriptor-relative filesystem support",
     ))
+}
+
+fn inspect_recognized_worktree_child(
+    parent: &File,
+    child: &str,
+) -> Result<Option<File>, WorkspaceLeaseError> {
+    open_existing_pinned_product_child(parent, child)
+        .map_err(|_| worktree_mismatch("recognized workspace child is not a private directory"))
+}
+
+fn hook_fails(hook: &Option<Arc<dyn Fn() -> bool + Send + Sync>>) -> bool {
+    hook.as_ref().is_some_and(|hook| hook())
+}
+
+fn injected_root_failure(message: &'static str) -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(WorkspaceLeaseErrorKind::ResourceUnavailable, message)
+}
+
+fn worktree_mismatch(message: &'static str) -> WorkspaceLeaseError {
+    WorkspaceLeaseError::new(WorkspaceLeaseErrorKind::ResourceMismatch, message)
 }
 
 #[cfg(target_os = "linux")]
@@ -939,103 +1405,196 @@ fn open_existing_pinned_product_child(
 }
 
 #[cfg(target_os = "linux")]
-fn remove_pinned_product_child(
-    parent: &File,
-    child: &str,
-    expected: &File,
-) -> Result<(), WorkspaceLeaseError> {
+fn rename_product_child(parent: &File, from: &str, to: &str) -> Result<(), WorkspaceLeaseError> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
-    use std::os::unix::fs::MetadataExt;
 
-    let quarantine = CString::new(format!(".{child}.cleanup"))
-        .map_err(|_| WorkspaceLeaseError::invalid("workspace quarantine contains a NUL byte"))?;
-    let child = CString::new(child)
+    let from = CString::new(from)
         .map_err(|_| WorkspaceLeaseError::invalid("workspace handle contains a NUL byte"))?;
-    let renamed = unsafe {
-        libc::renameat2(
-            parent.as_raw_fd(),
-            child.as_ptr(),
-            parent.as_raw_fd(),
-            quarantine.as_ptr(),
-            libc::RENAME_NOREPLACE,
-        )
-    };
-    if renamed != 0 {
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace product directory could not be quarantined",
-        ));
-    }
-
-    let quarantined = open_existing_pinned_product_child(
-        parent,
-        quarantine.to_str().expect("generated quarantine is UTF-8"),
-    );
-    let expected_metadata = expected.metadata().map_err(|_| {
-        WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace product directory identity became unavailable",
-        )
-    })?;
-    let matches = quarantined
-        .as_ref()
-        .ok()
-        .and_then(Option::as_ref)
-        .and_then(|directory| directory.metadata().ok())
-        .is_some_and(|metadata| {
-            metadata.dev() == expected_metadata.dev() && metadata.ino() == expected_metadata.ino()
-        });
-    if !matches {
-        restore_quarantined_child(parent, &quarantine, &child)?;
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceMismatch,
-            "workspace cleanup target changed before removal",
-        ));
-    }
-
-    if unsafe { libc::unlinkat(parent.as_raw_fd(), quarantine.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
-        restore_quarantined_child(parent, &quarantine, &child)?;
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace product directory could not be removed",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn restore_quarantined_child(
-    parent: &File,
-    quarantine: &std::ffi::CStr,
-    child: &std::ffi::CStr,
-) -> Result<(), WorkspaceLeaseError> {
-    use std::os::fd::AsRawFd;
-
+    let to = CString::new(to)
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace handle contains a NUL byte"))?;
     if unsafe {
         libc::renameat2(
             parent.as_raw_fd(),
-            quarantine.as_ptr(),
+            from.as_ptr(),
             parent.as_raw_fd(),
-            child.as_ptr(),
+            to.as_ptr(),
             libc::RENAME_NOREPLACE,
         )
     } != 0
     {
-        return Err(WorkspaceLeaseError::new(
-            WorkspaceLeaseErrorKind::ResourceUnavailable,
-            "workspace quarantined directory could not be restored",
+        return Err(injected_root_failure(
+            "workspace directory could not be atomically published",
         ));
     }
     Ok(())
 }
 
 #[cfg(not(target_os = "linux"))]
-fn remove_pinned_product_child(
+fn rename_product_child(_parent: &File, _from: &str, _to: &str) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn quarantine_product_child(
+    parent: &File,
+    child: &str,
+    expected: &File,
+) -> Result<(), WorkspaceLeaseError> {
+    rename_product_child(parent, child, &cleanup_name(child))?;
+    if !named_child_matches(parent, &cleanup_name(child), expected)? {
+        rename_product_child(parent, &cleanup_name(child), child)?;
+        return Err(worktree_mismatch(
+            "workspace cleanup target changed before removal",
+        ));
+    }
+    parent
+        .sync_all()
+        .map_err(|_| injected_root_failure("workspace quarantine rename could not be synchronized"))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn quarantine_product_child(
     _parent: &File,
     _child: &str,
     _expected: &File,
 ) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+fn quarantine_and_remove_product_child(
+    parent: &File,
+    child: &str,
+    expected: &File,
+    fail_after_quarantine: &Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+) -> Result<(), WorkspaceLeaseError> {
+    quarantine_product_child(parent, child, expected)?;
+    if hook_fails(fail_after_quarantine) {
+        return Err(injected_root_failure(
+            "workspace cleanup interrupted after inner quarantine",
+        ));
+    }
+    remove_quarantined_product_child(parent, child, expected)
+}
+
+#[cfg(target_os = "linux")]
+fn remove_quarantined_product_child(
+    parent: &File,
+    child: &str,
+    expected: &File,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+
+    let quarantine_name = cleanup_name(child);
+    if !named_child_matches(parent, &quarantine_name, expected)? {
+        return Err(worktree_mismatch(
+            "workspace cleanup quarantine identity changed",
+        ));
+    }
+    let quarantine = CString::new(quarantine_name)
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace quarantine contains a NUL byte"))?;
+    // Linux has no identity-conditional directory unlink: unlinkat(AT_EMPTY_PATH) rejects
+    // directories, while unlinkat(parent, name, AT_REMOVEDIR) cannot bind the final removal to
+    // `expected`. The private 0700 product root and the lease operation fence serialize supported
+    // manager writers; this immediate name/inode recheck fails closed for their recovery races.
+    // Uncooperative mutation by another process with the same uid is the local trust boundary.
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), quarantine.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
+        return Err(injected_root_failure(
+            "workspace quarantined directory could not be removed",
+        ));
+    }
+    parent.sync_all().map_err(|_| {
+        injected_root_failure("workspace quarantine removal could not be synchronized")
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_quarantined_product_child(
+    _parent: &File,
+    _child: &str,
+    _expected: &File,
+) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn finish_container_quarantine(
+    request: FinishContainerQuarantineRequest<'_>,
+) -> Result<(), WorkspaceLeaseError> {
+    if !named_child_matches(
+        request.parent,
+        &cleanup_name(request.child),
+        request.expected,
+    )? {
+        return Err(worktree_mismatch(
+            "workspace container quarantine identity changed",
+        ));
+    }
+    if worktree_owner_status(request.expected, request.lease)? == WorktreeOwnerStatus::Foreign {
+        return Err(worktree_mismatch(
+            "workspace container quarantine owner marker changed",
+        ));
+    }
+    remove_worktree_owner_if_present(request.expected)?;
+    if hook_fails(request.fail_after_owner_marker_removal) {
+        return Err(injected_root_failure(
+            "workspace cleanup interrupted after owner marker removal",
+        ));
+    }
+    if let Err(error) =
+        remove_quarantined_product_child(request.parent, request.child, request.expected)
+    {
+        let no_hook: Option<Arc<dyn Fn() -> bool + Send + Sync>> = None;
+        if read_worktree_owner(request.expected)?.is_none() {
+            let _ = set_worktree_owner(request.expected, request.lease, &no_hook);
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn finish_container_quarantine(
+    _request: FinishContainerQuarantineRequest<'_>,
+) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn named_child_matches(
+    parent: &File,
+    child: &str,
+    expected: &File,
+) -> Result<bool, WorkspaceLeaseError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let Some(current) = open_existing_pinned_product_child(parent, child)? else {
+        return Ok(false);
+    };
+    let current = current
+        .metadata()
+        .map_err(|_| injected_root_failure("workspace directory identity became unavailable"))?;
+    let expected = expected
+        .metadata()
+        .map_err(|_| injected_root_failure("workspace directory identity became unavailable"))?;
+    Ok(current.dev() == expected.dev() && current.ino() == expected.ino())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn named_child_matches(
+    _parent: &File,
+    _child: &str,
+    _expected: &File,
+) -> Result<bool, WorkspaceLeaseError> {
     Err(WorkspaceLeaseError::invalid(
         "owned workspace roots require Linux descriptor-relative filesystem support",
     ))

--- a/zeroshot-rust/src/workspace_lease/types.rs
+++ b/zeroshot-rust/src/workspace_lease/types.rs
@@ -1,0 +1,1095 @@
+use std::fmt;
+use std::fs::{self, File};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::cluster_ledger::{ExecutionId, OwnerId, ResourceId, RunSequence};
+use crate::execution::{WorkspaceAccessMode, WorkspaceAccessRef};
+use crate::source_code_provider::{
+    CanonicalRepository, SourceBranchId, SourceProfileId, SourceRevisionId,
+};
+
+use super::{WorkspaceLeaseError, WorkspaceLeaseErrorKind};
+
+const MAX_WORKSPACE_VALUE_BYTES: usize = 512;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct WorkspaceLeaseId(ResourceId);
+
+impl WorkspaceLeaseId {
+    pub fn derive(key: &WorkspaceLeaseKey) -> Self {
+        let mut digest = Sha256::new();
+        digest.update(b"zeroshot.workspace-lease/v1\0");
+        digest.update(key.cluster.as_str().as_bytes());
+        digest.update(b"\0");
+        digest.update(key.run.get().to_be_bytes());
+        digest.update(b"\0");
+        digest.update(key.logical_key.as_str().as_bytes());
+        match key.isolation {
+            WorkspaceIsolation::Shared => digest.update(b"\0shared"),
+            WorkspaceIsolation::Execution(execution) => {
+                digest.update(b"\0execution\0");
+                digest.update(execution.get().to_be_bytes());
+            }
+        }
+        let encoded = format!("workspace.{:x}", digest.finalize());
+        Self(ResourceId::new(encoded).expect("derived workspace resource id is valid"))
+    }
+
+    #[must_use]
+    pub fn resource_id(&self) -> &ResourceId {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_resource_id(self) -> ResourceId {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceLeaseId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let resource = ResourceId::deserialize(deserializer)?;
+        if !resource.as_str().starts_with("workspace.") {
+            return Err(serde::de::Error::custom(
+                "workspace lease id must use the workspace resource namespace",
+            ));
+        }
+        Ok(Self(resource))
+    }
+}
+
+impl fmt::Display for WorkspaceLeaseId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceIsolation {
+    Shared,
+    Execution(ExecutionId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceLeaseKey {
+    pub cluster: ResourceId,
+    pub run: RunSequence,
+    pub logical_key: ResourceId,
+    pub isolation: WorkspaceIsolation,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceLeaseState {
+    CreatePending,
+    Ready,
+    CleanupRequired,
+    Cleaned,
+}
+
+macro_rules! workspace_text {
+    ($name:ident, $label:literal) => {
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+                let value = value.into();
+                validate_text(&value, $label)?;
+                Ok(Self(value))
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+workspace_text!(WorkspaceProfile, "workspace profile");
+workspace_text!(WorkspaceMaterializationId, "workspace materialization id");
+workspace_text!(DockerResourceId, "Docker resource id");
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct WorkspaceFingerprint(String);
+
+impl WorkspaceFingerprint {
+    pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+        let value = value.into();
+        if !is_lower_hex(&value, 64) {
+            return Err(WorkspaceLeaseError::invalid(
+                "workspace fingerprint must be 64 lowercase hexadecimal characters",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct DockerImageDigest(String);
+
+impl DockerImageDigest {
+    pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+        let value = value.into();
+        if !value
+            .strip_prefix("sha256:")
+            .is_some_and(|digest| is_lower_hex(digest, 64))
+        {
+            return Err(WorkspaceLeaseError::invalid(
+                "Docker image digest must use canonical sha256:<64 lowercase hex>",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DockerImageDigest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct DockerMountHandleId(String);
+
+impl DockerMountHandleId {
+    pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+        let value = value.into();
+        validate_path_component(&value, "Docker mount handle id")?;
+        if value == "docker.sock" || value.ends_with(".sock") {
+            return Err(WorkspaceLeaseError::invalid(
+                "Docker mount handles cannot name a host socket",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for DockerMountHandleId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct WorkspaceName(String);
+
+impl WorkspaceName {
+    pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+        let value = value.into();
+        validate_text(&value, "workspace name")?;
+        let valid = value != "."
+            && value != ".."
+            && value.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"._-".contains(&byte)
+            });
+        if !valid {
+            return Err(WorkspaceLeaseError::invalid(
+                "workspace name must use lowercase ASCII letters, digits, '.', '_' or '-'",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct CanonicalWorkspaceRoot(String);
+
+impl CanonicalWorkspaceRoot {
+    pub fn new(value: impl Into<String>) -> Result<Self, WorkspaceLeaseError> {
+        let value = value.into();
+        validate_text(&value, "canonical workspace root")?;
+        let path = Path::new(&value);
+        if !path.is_absolute()
+            || path
+                .components()
+                .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+            || (value.len() > 1 && value.ends_with(std::path::MAIN_SEPARATOR))
+        {
+            return Err(WorkspaceLeaseError::invalid(
+                "canonical workspace root must be an absolute normalized path",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        Path::new(&self.0)
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for CanonicalWorkspaceRoot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BorrowedWorkspace {
+    pub canonical_root: CanonicalWorkspaceRoot,
+    pub fingerprint: WorkspaceFingerprint,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorktreeWorkspace {
+    pub repository: CanonicalRepository,
+    pub revision: SourceRevisionId,
+    pub source_profile: SourceProfileId,
+    pub name: WorkspaceName,
+    pub branch: SourceBranchId,
+    pub profile: WorkspaceProfile,
+    pub materialization: WorkspaceMaterializationId,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(try_from = "DockerWorkspaceWire")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DockerWorkspace {
+    image_digest: DockerImageDigest,
+    resource: DockerResourceId,
+    mount_handles: Vec<DockerMountHandleId>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DockerWorkspaceWire {
+    image_digest: DockerImageDigest,
+    resource: DockerResourceId,
+    mount_handles: Vec<DockerMountHandleId>,
+}
+
+impl TryFrom<DockerWorkspaceWire> for DockerWorkspace {
+    type Error = WorkspaceLeaseError;
+
+    fn try_from(value: DockerWorkspaceWire) -> Result<Self, Self::Error> {
+        Self::new(value.image_digest, value.resource, value.mount_handles)
+    }
+}
+
+impl DockerWorkspace {
+    pub fn new(
+        image_digest: DockerImageDigest,
+        resource: DockerResourceId,
+        mount_handles: Vec<DockerMountHandleId>,
+    ) -> Result<Self, WorkspaceLeaseError> {
+        if mount_handles.is_empty() || mount_handles.len() > 16 {
+            return Err(WorkspaceLeaseError::invalid(
+                "Docker workspace requires between one and sixteen mount handles",
+            ));
+        }
+        let mut canonical = mount_handles.clone();
+        canonical.sort();
+        canonical.dedup();
+        if canonical != mount_handles {
+            return Err(WorkspaceLeaseError::invalid(
+                "Docker mount handles must be sorted and unique",
+            ));
+        }
+        Ok(Self {
+            image_digest,
+            resource,
+            mount_handles,
+        })
+    }
+
+    #[must_use]
+    pub fn image_digest(&self) -> &DockerImageDigest {
+        &self.image_digest
+    }
+
+    #[must_use]
+    pub fn resource(&self) -> &DockerResourceId {
+        &self.resource
+    }
+
+    #[must_use]
+    pub fn mount_handles(&self) -> &[DockerMountHandleId] {
+        &self.mount_handles
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum WorkspaceMode {
+    Borrowed(BorrowedWorkspace),
+    Worktree(WorktreeWorkspace),
+    Docker(DockerWorkspace),
+}
+
+impl WorkspaceMode {
+    #[must_use]
+    pub const fn is_owned(&self) -> bool {
+        !matches!(self, Self::Borrowed(_))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkspaceLeaseRecord {
+    pub id: WorkspaceLeaseId,
+    pub owner: OwnerId,
+    pub access_mode: WorkspaceAccessMode,
+    pub mode: WorkspaceMode,
+    pub state: WorkspaceLeaseState,
+    pub revision: u64,
+}
+
+impl WorkspaceLeaseRecord {
+    pub(crate) fn pending(request: &PrepareWorkspaceRequest) -> Self {
+        Self {
+            id: WorkspaceLeaseId::derive(&request.key),
+            owner: request.owner.clone(),
+            access_mode: request.access_mode,
+            mode: request.mode.clone(),
+            state: WorkspaceLeaseState::CreatePending,
+            revision: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn access(&self) -> WorkspaceAccessRef {
+        WorkspaceAccessRef::new(self.id.0.clone(), self.access_mode)
+            .expect("persisted workspace access is valid")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PrepareWorkspaceRequest {
+    pub key: WorkspaceLeaseKey,
+    pub owner: OwnerId,
+    pub access_mode: WorkspaceAccessMode,
+    pub mode: WorkspaceMode,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceProductRoots {
+    worktree_directory: Arc<File>,
+    docker_mount_directory: Arc<File>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PinnedWorktree {
+    container: Arc<File>,
+    workspace: Option<Arc<File>>,
+}
+
+impl PinnedWorktree {
+    pub(crate) fn workspace(&self) -> Option<&Arc<File>> {
+        self.workspace.as_ref()
+    }
+}
+
+impl WorkspaceProductRoots {
+    pub fn new(base: CanonicalWorkspaceRoot) -> Result<Self, WorkspaceLeaseError> {
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = base;
+            return Err(WorkspaceLeaseError::invalid(
+                "owned workspace roots require Linux descriptor-relative filesystem support",
+            ));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let base_path = base.as_path();
+            validate_private_product_base(base_path)?;
+            let base_directory = open_directory_no_follow(base_path)?;
+            validate_private_product_base_descriptor(&base_directory)?;
+            let worktree_directory = open_pinned_product_child(&base_directory, "worktrees")?;
+            let docker_mount_directory = open_pinned_product_child(&base_directory, "mounts")?;
+            Ok(Self {
+                worktree_directory: Arc::new(worktree_directory),
+                docker_mount_directory: Arc::new(docker_mount_directory),
+            })
+        }
+    }
+
+    pub(crate) fn inspect_worktree(
+        &self,
+        name: &WorkspaceName,
+    ) -> Result<Option<PinnedWorktree>, WorkspaceLeaseError> {
+        let Some(container) =
+            open_existing_pinned_product_child(&self.worktree_directory, name.as_str())?
+        else {
+            return Ok(None);
+        };
+        let workspace = open_existing_pinned_product_child(&container, "workspace")?;
+        Ok(Some(PinnedWorktree {
+            container: Arc::new(container),
+            workspace: workspace.map(Arc::new),
+        }))
+    }
+
+    pub(crate) fn create_worktree(
+        &self,
+        name: &WorkspaceName,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<PinnedWorktree, WorkspaceLeaseError> {
+        let (container, created) =
+            open_pinned_product_child_with_status(&self.worktree_directory, name.as_str())?;
+        if created {
+            set_worktree_owner(&container, lease)?;
+        } else if !worktree_owner_matches(&container, lease)? {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceMismatch,
+                "workspace worktree owner marker does not match durable intent",
+            ));
+        }
+        let workspace = open_pinned_product_child(&container, "workspace")?;
+        Ok(PinnedWorktree {
+            container: Arc::new(container),
+            workspace: Some(Arc::new(workspace)),
+        })
+    }
+
+    pub(crate) fn remove_worktree(
+        &self,
+        name: &WorkspaceName,
+        worktree: &PinnedWorktree,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<(), WorkspaceLeaseError> {
+        if let Some(workspace) = worktree.workspace() {
+            remove_pinned_product_child(&worktree.container, "workspace", workspace)?;
+        }
+        remove_worktree_owner(&worktree.container)?;
+        if let Err(error) = remove_pinned_product_child(
+            &self.worktree_directory,
+            name.as_str(),
+            &worktree.container,
+        ) {
+            let _ = set_worktree_owner(&worktree.container, lease);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn worktree_owned_by(
+        &self,
+        worktree: &PinnedWorktree,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<bool, WorkspaceLeaseError> {
+        worktree_owner_matches(&worktree.container, lease)
+    }
+
+    pub(crate) fn worktree_destination(
+        &self,
+        worktree: &PinnedWorktree,
+    ) -> Result<PathBuf, WorkspaceLeaseError> {
+        descriptor_path(
+            worktree
+                .workspace()
+                .ok_or_else(|| WorkspaceLeaseError::invalid("workspace root is absent"))?,
+        )
+    }
+
+    fn docker_mount(
+        &self,
+        handle: &DockerMountHandleId,
+        container_path: PathBuf,
+    ) -> Result<DockerMount, WorkspaceLeaseError> {
+        let source_directory =
+            open_pinned_product_child(&self.docker_mount_directory, handle.as_str())?;
+        Ok(DockerMount {
+            handle: handle.clone(),
+            source_directory: Arc::new(source_directory),
+            container_path,
+            read_only: false,
+        })
+    }
+
+    pub fn default_docker_mounts(
+        &self,
+        mode: &DockerWorkspace,
+    ) -> Result<Vec<DockerMount>, WorkspaceLeaseError> {
+        mode.mount_handles
+            .iter()
+            .enumerate()
+            .map(|(index, handle)| {
+                self.docker_mount(
+                    handle,
+                    if index == 0 {
+                        PathBuf::from("/workspace")
+                    } else {
+                        PathBuf::from(format!("/workspace/mount-{index}"))
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone)]
+pub struct DockerMount {
+    pub handle: DockerMountHandleId,
+    source_directory: Arc<File>,
+    pub container_path: PathBuf,
+    pub read_only: bool,
+}
+
+impl DockerMount {
+    #[must_use]
+    pub fn source_directory(&self) -> &File {
+        &self.source_directory
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn validate_private_product_base(path: &Path) -> Result<(), WorkspaceLeaseError> {
+    let canonical = fs::canonicalize(path).map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product base must already exist",
+        )
+    })?;
+    let mut names = path.iter().rev();
+    if canonical != path
+        || names.next() != Some(std::ffi::OsStr::new("workspaces"))
+        || names.next() != Some(std::ffi::OsStr::new("zeroshot"))
+    {
+        return Err(WorkspaceLeaseError::invalid(
+            "workspace product base must be a canonical zeroshot/workspaces directory",
+        ));
+    }
+    let directory = open_directory_no_follow(path)?;
+    validate_private_product_base_descriptor(&directory)
+}
+
+#[cfg(target_os = "linux")]
+fn validate_private_product_base_descriptor(directory: &File) -> Result<(), WorkspaceLeaseError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = directory.metadata().map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product base could not be inspected",
+        )
+    })?;
+    if !metadata.is_dir()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.permissions().mode() & 0o777 != 0o700
+    {
+        return Err(WorkspaceLeaseError::invalid(
+            "workspace product base must be an owned private directory",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn validate_private_product_base(_path: &Path) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn validate_private_product_base_descriptor(_directory: &File) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn open_directory_no_follow(path: &Path) -> Result<File, WorkspaceLeaseError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|_| {
+            WorkspaceLeaseError::invalid(
+                "workspace product directory must be an existing non-symlink directory",
+            )
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_directory_no_follow(_path: &Path) -> Result<File, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn open_pinned_product_child(parent: &File, child: &str) -> Result<File, WorkspaceLeaseError> {
+    open_pinned_product_child_with_status(parent, child).map(|(directory, _)| directory)
+}
+
+#[cfg(target_os = "linux")]
+fn open_pinned_product_child_with_status(
+    parent: &File,
+    child: &str,
+) -> Result<(File, bool), WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let child = CString::new(child)
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace handle contains a NUL byte"))?;
+    let created = unsafe { libc::mkdirat(parent.as_raw_fd(), child.as_ptr(), 0o700) };
+    let created = if created == 0 {
+        true
+    } else {
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceUnavailable,
+                "workspace product directory could not be established",
+            ));
+        }
+        false
+    };
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            child.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        return Err(WorkspaceLeaseError::invalid(
+            "workspace product child must remain a non-symlink directory",
+        ));
+    }
+    let directory = unsafe { File::from_raw_fd(descriptor) };
+    let metadata = directory.metadata().map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product directory could not be inspected",
+        )
+    })?;
+    if metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.permissions().mode() & 0o777 != 0o700
+    {
+        return Err(WorkspaceLeaseError::invalid(
+            "workspace product child must be an owned private directory",
+        ));
+    }
+    Ok((directory, created))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_pinned_product_child(_parent: &File, _child: &str) -> Result<File, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_pinned_product_child_with_status(
+    _parent: &File,
+    _child: &str,
+) -> Result<(File, bool), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_pinned_product_child(_parent: &File, _child: &str) -> Result<File, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+const WORKTREE_OWNER_MARKER: &str = ".zeroshot-owner";
+
+#[cfg(target_os = "linux")]
+fn worktree_owner_bytes(lease: &WorkspaceLeaseRecord) -> Vec<u8> {
+    format!(
+        "zeroshot.workspace-worktree/v1\n{}\n{}\n",
+        lease.id.resource_id().as_str(),
+        lease.owner.as_str()
+    )
+    .into_bytes()
+}
+
+#[cfg(target_os = "linux")]
+fn set_worktree_owner(
+    directory: &File,
+    lease: &WorkspaceLeaseRecord,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::io::Write;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let marker = CString::new(WORKTREE_OWNER_MARKER).expect("static marker contains no NUL");
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            marker.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace owner marker could not be persisted",
+        ));
+    }
+    let mut file = unsafe { File::from_raw_fd(descriptor) };
+    file.write_all(&worktree_owner_bytes(lease))
+        .and_then(|()| file.sync_all())
+        .map_err(|_| {
+            WorkspaceLeaseError::new(
+                WorkspaceLeaseErrorKind::ResourceUnavailable,
+                "workspace owner marker could not be persisted",
+            )
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_worktree_owner(
+    _directory: &File,
+    _lease: &WorkspaceLeaseRecord,
+) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn worktree_owner_matches(
+    directory: &File,
+    lease: &WorkspaceLeaseRecord,
+) -> Result<bool, WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let marker = CString::new(WORKTREE_OWNER_MARKER).expect("static marker contains no NUL");
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            marker.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(false);
+        }
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace owner marker could not be inspected",
+        ));
+    }
+    let file = unsafe { File::from_raw_fd(descriptor) };
+    let mut value = Vec::new();
+    file.take(1025).read_to_end(&mut value).map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace owner marker could not be inspected",
+        )
+    })?;
+    Ok(value.len() <= 1024 && value == worktree_owner_bytes(lease))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn worktree_owner_matches(
+    _directory: &File,
+    _lease: &WorkspaceLeaseRecord,
+) -> Result<bool, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn remove_worktree_owner(directory: &File) -> Result<(), WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+
+    let marker = CString::new(WORKTREE_OWNER_MARKER).expect("static marker contains no NUL");
+    if unsafe { libc::unlinkat(directory.as_raw_fd(), marker.as_ptr(), 0) } != 0 {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace owner marker could not be removed",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_worktree_owner(_directory: &File) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn open_existing_pinned_product_child(
+    parent: &File,
+    child: &str,
+) -> Result<Option<File>, WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let child = CString::new(child)
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace handle contains a NUL byte"))?;
+    let descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            child.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None);
+        }
+        return Err(WorkspaceLeaseError::invalid(
+            "workspace product child must remain a non-symlink directory",
+        ));
+    }
+    Ok(Some(unsafe { File::from_raw_fd(descriptor) }))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn open_existing_pinned_product_child(
+    _parent: &File,
+    _child: &str,
+) -> Result<Option<File>, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn remove_pinned_product_child(
+    parent: &File,
+    child: &str,
+    expected: &File,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::MetadataExt;
+
+    let quarantine = CString::new(format!(".{child}.cleanup"))
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace quarantine contains a NUL byte"))?;
+    let child = CString::new(child)
+        .map_err(|_| WorkspaceLeaseError::invalid("workspace handle contains a NUL byte"))?;
+    let renamed = unsafe {
+        libc::renameat2(
+            parent.as_raw_fd(),
+            child.as_ptr(),
+            parent.as_raw_fd(),
+            quarantine.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if renamed != 0 {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product directory could not be quarantined",
+        ));
+    }
+
+    let quarantined = open_existing_pinned_product_child(
+        parent,
+        quarantine.to_str().expect("generated quarantine is UTF-8"),
+    );
+    let expected_metadata = expected.metadata().map_err(|_| {
+        WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product directory identity became unavailable",
+        )
+    })?;
+    let matches = quarantined
+        .as_ref()
+        .ok()
+        .and_then(Option::as_ref)
+        .and_then(|directory| directory.metadata().ok())
+        .is_some_and(|metadata| {
+            metadata.dev() == expected_metadata.dev() && metadata.ino() == expected_metadata.ino()
+        });
+    if !matches {
+        restore_quarantined_child(parent, &quarantine, &child)?;
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceMismatch,
+            "workspace cleanup target changed before removal",
+        ));
+    }
+
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), quarantine.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
+        restore_quarantined_child(parent, &quarantine, &child)?;
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace product directory could not be removed",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn restore_quarantined_child(
+    parent: &File,
+    quarantine: &std::ffi::CStr,
+    child: &std::ffi::CStr,
+) -> Result<(), WorkspaceLeaseError> {
+    use std::os::fd::AsRawFd;
+
+    if unsafe {
+        libc::renameat2(
+            parent.as_raw_fd(),
+            quarantine.as_ptr(),
+            parent.as_raw_fd(),
+            child.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    } != 0
+    {
+        return Err(WorkspaceLeaseError::new(
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "workspace quarantined directory could not be restored",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_pinned_product_child(
+    _parent: &File,
+    _child: &str,
+    _expected: &File,
+) -> Result<(), WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn descriptor_path(directory: &File) -> Result<PathBuf, WorkspaceLeaseError> {
+    use std::os::fd::AsRawFd;
+    Ok(PathBuf::from(format!(
+        "/proc/self/fd/{}",
+        directory.as_raw_fd()
+    )))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn descriptor_path(_directory: &File) -> Result<PathBuf, WorkspaceLeaseError> {
+    Err(WorkspaceLeaseError::invalid(
+        "owned workspace roots require Linux descriptor-relative filesystem support",
+    ))
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn validate_path_component(value: &str, label: &'static str) -> Result<(), WorkspaceLeaseError> {
+    validate_text(value, label)?;
+    if value == "."
+        || value == ".."
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(WorkspaceLeaseError::invalid(format!(
+            "{label} must be one lowercase safe path component"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, label: &'static str) -> Result<(), WorkspaceLeaseError> {
+    if value.is_empty()
+        || value.len() > MAX_WORKSPACE_VALUE_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err(WorkspaceLeaseError {
+            kind: WorkspaceLeaseErrorKind::InvalidInput,
+            message: format!(
+                "{label} must be non-empty, bounded, and contain no control characters"
+            ),
+        });
+    }
+    Ok(())
+}

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -621,6 +621,26 @@ fn manifest_has_no_client_testkit_or_node_dependencies() {
 }
 
 #[test]
+fn workspace_leases_cannot_mutate_graph_outcomes() {
+    let leases = rust_sources(&["src/workspace_lease.rs", "src/workspace_lease"]);
+    for forbidden in [
+        "ClusterLedger",
+        "CommitRequest",
+        "MutationIdentity",
+        "RecordPayload",
+        "ExecutionVoid",
+        "TerminalProjection",
+        "full_v1_reducer",
+        "crate::scheduler",
+    ] {
+        assert!(
+            !leases.contains(forbidden),
+            "workspace leases imported graph outcome authority: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn product_modules_require_issue_authorization() {
     let product = product_root();
     let mut product_files = BTreeSet::new();

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -63,6 +63,16 @@ fn product_contains_the_required_native_files() {
         "src/scheduler.rs",
         "src/issue_provider.rs",
         "src/source_code_provider.rs",
+        "src/workspace_lease.rs",
+        "src/workspace_lease/adapters.rs",
+        "src/workspace_lease/borrowed.rs",
+        "src/workspace_lease/manager.rs",
+        "src/workspace_lease/resource.rs",
+        "src/workspace_lease/resource/fake.rs",
+        "src/workspace_lease/store.rs",
+        "src/workspace_lease/store/fake.rs",
+        "src/workspace_lease/store/sqlite.rs",
+        "src/workspace_lease/types.rs",
         "src/worker_catalog.rs",
         "tests/architecture.rs",
         "tests/worker_catalog_architecture.rs",
@@ -84,6 +94,9 @@ fn product_contains_the_required_native_files() {
         "tests/source_authority_contract.rs",
         "tests/scheduler_contract.rs",
         "tests/worker_catalog.rs",
+        "tests/workspace_leases.rs",
+        "tests/workspace_modes.rs",
+        "tests/workspace_recovery.rs",
     ] {
         assert!(files.contains(required), "missing product file: {required}");
     }
@@ -121,6 +134,9 @@ fn workspace_metadata_preserves_package_lib_and_bin_identity() {
         ("required_proof_contract".to_owned(), "test".to_owned()),
         ("required_proof_architecture".to_owned(), "test".to_owned()),
         ("scheduler_contract".to_owned(), "test".to_owned()),
+        ("workspace_leases".to_owned(), "test".to_owned()),
+        ("workspace_modes".to_owned(), "test".to_owned()),
+        ("workspace_recovery".to_owned(), "test".to_owned()),
     ] {
         assert!(
             targets.contains(&required),
@@ -602,4 +618,51 @@ fn manifest_has_no_client_testkit_or_node_dependencies() {
             "forbidden product dependency: {forbidden_dependency}"
         );
     }
+}
+
+#[test]
+fn product_modules_require_issue_authorization() {
+    let product = product_root();
+    let mut product_files = BTreeSet::new();
+    relative_files(&product, &product.join("src"), &mut product_files);
+    let top_level_source_entries = product_files
+        .iter()
+        .filter_map(|relative| {
+            relative
+                .strip_prefix("src/")
+                .and_then(|path| path.split('/').next())
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        top_level_source_entries,
+        BTreeSet::from([
+            "artifact_store",
+            "artifact_store.rs",
+            "cluster_ledger",
+            "cluster_ledger.rs",
+            "daemon_auth.rs",
+            "daemon_discovery.rs",
+            "daemon_listener.rs",
+            "execution",
+            "execution.rs",
+            "fault",
+            "fault.rs",
+            "full_v1_reducer.rs",
+            "issue_provider",
+            "issue_provider.rs",
+            "lib.rs",
+            "main.rs",
+            "observability.rs",
+            "provider_value",
+            "provider_value.rs",
+            "required_proof.rs",
+            "scheduler.rs",
+            "source_code_provider",
+            "source_code_provider.rs",
+            "worker_catalog.rs",
+            "workspace_lease",
+            "workspace_lease.rs",
+        ]),
+        "new product modules require an issue-authorized architecture amendment"
+    );
 }

--- a/zeroshot-rust/tests/provider_contracts.rs
+++ b/zeroshot-rust/tests/provider_contracts.rs
@@ -190,11 +190,11 @@ impl SourceCodeProvider for FakeSourceProvider {
     async fn materialize(
         &self,
         request: &SourceMaterializeRequest,
-        mut destination: SourceMaterializationDestination<'_>,
+        destination: SourceMaterializationDestination<'_>,
     ) -> Result<SourceMaterializationReceipt, SourceProviderFailure> {
-        if let Some(written) = destination.downcast_mut::<bool>() {
-            *written = true;
-        }
+        destination
+            .write_file("materialized", b"provider-contract")
+            .expect("the engine-owned contract target accepts bounded writes");
         Ok(SourceMaterializationReceipt::new(
             request.repository().clone(),
             request.revision().clone(),

--- a/zeroshot-rust/tests/provider_contracts/cases.rs
+++ b/zeroshot-rust/tests/provider_contracts/cases.rs
@@ -461,14 +461,13 @@ async fn materialization_uses_only_an_ephemeral_destination_handle() {
         SourceRevisionId::new("head-sha").unwrap(),
     )
     .unwrap();
-    let mut written = false;
+    // SAFETY: this harness is used only for the external provider contract and carries no path,
+    // descriptor, or persisted workspace authority.
+    let target = unsafe { SourceMaterializationContractHarness::new() };
     let receipt = registry
-        .materialize(
-            &request,
-            SourceMaterializationDestination::new(&mut written),
-        )
+        .materialize(&request, target.destination())
         .await
         .unwrap();
-    assert!(written);
+    assert_eq!(target.write_count(), 1);
     assert_eq!(receipt.repository(), &repository);
 }

--- a/zeroshot-rust/tests/scheduler_contract.rs
+++ b/zeroshot-rust/tests/scheduler_contract.rs
@@ -3,9 +3,17 @@ use std::sync::Arc;
 #[path = "support/scheduler.rs"]
 mod scheduler_support;
 
+#[allow(dead_code)]
+#[path = "support/workspace.rs"]
+mod workspace_support;
+
 use tokio::time::Duration;
 use zeroshot_engine::execution::WorkspaceAccessMode;
 use zeroshot_engine::scheduler::{FairScheduler, SchedulerConfig, SchedulerError};
+use zeroshot_engine::workspace_lease::fake::FakeEffectFailure;
+use zeroshot_engine::workspace_lease::{
+    WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseState,
+};
 
 use scheduler_support::{BlockingRuntime, CommandSpec, RunningRuntime, command};
 
@@ -91,6 +99,58 @@ async fn non_terminal_dispatch_keeps_lane_and_global_permits_until_terminal_rele
             .await
     );
     assert_eq!(scheduler.active_len().await, 0);
+}
+
+#[tokio::test]
+async fn durable_workspace_identity_holds_capacity_across_restart_and_cleanup_failure() {
+    let fixture = workspace_support::LeaseFixture::new();
+    let ready = fixture
+        .manager
+        .prepare(workspace_support::docker_request("owner-a"))
+        .await
+        .unwrap();
+    let runtime = Arc::new(BlockingRuntime::default());
+    let scheduler = scheduler(
+        runtime.clone(),
+        SchedulerConfig {
+            global_active: 2,
+            per_cluster_active: 2,
+            per_lane_active: 2,
+            max_queued: 16,
+        },
+    );
+    let workspace = ready.access().lease_key().as_str().to_owned();
+    let first = command(spec(60, "lane.alpha", "cluster.a", &workspace));
+    scheduler.submit(first.clone()).await.unwrap();
+    runtime.wait_for_started(1).await;
+
+    fixture
+        .resources
+        .fail_next_cleanup(FakeEffectFailure::BeforeEffect);
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+    fixture.manager.cleanup(owner.clone()).await.unwrap_err();
+    let restarted = WorkspaceLeaseManager::new(fixture.store.clone(), fixture.resources.clone())
+        .restart(owner)
+        .await
+        .unwrap();
+    assert_eq!(restarted.state, WorkspaceLeaseState::CleanupRequired);
+    assert_eq!(restarted.access(), ready.access());
+
+    let recovered_workspace = restarted.access().lease_key().as_str().to_owned();
+    assert_eq!(recovered_workspace, workspace);
+    let blocked = command(spec(61, "lane.beta", "cluster.a", &recovered_workspace));
+    scheduler.submit(blocked.clone()).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(scheduler.active_len().await, 1);
+    assert_eq!(scheduler.queued_len().await, 1);
+
+    complete_and_release(&scheduler, &runtime, &first, 2).await;
+    runtime.release(61);
+    runtime.wait_for_completion(61).await;
+    assert!(scheduler.release_terminal(&blocked.control()).await);
 }
 
 async fn exclusive_workspace_conflicts_only_until_release() {

--- a/zeroshot-rust/tests/support/workspace.rs
+++ b/zeroshot-rust/tests/support/workspace.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use zeroshot_engine::cluster_ledger::{ExecutionId, OwnerId, ResourceId, RunSequence};
+use zeroshot_engine::execution::WorkspaceAccessMode;
+use zeroshot_engine::source_code_provider::{
+    CanonicalRepository, SourceAccountId, SourceBranchId, SourceProfileId, SourceProviderId,
+    SourceProviderRef, SourceRepositoryId, SourceRevisionId,
+};
+use zeroshot_engine::workspace_lease::fake::{FakeWorkspaceLeaseStore, FakeWorkspaceResourcePort};
+use zeroshot_engine::workspace_lease::{
+    BorrowedWorkspace, CanonicalWorkspaceRoot, DockerImageDigest, DockerMountHandleId,
+    DockerResourceId, DockerWorkspace, PrepareWorkspaceRequest, WorkspaceFingerprint,
+    WorkspaceIsolation, WorkspaceLeaseKey, WorkspaceLeaseManager, WorkspaceMaterializationId,
+    WorkspaceMode, WorkspaceName, WorkspaceProfile, WorktreeWorkspace,
+};
+
+pub struct LeaseFixture {
+    pub store: Arc<FakeWorkspaceLeaseStore>,
+    pub resources: Arc<FakeWorkspaceResourcePort>,
+    pub manager: WorkspaceLeaseManager,
+}
+
+impl LeaseFixture {
+    pub fn new() -> Self {
+        let store = Arc::new(FakeWorkspaceLeaseStore::default());
+        let resources = Arc::new(FakeWorkspaceResourcePort::default());
+        let manager = WorkspaceLeaseManager::new(store.clone(), resources.clone());
+        Self {
+            store,
+            resources,
+            manager,
+        }
+    }
+}
+
+pub fn docker_request(owner: &str) -> PrepareWorkspaceRequest {
+    PrepareWorkspaceRequest {
+        key: lease_key(WorkspaceIsolation::Shared),
+        owner: OwnerId::new(owner).unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Docker(
+            DockerWorkspace::new(
+                DockerImageDigest::new(format!("sha256:{}", "a".repeat(64))).unwrap(),
+                DockerResourceId::new("docker-resource-1").unwrap(),
+                vec![DockerMountHandleId::new("workspace").unwrap()],
+            )
+            .unwrap(),
+        ),
+    }
+}
+
+pub fn borrowed_request(owner: &str) -> PrepareWorkspaceRequest {
+    PrepareWorkspaceRequest {
+        key: lease_key(WorkspaceIsolation::Shared),
+        owner: OwnerId::new(owner).unwrap(),
+        access_mode: WorkspaceAccessMode::ReadOnly,
+        mode: WorkspaceMode::Borrowed(BorrowedWorkspace {
+            canonical_root: CanonicalWorkspaceRoot::new("/tmp/borrowed-workspace").unwrap(),
+            fingerprint: WorkspaceFingerprint::new("b".repeat(64)).unwrap(),
+        }),
+    }
+}
+
+pub fn worktree_request(owner: &str) -> PrepareWorkspaceRequest {
+    PrepareWorkspaceRequest {
+        key: lease_key(WorkspaceIsolation::Shared),
+        owner: OwnerId::new(owner).unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Worktree(WorktreeWorkspace {
+            repository: CanonicalRepository::new(
+                SourceProviderRef::new(SourceProviderId::new("source.github").unwrap(), 1).unwrap(),
+                SourceProfileId::new("production").unwrap(),
+                SourceAccountId::new("open-engine").unwrap(),
+                SourceRepositoryId::new("the-open-engine/zeroshot").unwrap(),
+            )
+            .unwrap(),
+            revision: SourceRevisionId::new("revision-abc").unwrap(),
+            source_profile: SourceProfileId::new("production").unwrap(),
+            name: WorkspaceName::new("workspace-test").unwrap(),
+            branch: SourceBranchId::new("feat/677").unwrap(),
+            profile: WorkspaceProfile::new("durable-worktree").unwrap(),
+            materialization: WorkspaceMaterializationId::new("materialization-1").unwrap(),
+        }),
+    }
+}
+
+pub fn lease_key(isolation: WorkspaceIsolation) -> WorkspaceLeaseKey {
+    WorkspaceLeaseKey {
+        cluster: ResourceId::new("cluster.test").unwrap(),
+        run: RunSequence::new(3).unwrap(),
+        logical_key: ResourceId::new("logical.workspace").unwrap(),
+        isolation,
+    }
+}
+
+pub fn execution(value: u64) -> ExecutionId {
+    ExecutionId::new(value).unwrap()
+}

--- a/zeroshot-rust/tests/worker_catalog_architecture.rs
+++ b/zeroshot-rust/tests/worker_catalog_architecture.rs
@@ -7,32 +7,6 @@ use architecture_support::{product_package, product_root, read, relative_files, 
 
 const _: fn() -> String = architecture_support::runtime_source;
 const _: fn(&[&str]) -> String = architecture_support::rust_sources;
-const EXPECTED_TOP_LEVEL_SOURCE_ENTRIES: [&str; 24] = [
-    "artifact_store",
-    "artifact_store.rs",
-    "cluster_ledger",
-    "cluster_ledger.rs",
-    "daemon_auth.rs",
-    "daemon_discovery.rs",
-    "daemon_listener.rs",
-    "execution",
-    "execution.rs",
-    "fault",
-    "fault.rs",
-    "full_v1_reducer.rs",
-    "issue_provider",
-    "issue_provider.rs",
-    "lib.rs",
-    "main.rs",
-    "observability.rs",
-    "provider_value",
-    "provider_value.rs",
-    "required_proof.rs",
-    "scheduler.rs",
-    "source_code_provider",
-    "source_code_provider.rs",
-    "worker_catalog.rs",
-];
 
 fn is_architecture_guard(relative: &str) -> bool {
     matches!(
@@ -120,21 +94,6 @@ fn worker_catalog_has_no_build_or_node_typescript_source_inputs() {
 #[test]
 fn worker_catalog_adds_no_out_of_scope_product_construction() {
     let product = product_root();
-    let mut product_files = BTreeSet::new();
-    relative_files(&product, &product.join("src"), &mut product_files);
-    let top_level_source_entries = product_files
-        .iter()
-        .filter_map(|relative| {
-            relative
-                .strip_prefix("src/")
-                .and_then(|path| path.split('/').next())
-        })
-        .collect::<BTreeSet<_>>();
-    assert_eq!(
-        top_level_source_entries,
-        BTreeSet::from(EXPECTED_TOP_LEVEL_SOURCE_ENTRIES),
-        "new product modules require an issue-authorized architecture amendment"
-    );
 
     let catalog_source = read(&product.join("src/worker_catalog.rs"));
     for forbidden in [

--- a/zeroshot-rust/tests/workspace_leases.rs
+++ b/zeroshot-rust/tests/workspace_leases.rs
@@ -1,0 +1,604 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Notify;
+
+use zeroshot_engine::cluster_ledger::OwnerId;
+use zeroshot_engine::workspace_lease::fake::{FakeEffectFailure, FakeResourceAction};
+use zeroshot_engine::workspace_lease::{
+    DockerImageDigest, DockerMountHandleId, DockerResourceId, DockerWorkspace,
+    PrepareWorkspaceRequest, SqliteWorkspaceLeaseHooks, SqliteWorkspaceLeaseStore,
+    WorkspaceIsolation, WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId,
+    WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseRecord, WorkspaceLeaseState,
+    WorkspaceLeaseStore, WorkspaceMode, WorkspaceResourceObservation, WorkspaceResourcePort,
+};
+
+#[path = "support/workspace.rs"]
+mod support;
+use support::{LeaseFixture, borrowed_request, docker_request, execution, lease_key, worktree_request};
+
+type WorkspaceRequestFactory = fn(&str) -> PrepareWorkspaceRequest;
+type NamedWorkspaceMode = (&'static str, WorkspaceRequestFactory);
+
+#[tokio::test]
+async fn lease_identity_is_the_scheduler_resource_and_execution_isolation_is_exact() {
+    let shared_a = WorkspaceLeaseId::derive(&lease_key(WorkspaceIsolation::Shared));
+    let shared_b = WorkspaceLeaseId::derive(&lease_key(WorkspaceIsolation::Shared));
+    let isolated =
+        WorkspaceLeaseId::derive(&lease_key(WorkspaceIsolation::Execution(execution(9))));
+
+    assert_eq!(shared_a, shared_b);
+    assert_ne!(shared_a, isolated);
+    assert!(shared_a.resource_id().as_str().starts_with("workspace."));
+
+    let fixture = LeaseFixture::new();
+    let ready = fixture
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    assert_eq!(ready.state, WorkspaceLeaseState::Ready);
+    assert_eq!(ready.access().lease_key(), ready.id.resource_id());
+    assert_eq!(ready.access().mode(), ready.access_mode);
+}
+
+#[tokio::test]
+async fn create_requires_committed_pending_intent_and_authoritative_absence() {
+    let fixture = LeaseFixture::new();
+    fixture
+        .resources
+        .fail_next_create(FakeEffectFailure::BeforeEffect);
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+
+    let error = fixture.manager.prepare(request).await.unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceUnavailable);
+    let pending = fixture.store.record(&id).expect("intent committed first");
+    assert_eq!(pending.state, WorkspaceLeaseState::CreatePending);
+    assert_eq!(pending.owner.as_str(), "owner-a");
+    assert_eq!(
+        fixture
+            .resources
+            .actions()
+            .into_iter()
+            .map(|(_, action)| action)
+            .collect::<Vec<_>>(),
+        vec![FakeResourceAction::Inspect, FakeResourceAction::Create]
+    );
+}
+
+#[tokio::test]
+async fn owner_and_mode_mismatches_preserve_the_existing_resource() {
+    let fixture = LeaseFixture::new();
+    fixture
+        .resources
+        .fail_next_create(FakeEffectFailure::AfterEffect);
+    let first = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&first.key);
+    fixture.manager.prepare(first).await.unwrap_err();
+    assert!(fixture.resources.contains(&id));
+
+    let error = fixture
+        .manager
+        .prepare(docker_request("owner-b"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::OwnerMismatch);
+    assert!(fixture.resources.contains(&id));
+    let mut changed_mode = docker_request("owner-a");
+    changed_mode.mode = WorkspaceMode::Docker(
+        DockerWorkspace::new(
+            DockerImageDigest::new(format!("sha256:{}", "d".repeat(64))).unwrap(),
+            DockerResourceId::new("different-resource").unwrap(),
+            vec![DockerMountHandleId::new("workspace").unwrap()],
+        )
+        .unwrap(),
+    );
+    let error = fixture.manager.prepare(changed_mode).await.unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceMismatch);
+    assert!(fixture.resources.contains(&id));
+
+    let error = fixture
+        .manager
+        .cleanup(WorkspaceLeaseOwnerRequest {
+            id: id.clone(),
+            owner: OwnerId::new("owner-b").unwrap(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::OwnerMismatch);
+    assert!(fixture.resources.contains(&id));
+}
+
+#[tokio::test]
+async fn cleanup_failure_is_retryable_and_never_releases_identity() {
+    let fixture = LeaseFixture::new();
+    let ready = fixture
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    fixture
+        .resources
+        .fail_next_cleanup(FakeEffectFailure::BeforeEffect);
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+
+    let error = fixture.manager.cleanup(owner.clone()).await.unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceUnavailable);
+    let required = fixture.store.record(&ready.id).unwrap();
+    assert_eq!(required.state, WorkspaceLeaseState::CleanupRequired);
+    assert_eq!(required.access(), ready.access());
+    assert!(fixture.resources.contains(&ready.id));
+
+    let cleaned = fixture.manager.cleanup(owner).await.unwrap();
+    assert_eq!(cleaned.state, WorkspaceLeaseState::Cleaned);
+    assert!(!fixture.resources.contains(&ready.id));
+}
+
+#[tokio::test]
+async fn direct_cleanup_reconciles_uncertain_create_for_every_owned_mode() {
+    let owned: [NamedWorkspaceMode; 2] =
+        [("worktree", worktree_request), ("docker", docker_request)];
+    for (name, request) in owned {
+        let fixture = LeaseFixture::new();
+        fixture
+            .resources
+            .fail_next_create(FakeEffectFailure::AfterEffect);
+        let request = request("owner-a");
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let owner = request.owner.clone();
+        fixture.manager.prepare(request).await.unwrap_err();
+        assert_eq!(
+            fixture.store.record(&id).unwrap().state,
+            WorkspaceLeaseState::CreatePending,
+            "{name}"
+        );
+
+        fixture
+            .resources
+            .fail_next_cleanup(FakeEffectFailure::AfterEffect);
+        let owner_request = WorkspaceLeaseOwnerRequest {
+            id: id.clone(),
+            owner,
+        };
+        let error = fixture
+            .manager
+            .cleanup(owner_request.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            WorkspaceLeaseErrorKind::ResourceUnavailable,
+            "{name}"
+        );
+        assert_eq!(
+            fixture.store.record(&id).unwrap().state,
+            WorkspaceLeaseState::CleanupRequired,
+            "{name}"
+        );
+
+        let cleaned = fixture.manager.cleanup(owner_request).await.unwrap();
+        assert_eq!(cleaned.state, WorkspaceLeaseState::Cleaned, "{name}");
+        assert!(!fixture.resources.contains(&id), "{name}");
+        let actions = fixture.resources.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|(_, action)| *action == FakeResourceAction::Create)
+                .count(),
+            1,
+            "{name}"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+                .count(),
+            1,
+            "{name}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn all_mode_race_table_is_deterministic_and_borrowed_never_deletes() {
+    let owned: [NamedWorkspaceMode; 2] =
+        [("worktree", worktree_request), ("docker", docker_request)];
+    for (name, request) in owned {
+        let fixture = LeaseFixture::new();
+        fixture
+            .resources
+            .fail_next_create(FakeEffectFailure::AfterEffect);
+        let request = request("owner-a");
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let owner = request.owner.clone();
+        fixture.manager.prepare(request).await.unwrap_err();
+        let ready = fixture
+            .manager
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(ready.state, WorkspaceLeaseState::Ready, "{name}");
+
+        fixture
+            .resources
+            .fail_next_cleanup(FakeEffectFailure::AfterEffect);
+        fixture
+            .manager
+            .cleanup(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap_err();
+        let cleaned = fixture
+            .manager
+            .restart(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap();
+        assert_eq!(cleaned.state, WorkspaceLeaseState::Cleaned, "{name}");
+        let actions = fixture.resources.actions();
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|(_, action)| *action == FakeResourceAction::Create)
+                .count(),
+            1,
+            "{name}"
+        );
+        assert_eq!(
+            actions
+                .iter()
+                .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+                .count(),
+            1,
+            "{name}"
+        );
+    }
+
+    let borrowed = LeaseFixture::new();
+    let request = borrowed_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        borrowed
+            .manager
+            .prepare(request.clone())
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::NotFound
+    );
+    let pending = borrowed.store.record(&id).unwrap();
+    borrowed.resources.seed(pending);
+    let ready = borrowed.manager.prepare(request).await.unwrap();
+    let actions_before_cleanup = borrowed.resources.actions();
+    let cleaned = borrowed
+        .manager
+        .cleanup(WorkspaceLeaseOwnerRequest {
+            id: id.clone(),
+            owner,
+        })
+        .await
+        .unwrap();
+    assert_eq!(ready.state, WorkspaceLeaseState::Ready);
+    assert_eq!(cleaned.state, WorkspaceLeaseState::Cleaned);
+    assert!(borrowed.resources.contains(&id));
+    assert_eq!(borrowed.resources.actions(), actions_before_cleanup);
+    assert!(
+        borrowed
+            .resources
+            .actions()
+            .iter()
+            .all(|(_, action)| *action == FakeResourceAction::Inspect)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn prepare_and_cleanup_serialize_the_absence_to_create_interval() {
+    let root = std::env::temp_dir().join(format!("zeroshot-workspace-race-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let resources = Arc::new(PausingResourcePort::default());
+    let prepare_manager = Arc::new(WorkspaceLeaseManager::new(
+        Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap()),
+        resources.clone(),
+    ));
+    let cleanup_manager = Arc::new(WorkspaceLeaseManager::new(
+        Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap()),
+        resources.clone(),
+    ));
+    let request = docker_request("owner-a");
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: WorkspaceLeaseId::derive(&request.key),
+        owner: request.owner.clone(),
+    };
+    resources.pause_next_inspect.store(true, Ordering::SeqCst);
+    let prepare = {
+        let manager = prepare_manager.clone();
+        tokio::spawn(async move { manager.prepare(request).await })
+    };
+    resources.inspected.notified().await;
+    let cleanup = {
+        let manager = cleanup_manager.clone();
+        let owner = owner.clone();
+        tokio::spawn(async move { manager.cleanup(owner).await })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    assert!(
+        !cleanup.is_finished(),
+        "cleanup must wait while create owns the per-lease operation interval"
+    );
+    resources.resume.notify_one();
+    assert_eq!(
+        prepare.await.unwrap().unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    assert_eq!(
+        cleanup.await.unwrap().unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert!(!resources.inner.contains(&owner.id));
+    drop(prepare_manager);
+    drop(cleanup_manager);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn database_symlink_alias_shares_the_absence_to_effect_operation_fence() {
+    use sha2::{Digest, Sha256};
+    use std::os::unix::fs::{MetadataExt, symlink};
+
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-alias-lock-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let alias = root.join("leases-alias.sqlite3");
+    let canonical_store = Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap());
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: id.clone(),
+        owner: request.owner.clone(),
+    };
+    let metadata = std::fs::metadata(&database).unwrap();
+    let legacy_lock_root = root.join(format!(
+        ".zeroshot-workspace-locks-{:x}-{:x}",
+        metadata.dev(),
+        metadata.ino()
+    ));
+    std::fs::create_dir_all(&legacy_lock_root).unwrap();
+    let digest = Sha256::digest(id.resource_id().as_str().as_bytes());
+    let replaceable_lock = legacy_lock_root.join(format!("{digest:x}.lock"));
+    std::fs::write(&replaceable_lock, b"original").unwrap();
+    symlink(&database, &alias).unwrap();
+    let blocked = Arc::new(Notify::new());
+    let alias_store = Arc::new(
+        SqliteWorkspaceLeaseStore::open_with_hooks(
+            &alias,
+            SqliteWorkspaceLeaseHooks {
+                lock_contention: Some({
+                    let blocked = blocked.clone();
+                    Arc::new(move || blocked.notify_one())
+                }),
+                ..SqliteWorkspaceLeaseHooks::default()
+            },
+        )
+        .unwrap(),
+    );
+    let resources = Arc::new(PausingResourcePort::default());
+    resources.pause_next_inspect.store(true, Ordering::SeqCst);
+    let prepare_manager = WorkspaceLeaseManager::new(canonical_store.clone(), resources.clone());
+    let cleanup_manager = WorkspaceLeaseManager::new(alias_store.clone(), resources.clone());
+
+    let prepare = tokio::spawn(async move { prepare_manager.prepare(request).await });
+    resources.inspected.notified().await;
+    std::fs::remove_file(&replaceable_lock).unwrap();
+    std::fs::write(&replaceable_lock, b"replacement").unwrap();
+    assert_eq!(
+        canonical_store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CreatePending
+    );
+    assert!(!resources.inner.contains(&id));
+    let cleanup = tokio::spawn(async move { cleanup_manager.cleanup(owner).await });
+    tokio::time::timeout(std::time::Duration::from_secs(5), blocked.notified())
+        .await
+        .expect("alias operation did not observe the canonical lock");
+    assert!(!cleanup.is_finished());
+    assert_eq!(
+        alias_store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CreatePending
+    );
+    assert!(!resources.inner.contains(&id));
+
+    resources.resume.notify_one();
+    assert_eq!(
+        prepare.await.unwrap().unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    assert_eq!(
+        cleanup.await.unwrap().unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert!(!resources.inner.contains(&id));
+    let actions = resources.inner.actions();
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Create)
+            .count(),
+        1
+    );
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+            .count(),
+        1
+    );
+    drop(canonical_store);
+    drop(alias_store);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[derive(Default)]
+struct PausingResourcePort {
+    inner: zeroshot_engine::workspace_lease::fake::FakeWorkspaceResourcePort,
+    pause_next_inspect: AtomicBool,
+    inspected: Notify,
+    resume: Notify,
+}
+
+#[async_trait]
+impl WorkspaceResourcePort for PausingResourcePort {
+    async fn inspect(
+        &self,
+        lease: &WorkspaceLeaseRecord,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        let observation = self.inner.inspect(lease).await?;
+        if self.pause_next_inspect.swap(false, Ordering::SeqCst) {
+            self.inspected.notify_one();
+            self.resume.notified().await;
+        }
+        Ok(observation)
+    }
+
+    async fn create(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.inner.create(lease).await
+    }
+
+    async fn cleanup(&self, lease: &WorkspaceLeaseRecord) -> Result<(), WorkspaceLeaseError> {
+        self.inner.cleanup(lease).await
+    }
+}
+
+#[tokio::test]
+async fn cleaned_owned_orphan_is_reconciled_exactly_once() {
+    let fixture = LeaseFixture::new();
+    let ready = fixture
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+    let cleaned = fixture.manager.cleanup(owner.clone()).await.unwrap();
+    fixture.resources.seed(cleaned);
+    let cleanup_before = fixture
+        .resources
+        .actions()
+        .iter()
+        .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+        .count();
+
+    assert_eq!(
+        fixture.manager.cleanup(owner.clone()).await.unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert!(!fixture.resources.contains(&owner.id));
+    let cleanup_after = fixture
+        .resources
+        .actions()
+        .iter()
+        .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+        .count();
+    assert_eq!(cleanup_after, cleanup_before + 1);
+    fixture.manager.cleanup(owner).await.unwrap();
+    let final_cleanup_count = fixture
+        .resources
+        .actions()
+        .iter()
+        .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+        .count();
+    assert_eq!(final_cleanup_count, cleanup_after);
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn workspace_operation_lock_spans_processes() {
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-process-lock-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let ready = root.join("child-ready");
+    let signal = root.join("parent-attempt-signal");
+    let blocked = root.join("child-blocked");
+    let acquired = root.join("child-acquired");
+    let store = SqliteWorkspaceLeaseStore::open(&database).unwrap();
+    let id = WorkspaceLeaseId::derive(&lease_key(WorkspaceIsolation::Shared));
+    let owner = OwnerId::new("owner-a").unwrap();
+    let guard = store.acquire_operation(&id, &owner).await.unwrap();
+    let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "workspace_operation_lock_child", "--nocapture"])
+        .env("ZEROSHOT_WORKSPACE_LOCK_DB", &database)
+        .env("ZEROSHOT_WORKSPACE_LOCK_READY", &ready)
+        .env("ZEROSHOT_WORKSPACE_LOCK_SIGNAL", &signal)
+        .env("ZEROSHOT_WORKSPACE_LOCK_BLOCKED", &blocked)
+        .env("ZEROSHOT_WORKSPACE_LOCK_ACQUIRED", &acquired)
+        .spawn()
+        .unwrap();
+    wait_for_marker(&ready).await;
+    std::fs::write(&signal, b"attempt").unwrap();
+    wait_for_marker(&blocked).await;
+    assert!(!acquired.exists());
+    assert!(child.try_wait().unwrap().is_none());
+    drop(guard);
+    assert!(child.wait().unwrap().success());
+    assert!(acquired.is_file());
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_marker(path: &std::path::Path) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !path.is_file() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("subprocess marker handshake timed out");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn workspace_operation_lock_child() {
+    let Some(database) = std::env::var_os("ZEROSHOT_WORKSPACE_LOCK_DB") else {
+        return;
+    };
+    let ready = std::env::var_os("ZEROSHOT_WORKSPACE_LOCK_READY").unwrap();
+    let signal = std::env::var_os("ZEROSHOT_WORKSPACE_LOCK_SIGNAL").unwrap();
+    let blocked =
+        std::path::PathBuf::from(std::env::var_os("ZEROSHOT_WORKSPACE_LOCK_BLOCKED").unwrap());
+    let acquired = std::env::var_os("ZEROSHOT_WORKSPACE_LOCK_ACQUIRED").unwrap();
+    let store = SqliteWorkspaceLeaseStore::open_with_hooks(
+        database,
+        SqliteWorkspaceLeaseHooks {
+            lock_contention: Some(Arc::new(move || {
+                std::fs::write(&blocked, b"blocked").unwrap();
+            })),
+            ..SqliteWorkspaceLeaseHooks::default()
+        },
+    )
+    .unwrap();
+    let id = WorkspaceLeaseId::derive(&lease_key(WorkspaceIsolation::Shared));
+    let owner = OwnerId::new("owner-a").unwrap();
+    std::fs::write(ready, b"ready").unwrap();
+    wait_for_marker(std::path::Path::new(&signal)).await;
+    let _guard = store.acquire_operation(&id, &owner).await.unwrap();
+    std::fs::write(acquired, b"acquired").unwrap();
+}

--- a/zeroshot-rust/tests/workspace_modes.rs
+++ b/zeroshot-rust/tests/workspace_modes.rs
@@ -1,0 +1,1039 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Notify;
+use zeroshot_engine::cluster_ledger::{OwnerId, ResourceId, RunSequence};
+use zeroshot_engine::execution::WorkspaceAccessMode;
+use zeroshot_engine::source_code_provider::{
+    CanonicalRepository, SourceAccountId, SourceBranchId, SourceMaterializationDestination,
+    SourceProfileId, SourceProviderId, SourceProviderRef, SourceRepositoryId, SourceRevisionId,
+};
+use zeroshot_engine::workspace_lease::fake::FakeWorkspaceLeaseStore;
+use zeroshot_engine::workspace_lease::{
+    BorrowedWorkspace, BorrowedWorkspaceAdapter, BorrowedWorkspaceFingerprintPort,
+    CanonicalWorkspaceRoot, DockerImageDigest, DockerMountHandleId, DockerResourceId,
+    DockerResourceRequest, DockerWorkspace, DockerWorkspaceAdapter, DockerWorkspaceEffects,
+    FilesystemBorrowedWorkspaceFingerprint, PrepareWorkspaceRequest, WorkspaceFingerprint,
+    WorkspaceIsolation, WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId,
+    WorkspaceLeaseKey, WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseState,
+    WorkspaceLeaseStore, WorkspaceMaterializationId, WorkspaceMode, WorkspaceName,
+    WorkspaceProductRoots, WorkspaceProfile, WorkspaceResourceObservation, WorktreeResourceRequest,
+    WorktreeWorkspace, WorktreeWorkspaceAdapter, WorktreeWorkspaceEffects,
+};
+
+fn injected_resource_unavailable() -> WorkspaceLeaseError {
+    let absent = std::env::temp_dir().join(format!(
+        "zeroshot-injected-absent-workspace-{}",
+        std::process::id()
+    ));
+    FilesystemBorrowedWorkspaceFingerprint
+        .fingerprint(&absent)
+        .unwrap_err()
+}
+
+#[cfg(target_os = "linux")]
+fn private_product_base(label: &str) -> (PathBuf, PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let scope =
+        std::env::temp_dir().join(format!("zeroshot-product-{label}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&scope);
+    let base = scope.join("zeroshot/workspaces");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let base = std::fs::canonicalize(base).unwrap();
+    (scope, base)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn owned_workspace_roots_fail_closed_without_linux_safe_primitives() {
+    let native_absolute = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+    assert!(
+        WorkspaceProductRoots::new(
+            CanonicalWorkspaceRoot::new(native_absolute.to_string_lossy()).unwrap()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn exact_mode_values_are_canonical_bounded_and_secret_free() {
+    assert!(WorkspaceFingerprint::new("A".repeat(64)).is_err());
+    assert!(DockerImageDigest::new("latest").is_err());
+    assert!(DockerMountHandleId::new("../socket").is_err());
+    assert!(WorkspaceName::new("feature/unsafe").is_err());
+    assert!(CanonicalWorkspaceRoot::new("relative/path").is_err());
+
+    let mode = WorkspaceMode::Worktree(worktree());
+    let encoded = serde_json::to_string(&mode).unwrap();
+    assert!(encoded.contains("the-open-engine/zeroshot"));
+    assert!(encoded.contains("revision-abc"));
+    assert!(encoded.contains("materialization-1"));
+    for prohibited in ["credential", "password", "token", "pid", "containerId"] {
+        assert!(
+            !encoded.contains(prohibited),
+            "persisted secret/runtime field: {prohibited}"
+        );
+    }
+    assert_eq!(
+        serde_json::from_str::<WorkspaceMode>(&encoded).unwrap(),
+        mode
+    );
+
+    let invalid_docker = format!(
+        r#"{{"imageDigest":"sha256:{}","resource":"docker-1","mountHandles":["z","a"]}}"#,
+        "a".repeat(64)
+    );
+    assert!(serde_json::from_str::<DockerWorkspace>(&invalid_docker).is_err());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn worktree_and_docker_roots_are_private_disjoint_and_never_broad() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (scope, base) = private_product_base("derivation");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let worktrees = base.join("worktrees");
+    let mounts_root = base.join("mounts");
+    assert!(worktrees.is_dir());
+    assert!(mounts_root.is_dir());
+    assert_ne!(worktrees, mounts_root);
+    assert!(!worktrees.starts_with(&mounts_root));
+    assert!(!mounts_root.starts_with(&worktrees));
+    assert_ne!(worktrees.join("lease-a"), mounts_root);
+
+    let mounts = roots.default_docker_mounts(&docker()).unwrap();
+    assert_eq!(mounts.len(), 2);
+    assert!(
+        mounts
+            .iter()
+            .all(|mount| mount.source_directory().metadata().unwrap().is_dir())
+    );
+    assert!(base.join("mounts/source").is_dir());
+    assert!(base.join("mounts/workspace").is_dir());
+    assert!(
+        mounts
+            .iter()
+            .all(|mount| mount.container_path.starts_with("/workspace"))
+    );
+
+    let tmp_mode = std::fs::metadata("/tmp").unwrap().permissions().mode();
+    let mut denied = vec![
+        "/",
+        "/tmp",
+        "/home",
+        "/root",
+        "/var",
+        "/etc",
+        "/usr",
+        "/run",
+        "/dev",
+        "/proc",
+        "/sys",
+        "/boot",
+        "/var/run/docker.sock",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<Vec<_>>();
+    if let Some(home) = std::env::var_os("HOME") {
+        denied.push(home.to_string_lossy().into_owned());
+    }
+    for root in denied {
+        assert!(WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(root).unwrap()).is_err());
+    }
+    assert_eq!(
+        std::fs::metadata("/tmp").unwrap().permissions().mode(),
+        tmp_mode,
+        "validation must never chmod an arbitrary existing root"
+    );
+    let lookalike = scope.join("not-zeroshot/workspaces");
+    std::fs::create_dir_all(&lookalike).unwrap();
+    std::fs::set_permissions(&lookalike, std::fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(
+        WorkspaceProductRoots::new(
+            CanonicalWorkspaceRoot::new(
+                std::fs::canonicalize(&lookalike).unwrap().to_string_lossy(),
+            )
+            .unwrap(),
+        )
+        .is_err()
+    );
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[tokio::test]
+async fn borrowed_workspace_is_inspected_but_never_owned_or_deleted() {
+    let path = std::env::temp_dir().join(format!("zeroshot-borrowed-{}", std::process::id()));
+    std::fs::create_dir_all(&path).unwrap();
+    let canonical = std::fs::canonicalize(&path).unwrap();
+    let fingerprint = FilesystemBorrowedWorkspaceFingerprint
+        .fingerprint(&canonical)
+        .unwrap();
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.borrowed").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.borrowed").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::ReadOnly,
+        mode: WorkspaceMode::Borrowed(BorrowedWorkspace {
+            canonical_root: CanonicalWorkspaceRoot::new(canonical.to_string_lossy()).unwrap(),
+            fingerprint,
+        }),
+    };
+    let mut mismatched = request.clone();
+    let WorkspaceMode::Borrowed(borrowed) = &mut mismatched.mode else {
+        unreachable!();
+    };
+    borrowed.fingerprint = WorkspaceFingerprint::new("b".repeat(64)).unwrap();
+    let mismatch_manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(BorrowedWorkspaceAdapter::default()),
+    );
+    assert_eq!(
+        mismatch_manager
+            .prepare(mismatched)
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let manager = WorkspaceLeaseManager::new(store, Arc::new(BorrowedWorkspaceAdapter::default()));
+    let ready = manager.prepare(request).await.unwrap();
+    assert_eq!(ready.state, WorkspaceLeaseState::Ready);
+    std::fs::write(path.join("drift"), b"changed").unwrap();
+    assert_eq!(
+        manager
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: ready.id.clone(),
+                owner: ready.owner.clone(),
+            })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    let cleaned = manager
+        .cleanup(WorkspaceLeaseOwnerRequest {
+            id: ready.id,
+            owner: ready.owner,
+        })
+        .await
+        .unwrap();
+    assert_eq!(cleaned.state, WorkspaceLeaseState::Cleaned);
+    assert!(path.is_dir(), "borrowed root must not be deleted");
+    std::fs::remove_dir_all(&path).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+struct PausingBorrowedFingerprint {
+    armed: AtomicBool,
+    reached: std::sync::mpsc::SyncSender<()>,
+    resume: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl BorrowedWorkspaceFingerprintPort for PausingBorrowedFingerprint {
+    fn fingerprint(
+        &self,
+        root: &std::path::Path,
+    ) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
+        if self.armed.swap(false, Ordering::SeqCst) {
+            self.reached.send(()).unwrap();
+            self.resume
+                .lock()
+                .unwrap()
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .map_err(|_| injected_resource_unavailable())?;
+        }
+        FilesystemBorrowedWorkspaceFingerprint.fingerprint(root)
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn borrowed_root_swap_between_canonical_check_and_fingerprint_fails_closed() {
+    use std::os::unix::fs::symlink;
+
+    let scope = std::env::temp_dir().join(format!("zeroshot-borrowed-swap-{}", std::process::id()));
+    let root = scope.join("root");
+    let aside = scope.join("root-aside");
+    let outside = scope.join("outside");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(root.join("same"), b"content").unwrap();
+    std::fs::write(outside.join("same"), b"content").unwrap();
+    let canonical = std::fs::canonicalize(&root).unwrap();
+    let fingerprint = FilesystemBorrowedWorkspaceFingerprint
+        .fingerprint(&canonical)
+        .unwrap();
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.borrowed-swap").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.borrowed-swap").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::ReadOnly,
+        mode: WorkspaceMode::Borrowed(BorrowedWorkspace {
+            canonical_root: CanonicalWorkspaceRoot::new(canonical.to_string_lossy()).unwrap(),
+            fingerprint,
+        }),
+    };
+    let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(1);
+    let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
+    let fingerprints = Arc::new(PausingBorrowedFingerprint {
+        armed: AtomicBool::new(true),
+        reached: reached_tx,
+        resume: std::sync::Mutex::new(resume_rx),
+    });
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(BorrowedWorkspaceAdapter::new(fingerprints)),
+    );
+    let worker_request = request.clone();
+    let worker = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = runtime.block_on(manager.prepare(worker_request));
+        (manager, result)
+    });
+    reached_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("borrowed inspection did not reach the fingerprint boundary");
+    std::fs::rename(&root, &aside).unwrap();
+    symlink(&outside, &root).unwrap();
+    resume_tx.send(()).unwrap();
+    let (manager, result) = worker.join().unwrap();
+    assert_eq!(
+        result.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    std::fs::remove_file(&root).unwrap();
+    std::fs::rename(&aside, &root).unwrap();
+    assert_eq!(
+        manager.prepare(request).await.unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+fn docker() -> DockerWorkspace {
+    DockerWorkspace::new(
+        DockerImageDigest::new(format!("sha256:{}", "c".repeat(64))).unwrap(),
+        DockerResourceId::new("docker-resource").unwrap(),
+        vec![
+            DockerMountHandleId::new("source").unwrap(),
+            DockerMountHandleId::new("workspace").unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_adapter_gives_source_delivery_only_an_ephemeral_destination() {
+    let (scope, base) = private_product_base("worktree-destination");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(CapturingWorktreeEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.worktree").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.worktree").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Worktree(worktree()),
+    };
+    let ready = manager.prepare(request).await.unwrap();
+    assert_eq!(ready.state, WorkspaceLeaseState::Ready);
+    assert!(effects.destination_seen.load(Ordering::SeqCst));
+    assert_eq!(
+        manager
+            .cleanup(WorkspaceLeaseOwnerRequest {
+                id: ready.id,
+                owner: ready.owner,
+            })
+            .await
+            .unwrap()
+            .state,
+        WorkspaceLeaseState::Cleaned
+    );
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[derive(Default)]
+struct CapturingWorktreeEffects {
+    exists: AtomicBool,
+    destination_seen: AtomicBool,
+}
+
+#[async_trait]
+impl WorktreeWorkspaceEffects for CapturingWorktreeEffects {
+    async fn inspect(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        Ok(if self.exists.load(Ordering::SeqCst) {
+            WorkspaceResourceObservation::Matching
+        } else {
+            WorkspaceResourceObservation::Absent
+        })
+    }
+
+    async fn create(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+        mut destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        use std::os::unix::fs::MetadataExt;
+        let root = destination
+            .downcast_mut::<std::path::PathBuf>()
+            .expect("adapter provides only the ephemeral destination capability");
+        assert!(root.starts_with("/proc/self/fd"));
+        let destination_metadata = std::fs::metadata(root).unwrap();
+        let capability_metadata = request.root_directory.metadata().unwrap();
+        assert_eq!(destination_metadata.dev(), capability_metadata.dev());
+        assert_eq!(destination_metadata.ino(), capability_metadata.ino());
+        self.destination_seen.store(true, Ordering::SeqCst);
+        self.exists.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.exists.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn worktree_request_for(label: &str) -> PrepareWorkspaceRequest {
+    PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new(format!("cluster.{label}")).unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new(format!("logical.{label}")).unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Worktree(worktree()),
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct FailingCreateWorktreeEffects {
+    cleanup_calls: AtomicUsize,
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl WorktreeWorkspaceEffects for FailingCreateWorktreeEffects {
+    async fn inspect(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        Ok(WorkspaceResourceObservation::Absent)
+    }
+
+    async fn create(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+        _destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        Err(injected_resource_unavailable())
+    }
+
+    async fn cleanup(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_create_failure_leaves_owned_scaffolding_for_retryable_cleanup() {
+    let (scope, base) = private_product_base("worktree-create-failure");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(FailingCreateWorktreeEffects::default());
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = worktree_request_for("worktree-create-failure");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+
+    assert_eq!(
+        manager.prepare(request).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    assert!(base.join("worktrees/lease-a/workspace").is_dir());
+    assert_eq!(
+        manager
+            .cleanup(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap()
+            .state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 1);
+    assert!(!base.join("worktrees/lease-a").exists());
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct ResidualCleanupWorktreeEffects {
+    exists: AtomicBool,
+    cleanup_calls: AtomicUsize,
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl WorktreeWorkspaceEffects for ResidualCleanupWorktreeEffects {
+    async fn inspect(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        Ok(if self.exists.load(Ordering::SeqCst) {
+            WorkspaceResourceObservation::Matching
+        } else {
+            WorkspaceResourceObservation::Absent
+        })
+    }
+
+    async fn create(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+        _destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        use std::os::fd::AsRawFd;
+        let root = PathBuf::from(format!(
+            "/proc/self/fd/{}",
+            request.root_directory.as_raw_fd()
+        ));
+        std::fs::write(root.join("residual"), b"still present").unwrap();
+        self.exists.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+        self.exists.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_root_removal_failure_stays_cleanup_required_and_retries() {
+    let (scope, base) = private_product_base("worktree-removal-failure");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(ResidualCleanupWorktreeEffects::default());
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = worktree_request_for("worktree-removal-failure");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        manager.prepare(request).await.unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+
+    assert_eq!(
+        manager
+            .cleanup(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CleanupRequired
+    );
+    std::fs::remove_file(base.join("worktrees/lease-a/workspace/residual")).unwrap();
+    assert_eq!(
+        manager
+            .cleanup(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap()
+            .state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 2);
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_effects_remain_pinned_after_product_parent_symlink_swap() {
+    use std::os::unix::fs::symlink;
+
+    let (scope, base) = private_product_base("worktree-parent-swap");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(RacingWorktreeEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.worktree-race").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.worktree-race").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Worktree(worktree()),
+    };
+    let prepare =
+        tokio::spawn(async move { manager.prepare(request).await.map(|ready| (manager, ready)) });
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        effects.received.notified(),
+    )
+    .await
+    .expect("worktree create did not reach the pinned effect boundary");
+    let detached = base.join("worktrees-detached");
+    let outside = scope.join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::rename(base.join("worktrees"), &detached).unwrap();
+    symlink(&outside, base.join("worktrees")).unwrap();
+    effects.resume.notify_one();
+    let (manager, ready) = prepare.await.unwrap().unwrap();
+    assert_eq!(ready.state, WorkspaceLeaseState::Ready);
+    assert!(detached.join("lease-a/workspace/materialized").is_file());
+    assert!(!outside.join("lease-a/materialized").exists());
+    assert_eq!(
+        manager
+            .cleanup(WorkspaceLeaseOwnerRequest {
+                id: ready.id,
+                owner: ready.owner,
+            })
+            .await
+            .unwrap()
+            .state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert!(!detached.join("lease-a/workspace").exists());
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct RacingWorktreeEffects {
+    received: Notify,
+    resume: Notify,
+    exists: AtomicBool,
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl WorktreeWorkspaceEffects for RacingWorktreeEffects {
+    async fn inspect(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        assert!(request.root_directory.metadata().unwrap().is_dir());
+        Ok(if self.exists.load(Ordering::SeqCst) {
+            WorkspaceResourceObservation::Matching
+        } else {
+            WorkspaceResourceObservation::Absent
+        })
+    }
+
+    async fn create(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+        mut destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.received.notify_one();
+        self.resume.notified().await;
+        assert!(request.root_directory.metadata().unwrap().is_dir());
+        let root = destination
+            .downcast_mut::<PathBuf>()
+            .expect("worktree destination remains an ephemeral capability");
+        std::fs::write(root.join("materialized"), b"safe").unwrap();
+        self.exists.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        use std::os::fd::AsRawFd;
+        let root = PathBuf::from(format!(
+            "/proc/self/fd/{}",
+            request.root_directory.as_raw_fd()
+        ));
+        std::fs::remove_file(root.join("materialized")).unwrap();
+        self.exists.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct PausingCleanupWorktreeEffects {
+    cleanup_started: Notify,
+    cleanup_resume: Notify,
+    exists: AtomicBool,
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl WorktreeWorkspaceEffects for PausingCleanupWorktreeEffects {
+    async fn inspect(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        Ok(if self.exists.load(Ordering::SeqCst) {
+            WorkspaceResourceObservation::Matching
+        } else {
+            WorkspaceResourceObservation::Absent
+        })
+    }
+
+    async fn create(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+        _destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        use std::os::fd::AsRawFd;
+        let root = PathBuf::from(format!(
+            "/proc/self/fd/{}",
+            request.root_directory.as_raw_fd()
+        ));
+        std::fs::write(root.join("materialized"), b"owned").unwrap();
+        self.exists.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        use std::os::fd::AsRawFd;
+        self.cleanup_started.notify_one();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.cleanup_resume.notified(),
+        )
+        .await
+        .map_err(|_| injected_resource_unavailable())?;
+        let root = PathBuf::from(format!(
+            "/proc/self/fd/{}",
+            request.root_directory.as_raw_fd()
+        ));
+        std::fs::remove_file(root.join("materialized")).unwrap();
+        self.exists.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_cleanup_preserves_a_renamed_replacement_and_stays_retryable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (scope, base) = private_product_base("worktree-child-substitution");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(PausingCleanupWorktreeEffects::default());
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = worktree_request_for("worktree-child-substitution");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        manager.prepare(request).await.unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+
+    let cleanup_manager = manager.clone();
+    let cleanup_id = id.clone();
+    let cleanup_owner = owner.clone();
+    let cleanup = tokio::spawn(async move {
+        cleanup_manager
+            .cleanup(WorkspaceLeaseOwnerRequest {
+                id: cleanup_id,
+                owner: cleanup_owner,
+            })
+            .await
+    });
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        effects.cleanup_started.notified(),
+    )
+    .await
+    .expect("cleanup did not reach the pinned effect boundary");
+    let original = base.join("worktrees/lease-a");
+    let detached = base.join("worktrees/lease-a-detached");
+    std::fs::rename(&original, &detached).unwrap();
+    std::fs::create_dir(&original).unwrap();
+    std::fs::set_permissions(&original, std::fs::Permissions::from_mode(0o700)).unwrap();
+    effects.cleanup_resume.notify_one();
+
+    assert_eq!(
+        cleanup.await.unwrap().unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert!(original.is_dir(), "the replacement must be preserved");
+    assert!(
+        detached.is_dir(),
+        "the inspected resource remains inspectable"
+    );
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CleanupRequired
+    );
+    assert_eq!(
+        manager
+            .inspect(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn borrowed_fingerprint_distinguishes_non_utf8_path_bytes() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-borrowed-path-bytes-{}",
+        std::process::id()
+    ));
+    let first = root.join("first");
+    let second = root.join("second");
+    std::fs::create_dir_all(&first).unwrap();
+    std::fs::create_dir_all(&second).unwrap();
+    std::fs::write(first.join(OsString::from_vec(vec![0x80])), b"x").unwrap();
+    std::fs::write(second.join(OsString::from_vec(vec![0x81])), b"x").unwrap();
+    let fingerprints = FilesystemBorrowedWorkspaceFingerprint;
+    assert_ne!(
+        fingerprints.fingerprint(&first).unwrap(),
+        fingerprints.fingerprint(&second).unwrap()
+    );
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn docker_adapter_rejects_a_symlinked_mount_parent_before_effects() {
+    use std::os::unix::fs::symlink;
+
+    let (scope, base) = private_product_base("docker-parent-symlink");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    std::fs::remove_dir(base.join("mounts")).unwrap();
+    symlink("/var/run", base.join("mounts")).unwrap();
+
+    let effects = Arc::new(CountingDockerEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(DockerWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.docker-symlink").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.docker-symlink").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Docker(docker()),
+    };
+    assert_eq!(
+        manager.prepare(request).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    assert_eq!(effects.calls.load(Ordering::SeqCst), 0);
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn docker_mount_capability_survives_post_validation_symlink_swap() {
+    use std::os::unix::fs::symlink;
+
+    let (scope, base) = private_product_base("docker-target-swap");
+    let roots =
+        WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
+            .unwrap();
+    let effects = Arc::new(RacingDockerEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(FakeWorkspaceLeaseStore::default()),
+        Arc::new(DockerWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = PrepareWorkspaceRequest {
+        key: WorkspaceLeaseKey {
+            cluster: ResourceId::new("cluster.docker-race").unwrap(),
+            run: RunSequence::new(1).unwrap(),
+            logical_key: ResourceId::new("logical.docker-race").unwrap(),
+            isolation: WorkspaceIsolation::Shared,
+        },
+        owner: OwnerId::new("owner-a").unwrap(),
+        access_mode: WorkspaceAccessMode::Exclusive,
+        mode: WorkspaceMode::Docker(docker()),
+    };
+    let prepare = tokio::spawn(async move { manager.prepare(request).await });
+    effects.received.notified().await;
+    let target = base.join("mounts/source");
+    std::fs::remove_dir(&target).unwrap();
+    symlink("/var/run/docker.sock", &target).unwrap();
+    effects.resume.notify_one();
+    assert_eq!(
+        prepare.await.unwrap().unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::InvalidInput
+    );
+    assert!(effects.pinned_directory_consumed.load(Ordering::SeqCst));
+    assert_eq!(effects.create_calls.load(Ordering::SeqCst), 0);
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[derive(Default)]
+struct RacingDockerEffects {
+    received: Notify,
+    resume: Notify,
+    pinned_directory_consumed: AtomicBool,
+    create_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl DockerWorkspaceEffects for RacingDockerEffects {
+    async fn inspect(
+        &self,
+        request: DockerResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        self.received.notify_one();
+        self.resume.notified().await;
+        assert!(
+            request.mounts.iter().all(|mount| mount
+                .source_directory()
+                .metadata()
+                .unwrap()
+                .is_dir())
+        );
+        self.pinned_directory_consumed.store(true, Ordering::SeqCst);
+        Ok(WorkspaceResourceObservation::Absent)
+    }
+
+    async fn create(&self, _request: DockerResourceRequest<'_>) -> Result<(), WorkspaceLeaseError> {
+        self.create_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        _request: DockerResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CountingDockerEffects {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl DockerWorkspaceEffects for CountingDockerEffects {
+    async fn inspect(
+        &self,
+        _request: DockerResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(WorkspaceResourceObservation::Absent)
+    }
+
+    async fn create(&self, _request: DockerResourceRequest<'_>) -> Result<(), WorkspaceLeaseError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &self,
+        _request: DockerResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn worktree() -> WorktreeWorkspace {
+    WorktreeWorkspace {
+        repository: CanonicalRepository::new(
+            SourceProviderRef::new(SourceProviderId::new("source.github").unwrap(), 1).unwrap(),
+            SourceProfileId::new("production").unwrap(),
+            SourceAccountId::new("open-engine").unwrap(),
+            SourceRepositoryId::new("the-open-engine/zeroshot").unwrap(),
+        )
+        .unwrap(),
+        revision: SourceRevisionId::new("revision-abc").unwrap(),
+        source_profile: SourceProfileId::new("production").unwrap(),
+        name: WorkspaceName::new("lease-a").unwrap(),
+        branch: SourceBranchId::new("feat/677").unwrap(),
+        profile: WorkspaceProfile::new("durable-worktree").unwrap(),
+        materialization: WorkspaceMaterializationId::new("materialization-1").unwrap(),
+    }
+}

--- a/zeroshot-rust/tests/workspace_modes.rs
+++ b/zeroshot-rust/tests/workspace_modes.rs
@@ -15,10 +15,11 @@ use zeroshot_engine::workspace_lease::{
     BorrowedWorkspace, BorrowedWorkspaceAdapter, BorrowedWorkspaceFingerprintPort,
     CanonicalWorkspaceRoot, DockerImageDigest, DockerMountHandleId, DockerResourceId,
     DockerResourceRequest, DockerWorkspace, DockerWorkspaceAdapter, DockerWorkspaceEffects,
-    FilesystemBorrowedWorkspaceFingerprint, PrepareWorkspaceRequest, WorkspaceFingerprint,
-    WorkspaceIsolation, WorkspaceLeaseError, WorkspaceLeaseErrorKind, WorkspaceLeaseId,
-    WorkspaceLeaseKey, WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseState,
-    WorkspaceLeaseStore, WorkspaceMaterializationId, WorkspaceMode, WorkspaceName,
+    FilesystemBorrowedWorkspaceFingerprint, FilesystemBorrowedWorkspaceFingerprintHooks,
+    PrepareWorkspaceRequest, WorkspaceFingerprint, WorkspaceIsolation, WorkspaceLeaseError,
+    WorkspaceLeaseErrorKind, WorkspaceLeaseId, WorkspaceLeaseKey, WorkspaceLeaseManager,
+    WorkspaceLeaseOwnerRequest, WorkspaceLeaseState, WorkspaceLeaseStore,
+    WorkspaceMaterializationId, WorkspaceMode, WorkspaceName, WorkspaceProductRootHooks,
     WorkspaceProductRoots, WorkspaceProfile, WorkspaceResourceObservation, WorktreeResourceRequest,
     WorktreeWorkspace, WorktreeWorkspaceAdapter, WorktreeWorkspaceEffects,
 };
@@ -28,7 +29,7 @@ fn injected_resource_unavailable() -> WorkspaceLeaseError {
         "zeroshot-injected-absent-workspace-{}",
         std::process::id()
     ));
-    FilesystemBorrowedWorkspaceFingerprint
+    FilesystemBorrowedWorkspaceFingerprint::default()
         .fingerprint(&absent)
         .unwrap_err()
 }
@@ -88,6 +89,12 @@ fn exact_mode_values_are_canonical_bounded_and_secret_free() {
         "a".repeat(64)
     );
     assert!(serde_json::from_str::<DockerWorkspace>(&invalid_docker).is_err());
+    let mut mode_with_unknown_field = serde_json::to_value(&mode).unwrap();
+    mode_with_unknown_field
+        .as_object_mut()
+        .unwrap()
+        .insert("unexpected".to_owned(), serde_json::json!(true));
+    assert!(serde_json::from_value::<WorkspaceMode>(mode_with_unknown_field).is_err());
 }
 
 #[cfg(target_os = "linux")]
@@ -168,12 +175,53 @@ fn worktree_and_docker_roots_are_private_disjoint_and_never_broad() {
     std::fs::remove_dir_all(scope).unwrap();
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn product_base_ancestor_swap_after_descriptor_open_fails_before_child_creation() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let (scope, base) = private_product_base("base-construction-swap");
+    let detached = scope.with_extension("detached");
+    let outside_scope = scope.with_extension("outside");
+    let outside_base = outside_scope.join("zeroshot/workspaces");
+    std::fs::create_dir_all(&outside_base).unwrap();
+    std::fs::set_permissions(&outside_base, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let hooks = WorkspaceProductRootHooks {
+        after_base_open: Some(Arc::new({
+            let scope = scope.clone();
+            let detached = detached.clone();
+            let outside_scope = outside_scope.clone();
+            move || {
+                std::fs::rename(&scope, &detached).unwrap();
+                symlink(&outside_scope, &scope).unwrap();
+            }
+        })),
+        ..WorkspaceProductRootHooks::default()
+    };
+    assert_eq!(
+        WorkspaceProductRoots::new_with_hooks(
+            CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            hooks,
+        )
+        .err()
+        .unwrap()
+        .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert!(!outside_base.join("worktrees").exists());
+    assert!(!outside_base.join("mounts").exists());
+    std::fs::remove_file(&scope).unwrap();
+    std::fs::rename(&detached, &scope).unwrap();
+    std::fs::remove_dir_all(scope).unwrap();
+    std::fs::remove_dir_all(outside_scope).unwrap();
+}
+
 #[tokio::test]
 async fn borrowed_workspace_is_inspected_but_never_owned_or_deleted() {
     let path = std::env::temp_dir().join(format!("zeroshot-borrowed-{}", std::process::id()));
     std::fs::create_dir_all(&path).unwrap();
     let canonical = std::fs::canonicalize(&path).unwrap();
-    let fingerprint = FilesystemBorrowedWorkspaceFingerprint
+    let fingerprint = FilesystemBorrowedWorkspaceFingerprint::default()
         .fingerprint(&canonical)
         .unwrap();
     let request = PrepareWorkspaceRequest {
@@ -237,97 +285,38 @@ async fn borrowed_workspace_is_inspected_but_never_owned_or_deleted() {
 }
 
 #[cfg(target_os = "linux")]
-struct PausingBorrowedFingerprint {
-    armed: AtomicBool,
-    reached: std::sync::mpsc::SyncSender<()>,
-    resume: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
-}
-
-#[cfg(target_os = "linux")]
-impl BorrowedWorkspaceFingerprintPort for PausingBorrowedFingerprint {
-    fn fingerprint(
-        &self,
-        root: &std::path::Path,
-    ) -> Result<WorkspaceFingerprint, WorkspaceLeaseError> {
-        if self.armed.swap(false, Ordering::SeqCst) {
-            self.reached.send(()).unwrap();
-            self.resume
-                .lock()
-                .unwrap()
-                .recv_timeout(std::time::Duration::from_secs(5))
-                .map_err(|_| injected_resource_unavailable())?;
-        }
-        FilesystemBorrowedWorkspaceFingerprint.fingerprint(root)
-    }
-}
-
-#[cfg(target_os = "linux")]
-#[tokio::test]
-async fn borrowed_root_swap_between_canonical_check_and_fingerprint_fails_closed() {
-    use std::os::unix::fs::symlink;
-
+#[test]
+fn borrowed_root_replacement_after_descriptor_traversal_fails_final_revalidation() {
     let scope = std::env::temp_dir().join(format!("zeroshot-borrowed-swap-{}", std::process::id()));
     let root = scope.join("root");
     let aside = scope.join("root-aside");
-    let outside = scope.join("outside");
+    let replacement = scope.join("replacement");
     std::fs::create_dir_all(&root).unwrap();
-    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::create_dir_all(&replacement).unwrap();
     std::fs::write(root.join("same"), b"content").unwrap();
-    std::fs::write(outside.join("same"), b"content").unwrap();
+    std::fs::write(replacement.join("same"), b"content").unwrap();
     let canonical = std::fs::canonicalize(&root).unwrap();
-    let fingerprint = FilesystemBorrowedWorkspaceFingerprint
-        .fingerprint(&canonical)
-        .unwrap();
-    let request = PrepareWorkspaceRequest {
-        key: WorkspaceLeaseKey {
-            cluster: ResourceId::new("cluster.borrowed-swap").unwrap(),
-            run: RunSequence::new(1).unwrap(),
-            logical_key: ResourceId::new("logical.borrowed-swap").unwrap(),
-            isolation: WorkspaceIsolation::Shared,
-        },
-        owner: OwnerId::new("owner-a").unwrap(),
-        access_mode: WorkspaceAccessMode::ReadOnly,
-        mode: WorkspaceMode::Borrowed(BorrowedWorkspace {
-            canonical_root: CanonicalWorkspaceRoot::new(canonical.to_string_lossy()).unwrap(),
-            fingerprint,
-        }),
+    let hooks = FilesystemBorrowedWorkspaceFingerprintHooks {
+        before_root_revalidation: Some(Arc::new({
+            let root = root.clone();
+            let aside = aside.clone();
+            let replacement = replacement.clone();
+            move || {
+                std::fs::rename(&root, &aside).unwrap();
+                std::fs::rename(&replacement, &root).unwrap();
+            }
+        })),
     };
-    let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(1);
-    let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(1);
-    let fingerprints = Arc::new(PausingBorrowedFingerprint {
-        armed: AtomicBool::new(true),
-        reached: reached_tx,
-        resume: std::sync::Mutex::new(resume_rx),
-    });
-    let manager = WorkspaceLeaseManager::new(
-        Arc::new(FakeWorkspaceLeaseStore::default()),
-        Arc::new(BorrowedWorkspaceAdapter::new(fingerprints)),
-    );
-    let worker_request = request.clone();
-    let worker = std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let result = runtime.block_on(manager.prepare(worker_request));
-        (manager, result)
-    });
-    reached_rx
-        .recv_timeout(std::time::Duration::from_secs(5))
-        .expect("borrowed inspection did not reach the fingerprint boundary");
-    std::fs::rename(&root, &aside).unwrap();
-    symlink(&outside, &root).unwrap();
-    resume_tx.send(()).unwrap();
-    let (manager, result) = worker.join().unwrap();
-    assert_eq!(
-        result.unwrap_err().kind(),
-        WorkspaceLeaseErrorKind::ResourceUnavailable
-    );
-    std::fs::remove_file(&root).unwrap();
+    let error = FilesystemBorrowedWorkspaceFingerprint::new_with_hooks(hooks)
+        .fingerprint(&canonical)
+        .unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceUnavailable);
+    std::fs::rename(&root, &replacement).unwrap();
     std::fs::rename(&aside, &root).unwrap();
-    assert_eq!(
-        manager.prepare(request).await.unwrap().state,
-        WorkspaceLeaseState::Ready
+    assert!(
+        FilesystemBorrowedWorkspaceFingerprint::default()
+            .fingerprint(&canonical)
+            .is_ok()
     );
     std::fs::remove_dir_all(scope).unwrap();
 }
@@ -406,17 +395,15 @@ impl WorktreeWorkspaceEffects for CapturingWorktreeEffects {
     async fn create(
         &self,
         request: WorktreeResourceRequest<'_>,
-        mut destination: SourceMaterializationDestination<'_>,
+        destination: SourceMaterializationDestination<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
-        use std::os::unix::fs::MetadataExt;
-        let root = destination
-            .downcast_mut::<std::path::PathBuf>()
-            .expect("adapter provides only the ephemeral destination capability");
-        assert!(root.starts_with("/proc/self/fd"));
-        let destination_metadata = std::fs::metadata(root).unwrap();
-        let capability_metadata = request.root_directory.metadata().unwrap();
-        assert_eq!(destination_metadata.dev(), capability_metadata.dev());
-        assert_eq!(destination_metadata.ino(), capability_metadata.ino());
+        destination
+            .write_file("capability-probe", b"pinned")
+            .expect("adapter provides only a scoped destination operation");
+        assert!(request.is_available());
+        request
+            .remove_file("capability-probe")
+            .expect("request capability addresses the same pinned workspace");
         self.destination_seen.store(true, Ordering::SeqCst);
         self.exists.store(true, Ordering::SeqCst);
         Ok(())
@@ -480,6 +467,124 @@ impl WorktreeWorkspaceEffects for FailingCreateWorktreeEffects {
 }
 
 #[cfg(target_os = "linux")]
+struct PartialCreateMismatchEffects {
+    cleanup_calls: AtomicUsize,
+    fail_cleanup_once: AtomicBool,
+    inspect_calls: AtomicUsize,
+}
+
+#[cfg(target_os = "linux")]
+impl Default for PartialCreateMismatchEffects {
+    fn default() -> Self {
+        Self {
+            cleanup_calls: AtomicUsize::new(0),
+            fail_cleanup_once: AtomicBool::new(true),
+            inspect_calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl WorktreeWorkspaceEffects for PartialCreateMismatchEffects {
+    async fn inspect(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+    ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
+        self.inspect_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(WorkspaceResourceObservation::Mismatch)
+    }
+
+    async fn create(
+        &self,
+        _request: WorktreeResourceRequest<'_>,
+        destination: SourceMaterializationDestination<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        destination
+            .write_file("partial", b"incomplete")
+            .expect("adapter provides the scoped materialization operation");
+        Err(injected_resource_unavailable())
+    }
+
+    async fn cleanup(
+        &self,
+        request: WorktreeResourceRequest<'_>,
+    ) -> Result<(), WorkspaceLeaseError> {
+        self.cleanup_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_cleanup_once.swap(false, Ordering::SeqCst) {
+            return Err(injected_resource_unavailable());
+        }
+        request.remove_file("partial").unwrap();
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn partial_private_materialization_restarts_into_retryable_owner_cleanup() {
+    let (scope, base) = private_product_base("partial-private-materialization");
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let effects = Arc::new(PartialCreateMismatchEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects.clone(),
+        )),
+    );
+    let request = worktree_request_for("partial-private-materialization");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        manager.prepare(request).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    let partial = base.join("worktrees/.lease-a.create-pending/.workspace.create-pending/partial");
+    assert_eq!(std::fs::read(&partial).unwrap(), b"incomplete");
+    assert!(!base.join("worktrees/lease-a").exists());
+
+    for expect_success in [false, true] {
+        let restarted_manager = WorkspaceLeaseManager::new(
+            store.clone(),
+            Arc::new(WorktreeWorkspaceAdapter::new(
+                WorkspaceProductRoots::new(
+                    CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+                )
+                .unwrap(),
+                effects.clone(),
+            )),
+        );
+        let result = restarted_manager
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await;
+        if expect_success {
+            assert_eq!(result.unwrap().state, WorkspaceLeaseState::Cleaned);
+        } else {
+            assert_eq!(
+                result.unwrap_err().kind(),
+                WorkspaceLeaseErrorKind::ResourceUnavailable
+            );
+            assert_eq!(
+                store.load(&id).await.unwrap().unwrap().state,
+                WorkspaceLeaseState::CleanupRequired
+            );
+            assert!(partial.is_file());
+        }
+    }
+    assert_eq!(effects.inspect_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 2);
+    assert!(!base.join("worktrees/.lease-a.create-pending").exists());
+    assert!(!base.join("worktrees/lease-a").exists());
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn worktree_create_failure_leaves_owned_scaffolding_for_retryable_cleanup() {
     let (scope, base) = private_product_base("worktree-create-failure");
@@ -500,7 +605,10 @@ async fn worktree_create_failure_leaves_owned_scaffolding_for_retryable_cleanup(
         manager.prepare(request).await.unwrap_err().kind(),
         WorkspaceLeaseErrorKind::ResourceUnavailable
     );
-    assert!(base.join("worktrees/lease-a/workspace").is_dir());
+    assert!(
+        base.join("worktrees/.lease-a.create-pending/.workspace.create-pending")
+            .is_dir()
+    );
     assert_eq!(
         manager
             .cleanup(WorkspaceLeaseOwnerRequest { id, owner })
@@ -511,6 +619,311 @@ async fn worktree_create_failure_leaves_owned_scaffolding_for_retryable_cleanup(
     );
     assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 1);
     assert!(!base.join("worktrees/lease-a").exists());
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn worktree_staging_crash_boundaries_remain_owner_cleanup_recoverable() {
+    let cases = [
+        (
+            "staging-directory-crash",
+            WorkspaceProductRootHooks {
+                fail_after_staging_directory: Some(Arc::new({
+                    let armed = AtomicBool::new(true);
+                    move || armed.swap(false, Ordering::SeqCst)
+                })),
+                ..WorkspaceProductRootHooks::default()
+            },
+        ),
+        (
+            "owner-marker-crash",
+            WorkspaceProductRootHooks {
+                fail_after_owner_marker_create: Some(Arc::new({
+                    let armed = AtomicBool::new(true);
+                    move || armed.swap(false, Ordering::SeqCst)
+                })),
+                ..WorkspaceProductRootHooks::default()
+            },
+        ),
+        (
+            "owner-marker-synced-crash",
+            WorkspaceProductRootHooks {
+                fail_after_owner_marker_sync: Some(Arc::new({
+                    let armed = AtomicBool::new(true);
+                    move || armed.swap(false, Ordering::SeqCst)
+                })),
+                ..WorkspaceProductRootHooks::default()
+            },
+        ),
+    ];
+    for (label, hooks) in cases {
+        let (scope, base) = private_product_base(label);
+        let roots = WorkspaceProductRoots::new_with_hooks(
+            CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            hooks,
+        )
+        .unwrap();
+        let store = Arc::new(FakeWorkspaceLeaseStore::default());
+        let effects = Arc::new(CapturingWorktreeEffects::default());
+        let manager = WorkspaceLeaseManager::new(
+            store.clone(),
+            Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+        );
+        let request = worktree_request_for(label);
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let owner = request.owner.clone();
+        assert_eq!(
+            manager.prepare(request).await.unwrap_err().kind(),
+            WorkspaceLeaseErrorKind::ResourceUnavailable
+        );
+        assert!(!base.join("worktrees/lease-a").exists());
+        assert!(base.join("worktrees/.lease-a.create-pending").is_dir());
+        let restarted_manager = WorkspaceLeaseManager::new(
+            store,
+            Arc::new(WorktreeWorkspaceAdapter::new(
+                WorkspaceProductRoots::new(
+                    CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+                )
+                .unwrap(),
+                effects,
+            )),
+        );
+        assert_eq!(
+            restarted_manager
+                .restart(WorkspaceLeaseOwnerRequest { id, owner })
+                .await
+                .unwrap()
+                .state,
+            WorkspaceLeaseState::Cleaned
+        );
+        assert!(!base.join("worktrees/.lease-a.create-pending").exists());
+        std::fs::remove_dir_all(scope).unwrap();
+    }
+}
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn staging_cleanup_quarantine_is_restartable_without_mutable_name_unlink() {
+    use std::os::unix::fs::symlink;
+    let (scope, base) = private_product_base("staging-quarantine-restart");
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let effects = Arc::new(CapturingWorktreeEffects::default());
+    let create_roots = WorkspaceProductRoots::new_with_hooks(
+        CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+        WorkspaceProductRootHooks {
+            fail_after_owner_marker_sync: Some(Arc::new(|| true)),
+            ..WorkspaceProductRootHooks::default()
+        },
+    )
+    .unwrap();
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(create_roots, effects.clone())),
+    );
+    let request = worktree_request_for("staging-quarantine-restart");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        manager.prepare(request).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+
+    let cleanup_roots = WorkspaceProductRoots::new_with_hooks(
+        CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+        WorkspaceProductRootHooks {
+            fail_after_staging_quarantine: Some(Arc::new({
+                let armed = AtomicBool::new(true);
+                move || armed.swap(false, Ordering::SeqCst)
+            })),
+            ..WorkspaceProductRootHooks::default()
+        },
+    )
+    .unwrap();
+    let interrupted = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            cleanup_roots,
+            effects.clone(),
+        )),
+    );
+    assert_eq!(
+        interrupted
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    let staging = base.join("worktrees/.lease-a.create-pending");
+    let quarantine = base.join("worktrees/..lease-a.create-pending.cleanup");
+    assert!(!staging.exists());
+    assert!(quarantine.is_dir());
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CleanupRequired
+    );
+
+    let detached = quarantine.with_extension("detached");
+    std::fs::rename(&quarantine, &detached).unwrap();
+    symlink(&detached, &quarantine).unwrap();
+    let substituted = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects.clone(),
+        )),
+    );
+    assert_eq!(
+        substituted
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert!(detached.is_dir());
+    assert!(quarantine.is_symlink());
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CleanupRequired
+    );
+    std::fs::remove_file(&quarantine).unwrap();
+    std::fs::rename(&detached, &quarantine).unwrap();
+
+    let restarted = WorkspaceLeaseManager::new(
+        store,
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects,
+        )),
+    );
+    assert_eq!(
+        restarted
+            .restart(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap()
+            .state,
+        WorkspaceLeaseState::Cleaned
+    );
+    assert!(!quarantine.exists());
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn foreign_content_in_interrupted_staging_is_preserved_as_mismatch() {
+    let (scope, base) = private_product_base("foreign-staging");
+    let hooks = WorkspaceProductRootHooks {
+        fail_after_owner_marker_sync: Some(Arc::new(|| true)),
+        ..WorkspaceProductRootHooks::default()
+    };
+    let roots = WorkspaceProductRoots::new_with_hooks(
+        CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+        hooks,
+    )
+    .unwrap();
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let effects = Arc::new(CapturingWorktreeEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+    );
+    let request = worktree_request_for("foreign-staging");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert!(manager.prepare(request).await.is_err());
+    let foreign = base.join("worktrees/.lease-a.create-pending/foreign");
+    std::fs::write(&foreign, b"preserve").unwrap();
+    let restarted_manager = WorkspaceLeaseManager::new(
+        store,
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects,
+        )),
+    );
+    assert_eq!(
+        restarted_manager
+            .restart(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert_eq!(std::fs::read(&foreign).unwrap(), b"preserve");
+    std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn ready_public_container_foreign_sibling_is_preserved_before_effects() {
+    let (scope, base) = private_product_base("foreign-public-sibling");
+    let store = Arc::new(FakeWorkspaceLeaseStore::default());
+    let effects = Arc::new(CapturingWorktreeEffects::default());
+    let manager = WorkspaceLeaseManager::new(
+        store.clone(),
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects.clone(),
+        )),
+    );
+    let request = worktree_request_for("foreign-public-sibling");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    assert_eq!(
+        manager.prepare(request).await.unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    let foreign = base.join("worktrees/lease-a/foreign");
+    std::fs::write(&foreign, b"preserve").unwrap();
+    let restarted_manager = WorkspaceLeaseManager::new(
+        store,
+        Arc::new(WorktreeWorkspaceAdapter::new(
+            WorkspaceProductRoots::new(
+                CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            )
+            .unwrap(),
+            effects,
+        )),
+    );
+    assert_eq!(
+        restarted_manager
+            .restart(WorkspaceLeaseOwnerRequest {
+                id: id.clone(),
+                owner: owner.clone(),
+            })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert_eq!(
+        restarted_manager
+            .cleanup(WorkspaceLeaseOwnerRequest { id, owner })
+            .await
+            .unwrap_err()
+            .kind(),
+        WorkspaceLeaseErrorKind::ResourceMismatch
+    );
+    assert_eq!(std::fs::read(&foreign).unwrap(), b"preserve");
+    assert!(base.join("worktrees/lease-a/workspace").is_dir());
     std::fs::remove_dir_all(scope).unwrap();
 }
 
@@ -540,12 +953,7 @@ impl WorktreeWorkspaceEffects for ResidualCleanupWorktreeEffects {
         request: WorktreeResourceRequest<'_>,
         _destination: SourceMaterializationDestination<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
-        use std::os::fd::AsRawFd;
-        let root = PathBuf::from(format!(
-            "/proc/self/fd/{}",
-            request.root_directory.as_raw_fd()
-        ));
-        std::fs::write(root.join("residual"), b"still present").unwrap();
+        request.write_file("residual", b"still present").unwrap();
         self.exists.store(true, Ordering::SeqCst);
         Ok(())
     }
@@ -596,7 +1004,7 @@ async fn worktree_root_removal_failure_stays_cleanup_required_and_retries() {
         store.load(&id).await.unwrap().unwrap().state,
         WorkspaceLeaseState::CleanupRequired
     );
-    std::fs::remove_file(base.join("worktrees/lease-a/workspace/residual")).unwrap();
+    std::fs::remove_file(base.join("worktrees/lease-a/.workspace.cleanup/residual")).unwrap();
     assert_eq!(
         manager
             .cleanup(WorkspaceLeaseOwnerRequest { id, owner })
@@ -605,8 +1013,187 @@ async fn worktree_root_removal_failure_stays_cleanup_required_and_retries() {
             .state,
         WorkspaceLeaseState::Cleaned
     );
-    assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(effects.cleanup_calls.load(Ordering::SeqCst), 1);
     std::fs::remove_dir_all(scope).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn cleanup_quarantine_crash_boundaries_reconcile_without_orphans() {
+    for (label, boundary) in [
+        ("inner-cleanup-quarantine-crash", 0),
+        ("outer-cleanup-quarantine-crash", 1),
+        ("owner-marker-removal-crash", 2),
+    ] {
+        let armed = Arc::new(AtomicBool::new(true));
+        let failpoint = Arc::new({
+            let armed = armed.clone();
+            move || armed.swap(false, Ordering::SeqCst)
+        });
+        let hooks = WorkspaceProductRootHooks {
+            fail_after_inner_quarantine: (boundary == 0).then_some(failpoint.clone()),
+            fail_after_outer_quarantine: (boundary == 1).then_some(failpoint.clone()),
+            fail_after_owner_marker_removal: (boundary == 2).then_some(failpoint),
+            ..WorkspaceProductRootHooks::default()
+        };
+        let (scope, base) = private_product_base(label);
+        let roots = WorkspaceProductRoots::new_with_hooks(
+            CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+            hooks,
+        )
+        .unwrap();
+        let effects = Arc::new(CapturingWorktreeEffects::default());
+        let store = Arc::new(FakeWorkspaceLeaseStore::default());
+        let manager = WorkspaceLeaseManager::new(
+            store.clone(),
+            Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
+        );
+        let request = worktree_request_for(label);
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let owner = request.owner.clone();
+        assert_eq!(
+            manager.prepare(request).await.unwrap().state,
+            WorkspaceLeaseState::Ready
+        );
+        assert_eq!(
+            manager
+                .cleanup(WorkspaceLeaseOwnerRequest {
+                    id: id.clone(),
+                    owner: owner.clone(),
+                })
+                .await
+                .unwrap_err()
+                .kind(),
+            WorkspaceLeaseErrorKind::ResourceUnavailable
+        );
+        assert_eq!(
+            store.load(&id).await.unwrap().unwrap().state,
+            WorkspaceLeaseState::CleanupRequired
+        );
+        let quarantine = if boundary == 0 {
+            base.join("worktrees/lease-a/.workspace.cleanup")
+        } else {
+            base.join("worktrees/.lease-a.cleanup")
+        };
+        assert!(quarantine.exists());
+        let restarted_manager = WorkspaceLeaseManager::new(
+            store.clone(),
+            Arc::new(WorktreeWorkspaceAdapter::new(
+                WorkspaceProductRoots::new(
+                    CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+                )
+                .unwrap(),
+                effects.clone(),
+            )),
+        );
+        assert_eq!(
+            restarted_manager
+                .restart(WorkspaceLeaseOwnerRequest { id, owner })
+                .await
+                .unwrap()
+                .state,
+            WorkspaceLeaseState::Cleaned
+        );
+        assert!(!effects.exists.load(Ordering::SeqCst));
+        for path in [
+            base.join("worktrees/lease-a"),
+            base.join("worktrees/.lease-a.create-pending"),
+            base.join("worktrees/.lease-a.cleanup"),
+        ] {
+            assert!(!path.exists(), "orphaned {}", path.display());
+        }
+        std::fs::remove_dir_all(scope).unwrap();
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn fresh_restart_preserves_substituted_quarantine_for_every_cleanup_boundary() {
+    use std::os::unix::fs::symlink;
+
+    for (label, boundary) in [
+        ("inner-quarantine-substitution", 0),
+        ("outer-quarantine-substitution", 1),
+        ("marker-removal-quarantine-substitution", 2),
+    ] {
+        let armed = Arc::new(AtomicBool::new(true));
+        let failpoint = Arc::new({
+            let armed = armed.clone();
+            move || armed.swap(false, Ordering::SeqCst)
+        });
+        let hooks = WorkspaceProductRootHooks {
+            fail_after_inner_quarantine: (boundary == 0).then_some(failpoint.clone()),
+            fail_after_outer_quarantine: (boundary == 1).then_some(failpoint.clone()),
+            fail_after_owner_marker_removal: (boundary == 2).then_some(failpoint),
+            ..WorkspaceProductRootHooks::default()
+        };
+        let (scope, base) = private_product_base(label);
+        let store = Arc::new(FakeWorkspaceLeaseStore::default());
+        let effects = Arc::new(CapturingWorktreeEffects::default());
+        let manager = WorkspaceLeaseManager::new(
+            store.clone(),
+            Arc::new(WorktreeWorkspaceAdapter::new(
+                WorkspaceProductRoots::new_with_hooks(
+                    CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+                    hooks,
+                )
+                .unwrap(),
+                effects.clone(),
+            )),
+        );
+        let request = worktree_request_for(label);
+        let id = WorkspaceLeaseId::derive(&request.key);
+        let owner = request.owner.clone();
+        assert_eq!(
+            manager.prepare(request).await.unwrap().state,
+            WorkspaceLeaseState::Ready
+        );
+        assert_eq!(
+            manager
+                .cleanup(WorkspaceLeaseOwnerRequest {
+                    id: id.clone(),
+                    owner: owner.clone(),
+                })
+                .await
+                .unwrap_err()
+                .kind(),
+            WorkspaceLeaseErrorKind::ResourceUnavailable
+        );
+        let quarantine = if boundary == 0 {
+            base.join("worktrees/lease-a/.workspace.cleanup")
+        } else {
+            base.join("worktrees/.lease-a.cleanup")
+        };
+        let detached = quarantine.with_extension("detached");
+        std::fs::rename(&quarantine, &detached).unwrap();
+        symlink(&detached, &quarantine).unwrap();
+        let restarted_manager = WorkspaceLeaseManager::new(
+            store,
+            Arc::new(WorktreeWorkspaceAdapter::new(
+                WorkspaceProductRoots::new(
+                    CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap(),
+                )
+                .unwrap(),
+                effects,
+            )),
+        );
+        assert_eq!(
+            restarted_manager
+                .restart(WorkspaceLeaseOwnerRequest { id, owner })
+                .await
+                .unwrap_err()
+                .kind(),
+            WorkspaceLeaseErrorKind::ResourceMismatch
+        );
+        assert!(
+            std::fs::symlink_metadata(&quarantine)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(detached.is_dir());
+        std::fs::remove_dir_all(scope).unwrap();
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -619,6 +1206,7 @@ async fn worktree_effects_remain_pinned_after_product_parent_symlink_swap() {
         WorkspaceProductRoots::new(CanonicalWorkspaceRoot::new(base.to_string_lossy()).unwrap())
             .unwrap();
     let effects = Arc::new(RacingWorktreeEffects::default());
+
     let manager = WorkspaceLeaseManager::new(
         Arc::new(FakeWorkspaceLeaseStore::default()),
         Arc::new(WorktreeWorkspaceAdapter::new(roots, effects.clone())),
@@ -682,7 +1270,7 @@ impl WorktreeWorkspaceEffects for RacingWorktreeEffects {
         &self,
         request: WorktreeResourceRequest<'_>,
     ) -> Result<WorkspaceResourceObservation, WorkspaceLeaseError> {
-        assert!(request.root_directory.metadata().unwrap().is_dir());
+        assert!(request.is_available());
         Ok(if self.exists.load(Ordering::SeqCst) {
             WorkspaceResourceObservation::Matching
         } else {
@@ -693,15 +1281,14 @@ impl WorktreeWorkspaceEffects for RacingWorktreeEffects {
     async fn create(
         &self,
         request: WorktreeResourceRequest<'_>,
-        mut destination: SourceMaterializationDestination<'_>,
+        destination: SourceMaterializationDestination<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
         self.received.notify_one();
         self.resume.notified().await;
-        assert!(request.root_directory.metadata().unwrap().is_dir());
-        let root = destination
-            .downcast_mut::<PathBuf>()
-            .expect("worktree destination remains an ephemeral capability");
-        std::fs::write(root.join("materialized"), b"safe").unwrap();
+        destination
+            .write_file("materialized", b"safe")
+            .expect("worktree destination remains an ephemeral operation capability");
+        assert!(request.is_available());
         self.exists.store(true, Ordering::SeqCst);
         Ok(())
     }
@@ -710,12 +1297,7 @@ impl WorktreeWorkspaceEffects for RacingWorktreeEffects {
         &self,
         request: WorktreeResourceRequest<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
-        use std::os::fd::AsRawFd;
-        let root = PathBuf::from(format!(
-            "/proc/self/fd/{}",
-            request.root_directory.as_raw_fd()
-        ));
-        std::fs::remove_file(root.join("materialized")).unwrap();
+        request.remove_file("materialized").unwrap();
         self.exists.store(false, Ordering::SeqCst);
         Ok(())
     }
@@ -748,12 +1330,7 @@ impl WorktreeWorkspaceEffects for PausingCleanupWorktreeEffects {
         request: WorktreeResourceRequest<'_>,
         _destination: SourceMaterializationDestination<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
-        use std::os::fd::AsRawFd;
-        let root = PathBuf::from(format!(
-            "/proc/self/fd/{}",
-            request.root_directory.as_raw_fd()
-        ));
-        std::fs::write(root.join("materialized"), b"owned").unwrap();
+        request.write_file("materialized", b"owned").unwrap();
         self.exists.store(true, Ordering::SeqCst);
         Ok(())
     }
@@ -762,7 +1339,6 @@ impl WorktreeWorkspaceEffects for PausingCleanupWorktreeEffects {
         &self,
         request: WorktreeResourceRequest<'_>,
     ) -> Result<(), WorkspaceLeaseError> {
-        use std::os::fd::AsRawFd;
         self.cleanup_started.notify_one();
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
@@ -770,11 +1346,7 @@ impl WorktreeWorkspaceEffects for PausingCleanupWorktreeEffects {
         )
         .await
         .map_err(|_| injected_resource_unavailable())?;
-        let root = PathBuf::from(format!(
-            "/proc/self/fd/{}",
-            request.root_directory.as_raw_fd()
-        ));
-        std::fs::remove_file(root.join("materialized")).unwrap();
+        request.remove_file("materialized").unwrap();
         self.exists.store(false, Ordering::SeqCst);
         Ok(())
     }
@@ -867,7 +1439,7 @@ fn borrowed_fingerprint_distinguishes_non_utf8_path_bytes() {
     std::fs::create_dir_all(&second).unwrap();
     std::fs::write(first.join(OsString::from_vec(vec![0x80])), b"x").unwrap();
     std::fs::write(second.join(OsString::from_vec(vec![0x81])), b"x").unwrap();
-    let fingerprints = FilesystemBorrowedWorkspaceFingerprint;
+    let fingerprints = FilesystemBorrowedWorkspaceFingerprint::default();
     assert_ne!(
         fingerprints.fingerprint(&first).unwrap(),
         fingerprints.fingerprint(&second).unwrap()

--- a/zeroshot-rust/tests/workspace_recovery.rs
+++ b/zeroshot-rust/tests/workspace_recovery.rs
@@ -1,0 +1,584 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use zeroshot_engine::cluster_ledger::OwnerId;
+
+use zeroshot_engine::workspace_lease::fake::{
+    FakeEffectFailure, FakeResourceAction, FakeWorkspaceResourcePort,
+};
+use zeroshot_engine::workspace_lease::{
+    SqliteWorkspaceLeaseHooks, SqliteWorkspaceLeaseStore, WorkspaceLeaseErrorKind,
+    WorkspaceLeaseId, WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseState,
+    WorkspaceLeaseStore, WorkspaceLeaseTransition,
+};
+
+#[allow(dead_code)]
+#[path = "support/workspace.rs"]
+mod support;
+use support::{LeaseFixture, docker_request};
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn sqlite_store_fails_closed_without_descriptor_identity_support() {
+    let path = std::env::temp_dir().join("zeroshot-unsupported-workspace-leases.sqlite3");
+    assert_eq!(
+        SqliteWorkspaceLeaseStore::open(path).err().unwrap().kind(),
+        WorkspaceLeaseErrorKind::StoreUnavailable
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_connection_is_bound_to_verified_descriptor_during_path_swap_restore() {
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-connection-swap-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let aside = root.join("leases-expected-aside.sqlite3");
+    let replacement = root.join("leases-replacement.sqlite3");
+    let armed = Arc::new(AtomicBool::new(false));
+    let swapped = Arc::new(AtomicBool::new(false));
+    let unrelated_expected_descriptors = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let hooks = SqliteWorkspaceLeaseHooks {
+        before_connection_open: Some({
+            let armed = armed.clone();
+            let swapped = swapped.clone();
+            let database = database.clone();
+            let aside = aside.clone();
+            let replacement = replacement.clone();
+            Arc::new(move || {
+                if armed.swap(false, Ordering::SeqCst) {
+                    std::fs::rename(&database, &aside).unwrap();
+                    std::fs::rename(&replacement, &database).unwrap();
+                    swapped.store(true, Ordering::SeqCst);
+                }
+            })
+        }),
+        after_connection_open: Some({
+            let swapped = swapped.clone();
+            let database = database.clone();
+            let aside = aside.clone();
+            let replacement = replacement.clone();
+            let unrelated_expected_descriptors = unrelated_expected_descriptors.clone();
+            Arc::new(move || {
+                if swapped.swap(false, Ordering::SeqCst) {
+                    std::fs::rename(&database, &replacement).unwrap();
+                    std::fs::rename(&aside, &database).unwrap();
+                    unrelated_expected_descriptors
+                        .lock()
+                        .unwrap()
+                        .push(std::fs::File::open(&database).unwrap());
+                }
+            })
+        }),
+        ..SqliteWorkspaceLeaseHooks::default()
+    };
+    let store = Arc::new(SqliteWorkspaceLeaseStore::open_with_hooks(&database, hooks).unwrap());
+    std::fs::copy(&database, &replacement).unwrap();
+    let resources = Arc::new(FakeWorkspaceResourcePort::default());
+    let manager = WorkspaceLeaseManager::new(store.clone(), resources.clone());
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    armed.store(true, Ordering::SeqCst);
+
+    assert_eq!(
+        manager.prepare(request.clone()).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::StoreUnavailable
+    );
+    assert!(store.load(&id).await.unwrap().is_none());
+    let replacement_store = SqliteWorkspaceLeaseStore::open(&replacement).unwrap();
+    assert!(
+        replacement_store.load(&id).await.unwrap().is_none(),
+        "a transient replacement must never receive lease rows"
+    );
+    assert!(
+        resources.actions().is_empty(),
+        "a safely rejected descriptor swap must precede resource effects"
+    );
+    drop(replacement_store);
+
+    assert_eq!(
+        manager.prepare(request).await.unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    assert_eq!(
+        resources
+            .actions()
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Create)
+            .count(),
+        1
+    );
+    drop(manager);
+    drop(store);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_post_connection_open_identity_check_precedes_row_and_resource_effects() {
+    assert_post_boundary_identity_check(true).await;
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_post_operation_lock_identity_check_precedes_row_and_resource_effects() {
+    assert_post_boundary_identity_check(false).await;
+}
+
+#[cfg(target_os = "linux")]
+async fn assert_post_boundary_identity_check(after_connection_open: bool) {
+    let boundary = if after_connection_open {
+        "connection"
+    } else {
+        "operation-lock"
+    };
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-post-{boundary}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let hardlink = root.join("leases-hardlink.sqlite3");
+    let armed = Arc::new(AtomicBool::new(false));
+    let mutate_identity: Arc<dyn Fn() + Send + Sync> = {
+        let armed = armed.clone();
+        let database = database.clone();
+        let hardlink = hardlink.clone();
+        Arc::new(move || {
+            if armed.swap(false, Ordering::SeqCst) {
+                std::fs::hard_link(&database, &hardlink).unwrap();
+            }
+        })
+    };
+    let hooks = if after_connection_open {
+        SqliteWorkspaceLeaseHooks {
+            after_connection_open: Some(mutate_identity),
+            ..SqliteWorkspaceLeaseHooks::default()
+        }
+    } else {
+        SqliteWorkspaceLeaseHooks {
+            after_operation_lock: Some(mutate_identity),
+            ..SqliteWorkspaceLeaseHooks::default()
+        }
+    };
+    let store = Arc::new(SqliteWorkspaceLeaseStore::open_with_hooks(&database, hooks).unwrap());
+    let resources = Arc::new(FakeWorkspaceResourcePort::default());
+    let manager = WorkspaceLeaseManager::new(store.clone(), resources.clone());
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    armed.store(true, Ordering::SeqCst);
+
+    assert_eq!(
+        manager.prepare(request).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::StoreUnavailable
+    );
+    assert!(resources.actions().is_empty());
+    std::fs::remove_file(hardlink).unwrap();
+    assert!(store.load(&id).await.unwrap().is_none());
+    drop(manager);
+    drop(store);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_store_rejects_same_directory_hardlink_authority() {
+    assert_hardlink_alias_rejected(false).await;
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_store_rejects_cross_directory_hardlink_authority() {
+    assert_hardlink_alias_rejected(true).await;
+}
+
+#[cfg(target_os = "linux")]
+async fn assert_hardlink_alias_rejected(cross_directory: bool) {
+    let scope = if cross_directory { "cross" } else { "same" };
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-hardlink-{scope}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let store = SqliteWorkspaceLeaseStore::open(&database).unwrap();
+    let alias_parent = if cross_directory {
+        let parent = root.join("alias-directory");
+        std::fs::create_dir_all(&parent).unwrap();
+        parent
+    } else {
+        root.clone()
+    };
+    let alias = alias_parent.join("leases-hardlink.sqlite3");
+    std::fs::hard_link(&database, &alias).unwrap();
+
+    let alias_error = SqliteWorkspaceLeaseStore::open(&alias).err().unwrap();
+    assert_eq!(
+        alias_error.kind(),
+        WorkspaceLeaseErrorKind::StoreUnavailable
+    );
+    let id = WorkspaceLeaseId::derive(&docker_request("owner-a").key);
+    assert_eq!(
+        store.load(&id).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::StoreUnavailable
+    );
+
+    std::fs::remove_file(alias).unwrap();
+    assert!(store.load(&id).await.unwrap().is_none());
+    drop(store);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_direct_cleanup_recovers_uncertain_create_without_restart() {
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-direct-cleanup-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let store = Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap());
+    let resources = Arc::new(FakeWorkspaceResourcePort::default());
+    let manager = WorkspaceLeaseManager::new(store.clone(), resources.clone());
+    resources.fail_next_create(FakeEffectFailure::AfterEffect);
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: id.clone(),
+        owner: request.owner.clone(),
+    };
+    manager.prepare(request).await.unwrap_err();
+
+    resources.fail_next_cleanup(FakeEffectFailure::AfterEffect);
+    assert_eq!(
+        manager.cleanup(owner.clone()).await.unwrap_err().kind(),
+        WorkspaceLeaseErrorKind::ResourceUnavailable
+    );
+    assert_eq!(
+        store.load(&id).await.unwrap().unwrap().state,
+        WorkspaceLeaseState::CleanupRequired
+    );
+    assert_eq!(
+        manager.cleanup(owner).await.unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+    let actions = resources.actions();
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Create)
+            .count(),
+        1
+    );
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Cleanup)
+            .count(),
+        1
+    );
+    drop(manager);
+    drop(store);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[tokio::test]
+async fn uncertain_create_recovers_by_inspection_without_duplicate_create() {
+    let fixture = LeaseFixture::new();
+    fixture
+        .resources
+        .fail_next_create(FakeEffectFailure::AfterEffect);
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    fixture.manager.prepare(request).await.unwrap_err();
+
+    let restarted = WorkspaceLeaseManager::new(fixture.store.clone(), fixture.resources.clone());
+    let recovered = restarted
+        .restart(WorkspaceLeaseOwnerRequest {
+            id: id.clone(),
+            owner,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(recovered.state, WorkspaceLeaseState::Ready);
+    assert_eq!(
+        fixture
+            .resources
+            .actions()
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Create)
+            .count(),
+        1
+    );
+    assert_eq!(recovered.access().lease_key(), id.resource_id());
+}
+
+#[tokio::test]
+async fn absent_pending_resource_is_not_created_by_restart_inspection() {
+    let fixture = LeaseFixture::new();
+    fixture
+        .resources
+        .fail_next_create(FakeEffectFailure::BeforeEffect);
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    let owner = request.owner.clone();
+    fixture.manager.prepare(request).await.unwrap_err();
+
+    let recovered = fixture
+        .manager
+        .restart(WorkspaceLeaseOwnerRequest { id, owner })
+        .await
+        .unwrap();
+    assert_eq!(recovered.state, WorkspaceLeaseState::CreatePending);
+    assert_eq!(
+        fixture
+            .resources
+            .actions()
+            .iter()
+            .filter(|(_, action)| *action == FakeResourceAction::Create)
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn uncertain_cleanup_stays_inspectable_and_reconciles_both_outcomes() {
+    let before = LeaseFixture::new();
+    let ready = before
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+    before
+        .resources
+        .fail_next_cleanup(FakeEffectFailure::BeforeEffect);
+    before.manager.cleanup(owner.clone()).await.unwrap_err();
+    let inspected = before.manager.restart(owner.clone()).await.unwrap();
+    assert_eq!(inspected.state, WorkspaceLeaseState::CleanupRequired);
+    assert!(before.resources.contains(&ready.id));
+    assert_eq!(
+        before.manager.cleanup(owner).await.unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+
+    let after = LeaseFixture::new();
+    let ready = after
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+    after
+        .resources
+        .fail_next_cleanup(FakeEffectFailure::AfterEffect);
+    after.manager.cleanup(owner.clone()).await.unwrap_err();
+    assert!(!after.resources.contains(&ready.id));
+    assert_eq!(
+        after.manager.restart(owner).await.unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+}
+
+#[tokio::test]
+async fn inspection_failure_and_resource_mismatch_fail_closed() {
+    let fixture = LeaseFixture::new();
+    let ready = fixture
+        .manager
+        .prepare(docker_request("owner-a"))
+        .await
+        .unwrap();
+    fixture.resources.fail_next_inspect();
+    let error = fixture
+        .manager
+        .restart(WorkspaceLeaseOwnerRequest {
+            id: ready.id.clone(),
+            owner: ready.owner.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceUnavailable);
+    assert_eq!(
+        fixture.store.record(&ready.id).unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+    assert!(fixture.resources.contains(&ready.id));
+    fixture.resources.remove(&ready.id);
+    let error = fixture
+        .manager
+        .restart(WorkspaceLeaseOwnerRequest {
+            id: ready.id.clone(),
+            owner: ready.owner.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), WorkspaceLeaseErrorKind::ResourceUnavailable);
+    assert_eq!(
+        fixture.store.record(&ready.id).unwrap().state,
+        WorkspaceLeaseState::Ready
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_store_reopens_exact_cleanup_required_lease_with_a_fresh_instance() {
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-workspace-lease-store-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let resources = Arc::new(FakeWorkspaceResourcePort::default());
+    let manager = WorkspaceLeaseManager::new(
+        Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap()),
+        resources.clone(),
+    );
+    let ready = manager.prepare(docker_request("owner-a")).await.unwrap();
+    let owner = WorkspaceLeaseOwnerRequest {
+        id: ready.id.clone(),
+        owner: ready.owner.clone(),
+    };
+    resources.fail_next_cleanup(FakeEffectFailure::BeforeEffect);
+    manager.cleanup(owner.clone()).await.unwrap_err();
+    let expected = manager.restart(owner.clone()).await.unwrap();
+    assert_eq!(expected.state, WorkspaceLeaseState::CleanupRequired);
+    drop(manager);
+
+    let reopened = WorkspaceLeaseManager::new(
+        Arc::new(SqliteWorkspaceLeaseStore::open(&database).unwrap()),
+        resources,
+    );
+    let recovered = reopened.restart(owner.clone()).await.unwrap();
+    assert_eq!(recovered, expected);
+    assert_eq!(
+        reopened.cleanup(owner).await.unwrap().state,
+        WorkspaceLeaseState::Cleaned
+    );
+    drop(reopened);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn sqlite_store_enforces_exact_owner_state_revision_and_competing_cas() {
+    let fixture = LeaseFixture::new();
+    fixture
+        .resources
+        .fail_next_create(FakeEffectFailure::BeforeEffect);
+    let request = docker_request("owner-a");
+    let id = WorkspaceLeaseId::derive(&request.key);
+    fixture.manager.prepare(request).await.unwrap_err();
+    let pending = fixture.store.record(&id).unwrap();
+
+    let root = std::env::temp_dir().join(format!("zeroshot-workspace-cas-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let database = root.join("leases.sqlite3");
+    let store = SqliteWorkspaceLeaseStore::open(&database).unwrap();
+    store.create_pending(pending.clone()).await.unwrap();
+
+    let wrong_owner = store
+        .transition(WorkspaceLeaseTransition {
+            id: id.clone(),
+            owner: OwnerId::new("owner-b").unwrap(),
+            expected_revision: 0,
+            expected_state: WorkspaceLeaseState::CreatePending,
+            next_state: WorkspaceLeaseState::Ready,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(wrong_owner.kind(), WorkspaceLeaseErrorKind::OwnerMismatch);
+    assert_eq!(store.load(&id).await.unwrap(), Some(pending.clone()));
+
+    let stale_revision = store
+        .transition(WorkspaceLeaseTransition {
+            id: id.clone(),
+            owner: pending.owner.clone(),
+            expected_revision: 1,
+            expected_state: WorkspaceLeaseState::CreatePending,
+            next_state: WorkspaceLeaseState::Ready,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(stale_revision.kind(), WorkspaceLeaseErrorKind::Conflict);
+    assert_eq!(store.load(&id).await.unwrap(), Some(pending.clone()));
+
+    let stale_state = store
+        .transition(WorkspaceLeaseTransition {
+            id: id.clone(),
+            owner: pending.owner.clone(),
+            expected_revision: 0,
+            expected_state: WorkspaceLeaseState::Ready,
+            next_state: WorkspaceLeaseState::Cleaned,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(stale_state.kind(), WorkspaceLeaseErrorKind::Conflict);
+    assert_eq!(store.load(&id).await.unwrap(), Some(pending.clone()));
+
+    let illegal = store
+        .transition(WorkspaceLeaseTransition {
+            id: id.clone(),
+            owner: pending.owner.clone(),
+            expected_revision: 0,
+            expected_state: WorkspaceLeaseState::CreatePending,
+            next_state: WorkspaceLeaseState::CreatePending,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(illegal.kind(), WorkspaceLeaseErrorKind::Conflict);
+    assert_eq!(store.load(&id).await.unwrap(), Some(pending.clone()));
+    drop(store);
+
+    let first = SqliteWorkspaceLeaseStore::open(&database).unwrap();
+    let second = SqliteWorkspaceLeaseStore::open(&database).unwrap();
+    let ready = WorkspaceLeaseTransition {
+        id: id.clone(),
+        owner: pending.owner.clone(),
+        expected_revision: 0,
+        expected_state: WorkspaceLeaseState::CreatePending,
+        next_state: WorkspaceLeaseState::Ready,
+    };
+    let cleaned = WorkspaceLeaseTransition {
+        id: id.clone(),
+        owner: pending.owner.clone(),
+        expected_revision: 0,
+        expected_state: WorkspaceLeaseState::CreatePending,
+        next_state: WorkspaceLeaseState::Cleaned,
+    };
+    let (first_result, second_result) =
+        tokio::join!(first.transition(ready), second.transition(cleaned));
+    assert_ne!(first_result.is_ok(), second_result.is_ok());
+    let loser = if let Err(error) = first_result {
+        error
+    } else {
+        second_result.unwrap_err()
+    };
+    assert_eq!(loser.kind(), WorkspaceLeaseErrorKind::Conflict);
+    let persisted = SqliteWorkspaceLeaseStore::open(&database)
+        .unwrap()
+        .load(&id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(persisted.revision, 1);
+    assert!(matches!(
+        persisted.state,
+        WorkspaceLeaseState::Ready | WorkspaceLeaseState::Cleaned
+    ));
+    std::fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Closes #677

## Decision

Add one durable, owner-fenced `WorkspaceLeaseManager` for borrowed, managed-worktree, and Docker modes. Stable lease identity is derived from existing scheduler resource identity; `CreatePending` is committed before effects, and uncertain create/cleanup paths advance only after authoritative inspection.

Owned roots are Linux descriptor-relative capabilities below a private product base. Worktree publication uses owner-marked private staging, exact container shapes, atomic publication, and restart-reconciled quarantines. Borrowed roots are fingerprinted through a pinned descriptor and are never deleted. Docker defaults expose only pinned product-local mounts; home, Docker socket, and broad host paths are intentionally excluded. `docs/v2/parity-matrix.md` records this as replacing Node defaults and the resulting `git`/`gh`/`docker` compatibility break.

Source materialization receives a scoped, non-mintable, non-cloneable operation capability; no raw path or file descriptor escapes. SQLite lease storage is Linux-only and binds connections/operation locks to the verified database inode; other platforms fail before effects.

Linux has no identity-conditional directory rmdir by open file descriptor (`unlinkat(..., AT_EMPTY_PATH)` rejects directories). The enforceable boundary therefore serializes supported manager writers with the global lease operation fence under a private 0700 same-UID product root. Defending against an uncooperative same-UID namespace mutator requires a separate UID or broker and is outside this local-adapter issue; final removal still rechecks name and inode immediately before `unlinkat`.

## Verification

Focused targets, run first:
- `workspace_leases`: 11 top-level + 1 exact subprocess passed
- `workspace_recovery`: 12 passed
- `workspace_modes`: 20 passed
- `scheduler_contract`: 5 passed
- `local_process_runner`: 5 passed

Common gates:
- `npm run rust:check` — passed, including fmt, workspace Clippy `-D warnings`, and workspace tests
- `npm run protocol:check` — passed, no drift
- `npm run typecheck` — passed
- `npm run lint` — passed, 0 errors
- `npm run test:unit` — 2,115 passed, 18 pending, 0 failed
- `opcore check --changed` — passed

Two independent final verifiers reran the focused/common gates, mapped every acceptance criterion and non-goal, and returned PASS with no findings.