### PR TITLE
feat: add opt-in provider web search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Generated graph fixtures     | `protocol/openengine-cluster/v1/fixtures/graph/`                        |
 | Generated watch fixtures     | `protocol/openengine-cluster/v1/fixtures/watch/`                        |
 
+Provider-specific settings, defaults, validation, and static capabilities derive from the provider
+registry; do not add parallel provider lists. Opt-in native CLI capabilities must keep requested
+and effective state distinct and fail closed unless local help/version evidence proves the control.
+
 Cluster Protocol Rust types are the source of truth. Files under
 `protocol/openengine-cluster/v1/` are generated projections; update them with
 `cargo run -p openengine-cluster-testkit --bin generate-cluster-protocol -- --write` and

--- a/cli/commands/providers.js
+++ b/cli/commands/providers.js
@@ -138,6 +138,7 @@ async function setupCommand(args) {
     mutateSettings((settings) => {
       settings.providerSettings = settings.providerSettings || {};
       settings.providerSettings[provider] = {
+        ...(settings.providerSettings[provider] || {}),
         maxLevel: levelKeys[maxIdx - 1],
         minLevel: levelKeys[minIdx - 1],
         defaultLevel: levelKeys[defaultIdxNum - 1],

--- a/cli/index.js
+++ b/cli/index.js
@@ -2880,7 +2880,7 @@ taskCmd
     } catch (error) {
       console.error('Error:', error.message);
       const startupEnvelope = serializeTaskStartupError(error);
-      if (startupEnvelope) process.stderr.write(`${startupEnvelope}\n`);
+      if (startupEnvelope) fs.writeSync(process.stderr.fd, `${startupEnvelope}\n`);
       process.exit(1);
     }
   });

--- a/cli/index.js
+++ b/cli/index.js
@@ -69,6 +69,7 @@ const {
   startClusterFromText,
 } = require('../lib/start-cluster');
 const { requirePreflight } = require('../src/preflight');
+const { serializeTaskStartupError } = require('../src/task-startup-error');
 const { providersCommand, setDefaultCommand, setupCommand } = require('./commands/providers');
 const { runInspectCommand } = require('./commands/inspect');
 const { runCmdproof } = require('./commands/cmdproof');
@@ -2878,6 +2879,8 @@ taskCmd
       await runTask(prompt, options);
     } catch (error) {
       console.error('Error:', error.message);
+      const startupEnvelope = serializeTaskStartupError(error);
+      if (startupEnvelope) process.stderr.write(`${startupEnvelope}\n`);
       process.exit(1);
     }
   });

--- a/cli/index.js
+++ b/cli/index.js
@@ -2843,9 +2843,14 @@ taskCmd
   .option('--provider <provider>', `Provider to use (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
-  .option('--reasoning-effort <effort>', 'Reasoning effort (low, medium, high, xhigh, max)')
-  .option('-r, --resume <sessionId>', 'Resume a specific provider session (Claude or Codex)')
-  .option('-c, --continue', 'Continue the most recent Claude session (claude only)')
+  .option(
+    '-r, --resume <sessionId>',
+    'Resume a specific provider session (Claude, Codex, or OpenCode)'
+  )
+  .option(
+    '-c, --continue',
+    'Continue the most recent provider session (Claude or OpenCode)'
+  )
   .option(
     '-o, --output-format <format>',
     'Output format: stream-json (default), text, json',

--- a/cli/index.js
+++ b/cli/index.js
@@ -49,7 +49,13 @@ const {
   DEFAULT_SETTINGS,
   settingsFileExists,
 } = require('../lib/settings');
-const { VALID_PROVIDERS, normalizeProviderName } = require('../lib/provider-names');
+const {
+  VALID_PROVIDERS,
+  getProviderMetadata,
+  normalizeProviderName,
+  resolveProviderCommand,
+} = require('../lib/provider-names');
+const { commandExists } = require('../lib/provider-detection');
 const { getProvider, parseProviderChunk } = require('../src/providers');
 const { readClustersFileSync } = require('../lib/clusters-registry');
 const { MOUNT_PRESETS, resolveEnvs } = require('../lib/docker-config');
@@ -69,7 +75,10 @@ const {
   startClusterFromText,
 } = require('../lib/start-cluster');
 const { requirePreflight } = require('../src/preflight');
-const { serializeTaskStartupError } = require('../src/task-startup-error');
+const {
+  createUnsupportedProviderCapabilityError,
+  serializeTaskStartupError,
+} = require('../src/task-startup-error');
 const { providersCommand, setDefaultCommand, setupCommand } = require('./commands/providers');
 const { runInspectCommand } = require('./commands/inspect');
 const { runCmdproof } = require('./commands/cmdproof');
@@ -2836,6 +2845,24 @@ for (const mode of ['prove', 'verify', 'check']) {
     });
 }
 
+function assertRequestedWebSearchCliAvailable(
+  provider,
+  settings,
+  exists = commandExists
+) {
+  const metadata = getProviderMetadata(provider);
+  if (!metadata.settingsFields.includes('webSearch')) return;
+  if (settings.providerSettings?.[provider]?.webSearch !== true) return;
+  const { command } = resolveProviderCommand(provider);
+  if (exists(command)) return;
+  throw createUnsupportedProviderCapabilityError(
+    provider,
+    'webSearch',
+    `${metadata.displayName} web search was requested, but the ${command} CLI is not installed. ` +
+      `${metadata.installInstructions}. Install it or set providerSettings.${provider}.webSearch to false.`
+  );
+}
+
 taskCmd
   .command('run <prompt>')
   .description('Run a single-agent background task')
@@ -2843,6 +2870,10 @@ taskCmd
   .option('--provider <provider>', `Provider to use (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Model id override for the provider')
   .option('--model-level <level>', 'Model level override (level1, level2, level3)')
+  .option(
+    '--reasoning-effort <effort>',
+    'Reasoning effort override (low, medium, high, xhigh, max)'
+  )
   .option(
     '-r, --resume <sessionId>',
     'Resume a specific provider session (Claude, Codex, or OpenCode)'
@@ -2872,6 +2903,7 @@ taskCmd
       const providerOverride = normalizeProviderName(
         options.provider || process.env.ZEROSHOT_PROVIDER || settings.defaultProvider
       );
+      assertRequestedWebSearchCliAvailable(providerOverride, settings);
       await requirePreflight({
         requireGh: false, // gh not needed for plain tasks
         requireDocker: false, // Docker not needed for plain tasks
@@ -6018,6 +6050,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  assertRequestedWebSearchCliAvailable,
   applyModelOverrideToConfig,
   inspectAgentAttachment,
   printAttachableAgentList,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -66,9 +66,11 @@ Codex does **not** use `codex exec --search`: current `ExecCli` rejects that
 argument, while the top-level TUI flag does not configure noninteractive exec.
 The config override above matches the
 [Codex TypeScript SDK](https://github.com/openai/codex/blob/main/sdk/typescript/src/exec.ts)
-for fresh and resumed commands. OpenCode's environment control is documented by
-its [runtime flag](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/effect/runtime-flags.ts)
-and [web-search registration](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/tool/registry.ts).
+for fresh and resumed commands. OpenCode documents the environment control in
+its [web-search tool guide](https://opencode.ai/docs/tools/#websearch); the
+[versioned runtime flag](https://github.com/anomalyco/opencode/blob/v1.18.10/packages/opencode/src/effect/runtime-flags.ts)
+and [tool registration](https://github.com/anomalyco/opencode/blob/v1.18.10/packages/opencode/src/tool/registry.ts)
+show the corresponding bundled control.
 
 Claude, Gemini, Kiro, Copilot, Pi, and Gateway do not declare `webSearch`;
 setting it for those providers is rejected. No equally safe, explicit,

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -27,6 +27,55 @@ Zeroshot supports two provider shapes:
 - Override per run: `zeroshot run ... --provider <provider>`
 - Env override: `ZEROSHOT_PROVIDER=codex`
 
+## Opt-in native web search
+
+Native or bundled search is off by default. It can be enabled only for Codex or
+Opencode with strict boolean provider settings:
+
+```json
+{
+  "providerSettings": {
+    "codex": { "webSearch": true },
+    "opencode": { "webSearch": true }
+  }
+}
+```
+
+| Provider | Setting                                  | Canonical child control                          | Minimum CLI |
+| -------- | ---------------------------------------- | ------------------------------------------------ | ----------- |
+| Codex    | `providerSettings.codex.webSearch`       | `codex exec --config 'web_search="live"' ...`    | `0.146.0`   |
+| Opencode | `providerSettings.opencode.webSearch`    | command environment `OPENCODE_ENABLE_EXA=1`      | `1.0.137`   |
+
+Both settings default to `false`; absent and explicit `false` settings leave
+the child command and environment unchanged. Codex applies the config override
+before the prompt and, for a resumed session, before `resume`. Opencode applies
+the environment control to fresh `run` commands and to `run --session` or
+`run --continue`.
+
+Enabled mode fails closed before starting the provider when local support
+cannot be proved. Codex requires nonempty `codex exec --help` output advertising
+`--config` and a parseable version at or above `0.146.0`. Opencode requires a
+parseable version at or above `1.0.137`. Missing, malformed, or older versions
+are unsupported. These checks attest only the installed CLI control: they do
+not claim provider-account access, backend availability, or network reachability.
+Executable probe and build-command output report `supportsWebSearch` separately
+from `configuration.webSearch.requested` and `.effective`; effective is true
+only after local support proof.
+
+Codex does **not** use `codex exec --search`: current `ExecCli` rejects that
+argument, while the top-level TUI flag does not configure noninteractive exec.
+The config override above matches the
+[Codex TypeScript SDK](https://github.com/openai/codex/blob/main/sdk/typescript/src/exec.ts)
+for fresh and resumed commands. Opencode's environment control is documented by
+its [runtime flag](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/effect/runtime-flags.ts)
+and [web-search registration](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/tool/registry.ts).
+
+Claude, Gemini, Kiro, Copilot, Pi, and Gateway do not declare `webSearch`;
+setting it for those providers is rejected. No equally safe, explicit,
+support-detectable additive native-search control is established for them.
+Permission or tool allowlists authorize already-present tools; they must not be
+presented as controls that enable search.
+
 ## Gateway Provider
 
 Use `gateway` for OpenAI-compatible or Anthropic-compatible model endpoints.
@@ -144,9 +193,9 @@ Configured IDs must use Opencode's `provider/model` shape. Nested model paths
 such as `openrouter/anthropic/claude-sonnet-4` are accepted; whitespace and
 empty path segments are rejected before Opencode is started. Direct agent
 `model` fields remain limited to the built-in catalog. Nested Docker tasks
-receive only a temporary settings-file projection for the requested level and
-model; arbitrary provider settings and environment overlays are not trusted or
-forwarded to the provider process.
+receive only a temporary settings-file projection for the requested level/model
+and an explicitly enabled declared `webSearch`; arbitrary provider settings and
+environment overlays are not trusted or forwarded to the provider process.
 
 ### Current explicit model IDs
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,7 +30,7 @@ Zeroshot supports two provider shapes:
 ## Opt-in native web search
 
 Native or bundled search is off by default. It can be enabled only for Codex or
-Opencode with strict boolean provider settings:
+OpenCode with strict boolean provider settings:
 
 ```json
 {
@@ -44,17 +44,17 @@ Opencode with strict boolean provider settings:
 | Provider | Setting                                  | Canonical child control                          | Minimum CLI |
 | -------- | ---------------------------------------- | ------------------------------------------------ | ----------- |
 | Codex    | `providerSettings.codex.webSearch`       | `codex exec --config 'web_search="live"' ...`    | `0.146.0`   |
-| Opencode | `providerSettings.opencode.webSearch`    | command environment `OPENCODE_ENABLE_EXA=1`      | `1.0.137`   |
+| OpenCode | `providerSettings.opencode.webSearch`    | command environment `OPENCODE_ENABLE_EXA=1`      | `1.0.137`   |
 
 Both settings default to `false`; absent and explicit `false` settings leave
 the child command and environment unchanged. Codex applies the config override
-before the prompt and, for a resumed session, before `resume`. Opencode applies
+before the prompt and, for a resumed session, before `resume`. OpenCode applies
 the environment control to fresh `run` commands and to `run --session` or
 `run --continue`.
 
 Enabled mode fails closed before starting the provider when local support
 cannot be proved. Codex requires nonempty `codex exec --help` output advertising
-`--config` and a parseable version at or above `0.146.0`. Opencode requires a
+`--config` and a parseable version at or above `0.146.0`. OpenCode requires a
 parseable version at or above `1.0.137`. Missing, malformed, or older versions
 are unsupported. These checks attest only the installed CLI control: they do
 not claim provider-account access, backend availability, or network reachability.
@@ -66,7 +66,7 @@ Codex does **not** use `codex exec --search`: current `ExecCli` rejects that
 argument, while the top-level TUI flag does not configure noninteractive exec.
 The config override above matches the
 [Codex TypeScript SDK](https://github.com/openai/codex/blob/main/sdk/typescript/src/exec.ts)
-for fresh and resumed commands. Opencode's environment control is documented by
+for fresh and resumed commands. OpenCode's environment control is documented by
 its [runtime flag](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/effect/runtime-flags.ts)
 and [web-search registration](https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/tool/registry.ts).
 

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -1,3 +1,4 @@
+import { UnsupportedProviderCapabilityError } from '../errors';
 import { getString, isRecord, tryParseJson } from '../json';
 import { appendJsonSchemaPrompt, writeStrictOutputSchemaFile } from '../schema';
 import {
@@ -17,6 +18,7 @@ import {
   classifyBaseProviderError,
   commandSpec,
   createParserState,
+  isCliVersionAtLeast,
   optionFeatures,
   resolveModelSpecWithConfig,
   validateModelIdFromCatalog,
@@ -46,19 +48,25 @@ function supports(help: string, pattern: RegExp): boolean {
   return help ? pattern.test(help) : true;
 }
 
-function detectCliFeatures(helpText?: string | null): CodexCliFeatures {
+function detectCliFeatures(
+  helpText?: string | null,
+  versionText?: string | null
+): CodexCliFeatures {
   const help = helpText ?? '';
   const unknown = !help;
+  const supportsConfigOverride = supports(help, /--config\b/);
   return {
     provider: 'codex',
     supportsJson: supports(help, /--json\b/),
     supportsOutputSchema: supports(help, /--output-schema\b/),
     supportsAutoApprove: supports(help, /--dangerously-bypass-approvals-and-sandbox\b/),
     supportsCwd: supports(help, /\s-C\b/) || supports(help, /--cwd\b/),
-    supportsConfigOverride: supports(help, /--config\b/),
+    supportsConfigOverride,
     supportsModel: supports(help, /\s-m\b/) || supports(help, /--model\b/),
     supportsSkipGitRepoCheck: supports(help, /--skip-git-repo-check\b/),
     supportsResume: supports(help, /\bresume\b/),
+    supportsWebSearch:
+      !unknown && supportsConfigOverride && isCliVersionAtLeast(versionText, '0.146.0'),
     unknown,
   };
 }
@@ -178,6 +186,18 @@ function collectWarnings(options: BuildProviderCommandOptions): WarningMetadata[
   return warnings;
 }
 
+function addWebSearchArgs(args: string[], options: BuildProviderCommandOptions): void {
+  if (options.webSearch !== true) return;
+  if (optionFeatures(options).supportsWebSearch !== true) {
+    throw new UnsupportedProviderCapabilityError(
+      'codex',
+      'webSearch',
+      'Codex web search requires nonempty `codex exec --help` support for `--config` and a parseable Codex CLI version >= 0.146.0. Update @openai/codex or set providerSettings.codex.webSearch to false.'
+    );
+  }
+  args.push('--config', 'web_search="live"');
+}
+
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
   if (options.resumeSessionId && optionFeatures(options).supportsResume === false) {
     throw new Error(
@@ -190,6 +210,7 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
     options.resumeSessionId && optionFeatures(options).supportsResume !== false
       ? options.resumeSessionId
       : null;
+  addWebSearchArgs(args, options);
   if (resumeSessionId) {
     args.push('resume');
   }

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -125,7 +125,7 @@ export function optionFeatures(
 }
 
 export function isCliVersionAtLeast(versionText: string | null | undefined, floor: string): boolean {
-  const actualMatch = /(?:^|[^\d.])v?(\d+)\.(\d+)\.(\d+)(?![\d.-])/.exec(
+  const actualMatch = /(?:^|[^\w.])v?(\d+)\.(\d+)\.(\d+)(?![\w.-])/.exec(
     versionText ?? ''
   );
   const floorMatch = /^(\d+)\.(\d+)\.(\d+)$/.exec(floor);

--- a/src/agent-cli-provider/adapters/common.ts
+++ b/src/agent-cli-provider/adapters/common.ts
@@ -123,3 +123,17 @@ export function optionFeatures(
 ): CliFeatureOverrides {
   return options?.cliFeatures ?? {};
 }
+
+export function isCliVersionAtLeast(versionText: string | null | undefined, floor: string): boolean {
+  const actualMatch = /(?:^|[^\d.])v?(\d+)\.(\d+)\.(\d+)(?![\d.-])/.exec(
+    versionText ?? ''
+  );
+  const floorMatch = /^(\d+)\.(\d+)\.(\d+)$/.exec(floor);
+  if (!actualMatch || !floorMatch) return false;
+  for (let index = 1; index <= 3; index += 1) {
+    const actual = Number(actualMatch[index]);
+    const minimum = Number(floorMatch[index]);
+    if (actual !== minimum) return actual > minimum;
+  }
+  return true;
+}

--- a/src/agent-cli-provider/adapters/index.ts
+++ b/src/agent-cli-provider/adapters/index.ts
@@ -1,5 +1,11 @@
 import { stripTimestampPrefix } from '../log-prefix';
-import { getProviderRegistryEntry, normalizeProviderName, providerIds } from '../provider-registry';
+import { UnsupportedProviderCapabilityError } from '../errors';
+import {
+  getProviderRegistryEntry,
+  normalizeProviderName,
+  providerIds,
+  supportsProviderCapability,
+} from '../provider-registry';
 import type {
   BuildProviderCommandOptions,
   CommandSpec,
@@ -52,7 +58,15 @@ export function buildProviderCommand(
   context: string,
   options?: BuildProviderCommandOptions
 ): CommandSpec {
-  return getProviderAdapter(providerName).buildCommand(context, options);
+  const adapter = getProviderAdapter(providerName);
+  if (options?.webSearch !== undefined && !supportsProviderCapability(adapter.id, 'webSearch')) {
+    throw new UnsupportedProviderCapabilityError(
+      adapter.id,
+      'webSearch',
+      `Provider ${adapter.id} does not expose provider-controlled native web search; remove options.webSearch.`
+    );
+  }
+  return adapter.buildCommand(context, options);
 }
 
 export function parseProviderChunk(

--- a/src/agent-cli-provider/adapters/opencode.ts
+++ b/src/agent-cli-provider/adapters/opencode.ts
@@ -48,7 +48,7 @@ function detectCliFeatures(
     supportsDir: unknown ? false : /--dir\b/.test(help),
     supportsCwd: unknown ? false : /--cwd\b/.test(help),
     supportsAutoApprove: false,
-    supportsResume: unknown ? true : /--session\b/.test(help) && /--continue\b/.test(help),
+    supportsResume: !unknown && /--session\b/.test(help) && /--continue\b/.test(help),
     supportsWebSearch: isCliVersionAtLeast(versionText, '1.0.137'),
     unknown,
   };

--- a/src/agent-cli-provider/adapters/opencode.ts
+++ b/src/agent-cli-provider/adapters/opencode.ts
@@ -130,7 +130,7 @@ function webSearchEnv(options: BuildProviderCommandOptions): Readonly<Record<str
     throw new UnsupportedProviderCapabilityError(
       'opencode',
       'webSearch',
-      'Opencode web search requires a parseable Opencode CLI version >= 1.0.137. Update Opencode or set providerSettings.opencode.webSearch to false.'
+      'OpenCode web search requires a parseable OpenCode CLI version >= 1.0.137. Update OpenCode or set providerSettings.opencode.webSearch to false.'
     );
   }
   return { OPENCODE_ENABLE_EXA: '1' };

--- a/src/agent-cli-provider/adapters/opencode.ts
+++ b/src/agent-cli-provider/adapters/opencode.ts
@@ -1,3 +1,5 @@
+import { contractError } from '../contract-errors';
+import { UnsupportedProviderCapabilityError } from '../errors';
 import { appendJsonSchemaPrompt } from '../schema';
 import {
   getNumber,
@@ -20,8 +22,8 @@ import {
   classifyBaseProviderError,
   commandSpec,
   createParserState,
+  isCliVersionAtLeast,
   optionFeatures,
-  unsupportedSessionControlWarnings,
   warning,
 } from './common';
 import {
@@ -32,7 +34,10 @@ import {
   validateModelId,
 } from './opencode-models';
 
-function detectCliFeatures(helpText?: string | null): OpencodeCliFeatures {
+function detectCliFeatures(
+  helpText?: string | null,
+  versionText?: string | null
+): OpencodeCliFeatures {
   const help = helpText ?? '';
   const unknown = !help;
   return {
@@ -43,6 +48,8 @@ function detectCliFeatures(helpText?: string | null): OpencodeCliFeatures {
     supportsDir: unknown ? false : /--dir\b/.test(help),
     supportsCwd: unknown ? false : /--cwd\b/.test(help),
     supportsAutoApprove: false,
+    supportsResume: unknown ? true : /--session\b/.test(help) && /--continue\b/.test(help),
+    supportsWebSearch: isCliVersionAtLeast(versionText, '1.0.137'),
     unknown,
   };
 }
@@ -76,7 +83,7 @@ function addOpencodeOptionalArgs(args: string[], options: BuildProviderCommandOp
 
 function collectOpencodeWarnings(options: BuildProviderCommandOptions): WarningMetadata[] {
   const features = optionFeatures(options);
-  const warnings: WarningMetadata[] = unsupportedSessionControlWarnings('opencode', options);
+  const warnings: WarningMetadata[] = [];
   if (options.modelSpec?.reasoningEffort && features.supportsVariant === false) {
     warnings.push(
       warning(
@@ -89,19 +96,67 @@ function collectOpencodeWarnings(options: BuildProviderCommandOptions): WarningM
   return warnings;
 }
 
+function addSessionArgs(args: string[], options: BuildProviderCommandOptions): void {
+  const hasResumeSessionId = options.resumeSessionId !== undefined;
+  if (!hasResumeSessionId && !options.continueSession) return;
+  const field = hasResumeSessionId ? 'options.resumeSessionId' : 'options.continueSession';
+  if (hasResumeSessionId && options.resumeSessionId?.trim().length === 0) {
+    throw contractError({
+      code: 'invalid-field',
+      field,
+      exitCode: 2,
+      message: 'options.resumeSessionId must be a non-empty OpenCode session ID.',
+    });
+  }
+  if (optionFeatures(options).supportsResume === false) {
+    throw contractError({
+      code: 'invalid-field',
+      field,
+      exitCode: 2,
+      message:
+        'OpenCode CLI cannot safely run continuation context because this installation lacks run --session/--continue.',
+    });
+  }
+  if (options.resumeSessionId) {
+    args.push('--session', options.resumeSessionId);
+  } else {
+    args.push('--continue');
+  }
+}
+
+function webSearchEnv(options: BuildProviderCommandOptions): Readonly<Record<string, string>> {
+  if (options.webSearch !== true) return {};
+  if (optionFeatures(options).supportsWebSearch !== true) {
+    throw new UnsupportedProviderCapabilityError(
+      'opencode',
+      'webSearch',
+      'Opencode web search requires a parseable Opencode CLI version >= 1.0.137. Update Opencode or set providerSettings.opencode.webSearch to false.'
+    );
+  }
+  return { OPENCODE_ENABLE_EXA: '1' };
+}
+
+function extractSessionId(line: string): string | null {
+  const event = tryParseJson(line.trim());
+  if (!isRecord(event)) return null;
+  const sessionId = getString(event, 'sessionID') ?? getString(event, 'sessionId');
+  return sessionId?.trim() || null;
+}
+
 function buildCommand(context: string, options: BuildProviderCommandOptions = {}): CommandSpec {
   const finalContext = options.jsonSchema
     ? appendJsonSchemaPrompt(context, options.jsonSchema)
     : context;
   const args: string[] = ['run'];
   addOpencodeOptionalArgs(args, options);
+  addSessionArgs(args, options);
 
   args.push(finalContext);
 
   return commandSpec({
     binary: 'opencode',
     args,
-    env: {},
+    env: webSearchEnv(options),
     ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
     warnings: collectOpencodeWarnings(options),
   });
@@ -226,6 +281,7 @@ export const opencodeAdapter: ProviderAdapter = {
   defaultMinLevel: 'level1',
   detectCliFeatures,
   buildCommand,
+  extractSessionId,
   parseEvent,
   createParserState: () => createParserState('opencode'),
   resolveModelSpec,

--- a/src/agent-cli-provider/contract-actions.ts
+++ b/src/agent-cli-provider/contract-actions.ts
@@ -23,6 +23,10 @@ import type { ProcessRunner } from './process-runner';
 
 function runBuildCommand(request: RequestData): ContractEnvelope {
   const { adapter, commandSpec, options } = buildCommandSpec(request);
+  const webSearch = {
+    requested: options.webSearch === true,
+    effective: options.webSearch === true && options.cliFeatures?.supportsWebSearch === true,
+  };
   return successEnvelope({
     command: request.command ?? 'build-command',
     adapter,
@@ -31,11 +35,13 @@ function runBuildCommand(request: RequestData): ContractEnvelope {
     evidence: {
       outputFormat: options.outputFormat ?? null,
       schemaMode: schemaMode(options),
+      configuration: { webSearch },
     },
     result: {
       commandSpec,
       outputFormat: options.outputFormat ?? null,
       schemaMode: schemaMode(options),
+      configuration: { webSearch },
     },
   });
 }
@@ -43,11 +49,15 @@ function runBuildCommand(request: RequestData): ContractEnvelope {
 function runProbe(request: RequestData): ContractEnvelope {
   const adapter = adapterForProvider(request.provider);
   const helpText = typeof request.raw.helpText === 'string' ? request.raw.helpText : null;
-  const runtimeProbe = helpText === null ? probeRuntimeProviderCli(adapter.id) : null;
-  const capabilities =
-    runtimeProbe === null
-      ? adapter.detectCliFeatures(helpText)
-      : runtimeProbe.capabilities;
+  const versionText = typeof request.raw.versionText === 'string' ? request.raw.versionText : '';
+  const runtimeProbe =
+    helpText === null
+      ? probeRuntimeProviderCli(adapter.id)
+      : probeRuntimeProviderCli(adapter.id, {
+          available: true,
+          helpText,
+          versionText,
+        });
   return successEnvelope({
     command: request.command ?? 'probe',
     adapter,
@@ -60,10 +70,11 @@ function runProbe(request: RequestData): ContractEnvelope {
       },
       contractVersion: providerExecutableSchemaVersion,
       adapterVersion: adapter.adapterVersion,
-      available: runtimeProbe?.available ?? true,
-      helpText: runtimeProbe?.helpText ?? helpText,
-      versionText: runtimeProbe?.versionText ?? null,
-      capabilities,
+      available: runtimeProbe.available,
+      helpText: runtimeProbe.helpText,
+      versionText: runtimeProbe.versionText,
+      capabilities: runtimeProbe.capabilities,
+      configuration: runtimeProbe.configuration,
       credentials: adapter.credentialEnvKeys.map((key) => ({
         key,
         present: Boolean(request.env[key] ?? process.env[key]),

--- a/src/agent-cli-provider/contract-fallback.ts
+++ b/src/agent-cli-provider/contract-fallback.ts
@@ -6,6 +6,7 @@ import {
   type ContractErrorObject,
   type ContractEnvelope,
 } from './contract-envelope';
+import { UnsupportedProviderCapabilityError } from './errors';
 import { getString, isRecord, parseJson, unknownToMessage } from './json';
 import { mergeRedactions, redactString } from './redaction';
 import type { ProviderAdapter } from './types';
@@ -77,6 +78,14 @@ function errorObject(requestError: ContractRequestError): ContractErrorObject {
 
 export function requestErrorFromUnknown(error: unknown): ContractRequestError {
   if (error instanceof ContractRequestError) return error;
+  if (error instanceof UnsupportedProviderCapabilityError) {
+    return contractError({
+      code: error.code,
+      message: error.message,
+      exitCode: 4,
+      field: 'options.webSearch',
+    });
+  }
   return contractError({
     code: 'internal-error',
     message: unknownToMessage(error),

--- a/src/agent-cli-provider/contract-options.ts
+++ b/src/agent-cli-provider/contract-options.ts
@@ -44,6 +44,7 @@ const CLI_FEATURE_FIELDS = [
   'supportsAddDir',
   'supportsMcpConfig',
   'supportsResume',
+  'supportsWebSearch',
   'supportsBundledRunner',
   'supportsAcpStdio',
   'supportsPromptImages',
@@ -210,6 +211,7 @@ function normalizeBuildOptions(value: Record<string, unknown>): BuildProviderCom
     'continueSession',
     optionalBooleanValue(value.continueSession, 'options.continueSession')
   );
+  addDefined(result, 'webSearch', optionalBooleanValue(value.webSearch, 'options.webSearch'));
   addDefined(
     result,
     'claudeSettingsFile',

--- a/src/agent-cli-provider/errors.ts
+++ b/src/agent-cli-provider/errors.ts
@@ -1,6 +1,20 @@
 import { getNumber, getRecord, getString, isRecord, unknownToMessage } from './json';
 import type { ErrorClassification } from './types';
 
+export class UnsupportedProviderCapabilityError extends Error {
+  readonly code = 'unsupported-capability';
+  readonly permanent = true;
+  readonly provider: string;
+  readonly capability: string;
+
+  constructor(provider: string, capability: string, message: string) {
+    super(message);
+    this.name = 'UnsupportedProviderCapabilityError';
+    this.provider = provider;
+    this.capability = capability;
+  }
+}
+
 const BASE_RETRYABLE_PATTERNS: readonly RegExp[] = [
   /rate.?limit/i,
   /\b429\b/i,

--- a/src/agent-cli-provider/index.ts
+++ b/src/agent-cli-provider/index.ts
@@ -102,6 +102,7 @@ export type {
   ToolCallEvent,
   ToolResultEvent,
   WarningMetadata,
+  WebSearchAttestation,
 } from './types';
 
 import type { AgentCliProviderHelperMetadata } from './types';

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -20,6 +20,7 @@ export interface ProviderCapabilities {
   readonly thinkingMode: ProviderCapabilityState;
   readonly reasoningEffort: ProviderCapabilityState;
   readonly sessionResume: ProviderCapabilityState;
+  readonly webSearch: ProviderCapabilityState;
 }
 
 interface FixedProviderCommandSpec {
@@ -102,6 +103,7 @@ const STANDARD_CAPABILITIES: Readonly<
     | 'streamJson'
     | 'thinkingMode'
     | 'sessionResume'
+    | 'webSearch'
   >
 > = {
   dockerIsolation: true,
@@ -110,6 +112,7 @@ const STANDARD_CAPABILITIES: Readonly<
   streamJson: true,
   thinkingMode: true,
   sessionResume: false,
+  webSearch: false,
 };
 
 const CLAUDE_DOCKER_ENV_PASSTHROUGH = [
@@ -203,12 +206,15 @@ export const providerRegistry = [
     authInstructions: 'codex login',
     credentialPaths: ['~/.config/codex', '~/.codex'],
     credentialEnvKeys: codexAdapter.credentialEnvKeys,
-    settingsFields: [],
+    settingsFields: ['webSearch'],
+    settingsDefaults: { webSearch: false },
+    settingsValidator: (settings) => validateWebSearchSettings('codex', settings),
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
       reasoningEffort: true,
       sessionResume: true,
+      webSearch: true,
     },
     docs: {
       label: 'Codex',
@@ -326,11 +332,15 @@ export const providerRegistry = [
     authInstructions: 'opencode auth login',
     credentialPaths: ['~/.local/share/opencode'],
     credentialEnvKeys: opencodeAdapter.credentialEnvKeys,
-    settingsFields: [],
+    settingsFields: ['webSearch'],
+    settingsDefaults: { webSearch: false },
+    settingsValidator: (settings) => validateWebSearchSettings('opencode', settings),
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: 'experimental',
       reasoningEffort: true,
+      sessionResume: true,
+      webSearch: true,
     },
     docs: {
       label: 'Opencode',
@@ -471,6 +481,14 @@ export const providerRegistry = [
     adapter: copilotAdapter,
   },
 ] as const satisfies readonly ProviderRegistryEntry[];
+
+function validateWebSearchSettings(
+  provider: 'codex' | 'opencode',
+  settings: Record<string, unknown>
+): string | null {
+  if (settings.webSearch === undefined || typeof settings.webSearch === 'boolean') return null;
+  return `providerSettings.${provider}.webSearch must be a boolean`;
+}
 
 type RegistryProviderId = (typeof providerRegistry)[number]['id'];
 type RegistryProviderAlias = (typeof providerRegistry)[number]['aliases'][number];

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -208,7 +208,7 @@ export const providerRegistry = [
     credentialEnvKeys: codexAdapter.credentialEnvKeys,
     settingsFields: ['webSearch'],
     settingsDefaults: { webSearch: false },
-    settingsValidator: (settings) => validateWebSearchSettings('codex', settings),
+    settingsValidator: (settings): string | null => validateWebSearchSettings('codex', settings),
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
@@ -334,7 +334,7 @@ export const providerRegistry = [
     credentialEnvKeys: opencodeAdapter.credentialEnvKeys,
     settingsFields: ['webSearch'],
     settingsDefaults: { webSearch: false },
-    settingsValidator: (settings) => validateWebSearchSettings('opencode', settings),
+    settingsValidator: (settings): string | null => validateWebSearchSettings('opencode', settings),
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: 'experimental',

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -1,4 +1,5 @@
 import { getProviderAdapter } from './adapters';
+import { UnsupportedProviderCapabilityError } from './errors';
 import { normalizeGatewayBuildOptions, resolveGatewayConfiguration } from './gateway-tools';
 import { isRecord } from './json';
 import {
@@ -19,6 +20,7 @@ import type {
   ProviderId,
   ResolvedGatewayBuildOptions,
   ReasoningEffort,
+  WebSearchAttestation,
 } from './types';
 
 type UnknownFunction = (...args: readonly unknown[]) => unknown;
@@ -32,6 +34,7 @@ interface RuntimeProviderSettings {
   readonly defaultLevel?: ModelLevel;
   readonly levelOverrides: LevelOverrides;
   readonly gateway?: GatewayBuildOptions;
+  readonly webSearch?: boolean;
 }
 
 interface RuntimeCommandContext {
@@ -50,6 +53,9 @@ export interface PreparedSingleAgentProviderCommand {
   readonly commandSpec: CommandSpec;
   readonly options: BuildProviderCommandOptions;
   readonly cliFeatures: CliFeatureOverrides;
+  readonly configuration: {
+    readonly webSearch: WebSearchAttestation;
+  };
 }
 
 export interface RuntimeProviderProbe {
@@ -57,6 +63,15 @@ export interface RuntimeProviderProbe {
   readonly helpText: string;
   readonly versionText: string;
   readonly capabilities: ProviderCliFeatures;
+  readonly configuration: {
+    readonly webSearch: WebSearchAttestation;
+  };
+}
+
+interface RuntimeProbeEvidence {
+  readonly available?: boolean;
+  readonly helpText: string;
+  readonly versionText: string;
 }
 
 type MutableModelSpec = {
@@ -101,6 +116,9 @@ export function prepareSingleAgentProviderCommand(
     adapter,
     options,
     cliFeatures,
+    configuration: {
+      webSearch: webSearchAttestation(options),
+    },
     commandSpec: adapter.buildCommand(input.context, options),
   };
 }
@@ -113,20 +131,27 @@ function resolveRuntimeCliFeatures(
   provider: ProviderId,
   overrides: CliFeatureOverrides | undefined
 ): CliFeatureOverrides {
+  const detected = detectRuntimeProviderCliFeatures(provider);
   if (provider === 'gateway') {
     return {
-      ...detectRuntimeProviderCliFeatures(provider),
+      ...detected,
       ...overrides,
       supportsBundledRunner: true,
+      supportsWebSearch: false,
     };
   }
-  if (getProviderRegistryEntry(provider).invoke.lane !== 'acp-stdio') {
-    return overrides ?? detectRuntimeProviderCliFeatures(provider);
+  if (getProviderRegistryEntry(provider).invoke.lane === 'acp-stdio') {
+    if (overrides === undefined) return detected;
+    return mergeAcpFailClosedCliFeatures(detected, overrides);
   }
-
-  const detected = detectRuntimeProviderCliFeatures(provider);
   if (overrides === undefined) return detected;
-  return mergeAcpFailClosedCliFeatures(detected, overrides);
+  const merged = { ...detected, ...overrides };
+  if (!('supportsWebSearch' in detected)) return merged;
+  return {
+    ...merged,
+    supportsWebSearch:
+      detected.supportsWebSearch === true && overrides.supportsWebSearch !== false,
+  };
 }
 
 function mergeAcpFailClosedCliFeatures(
@@ -154,33 +179,61 @@ function mergeAcpFailClosedCliFeatures(
   };
 }
 
-export function probeRuntimeProviderCli(provider: string): RuntimeProviderProbe {
+export function probeRuntimeProviderCli(
+  provider: string,
+  evidence?: RuntimeProbeEvidence
+): RuntimeProviderProbe {
   const adapter = getProviderAdapter(provider);
   if (adapter.id === 'gateway') {
     return probeGatewayProvider(adapter);
   }
+  const requested = getProviderRegistryEntry(adapter.id).settingsFields.includes('webSearch')
+    ? runtimeProviderSettings(loadRuntimeSettings(), adapter.id, process.cwd()).webSearch === true
+    : false;
   const helpCommand = runtimeHelpCommand(adapter.id);
-  const commandAvailable = booleanResult(commandExistsFn(helpCommand.command));
+  const commandAvailable =
+    evidence === undefined
+      ? booleanResult(commandExistsFn(helpCommand.command))
+      : evidence.available !== false;
   if (!commandAvailable) {
+    const capabilities = attestedCliFeatures(adapter, '', '');
     return {
       available: false,
       helpText: '',
       versionText: '',
-      capabilities: adapter.detectCliFeatures(''),
+      capabilities,
+      configuration: {
+        webSearch: webSearchAttestation({ webSearch: requested, cliFeatures: capabilities }),
+      },
     };
   }
 
-  const helpText = stringResult(getHelpOutputFn(helpCommand.command, helpCommand.args)).trim();
-  const versionText = stringResult(
-    getVersionOutputFn(helpCommand.command, helpCommand.args)
-  ).trim();
+  const helpText =
+    evidence?.helpText ??
+    stringResult(getHelpOutputFn(helpCommand.command, helpCommand.args)).trim();
+  const versionText =
+    evidence?.versionText ??
+    stringResult(
+      getVersionOutputFn(
+        helpCommand.command,
+        getProviderRegistryEntry(adapter.id).capabilities.webSearch === true
+          ? []
+          : helpCommand.args
+      )
+    ).trim();
   const availabilityProbe = getProviderRegistryEntry(adapter.id).availabilityProbe ?? 'command';
+  const capabilities = attestedCliFeatures(adapter, helpText, versionText);
 
   return {
-    available: availabilityProbe === 'help-or-version' ? Boolean(helpText || versionText) : true,
+    available:
+      evidence?.available ??
+      (availabilityProbe === 'help-or-version' ? Boolean(helpText || versionText) : true),
     helpText,
     versionText,
-    capabilities: adapter.detectCliFeatures(helpText),
+    capabilities,
+    configuration: {
+      webSearch: webSearchAttestation({ webSearch: requested, cliFeatures: capabilities }),
+    },
   };
 }
 
@@ -197,10 +250,13 @@ function buildRuntimeOptions(
     providerSettings,
     modelSpec
   );
+  const webSearch = baseOptions.webSearch ?? providerSettings.webSearch;
+  assertWebSearchDeclared(adapter.id, webSearch);
   const resolved = {
     ...baseOptions,
     modelSpec,
     ...(gateway === undefined ? {} : { gateway }),
+    ...(webSearch === undefined ? {} : { webSearch }),
     cliFeatures: runtime.cliFeatures,
   };
   if (baseOptions.jsonSchema && !supportsProviderCapability(adapter.id, 'jsonSchema')) {
@@ -320,16 +376,20 @@ function runtimeProviderSettings(
     providerSettings.levelOverrides,
     `settings.providerSettings.${provider}.levelOverrides`
   );
+  const webSearch = optionalBoolean(
+    providerSettings.webSearch,
+    `settings.providerSettings.${provider}.webSearch`
+  );
   const gateway =
     provider === 'gateway'
       ? normalizeGatewayBuildOptions(providerSettings, 'settings.providerSettings.gateway', cwd)
       : undefined;
-  if (defaultLevel === undefined) {
-    return gateway === undefined ? { levelOverrides } : { levelOverrides, gateway };
-  }
-  return gateway === undefined
-    ? { defaultLevel, levelOverrides }
-    : { defaultLevel, levelOverrides, gateway };
+  const base = {
+    levelOverrides,
+    ...(gateway === undefined ? {} : { gateway }),
+    ...(webSearch === undefined ? {} : { webSearch }),
+  };
+  return defaultLevel === undefined ? base : { ...base, defaultLevel };
 }
 
 function runtimeHelpCommand(provider: ProviderId): CommandParts {
@@ -340,7 +400,7 @@ function runtimeHelpCommand(provider: ProviderId): CommandParts {
 }
 
 function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
-  const capabilities = adapter.detectCliFeatures('');
+  const capabilities = attestedCliFeatures(adapter, '', '');
   try {
     const settings = loadRuntimeSettings();
     const providerSettings = runtimeProviderSettings(settings, 'gateway', process.cwd());
@@ -354,6 +414,9 @@ function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
       helpText: 'Bundled gateway runner',
       versionText: process.version,
       capabilities,
+      configuration: {
+        webSearch: { requested: false, effective: false },
+      },
     };
   } catch {
     return {
@@ -361,8 +424,47 @@ function probeGatewayProvider(adapter: ProviderAdapter): RuntimeProviderProbe {
       helpText: 'Bundled gateway runner',
       versionText: process.version,
       capabilities,
+      configuration: {
+        webSearch: { requested: false, effective: false },
+      },
     };
   }
+}
+
+function attestedCliFeatures(
+  adapter: ProviderAdapter,
+  helpText: string,
+  versionText: string
+): ProviderCliFeatures {
+  const detected = adapter.detectCliFeatures(helpText, versionText);
+  return {
+    ...detected,
+    supportsWebSearch:
+      getProviderRegistryEntry(adapter.id).capabilities.webSearch === true &&
+      detected.supportsWebSearch === true,
+  };
+}
+
+function webSearchAttestation(options: {
+  readonly webSearch?: boolean;
+  readonly cliFeatures?: CliFeatureOverrides;
+}): WebSearchAttestation {
+  const requested = options.webSearch === true;
+  return {
+    requested,
+    effective: requested && options.cliFeatures?.supportsWebSearch === true,
+  };
+}
+
+function assertWebSearchDeclared(provider: ProviderId, requested: boolean | undefined): void {
+  if (requested === undefined || getProviderRegistryEntry(provider).capabilities.webSearch === true) {
+    return;
+  }
+  throw new UnsupportedProviderCapabilityError(
+    provider,
+    'webSearch',
+    `Provider ${provider} does not expose provider-controlled native web search; remove options.webSearch.`
+  );
 }
 
 function loadRuntimeSettings(): Record<string, unknown> {
@@ -437,6 +539,12 @@ function addModel(result: MutableModelSpec, value: unknown, field: string): void
 function addReasoningEffort(result: MutableModelSpec, value: unknown, field: string): void {
   const effort = optionalReasoningEffort(value, field);
   if (effort !== undefined) result.reasoningEffort = effort;
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  throw new Error(`${field} must be a boolean.`);
 }
 
 function optionalModelLevel(value: unknown, field: string): ModelLevel | undefined {

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -158,7 +158,9 @@ function resolveRuntimeCliFeatures(
   return {
     ...overrides,
     supportsResume:
-      detected.supportsResume === true && overrides.supportsResume !== false,
+      'supportsResume' in detected &&
+      detected.supportsResume === true &&
+      overrides.supportsResume !== false,
     supportsWebSearch:
       detected.supportsWebSearch === true && overrides.supportsWebSearch !== false,
   };

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -106,7 +106,13 @@ export function prepareSingleAgentProviderCommand(
     adapter.id,
     baseOptions.cwd ?? process.cwd()
   );
-  const cliFeatures = resolveRuntimeCliFeatures(adapter.id, baseOptions.cliFeatures);
+  const requestedWebSearch = baseOptions.webSearch ?? providerSettings.webSearch;
+  assertWebSearchDeclared(adapter.id, requestedWebSearch);
+  const cliFeatures = resolveRuntimeCliFeatures(
+    adapter.id,
+    baseOptions.cliFeatures,
+    requestedWebSearch === true
+  );
   const authEnv = baseOptions.authEnv ?? resolveRuntimeAuthEnv(adapter.id, settings);
   const options = buildRuntimeOptions(baseOptions, adapter, providerSettings, {
     cliFeatures,
@@ -129,10 +135,11 @@ export function detectRuntimeProviderCliFeatures(provider: string): ProviderCliF
 
 function resolveRuntimeCliFeatures(
   provider: ProviderId,
-  overrides: CliFeatureOverrides | undefined
+  overrides: CliFeatureOverrides | undefined,
+  webSearchRequested: boolean
 ): CliFeatureOverrides {
-  const detected = detectRuntimeProviderCliFeatures(provider);
   if (provider === 'gateway') {
+    const detected = detectRuntimeProviderCliFeatures(provider);
     return {
       ...detected,
       ...overrides,
@@ -141,14 +148,15 @@ function resolveRuntimeCliFeatures(
     };
   }
   if (getProviderRegistryEntry(provider).invoke.lane === 'acp-stdio') {
+    const detected = detectRuntimeProviderCliFeatures(provider);
     if (overrides === undefined) return detected;
     return mergeAcpFailClosedCliFeatures(detected, overrides);
   }
-  if (overrides === undefined) return detected;
-  const merged = { ...detected, ...overrides };
-  if (!('supportsWebSearch' in detected)) return merged;
+  if (overrides === undefined) return detectRuntimeProviderCliFeatures(provider);
+  if (!webSearchRequested) return overrides;
+  const detected = detectRuntimeProviderCliFeatures(provider);
   return {
-    ...merged,
+    ...overrides,
     supportsWebSearch:
       detected.supportsWebSearch === true && overrides.supportsWebSearch !== false,
   };

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -157,6 +157,8 @@ function resolveRuntimeCliFeatures(
   const detected = detectRuntimeProviderCliFeatures(provider);
   return {
     ...overrides,
+    supportsResume:
+      detected.supportsResume === true && overrides.supportsResume !== false,
     supportsWebSearch:
       detected.supportsWebSearch === true && overrides.supportsWebSearch !== false,
   };

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -89,6 +89,7 @@ export interface ResolvedGatewayBuildOptions {
 export interface BaseCliFeatures {
   readonly provider?: ProviderId;
   readonly unknown?: boolean;
+  readonly supportsWebSearch?: boolean;
 }
 
 export interface ClaudeCliFeatures extends BaseCliFeatures {
@@ -116,6 +117,7 @@ export interface CodexCliFeatures extends BaseCliFeatures {
   readonly supportsModel: boolean;
   readonly supportsSkipGitRepoCheck: boolean;
   readonly supportsResume: boolean;
+  readonly supportsWebSearch: boolean;
 }
 
 export interface GeminiCliFeatures extends BaseCliFeatures {
@@ -134,6 +136,8 @@ export interface OpencodeCliFeatures extends BaseCliFeatures {
   readonly supportsDir: boolean;
   readonly supportsCwd: boolean;
   readonly supportsAutoApprove: false;
+  readonly supportsResume: boolean;
+  readonly supportsWebSearch: boolean;
 }
 
 export interface PiCliFeatures extends BaseCliFeatures {
@@ -218,6 +222,7 @@ export interface CliFeatureOverrides {
   readonly supportsAddDir?: boolean;
   readonly supportsMcpConfig?: boolean;
   readonly supportsResume?: boolean;
+  readonly supportsWebSearch?: boolean;
   readonly supportsBundledRunner?: boolean;
   readonly supportsAcpStdio?: boolean;
   readonly supportsPromptImages?: boolean;
@@ -252,6 +257,11 @@ export interface RedactionMetadata {
   readonly source?: string;
 }
 
+export interface WebSearchAttestation {
+  readonly requested: boolean;
+  readonly effective: boolean;
+}
+
 export interface CommandSpec {
   readonly binary: string;
   readonly args: readonly string[];
@@ -272,6 +282,7 @@ export interface BuildProviderCommandOptions {
   readonly autoApprove?: boolean;
   readonly resumeSessionId?: string;
   readonly continueSession?: boolean;
+  readonly webSearch?: boolean;
   readonly claudeSettingsFile?: string;
   readonly cliFeatures?: CliFeatureOverrides;
   readonly authEnv?: Readonly<Record<string, string>>;
@@ -373,7 +384,7 @@ export interface ProviderAdapter {
   readonly defaultLevel: ModelLevel;
   readonly defaultMaxLevel: ModelLevel;
   readonly defaultMinLevel: ModelLevel;
-  detectCliFeatures(helpText?: string | null): ProviderCliFeatures;
+  detectCliFeatures(helpText?: string | null, versionText?: string | null): ProviderCliFeatures;
   buildCommand(context: string, options?: BuildProviderCommandOptions): CommandSpec;
   extractSessionId?(line: string): string | null;
   parseEvent(line: string, state: ProviderParserState): ProviderParseResult;

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -662,6 +662,8 @@ async function handleLockContention() {
 
 async function handleFinalFailure(agent, triggeringMessage, error, maxRetries) {
   const failureAttempts = error?.terminationAttempts ?? maxRetries;
+  const unsupportedCapability =
+    error?.code === 'unsupported-capability' && error?.permanent === true;
   console.error(`
 ${'='.repeat(80)}`);
   console.error(`🔴🔴🔴 MAX RETRIES EXHAUSTED - AGENT: ${agent.id} 🔴🔴🔴`);
@@ -737,6 +739,26 @@ ${'='.repeat(80)}`);
     });
   }
 
+  if (unsupportedCapability) {
+    agent._publish({
+      topic: 'CLUSTER_FAILED',
+      receiver: 'broadcast',
+      content: {
+        text: `Cluster failed: unsupported provider capability for ${agent.id} - ${error.message}`,
+        data: {
+          reason: 'unsupported_capability',
+          agentId: agent.id,
+          role: agent.role,
+          code: error.code,
+          permanent: true,
+          provider: error.provider,
+          capability: error.capability,
+          error: error.message,
+        },
+      },
+    });
+  }
+
   if (error?.vertexModelError) {
     agent._publish({
       topic: 'CLUSTER_FAILED',
@@ -779,6 +801,14 @@ ${'='.repeat(80)}`);
     iteration: agent.iteration,
     error: error.message,
     attempts: failureAttempts,
+    ...(unsupportedCapability
+      ? {
+          code: error.code,
+          permanent: true,
+          provider: error.provider,
+          capability: error.capability,
+        }
+      : {}),
     timestamp: Date.now(),
   };
 
@@ -801,6 +831,14 @@ ${'='.repeat(80)}`);
         iteration: agent.iteration,
         taskId: error?.taskId || agent.currentTaskId,
         attempts: failureAttempts,
+        ...(unsupportedCapability
+          ? {
+              code: error.code,
+              permanent: true,
+              provider: error.provider,
+              capability: error.capability,
+            }
+          : {}),
         hookFailureContext: error.message.includes('Hook uses result')
           ? {
               taskId: agent.currentTaskId || 'UNKNOWN',
@@ -827,7 +865,7 @@ ${'='.repeat(80)}`);
     orchestrator: agent.orchestrator,
   });
 
-  if (!error?.terminationExhausted) {
+  if (!error?.terminationExhausted && !unsupportedCapability) {
     agent.state = 'idle';
   }
 }
@@ -1041,6 +1079,19 @@ async function executeTask(agent, triggeringMessage) {
         return;
       }
       if (error?.permanent) {
+        if (error.code === 'unsupported-capability') {
+          agent._publishLifecycle('TASK_FAILED', {
+            iteration: agent.iteration,
+            taskId: error.taskId || agent.currentTaskId,
+            error: error.message,
+            code: error.code,
+            permanent: true,
+            provider: error.provider,
+            capability: error.capability,
+            attempt,
+          });
+          clearTransientTaskState(agent, error);
+        }
         await handleFinalFailure(agent, triggeringMessage, error, attempt);
         return;
       }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2170,11 +2170,6 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
       pendingLaunch: true,
       cancelled: false,
       async kill(reason = 'Task killed', sourceError = null) {
-        if (isolatedPendingLaunch.cancelled) {
-          return Promise.reject(
-            sourceError instanceof Error ? sourceError : new Error(reason || 'Task launch cancelled')
-          );
-        }
         isolatedPendingLaunch.cancelled = true;
         if (cancellation) return cancellation;
         cancellation = (async () => {

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2169,7 +2169,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
     isolatedPendingLaunch = {
       pendingLaunch: true,
       cancelled: false,
-      async kill(reason = 'Task killed') {
+      async kill(reason = 'Task killed', sourceError = null) {
         isolatedPendingLaunch.cancelled = true;
         if (cancellation) return cancellation;
         cancellation = (async () => {
@@ -2213,6 +2213,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
         if (termination?.forced === false) cancellation = null;
         if (!resolved) {
           const error =
+            sourceError ||
             timeoutError ||
             new Error(
               termination?.forced === false
@@ -2279,7 +2280,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
         resolved = true;
         resolve(spawnedTaskId);
       } catch (error) {
-        const termination = await isolatedPendingLaunch.kill(error.message);
+        const termination = await isolatedPendingLaunch.kill(error.message, error);
         if (!resolved) {
           rejectLaunch(error, { retainHandle: termination?.forced === false });
         }
@@ -2289,7 +2290,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
     proc.on('error', async (error) => {
       clearTimeout(spawnTimeout);
       if (resolved || isolatedPendingLaunch.cancelled) return;
-      const termination = await isolatedPendingLaunch.kill(error.message);
+      const termination = await isolatedPendingLaunch.kill(error.message, error);
       if (termination?.forced === false && !resolved) {
         rejectLaunch(error, { retainHandle: true });
       }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2213,7 +2213,11 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
         if (termination?.forced === false) cancellation = null;
         if (!resolved) {
           const error =
-            (sourceError instanceof Error ? sourceError : null) ||
+            (sourceError instanceof Error &&
+              sourceError.code === 'unsupported-capability' &&
+              sourceError.permanent === true
+              ? sourceError
+              : null) ||
             timeoutError ||
             new Error(
               termination?.forced === false

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2170,6 +2170,11 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
       pendingLaunch: true,
       cancelled: false,
       async kill(reason = 'Task killed', sourceError = null) {
+        if (isolatedPendingLaunch.cancelled) {
+          return Promise.reject(
+            sourceError instanceof Error ? sourceError : new Error(reason || 'Task launch cancelled')
+          );
+        }
         isolatedPendingLaunch.cancelled = true;
         if (cancellation) return cancellation;
         cancellation = (async () => {
@@ -2213,7 +2218,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
         if (termination?.forced === false) cancellation = null;
         if (!resolved) {
           const error =
-            sourceError ||
+            (sourceError instanceof Error ? sourceError : null) ||
             timeoutError ||
             new Error(
               termination?.forced === false

--- a/src/claude-task-runner.js
+++ b/src/claude-task-runner.js
@@ -34,6 +34,7 @@ const {
   appendTaskRunModelArgs,
   wrapTaskRunWithIsolatedSettings,
 } = require('./task-run-model-args');
+const { parseTaskStartupError } = require('./task-startup-error');
 
 function rejectCallerSuppliedModelProvenance(options) {
   if (Object.prototype.hasOwnProperty.call(options, 'modelSpecSource')) {
@@ -98,6 +99,7 @@ function runCommand(command, args, options = {}, callback = null) {
 }
 
 const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale', 'cancelled']);
+const TASK_STARTUP_STDERR_MAX_CHARS = 500;
 
 async function cleanupPersistedTaskAfterLaunchFailure(ctPath, taskId) {
   let lastError = null;
@@ -808,6 +810,7 @@ class ClaudeTaskRunner extends TaskRunner {
     return new Promise((resolve, reject) => {
       let output = '';
       let resolved = false;
+      let stderr = '';
 
       const proc = manager.spawnInContainer(clusterId, command, {
         env: {
@@ -828,6 +831,7 @@ class ClaudeTaskRunner extends TaskRunner {
 
       proc.stderr.on('data', (/** @type {Buffer} */ data) => {
         const chunk = data.toString();
+        stderr = `${stderr}${chunk}`.slice(-TASK_STARTUP_STDERR_MAX_CHARS);
         if (!this.quiet) {
           console.error(`[${agentId}] stderr:`, chunk);
         }
@@ -836,6 +840,13 @@ class ClaudeTaskRunner extends TaskRunner {
       proc.on('close', (/** @type {number|null} */ code) => {
         if (resolved) return;
         resolved = true;
+        if (code !== 0) {
+          const startupError = parseTaskStartupError(stderr);
+          if (startupError) {
+            reject(startupError);
+            return;
+          }
+        }
 
         resolve({
           success: code === 0,

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -2716,12 +2716,17 @@ class Orchestrator {
     });
 
     for (const error of errors) {
+      const errorData = error.content?.data || {};
       const failureInfo = {
         agentId: error.sender,
-        taskId: error.content?.data?.taskId || null,
-        iteration: error.content?.data?.iteration || 0,
-        error: error.content?.data?.error || error.content?.text,
+        taskId: errorData.taskId || null,
+        iteration: errorData.iteration || 0,
+        error: errorData.error || error.content?.text,
         timestamp: error.timestamp,
+        ...(errorData.code !== undefined ? { code: errorData.code } : {}),
+        ...(errorData.permanent !== undefined ? { permanent: errorData.permanent } : {}),
+        ...(errorData.provider !== undefined ? { provider: errorData.provider } : {}),
+        ...(errorData.capability !== undefined ? { capability: errorData.capability } : {}),
       };
       if (this._hasDurableProgressAfterFailure(cluster, clusterId, failureInfo)) {
         this._log(

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -159,6 +159,11 @@ class RuntimeProvider extends BaseProvider {
   validateSettings(settings) {
     const baseError = super.validateSettings(settings);
     if (baseError) return baseError;
+    const declaredFields = new Set(this.getSettingsFields());
+    const unknownField = Object.keys(settings).find((field) => !declaredFields.has(field));
+    if (unknownField) {
+      return `Unknown provider setting: providerSettings.${this.name}.${unknownField}`;
+    }
     if (this._metadata.settingsValidator) {
       const providerError = this._metadata.settingsValidator(settings);
       if (providerError) return providerError;

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -159,10 +159,11 @@ class RuntimeProvider extends BaseProvider {
   validateSettings(settings) {
     const baseError = super.validateSettings(settings);
     if (baseError) return baseError;
-    const declaredFields = new Set(this.getSettingsFields());
-    const unknownField = Object.keys(settings).find((field) => !declaredFields.has(field));
-    if (unknownField) {
-      return `Unknown provider setting: providerSettings.${this.name}.${unknownField}`;
+    if (
+      Object.prototype.hasOwnProperty.call(settings, 'webSearch') &&
+      !this._metadata.settingsFields.includes('webSearch')
+    ) {
+      return `Unknown provider setting: providerSettings.${this.name}.webSearch`;
     }
     if (this._metadata.settingsValidator) {
       const providerError = this._metadata.settingsValidator(settings);

--- a/src/task-run-model-args.js
+++ b/src/task-run-model-args.js
@@ -1,3 +1,5 @@
+const { providerSupportsCapability } = require('../lib/provider-names');
+
 /**
  * Append a resolved model selection to a nested `zeroshot task run` invocation.
  *
@@ -61,9 +63,9 @@ try {
 
 /**
  * Wrap an isolated task command with a Docker-only, temporary settings-file
- * bootstrap. The snapshot is a closed projection containing only the selected
- * OpenCode level and its model. It never contains arbitrary provider settings,
- * credentials, or caller-owned keys.
+ * bootstrap. The snapshot is a closed projection containing only an enabled
+ * native-search control and, when needed, the selected OpenCode level/model.
+ * It never contains credentials or caller-owned keys.
  *
  * @param {string[]} command
  * @param {{providerName: string, settings: Object, modelSpecSource: 'direct'|'provider-level', modelSpec: Object|null|undefined}} context
@@ -71,57 +73,73 @@ try {
  */
 function wrapTaskRunWithIsolatedSettings(command, context) {
   const { providerName, settings, modelSpecSource, modelSpec } = context;
-  if (providerName !== 'opencode' || modelSpecSource !== 'provider-level') return command;
-  const snapshot = buildIsolatedSettingsSnapshot(settings, modelSpec);
+  if (!providerSupportsCapability(providerName, 'webSearch')) return command;
+  const includesOpencodeModel =
+    providerName === 'opencode' && modelSpecSource === 'provider-level';
+  const snapshot = buildIsolatedSettingsSnapshot(
+    settings,
+    providerName,
+    includesOpencodeModel ? modelSpec : null
+  );
   if (snapshot === null) return command;
   return ['node', '-e', SETTINGS_BOOTSTRAP_SCRIPT, snapshot, ...command];
 }
 
-function buildIsolatedSettingsSnapshot(settings, modelSpec) {
-  const level = modelSpec?.level;
-  if (!['level1', 'level2', 'level3'].includes(level)) {
-    throw permanentError(
-      'Provider-level isolated OpenCode selections require a valid model level.'
-    );
-  }
-
+function buildIsolatedSettingsSnapshot(settings, providerName, opencodeModelSpec) {
   const providerSettings = ownRecordValue(settings, 'providerSettings', 'settings') ?? {};
-  const opencodeSettings = ownRecordValue(
+  const selectedSettings = ownRecordValue(
     providerSettings,
-    'opencode',
+    providerName,
     'settings.providerSettings'
   );
-  const levelOverrides = ownRecordValue(
-    opencodeSettings,
-    'levelOverrides',
-    'settings.providerSettings.opencode'
-  );
-  const levelOverride = ownRecordValue(
-    levelOverrides,
-    level,
-    'settings.providerSettings.opencode.levelOverrides'
-  );
-  const configuredModel =
-    levelOverride && Object.prototype.hasOwnProperty.call(levelOverride, 'model')
-      ? levelOverride.model
-      : null;
-  if (configuredModel !== null && typeof configuredModel !== 'string') {
-    throw permanentError(`Configured isolated OpenCode ${level} model must be a string or null.`);
+  const webSearch = selectedSettings?.webSearch;
+  if (webSearch !== undefined && typeof webSearch !== 'boolean') {
+    throw permanentError(`settings.providerSettings.${providerName}.webSearch must be a boolean.`);
   }
-  if (modelSpec?.model !== configuredModel) {
-    throw permanentError(
-      `Provider-level model "${modelSpec?.model}" does not match the effective isolated ${modelSpec?.level} model "${configuredModel}".`
-    );
-  }
-  if (configuredModel === null) return null;
 
+  const snapshot = {};
+  if (webSearch === true) snapshot.webSearch = true;
+  if (opencodeModelSpec !== null) {
+    const level = opencodeModelSpec?.level;
+    if (!['level1', 'level2', 'level3'].includes(level)) {
+      throw permanentError(
+        'Provider-level isolated OpenCode selections require a valid model level.'
+      );
+    }
+
+    const levelOverrides = ownRecordValue(
+      selectedSettings,
+      'levelOverrides',
+      'settings.providerSettings.opencode'
+    );
+    const levelOverride = ownRecordValue(
+      levelOverrides,
+      level,
+      'settings.providerSettings.opencode.levelOverrides'
+    );
+    const configuredModel =
+      levelOverride && Object.prototype.hasOwnProperty.call(levelOverride, 'model')
+        ? levelOverride.model
+        : null;
+    if (configuredModel !== null && typeof configuredModel !== 'string') {
+      throw permanentError(`Configured isolated OpenCode ${level} model must be a string or null.`);
+    }
+    if (opencodeModelSpec.model !== configuredModel) {
+      throw permanentError(
+        `Provider-level model "${opencodeModelSpec.model}" does not match the effective isolated ${level} model "${configuredModel}".`
+      );
+    }
+    if (configuredModel !== null) {
+      snapshot.levelOverrides = {
+        [level]: { model: configuredModel },
+      };
+    }
+  }
+
+  if (Object.keys(snapshot).length === 0) return null;
   return JSON.stringify({
     providerSettings: {
-      opencode: {
-        levelOverrides: {
-          [level]: { model: configuredModel },
-        },
-      },
+      [providerName]: snapshot,
     },
   });
 }

--- a/src/task-spawn-cleanup-ownership.js
+++ b/src/task-spawn-cleanup-ownership.js
@@ -1,4 +1,5 @@
 const { randomUUID } = require('node:crypto');
+const { parseTaskStartupError } = require('./task-startup-error');
 
 const TASK_SPAWN_OWNERSHIP_TOKEN_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
 
@@ -38,6 +39,8 @@ function requireTaskIdFromWrapperResult({
   persistedTaskId = null,
 }) {
   if (code !== 0) {
+    const startupError = parseTaskStartupError(stderr);
+    if (startupError) throw startupError;
     throw new Error(`zeroshot task run failed with code ${code}: ${stderr}`);
   }
   if (!persistedTaskId) {

--- a/src/task-startup-error.js
+++ b/src/task-startup-error.js
@@ -1,6 +1,16 @@
 const TASK_STARTUP_ERROR_PREFIX = 'ZEROSHOT_TASK_STARTUP_ERROR:';
 const SUPPORTED_STARTUP_ERROR_CODES = new Set(['unsupported-capability']);
 
+function createUnsupportedProviderCapabilityError(provider, capability, message) {
+  const error = new Error(message);
+  error.name = 'UnsupportedProviderCapabilityError';
+  error.code = 'unsupported-capability';
+  error.permanent = true;
+  error.provider = provider;
+  error.capability = capability;
+  return error;
+}
+
 function serializeTaskStartupError(error) {
   if (
     !SUPPORTED_STARTUP_ERROR_CODES.has(error?.code) ||
@@ -52,6 +62,7 @@ function parseTaskStartupError(stderr) {
 
 module.exports = {
   TASK_STARTUP_ERROR_PREFIX,
+  createUnsupportedProviderCapabilityError,
   parseTaskStartupError,
   serializeTaskStartupError,
 };

--- a/src/task-startup-error.js
+++ b/src/task-startup-error.js
@@ -1,0 +1,57 @@
+const TASK_STARTUP_ERROR_PREFIX = 'ZEROSHOT_TASK_STARTUP_ERROR:';
+const SUPPORTED_STARTUP_ERROR_CODES = new Set(['unsupported-capability']);
+
+function serializeTaskStartupError(error) {
+  if (
+    !SUPPORTED_STARTUP_ERROR_CODES.has(error?.code) ||
+    error?.permanent !== true
+  ) {
+    return null;
+  }
+  const payload = {
+    version: 1,
+    code: error.code,
+    permanent: true,
+    message: String(error.message || error.code),
+  };
+  if (typeof error.provider === 'string') payload.provider = error.provider;
+  if (typeof error.capability === 'string') payload.capability = error.capability;
+  return `${TASK_STARTUP_ERROR_PREFIX}${JSON.stringify(payload)}`;
+}
+
+function parseTaskStartupError(stderr) {
+  const lines = String(stderr || '').split(/\r?\n/);
+  let line = lines.pop();
+  while (line === '' && lines.length > 0) line = lines.pop();
+  if (!line?.startsWith(TASK_STARTUP_ERROR_PREFIX)) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(line.slice(TASK_STARTUP_ERROR_PREFIX.length));
+  } catch {
+    return null;
+  }
+  if (
+    parsed?.version !== 1 ||
+    !SUPPORTED_STARTUP_ERROR_CODES.has(parsed.code) ||
+    parsed.permanent !== true ||
+    typeof parsed.message !== 'string' ||
+    parsed.message.length === 0 ||
+    (parsed.provider !== undefined && typeof parsed.provider !== 'string') ||
+    (parsed.capability !== undefined && typeof parsed.capability !== 'string')
+  ) {
+    return null;
+  }
+  const error = new Error(parsed.message);
+  error.code = parsed.code;
+  error.permanent = true;
+  if (parsed.provider !== undefined) error.provider = parsed.provider;
+  if (parsed.capability !== undefined) error.capability = parsed.capability;
+  return error;
+}
+
+module.exports = {
+  TASK_STARTUP_ERROR_PREFIX,
+  parseTaskStartupError,
+  serializeTaskStartupError,
+};

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -46,6 +46,58 @@ test('build-command returns command spec without executing provider CLI', () => 
   assert.ok(Array.isArray(response.envelope.redactions));
 });
 
+test('partial CLI feature overrides do not probe or drift when web search is off', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-no-search-probe-'));
+  const settingsFile = path.join(tempDir, 'settings.json');
+  fs.writeFileSync(settingsFile, '{}');
+
+  try {
+    for (const provider of ['codex', 'opencode']) {
+      const marker = path.join(tempDir, `${provider}-probed`);
+      const script = `#!/usr/bin/env node
+require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'probed');
+process.exit(0);
+`;
+      withFakeProviderCli(provider, script, () =>
+        withTempEnv({ ZEROSHOT_SETTINGS_FILE: settingsFile }, () => {
+          const cliFeatures =
+            provider === 'codex'
+              ? { supportsJson: true, supportsSkipGitRepoCheck: true }
+              : { supportsJson: true };
+          const baseRequest = {
+            schemaVersion: 1,
+            command: 'build-command',
+            provider,
+            context: 'ctx',
+          };
+          const absent = runExecutable({
+            ...baseRequest,
+            options: { outputFormat: 'json', cliFeatures },
+          });
+          const disabled = runExecutable({
+            ...baseRequest,
+            options: { outputFormat: 'json', webSearch: false, cliFeatures },
+          });
+
+          assert.equal(absent.exitCode, 0);
+          assert.equal(disabled.exitCode, 0);
+          assert.deepEqual(
+            disabled.envelope.result.commandSpec.args,
+            absent.envelope.result.commandSpec.args
+          );
+          assert.deepEqual(
+            disabled.envelope.result.commandSpec.env,
+            absent.envelope.result.commandSpec.env
+          );
+          assert.equal(fs.existsSync(marker), false);
+        })
+      );
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('build-command preserves Claude resume and continue options through JSON contract', () => {
   const resumed = runExecutable({
     schemaVersion: 1,

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -807,6 +807,63 @@ process.exit(17);
   }
 });
 
+test('enabled search retains fail-closed resume proof with partial feature overrides', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-search-resume-proof-'));
+  const settingsFile = path.join(tempDir, 'settings.json');
+
+  try {
+    for (const provider of ['codex', 'opencode']) {
+      fs.writeFileSync(
+        settingsFile,
+        JSON.stringify({ providerSettings: { [provider]: { webSearch: true } } })
+      );
+      const script =
+        provider === 'codex'
+          ? fakeCodexScript(`
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: codex exec --config --json\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex-cli 0.146.0\\n');
+  process.exit(0);
+}
+process.exit(17);
+`)
+          : `#!/usr/bin/env node
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: opencode run --format\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('1.0.137\\n');
+  process.exit(0);
+}
+process.exit(17);
+`;
+
+      withFakeProviderCli(provider, script, () =>
+        withTempEnv({ ZEROSHOT_SETTINGS_FILE: settingsFile }, () => {
+          const response = runExecutable({
+            schemaVersion: 1,
+            command: 'build-command',
+            provider,
+            context: 'resume',
+            options: {
+              resumeSessionId: 'session-1',
+              cliFeatures: { supportsJson: true },
+            },
+          });
+          assert.equal(response.envelope.ok, false);
+          assert.match(response.envelope.error.message, /cannot safely run continuation context/);
+        })
+      );
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('build-command returns structured unsupported-capability for old Codex', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-web-search-old-'));
   const settingsFile = path.join(tempDir, 'settings.json');

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -650,6 +650,217 @@ process.exit(17);
   }
 });
 
+test('probe attests Codex and OpenCode web-search version floors', () => {
+  const codexHelp = 'Usage: codex exec --config --json resume';
+  for (const [versionText, expected] of [
+    ['codex-cli 0.146.0', true],
+    ['codex-cli 0.145.9', false],
+    ['codex-cli unknown', false],
+    ['', false],
+  ]) {
+    const response = runExecutable({
+      schemaVersion: 1,
+      command: 'probe',
+      provider: 'codex',
+      helpText: codexHelp,
+      versionText,
+    });
+    assert.equal(response.envelope.result.capabilities.supportsWebSearch, expected);
+  }
+
+  const missingConfig = runExecutable({
+    schemaVersion: 1,
+    command: 'probe',
+    provider: 'codex',
+    helpText: 'Usage: codex exec --json resume',
+    versionText: 'codex-cli 0.146.0',
+  });
+  assert.equal(missingConfig.envelope.result.capabilities.supportsWebSearch, false);
+
+  for (const [versionText, expected] of [
+    ['1.0.137', true],
+    ['opencode 1.0.136', false],
+    ['dev', false],
+  ]) {
+    const response = runExecutable({
+      schemaVersion: 1,
+      command: 'probe',
+      provider: 'opencode',
+      helpText: 'Usage: opencode run --session --continue',
+      versionText,
+    });
+    assert.equal(response.envelope.result.capabilities.supportsWebSearch, expected);
+  }
+});
+
+test('probe and build-command distinguish requested and effective Codex search', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-web-search-settings-'));
+  const settingsFile = path.join(tempDir, 'settings.json');
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({ providerSettings: { codex: { webSearch: true } } })
+  );
+
+  try {
+    withTempEnv({ ZEROSHOT_SETTINGS_FILE: settingsFile }, () => {
+      const probe = runExecutable({
+        schemaVersion: 1,
+        command: 'probe',
+        provider: 'codex',
+        helpText: 'Usage: codex exec --config resume',
+        versionText: 'codex-cli 0.146.0',
+      });
+      assert.deepEqual(probe.envelope.result.configuration.webSearch, {
+        requested: true,
+        effective: true,
+      });
+
+      withFakeProviderCli(
+        'codex',
+        fakeCodexScript(`
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: codex exec --config --json resume\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex-cli 0.146.0\\n');
+  process.exit(0);
+}
+process.exit(17);
+`),
+        () => {
+          const built = runExecutable({
+            schemaVersion: 1,
+            command: 'build-command',
+            provider: 'codex',
+            context: 'ctx',
+            options: { resumeSessionId: 'thread-1' },
+          });
+          assert.equal(built.exitCode, 0);
+          assert.deepEqual(built.envelope.result.configuration.webSearch, {
+            requested: true,
+            effective: true,
+          });
+          assert.deepEqual(built.envelope.result.commandSpec.args.slice(0, 4), [
+            'exec',
+            '--config',
+            'web_search="live"',
+            'resume',
+          ]);
+        }
+      );
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('build-command returns structured unsupported-capability for old Codex', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-web-search-old-'));
+  const settingsFile = path.join(tempDir, 'settings.json');
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({ providerSettings: { codex: { webSearch: true } } })
+  );
+
+  try {
+    withFakeProviderCli(
+      'codex',
+      fakeCodexScript(`
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: codex exec --config resume\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex-cli 0.145.0\\n');
+  process.exit(0);
+}
+process.exit(17);
+`),
+      () =>
+        withTempEnv({ ZEROSHOT_SETTINGS_FILE: settingsFile }, () => {
+          const response = runExecutable({
+            schemaVersion: 1,
+            command: 'build-command',
+            provider: 'codex',
+            context: 'ctx',
+            options: {
+              webSearch: true,
+              cliFeatures: { supportsWebSearch: true },
+            },
+          });
+          assert.equal(response.envelope.ok, false);
+          assert.equal(response.envelope.error.code, 'unsupported-capability');
+          assert.equal(response.envelope.error.field, 'options.webSearch');
+          assert.match(response.envelope.error.message, /version >= 0\.146\.0/);
+        })
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('build-command applies OpenCode search env to fresh and resumed commands', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-opencode-search-'));
+  const settingsFile = path.join(tempDir, 'settings.json');
+  fs.writeFileSync(
+    settingsFile,
+    JSON.stringify({ providerSettings: { opencode: { webSearch: true } } })
+  );
+  const script = `#!/usr/bin/env node
+if (process.argv.includes('--help')) {
+  process.stdout.write('Usage: opencode run --session --continue --format --model --variant\\n');
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  process.stdout.write('1.0.137\\n');
+  process.exit(0);
+}
+process.exit(17);
+`;
+
+  try {
+    withFakeProviderCli('opencode', script, () =>
+      withTempEnv({ ZEROSHOT_SETTINGS_FILE: settingsFile }, () => {
+        const fresh = runExecutable({
+          schemaVersion: 1,
+          command: 'build-command',
+          provider: 'opencode',
+          context: 'fresh',
+          env: { KEEP_ME: 'yes' },
+        });
+        assert.deepEqual(fresh.envelope.result.commandSpec.env, {
+          KEEP_ME: '[REDACTED:KEEP_ME]',
+          OPENCODE_ENABLE_EXA: '[REDACTED:OPENCODE_ENABLE_EXA]',
+        });
+        assert.deepEqual(fresh.envelope.result.configuration.webSearch, {
+          requested: true,
+          effective: true,
+        });
+
+        const resumed = runExecutable({
+          schemaVersion: 1,
+          command: 'build-command',
+          provider: 'opencode',
+          context: 'resume',
+          options: { resumeSessionId: 'session-1' },
+        });
+        assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(-3), [
+          '--session',
+          'session-1',
+          'resume',
+        ]);
+        assert.equal(
+          resumed.envelope.result.commandSpec.env.OPENCODE_ENABLE_EXA,
+          '[REDACTED:OPENCODE_ENABLE_EXA]'
+        );
+      })
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('probe reports capabilities and credential presence without exposing values', () => {
   const response = runExecutable({
     schemaVersion: 1,

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -706,6 +706,7 @@ test('probe attests Codex and OpenCode web-search version floors', () => {
   const codexHelp = 'Usage: codex exec --config --json resume';
   for (const [versionText, expected] of [
     ['codex-cli 0.146.0', true],
+    ['codex-cli 0.146.0beta', false],
     ['codex-cli 0.145.9', false],
     ['codex-cli unknown', false],
     ['', false],
@@ -731,6 +732,7 @@ test('probe attests Codex and OpenCode web-search version floors', () => {
 
   for (const [versionText, expected] of [
     ['1.0.137', true],
+    ['opencode 1.0.137garbage', false],
     ['opencode 1.0.136', false],
     ['dev', false],
   ]) {

--- a/tests/agent-cli-provider/executable-contract-option-validation.test.js
+++ b/tests/agent-cli-provider/executable-contract-option-validation.test.js
@@ -24,6 +24,7 @@ const invalidNestedOptionCases = [
     options: { continueSession: 'yes' },
     field: 'options.continueSession',
   },
+  { name: 'webSearch type', options: { webSearch: 'yes' }, field: 'options.webSearch' },
   { name: 'strictSchema type', options: { strictSchema: 'yes' }, field: 'options.strictSchema' },
   {
     name: 'cliFeatures boolean',

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -740,6 +740,7 @@ test('feature probing is deterministic from injected help text', () => {
     helper.getProviderAdapter('opencode').detectCliFeatures('opencode run --format').supportsCwd,
     false
   );
+  assert.equal(helper.getProviderAdapter('opencode').detectCliFeatures('').supportsResume, false);
   assert.equal(
     helper
       .getProviderAdapter('pi')

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -790,12 +790,24 @@ test('provider registry stays in parity across helper runtime settings and probe
     KNOWN_PROVIDER_NAMES.map((name) => helper.normalizeProviderName(name))
   );
 
+  assert.deepEqual(
+    helper
+      .listProviderRegistryEntries()
+      .filter((entry) => entry.capabilities.webSearch === true)
+      .map((entry) => entry.id),
+    ['codex', 'opencode']
+  );
+
   for (const provider of VALID_PROVIDERS) {
     const metadata = helper.getProviderRegistryEntry(provider);
     const runtime = runtimeProviders.getProvider(provider);
     assert.equal(runtime.displayName, metadata.displayName);
     assert.deepEqual(runtime.getCredentialPaths(), metadata.credentialPaths);
     assert.deepEqual(runtime.getSettingsFields().slice(4), metadata.settingsFields);
+    assert.equal(
+      metadata.settingsFields.includes('webSearch'),
+      metadata.capabilities.webSearch === true
+    );
 
     const response = await helper.runProviderExecutable(
       JSON.stringify({

--- a/tests/agent-cli-provider/providers-command-parity.test.js
+++ b/tests/agent-cli-provider/providers-command-parity.test.js
@@ -110,7 +110,7 @@ test('provider setup prints install and auth instructions from registry metadata
 
   const settings = {
     defaultProvider: 'claude',
-    providerSettings: {},
+    providerSettings: { opencode: { webSearch: true } },
   };
   const saved = [];
   const { setupCommand } = loadCommands({
@@ -146,4 +146,5 @@ test('provider setup prints install and auth instructions from registry metadata
   assert.ok(logs.includes(metadata.authInstructions));
   assert.equal(saved.length, 1);
   assert.equal(saved[0].providerSettings[provider].defaultLevel, 'level3');
+  assert.equal(saved[0].providerSettings[provider].webSearch, true);
 });

--- a/tests/cli-run-mode.test.js
+++ b/tests/cli-run-mode.test.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
 const { isStartupUpdateEligible, resolveRunMode } = require('../cli/index.js');
 
 describe('resolveRunMode', () => {
@@ -90,5 +92,24 @@ describe('startup update option integration', function () {
       isStartupUpdateEligible(['export', 'nonexistent', '--', '-qfjson'], options),
       true
     );
+  });
+
+  it('accepts reasoning effort on task run', function () {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.resolve(__dirname, '../cli/index.js'),
+        'task',
+        'run',
+        'prompt',
+        '--reasoning-effort',
+        'max',
+        '--help',
+      ],
+      { encoding: 'utf8' }
+    );
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.match(result.stdout, /--reasoning-effort <effort>/);
   });
 });

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -8,6 +8,7 @@ const {
   spawnClaudeTaskIsolated,
 } = require('../src/agent/agent-task-executor');
 
+const { serializeTaskStartupError } = require('../src/task-startup-error');
 const OWNERSHIP_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
 
 function createProcess() {
@@ -117,6 +118,33 @@ describe('Isolated detached launch ownership', function () {
     assert.strictEqual(termination.taskId, null);
     assert.strictEqual(harness.commands.some((command) => command[1] === 'kill'), false);
     assert.ok(harness.capturedEnv[OWNERSHIP_ENV]);
+  });
+
+  it('restores permanent capability faults from the isolated task-start wrapper', async function () {
+    const harness = createLaunchHarness();
+    const launch = spawnClaudeTaskIsolated(harness.agent, 'test context');
+    await waitFor(() => harness.agent.currentTask?.pendingLaunch);
+    const capabilityError = Object.assign(new Error('OpenCode web search is unsupported.'), {
+      code: 'unsupported-capability',
+      permanent: true,
+      provider: 'opencode',
+      capability: 'webSearch',
+    });
+    harness.proc.stderr.write(`${serializeTaskStartupError(capabilityError)}\n`);
+    harness.proc.closed = true;
+    harness.proc.emit('close', 1, null);
+    const rejection = await launch.then(
+      () => null,
+      (error) => error
+    );
+
+    assert.strictEqual(rejection.code, 'unsupported-capability');
+    assert.strictEqual(rejection.permanent, true);
+    assert.strictEqual(rejection.provider, capabilityError.provider);
+    assert.strictEqual(rejection.capability, capabilityError.capability);
+    assert.strictEqual(rejection.message, capabilityError.message);
+    assert.strictEqual(harness.agent.currentTask, null);
+    assert.strictEqual(harness.commands.some((command) => command[1] === 'kill'), false);
   });
 
   it('resolves the durable token and kills a post-row task before wrapper close', async function () {

--- a/tests/opencode-docker-settings-boundary.test.js
+++ b/tests/opencode-docker-settings-boundary.test.js
@@ -107,6 +107,54 @@ describe('Docker provider settings trust boundary', function () {
     assert.strictEqual(wrapped.join(' ').includes('unknown'), false);
   });
 
+  it('projects only explicitly enabled native search into isolated children', function () {
+    const command = ['zeroshot', 'task', 'run'];
+    for (const providerName of ['codex', 'opencode']) {
+      assert.strictEqual(
+        wrapTaskRunWithIsolatedSettings(command, {
+          providerName,
+          settings: { providerSettings: { [providerName]: { webSearch: false } } },
+          modelSpecSource: 'direct',
+          modelSpec: null,
+        }),
+        command
+      );
+
+      const wrapped = wrapTaskRunWithIsolatedSettings(command, {
+        providerName,
+        settings: { providerSettings: { [providerName]: { webSearch: true } } },
+        modelSpecSource: 'direct',
+        modelSpec: null,
+      });
+      assert.deepStrictEqual(JSON.parse(wrapped[3]), {
+        providerSettings: {
+          [providerName]: { webSearch: true },
+        },
+      });
+    }
+  });
+
+  it('keeps enabled OpenCode search alongside the trusted model projection', function () {
+    const settings = configuredSettings();
+    settings.providerSettings.opencode.webSearch = true;
+    const wrapped = wrapTaskRunWithIsolatedSettings(['zeroshot', 'task', 'run'], {
+      providerName: 'opencode',
+      settings,
+      modelSpecSource: 'provider-level',
+      modelSpec: { level: 'level2', model: EXTERNAL_MODEL },
+    });
+    assert.deepStrictEqual(JSON.parse(wrapped[3]), {
+      providerSettings: {
+        opencode: {
+          webSearch: true,
+          levelOverrides: {
+            level2: { model: EXTERNAL_MODEL },
+          },
+        },
+      },
+    });
+  });
+
   it('stages a legitimate minimal snapshot through the temporary settings file', function () {
     const readSettingsScript = String.raw`
 const fs = require('node:fs');

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -451,14 +451,19 @@ function prepareInterruptedCodeValidator(cluster, clusterId) {
   });
 }
 
-function publishAgentError(cluster, clusterId, agentId, { error, iteration, taskId }) {
+function publishAgentError(
+  cluster,
+  clusterId,
+  agentId,
+  { error, iteration, taskId, ...details }
+) {
   cluster.messageBus.publish({
     cluster_id: clusterId,
     topic: 'AGENT_ERROR',
     sender: agentId,
     content: {
       text: error,
-      data: { agent: agentId, error, iteration, taskId },
+      data: { agent: agentId, error, iteration, taskId, ...details },
     },
   });
 }
@@ -1837,6 +1842,10 @@ function defineLifecycleResumeTests() {
         error: 'unresolved code validator failure',
         iteration: 5,
         taskId: 'unresolved-code-task',
+        code: 'unsupported-capability',
+        permanent: true,
+        provider: 'codex',
+        capability: 'webSearch',
       });
       publishRecoveredWorkerFailureHistory(cluster, result.id);
 
@@ -1855,6 +1864,10 @@ function defineLifecycleResumeTests() {
       const failureInfo = lifecycleOrchestrator._resolveFailureInfo(restored, result.id);
       assert.strictEqual(failureInfo.agentId, 'validator-code');
       assert.strictEqual(failureInfo.taskId, 'unresolved-code-task');
+      assert.strictEqual(failureInfo.code, 'unsupported-capability');
+      assert.strictEqual(failureInfo.permanent, true);
+      assert.strictEqual(failureInfo.provider, 'codex');
+      assert.strictEqual(failureInfo.capability, 'webSearch');
 
       const resumed = await lifecycleOrchestrator.resume(result.id);
       await waitForAgentCalls(resumedRunner, { 'validator-code': 1 });

--- a/tests/provider-cli-builder.test.js
+++ b/tests/provider-cli-builder.test.js
@@ -53,6 +53,60 @@ describe('Codex provider helper builder', function () {
     );
   });
 
+  it('keeps absent and disabled web search byte-compatible', function () {
+    const absent = buildCommand('codex', 'test context', {
+      outputFormat: 'json',
+      cliFeatures: { supportsJson: true },
+    });
+    const disabled = buildCommand('codex', 'test context', {
+      outputFormat: 'json',
+      webSearch: false,
+      cliFeatures: { supportsJson: true },
+    });
+
+    assert.deepStrictEqual(disabled.args, absent.args);
+    assert.deepStrictEqual(disabled.env, absent.env);
+  });
+
+  it('adds the canonical web-search config before fresh and resumed prompts', function () {
+    const fresh = buildCommand('codex', 'fresh context', {
+      webSearch: true,
+      cliFeatures: { supportsWebSearch: true },
+    });
+    assert.deepStrictEqual(fresh.args.slice(0, 3), [
+      'exec',
+      '--config',
+      'web_search="live"',
+    ]);
+    assert.strictEqual(fresh.args.includes('--search'), false);
+
+    const resumed = buildCommand('codex', 'resume context', {
+      resumeSessionId: 'session-123',
+      webSearch: true,
+      cliFeatures: { supportsResume: true, supportsWebSearch: true },
+    });
+    assert.deepStrictEqual(resumed.args.slice(0, 4), [
+      'exec',
+      '--config',
+      'web_search="live"',
+      'resume',
+    ]);
+    assert.deepStrictEqual(resumed.args.slice(-2), ['session-123', 'resume context']);
+  });
+
+  it('fails closed when web-search support is not attested', function () {
+    assert.throws(
+      () =>
+        buildCommand('codex', 'test context', {
+          webSearch: true,
+          cliFeatures: { supportsWebSearch: false },
+        }),
+      (error) =>
+        error.code === 'unsupported-capability' &&
+        /version >= 0\.146\.0/.test(error.message)
+    );
+  });
+
   it('passes --output-schema when CLI supports it', function () {
     const result = buildCommand('codex', 'test context', {
       jsonSchema: { type: 'object', properties: { foo: { type: 'string' } } },
@@ -188,25 +242,85 @@ describe('Gemini provider helper builder', function () {
 });
 
 describe('Opencode provider helper builder', function () {
-  it('warns when unsupported session control options are ignored', function () {
+  it('uses explicit-session precedence for native resume controls', function () {
     const resumed = buildCommand('opencode', 'test context', {
       resumeSessionId: 'session-123',
+      continueSession: true,
+      cliFeatures: { supportsResume: true },
     });
-    assert.ok(!resumed.args.includes('--resume'));
-    assert.ok(
-      resumed.warnings.some(
-        (warning) =>
-          warning.code === 'unsupported-session-control' &&
-          warning.message ===
-            'Provider opencode does not support resume/continue session control; ignoring.'
-      )
-    );
+    assert.deepStrictEqual(resumed.args.slice(-3), [
+      '--session',
+      'session-123',
+      'test context',
+    ]);
+    assert.strictEqual(resumed.args.includes('--continue'), false);
 
     const continued = buildCommand('opencode', 'test context', {
       continueSession: true,
+      cliFeatures: { supportsResume: true },
     });
-    assert.ok(!continued.args.includes('--continue'));
-    assert.ok(continued.warnings.some((warning) => warning.code === 'unsupported-session-control'));
+    assert.deepStrictEqual(continued.args.slice(-2), ['--continue', 'test context']);
+
+    assert.throws(
+      () =>
+        buildCommand('opencode', 'test context', {
+          resumeSessionId: 'session-123',
+          cliFeatures: { supportsResume: false },
+        }),
+      /cannot safely run continuation context/
+    );
+  });
+
+  it('extracts the OpenCode session ID used by resume commands', function () {
+    assert.strictEqual(
+      helper.extractProviderSessionId(
+        'opencode',
+        '{"type":"step_start","sessionID":"session-123","part":{}}'
+      ),
+      'session-123'
+    );
+  });
+
+  it('keeps disabled search unchanged and enables EXA for fresh and resumed commands', function () {
+    const absent = buildCommand('opencode', 'test context');
+    const disabled = buildCommand('opencode', 'test context', { webSearch: false });
+    assert.deepStrictEqual(disabled.args, absent.args);
+    assert.deepStrictEqual(disabled.env, absent.env);
+
+    const fresh = buildCommand('opencode', 'test context', {
+      webSearch: true,
+      cliFeatures: { supportsWebSearch: true },
+    });
+    assert.deepStrictEqual(fresh.env, { OPENCODE_ENABLE_EXA: '1' });
+
+    const resumed = buildCommand('opencode', 'test context', {
+      resumeSessionId: 'session-123',
+      webSearch: true,
+      cliFeatures: { supportsResume: true, supportsWebSearch: true },
+    });
+    assert.deepStrictEqual(resumed.args.slice(-3), ['--session', 'session-123', 'test context']);
+    assert.deepStrictEqual(resumed.env, { OPENCODE_ENABLE_EXA: '1' });
+
+    const continued = buildCommand('opencode', 'test context', {
+      continueSession: true,
+      webSearch: true,
+      cliFeatures: { supportsResume: true, supportsWebSearch: true },
+    });
+    assert.deepStrictEqual(continued.args.slice(-2), ['--continue', 'test context']);
+    assert.deepStrictEqual(continued.env, { OPENCODE_ENABLE_EXA: '1' });
+  });
+
+  it('fails closed when the OpenCode version is not attested', function () {
+    assert.throws(
+      () =>
+        buildCommand('opencode', 'test context', {
+          webSearch: true,
+          cliFeatures: { supportsWebSearch: false },
+        }),
+      (error) =>
+        error.code === 'unsupported-capability' &&
+        /version >= 1\.0\.137/.test(error.message)
+    );
   });
 
   it('injects schema into context when jsonSchema is provided', function () {

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { loadSettings, validateSetting } = require('../lib/settings');
+const { loadSettings, mutateSettings, validateSetting } = require('../lib/settings');
 const {
   validateProviderFeatures,
   validateProviderSettings,
@@ -100,6 +100,42 @@ describe('Provider settings', function () {
         },
       });
     }, /reasoningEffort overrides are only supported/);
+  });
+
+  it('declares strict default-off web search only for Codex and OpenCode', function () {
+    assert.strictEqual(getProvider('codex').getDefaultSettings().webSearch, false);
+    assert.strictEqual(getProvider('opencode').getDefaultSettings().webSearch, false);
+    assert.strictEqual(
+      validateSetting('providerSettings', {
+        codex: { webSearch: true },
+        opencode: { webSearch: false },
+      }),
+      null
+    );
+    assert.match(
+      validateSetting('providerSettings', { codex: { webSearch: 'yes' } }),
+      /providerSettings\.codex\.webSearch must be a boolean/
+    );
+    assert.match(
+      validateSetting('providerSettings', { claude: { webSearch: true } }),
+      /Unknown provider setting: providerSettings\.claude\.webSearch/
+    );
+  });
+
+  it('round-trips web search through settings mutation and reads', function () {
+    process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
+    fs.writeFileSync(settingsFile, '{}', 'utf8');
+    try {
+      mutateSettings((settings) => {
+        settings.providerSettings.codex.webSearch = true;
+        settings.providerSettings.opencode.webSearch = true;
+      });
+      const settings = loadSettings();
+      assert.strictEqual(settings.providerSettings.codex.webSearch, true);
+      assert.strictEqual(settings.providerSettings.opencode.webSearch, true);
+    } finally {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    }
   });
 
   it('validates gateway settings and accepts arbitrary model ids', function () {

--- a/tests/unit/task-startup-capability-error.test.js
+++ b/tests/unit/task-startup-capability-error.test.js
@@ -1,0 +1,153 @@
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const sinon = require('sinon');
+
+const { executeTask } = require('../../src/agent/agent-lifecycle');
+const {
+  parseTaskStartupError,
+  serializeTaskStartupError,
+} = require('../../src/task-startup-error');
+
+function capabilityError() {
+  return Object.assign(new Error('Codex web search is unsupported.'), {
+    code: 'unsupported-capability',
+    permanent: true,
+    provider: 'codex',
+    capability: 'webSearch',
+  });
+}
+
+function createAgent(startupError) {
+  const lifecycleEvents = [];
+  const published = [];
+  let spawnCalls = 0;
+  const agent = {
+    id: 'capability-worker',
+    role: 'implementation',
+    cluster: { id: 'capability-cluster' },
+    config: { hooks: {}, maxRetries: 3, outputFormat: 'json' },
+    iteration: 0,
+    maxIterations: 10,
+    running: true,
+    state: 'idle',
+    testMode: true,
+    quiet: true,
+    currentTask: null,
+    currentTaskId: null,
+    processPid: null,
+    lastOutputTime: null,
+    taskStartedAt: null,
+    messageBus: { publish() {} },
+    _buildContext: () => 'task context',
+    _selectModel: () => 'sonnet',
+    _resolveModelSpec: () => null,
+    _resolveProvider: () => 'codex',
+    _log() {},
+    _publishLifecycle(event, data) {
+      lifecycleEvents.push({ event, data });
+    },
+    _publish(message) {
+      published.push(message);
+    },
+    async _spawnClaudeTask() {
+      spawnCalls += 1;
+      throw startupError;
+    },
+  };
+  return { agent, lifecycleEvents, published, getSpawnCalls: () => spawnCalls };
+}
+
+describe('Task startup capability errors', function () {
+  let originalSettingsFile;
+  let settingsDir;
+
+  beforeEach(function () {
+    originalSettingsFile = process.env.ZEROSHOT_SETTINGS_FILE;
+    settingsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-capability-startup-'));
+    process.env.ZEROSHOT_SETTINGS_FILE = path.join(settingsDir, 'settings.json');
+    fs.writeFileSync(
+      process.env.ZEROSHOT_SETTINGS_FILE,
+      JSON.stringify({ backoffBaseMs: 0, backoffMaxMs: 0, jitterFactor: 0 })
+    );
+  });
+
+  afterEach(function () {
+    if (originalSettingsFile === undefined) {
+      delete process.env.ZEROSHOT_SETTINGS_FILE;
+    } else {
+      process.env.ZEROSHOT_SETTINGS_FILE = originalSettingsFile;
+    }
+    fs.rmSync(settingsDir, { recursive: true, force: true });
+  });
+
+  it('restores permanent capability faults from the host task-start wrapper', async function () {
+    const fakeChild = new EventEmitter();
+    fakeChild.stdout = new EventEmitter();
+    fakeChild.stderr = new EventEmitter();
+    const spawnStub = sinon.stub(childProcess, 'spawn').returns(fakeChild);
+    const original = capabilityError();
+
+    try {
+      const runnerPath = require.resolve('../../src/claude-task-runner');
+      delete require.cache[runnerPath];
+      const ClaudeTaskRunner = require(runnerPath);
+      const runner = new ClaudeTaskRunner({ quiet: true });
+      const pending = runner._spawnAndGetTaskId(
+        'zeroshot',
+        ['task', 'run'],
+        '/tmp',
+        {},
+        'agent-1'
+      );
+      fakeChild.stderr.emit('data', Buffer.from(`${serializeTaskStartupError(original)}\n`));
+      fakeChild.emit('close', 1);
+      const rejection = await pending.then(
+        () => null,
+        (error) => error
+      );
+
+      assert.strictEqual(rejection.code, 'unsupported-capability');
+      assert.strictEqual(rejection.permanent, true);
+      assert.strictEqual(rejection.message, original.message);
+      assert.strictEqual(rejection.provider, original.provider);
+      assert.strictEqual(rejection.capability, original.capability);
+    } finally {
+      spawnStub.restore();
+      const runnerPath = require.resolve('../../src/claude-task-runner');
+      delete require.cache[runnerPath];
+    }
+  });
+
+  it('does not retry a restored permanent capability fault', async function () {
+    const original = capabilityError();
+    const restored = parseTaskStartupError(`${serializeTaskStartupError(original)}\n`);
+    assert(restored);
+    const { agent, lifecycleEvents, published, getSpawnCalls } = createAgent(restored);
+    const originalConsoleError = console.error;
+    const originalConsoleWarn = console.warn;
+    console.error = () => {};
+    console.warn = () => {};
+
+    try {
+      await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'system' });
+    } finally {
+      console.error = originalConsoleError;
+      console.warn = originalConsoleWarn;
+    }
+
+    assert.strictEqual(getSpawnCalls(), 1);
+    assert.strictEqual(
+      lifecycleEvents.filter(({ event }) => event === 'RETRY_SCHEDULED').length,
+      0
+    );
+    assert.strictEqual(
+      lifecycleEvents.filter(({ event }) => event === 'TASK_FAILED').length,
+      1
+    );
+    assert(published.some(({ topic }) => topic === 'CLUSTER_FAILED'));
+  });
+});

--- a/tests/unit/task-startup-capability-error.test.js
+++ b/tests/unit/task-startup-capability-error.test.js
@@ -53,9 +53,9 @@ function createAgent(startupError) {
     _publish(message) {
       published.push(message);
     },
-    async _spawnClaudeTask() {
+    _spawnClaudeTask() {
       spawnCalls += 1;
-      throw startupError;
+      return Promise.reject(startupError);
     },
   };
   return { agent, lifecycleEvents, published, getSpawnCalls: () => spawnCalls };
@@ -144,10 +144,36 @@ describe('Task startup capability errors', function () {
       lifecycleEvents.filter(({ event }) => event === 'RETRY_SCHEDULED').length,
       0
     );
-    assert.strictEqual(
-      lifecycleEvents.filter(({ event }) => event === 'TASK_FAILED').length,
-      1
-    );
-    assert(published.some(({ topic }) => topic === 'CLUSTER_FAILED'));
+    const taskFailed = lifecycleEvents.find(({ event }) => event === 'TASK_FAILED');
+    assert.deepStrictEqual(taskFailed.data, {
+      iteration: 0,
+      taskId: null,
+      error: original.message,
+      code: 'unsupported-capability',
+      permanent: true,
+      provider: 'codex',
+      capability: 'webSearch',
+      attempt: 1,
+    });
+    const clusterFailed = published.find(({ topic }) => topic === 'CLUSTER_FAILED');
+    assert(clusterFailed);
+    assert.deepStrictEqual(clusterFailed.content.data, {
+      reason: 'unsupported_capability',
+      agentId: agent.id,
+      role: agent.role,
+      code: 'unsupported-capability',
+      permanent: true,
+      provider: 'codex',
+      capability: 'webSearch',
+      error: original.message,
+    });
+    const agentError = published.find(({ topic }) => topic === 'AGENT_ERROR');
+    assert.strictEqual(agentError.content.data.code, 'unsupported-capability');
+    assert.strictEqual(agentError.content.data.permanent, true);
+    assert.strictEqual(agent.cluster.failureInfo.code, 'unsupported-capability');
+    assert.strictEqual(agent.cluster.failureInfo.permanent, true);
+    assert.strictEqual(agent.cluster.failureInfo.provider, 'codex');
+    assert.strictEqual(agent.cluster.failureInfo.capability, 'webSearch');
+    assert.strictEqual(agent.state, 'error');
   });
 });

--- a/tests/unit/task-startup-capability-error.test.js
+++ b/tests/unit/task-startup-capability-error.test.js
@@ -6,19 +6,22 @@ const os = require('node:os');
 const path = require('node:path');
 const sinon = require('sinon');
 
+const {
+  assertRequestedWebSearchCliAvailable,
+} = require('../../cli/index');
 const { executeTask } = require('../../src/agent/agent-lifecycle');
 const {
+  createUnsupportedProviderCapabilityError,
   parseTaskStartupError,
   serializeTaskStartupError,
 } = require('../../src/task-startup-error');
 
 function capabilityError() {
-  return Object.assign(new Error('Codex web search is unsupported.'), {
-    code: 'unsupported-capability',
-    permanent: true,
-    provider: 'codex',
-    capability: 'webSearch',
-  });
+  return createUnsupportedProviderCapabilityError(
+    'codex',
+    'webSearch',
+    'Codex web search was requested, but the codex CLI is not installed.'
+  );
 }
 
 function createAgent(startupError) {
@@ -84,6 +87,36 @@ describe('Task startup capability errors', function () {
     fs.rmSync(settingsDir, { recursive: true, force: true });
   });
 
+  it('classifies a missing CLI only when declared web search is enabled', function () {
+    assert.throws(
+      () =>
+        assertRequestedWebSearchCliAvailable(
+          'codex',
+          { providerSettings: { codex: { webSearch: true } } },
+          () => false
+        ),
+      (error) =>
+        error.code === 'unsupported-capability' &&
+        error.permanent === true &&
+        error.provider === 'codex' &&
+        error.capability === 'webSearch' &&
+        /codex CLI is not installed/.test(error.message)
+    );
+
+    let availabilityChecks = 0;
+    assert.doesNotThrow(() =>
+      assertRequestedWebSearchCliAvailable(
+        'codex',
+        { providerSettings: { codex: { webSearch: false } } },
+        () => {
+          availabilityChecks += 1;
+          return false;
+        }
+      )
+    );
+    assert.strictEqual(availabilityChecks, 0);
+  });
+
   it('restores permanent capability faults from the host task-start wrapper', async function () {
     const fakeChild = new EventEmitter();
     fakeChild.stdout = new EventEmitter();
@@ -122,6 +155,41 @@ describe('Task startup capability errors', function () {
     }
   });
 
+  it('restores permanent capability faults from the isolated TaskRunner', async function () {
+    const proc = new EventEmitter();
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = () => {};
+    const runnerPath = require.resolve('../../src/claude-task-runner');
+    delete require.cache[runnerPath];
+    const runner = new ClaudeTaskRunner({ quiet: true, timeout: 1 });
+    const original = capabilityError();
+    const pending = runner._runIsolated('task context', {
+      provider: 'codex',
+      isolation: {
+        clusterId: 'cluster-1',
+        manager: {
+          spawnInContainer() {
+            return proc;
+          },
+        },
+      },
+    });
+    proc.stderr.emit('data', Buffer.from(`${'noise'.repeat(120)}\n`));
+    proc.stderr.emit('data', Buffer.from(`${serializeTaskStartupError(original)}\n`));
+    proc.emit('close', 1);
+    const rejection = await pending.then(
+      () => null,
+      (error) => error
+    );
+
+    assert.strictEqual(rejection.code, 'unsupported-capability');
+    assert.strictEqual(rejection.permanent, true);
+    assert.strictEqual(rejection.provider, original.provider);
+    assert.strictEqual(rejection.capability, original.capability);
+    assert.strictEqual(rejection.message, original.message);
+  });
+
   it('does not retry a restored permanent capability fault', async function () {
     const original = capabilityError();
     const restored = parseTaskStartupError(`${serializeTaskStartupError(original)}\n`);
@@ -146,7 +214,7 @@ describe('Task startup capability errors', function () {
     );
     const taskFailed = lifecycleEvents.find(({ event }) => event === 'TASK_FAILED');
     assert.deepStrictEqual(taskFailed.data, {
-      iteration: 0,
+      iteration: 1,
       taskId: null,
       error: original.message,
       code: 'unsupported-capability',

--- a/tests/unit/task-startup-capability-error.test.js
+++ b/tests/unit/task-startup-capability-error.test.js
@@ -162,6 +162,7 @@ describe('Task startup capability errors', function () {
     proc.kill = () => {};
     const runnerPath = require.resolve('../../src/claude-task-runner');
     delete require.cache[runnerPath];
+    const ClaudeTaskRunner = require(runnerPath);
     const runner = new ClaudeTaskRunner({ quiet: true, timeout: 1 });
     const original = capabilityError();
     const pending = runner._runIsolated('task context', {


### PR DESCRIPTION
## Summary

- add strict, registry-derived `providerSettings.codex.webSearch` and `providerSettings.opencode.webSearch` booleans, both defaulting to `false`
- dynamically attest local CLI control support while keeping requested and effective state distinct in runtime probe and executable build output
- apply native search controls to fresh and resumed commands, including isolated child settings projection
- fail closed with an actionable `unsupported-capability` error when explicitly enabled search cannot be proven; preserve that structured permanent fault through host and isolated task-start wrappers so lifecycle retry logic terminalizes it

Closes #859

## Exact behavior

### Codex

Enabled commands use the upstream noninteractive control:

```text
codex exec --config 'web_search="live"' ...
codex exec --config 'web_search="live"' resume SESSION_ID ...
```

Support requires nonempty `codex exec --help` output containing `--config` and a parseable Codex version >= `0.146.0`. Missing, malformed, older, or help-incompatible installations are unsupported. Absent/false settings add no arguments and do not trigger search-specific probing when caller-supplied feature metadata is otherwise sufficient.

This intentionally does **not** emit `codex exec --search`: current upstream `ExecCli` rejects that argument, and the top-level TUI `--search` flag is not translated into noninteractive exec configuration. Codex's TypeScript SDK emits `--config 'web_search="live"'` before both fresh prompts and `resume`:

- https://github.com/openai/codex/blob/main/sdk/typescript/src/exec.ts
- https://github.com/openai/codex/blob/main/codex-rs/cli/src/main.rs
- https://github.com/openai/codex/blob/main/codex-rs/exec/src/cli.rs

### OpenCode

Enabled fresh and resumed commands receive `OPENCODE_ENABLE_EXA=1`; unrelated environment entries are retained. Support requires a parseable OpenCode version >= `1.0.137`. Missing, malformed, or older versions are unsupported.

Upstream sources:

- https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/effect/runtime-flags.ts
- https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/tool/registry.ts

### Scope matrix

| Provider | Declared setting | Additive control | Support proof |
| --- | --- | --- | --- |
| Codex | `providerSettings.codex.webSearch` | `--config 'web_search="live"'` | nonempty exec help with `--config` + version >= `0.146.0` |
| OpenCode | `providerSettings.opencode.webSearch` | `OPENCODE_ENABLE_EXA=1` | version >= `1.0.137` |
| Claude, Gemini, Kiro, Copilot, Pi, Gateway | unsupported; field rejected | none established | none established |

Permission/tool allowlists authorize tools already present; they are not treated as controls that enable search. Probes attest only installed CLI support, not account, backend, network, or browser/API reachability.

## Files changed

- `AGENTS.md`
- `cli/commands/providers.js`
- `cli/index.js`
- `docs/providers.md`
- `src/agent-cli-provider/adapters/codex.ts`
- `src/agent-cli-provider/adapters/common.ts`
- `src/agent-cli-provider/adapters/index.ts`
- `src/agent-cli-provider/adapters/opencode.ts`
- `src/agent-cli-provider/contract-actions.ts`
- `src/agent-cli-provider/contract-fallback.ts`
- `src/agent-cli-provider/contract-options.ts`
- `src/agent-cli-provider/errors.ts`
- `src/agent-cli-provider/index.ts`
- `src/agent-cli-provider/provider-registry.ts`
- `src/agent-cli-provider/single-agent-runtime.ts`
- `src/agent-cli-provider/types.ts`
- `src/providers/index.js`
- `src/task-run-model-args.js`
- `src/task-spawn-cleanup-ownership.js`
- `src/task-startup-error.js`
- `tests/agent-cli-provider/executable-contract-build.test.js`
- `tests/agent-cli-provider/executable-contract-option-validation.test.js`
- `tests/agent-cli-provider/parity.test.js`
- `tests/agent-cli-provider/providers-command-parity.test.js`
- `tests/isolated-task-launch-recovery.test.js`
- `tests/opencode-docker-settings-boundary.test.js`
- `tests/provider-cli-builder.test.js`
- `tests/settings-providers.test.js`
- `tests/unit/task-startup-capability-error.test.js`

## Focused checks for supervisor

Not run, per request:

```bash
npm run build:agent-cli-provider
npx mocha tests/provider-cli-builder.test.js tests/settings-providers.test.js tests/opencode-docker-settings-boundary.test.js tests/isolated-task-launch-recovery.test.js tests/unit/task-startup-capability-error.test.js
npx mocha tests/agent-cli-provider/executable-contract-build.test.js tests/agent-cli-provider/executable-contract-option-validation.test.js tests/agent-cli-provider/parity.test.js tests/agent-cli-provider/providers-command-parity.test.js
npx eslint cli/index.js cli/commands/providers.js src/agent-cli-provider src/providers/index.js src/task-run-model-args.js src/task-spawn-cleanup-ownership.js src/task-startup-error.js tests/provider-cli-builder.test.js tests/settings-providers.test.js tests/opencode-docker-settings-boundary.test.js tests/isolated-task-launch-recovery.test.js tests/unit/task-startup-capability-error.test.js tests/agent-cli-provider/*.test.js
npx prettier --check AGENTS.md docs/providers.md cli/index.js cli/commands/providers.js src/agent-cli-provider src/providers/index.js src/task-run-model-args.js src/task-spawn-cleanup-ownership.js src/task-startup-error.js tests/provider-cli-builder.test.js tests/settings-providers.test.js tests/opencode-docker-settings-boundary.test.js tests/isolated-task-launch-recovery.test.js tests/unit/task-startup-capability-error.test.js tests/agent-cli-provider/*.test.js
npm test
```

No live model API, browser/API reachability, gateway, retry, or telemetry checks are required.