### PR TITLE
feat(hosted): add minimal OECP capsule server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.cluster-build
+coverage
+node_modules
+target
+**/target
+*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,6 +489,22 @@ Pub/sub message bus + SQLite ledger. Agents subscribe to topics, execute on trig
 Agent A -> publish() -> SQLite Ledger -> LogicEngine -> trigger match -> Agent B executes
 ```
 
+### Hosted OECP Capsule Boundary
+
+`zeroshot-oecp-server` is the in-capsule OECP process. It owns one reconnectable
+single-worker run and the child `zeroshot-cluster-worker`; it never allocates, bills, stops, or
+terminates the capsule. Zero Cloud owns that lifecycle outside OECP.
+
+The public OECP protocol carries graph/input data only. A separate capsule-access-authorized
+upload installs the exact GitHub/OpenRouter credential bundle once, in memory. The server writes
+only secret-free Codex and Git helper configuration below `/workspace`, and passes credential
+values only in the child process environment. Do not add credential values, arbitrary environment
+maps, refresh tokens, or capsule lifecycle methods to OECP frames.
+
+Named target metadata lives in `~/.zeroshot/targets.json`; refresh tokens belong in the OS
+credential store. `ZEROSHOT_TARGET_REFRESH_TOKEN` is the explicit, process-only automation escape
+hatch and must never be persisted by the CLI.
+
 ### Core Primitives
 
 | Primitive    | Purpose                                                     |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,10 +54,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -348,6 +406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fraction"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +439,15 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -493,10 +569,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "icu_collections"
@@ -696,10 +836,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1299,6 +1451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1580,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1701,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1708,6 +1895,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2092,6 +2327,7 @@ name = "zeroshot-rust"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
  "fs2",
  "futures-util",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/the-open-engine/zeroshot"
 
 [workspace.dependencies]
 async-trait = "0.1.89"
+axum = { version = "0.8.4", features = ["json"] }
 fs2 = "0.4.3"
 getrandom = "0.3.4"
 libc = "0.2.177"
@@ -27,7 +28,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.48.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = "0.1"
 tokio-tungstenite = "0.26"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ export OPENROUTER_API_KEY=...
 zeroshot run org/repo#123 --target production --pr
 ```
 
+`--size tiny|small|standard|large` selects the capsule tier; it is optional and defaults to
+`standard`.
+
 `--pr` runs in an isolated worktree, pushes the implementation branch, creates a pull request for
 human review, verifies that GitHub reports it, and prints the pull request URL. Without `--pr`, the
 hosted run does not push repository changes.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ zeroshot target login production
 
 export GH_TOKEN=...                 # optional when `gh auth token` works
 export OPENROUTER_API_KEY=...
-zeroshot run org/repo#123 --target production
+zeroshot run org/repo#123 --target production --pr
 ```
+
+`--pr` runs in an isolated worktree, pushes the implementation branch, creates a pull request for
+human review, verifies that GitHub reports it, and prints the pull request URL. Without `--pr`, the
+hosted run does not push repository changes.
 
 For one-shot non-interactive automation, `ZEROSHOT_TARGET_REFRESH_TOKEN` supplies a process-only
 login and is never written to the target metadata file. Because Zero Cloud rotates refresh tokens,

--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ zeroshot cmdproof check <id>    # reuse a verified command result
 
 </details>
 
+## Hosted capsule runs
+
+Named Zero Cloud targets use the same issue, file, stdin, and prompt inputs as local runs. Login
+uses the device flow and stores only the rotating refresh token in the OS credential service. The
+GitHub and OpenRouter credentials are read for each run, uploaded under the short-lived capsule
+access grant, and kept only in the capsule process environment.
+
+```bash
+zeroshot target add production https://cloud.example
+zeroshot target login production
+
+export GH_TOKEN=...                 # optional when `gh auth token` works
+export OPENROUTER_API_KEY=...
+zeroshot run org/repo#123 --target production
+```
+
+For one-shot non-interactive automation, `ZEROSHOT_TARGET_REFRESH_TOKEN` supplies a process-only
+login and is never written to the target metadata file. Because Zero Cloud rotates refresh tokens,
+repeat runs should use the persistent Secret Service login rather than reusing that environment
+value.
+
 ## Providers and backends
 
 Zeroshot shells out to provider CLIs; it stores no API keys and manages no auth. Pick a default and override per run.

--- a/cli/hosted/auth.js
+++ b/cli/hosted/auth.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
+
+const { loadRefreshToken, storeRefreshToken } = require('./credential-store');
+const { HostedHttpError, request } = require('./http');
+
+const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function tryOpenBrowser(url) {
+  let command = 'xdg-open';
+  if (process.platform === 'darwin') command = 'open';
+  if (process.platform === 'win32') command = 'cmd';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  try {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+    child.on('error', () => undefined);
+    child.unref();
+  } catch {
+    // The printed URL is the portable fallback.
+  }
+}
+
+function tokenEnvelope(value) {
+  if (
+    value?.token_type !== 'Bearer' ||
+    typeof value.access_token !== 'string' ||
+    !value.access_token ||
+    typeof value.refresh_token !== 'string' ||
+    !value.refresh_token
+  ) {
+    throw new Error('Zero Cloud returned an invalid token envelope');
+  }
+  return value;
+}
+
+function validateDeviceGrant(grant) {
+  if (
+    typeof grant?.device_code !== 'string' ||
+    typeof grant?.verification_uri_complete !== 'string' ||
+    !Number.isSafeInteger(grant.interval) ||
+    grant.interval < 1
+  ) {
+    throw new Error('Zero Cloud returned an invalid device authorization');
+  }
+  return grant;
+}
+
+function devicePollDisposition(error) {
+  if (!(error instanceof HostedHttpError)) throw error;
+  if (error.code === 'authorization_pending') return 'pending';
+  if (error.code === 'slow_down') return 'slow_down';
+  if (error.code === 'expired_token') return 'expired';
+  if (error.code === 'access_denied') throw new Error('device authorization was denied');
+  throw error;
+}
+
+async function pollDeviceAuthorization(target, grant, deviceToken) {
+  const deadline = Date.now() + (Number(grant.expires_in) || 600) * 1_000;
+  let intervalSeconds = grant.interval;
+  while (Date.now() < deadline) {
+    await wait(intervalSeconds * 1_000);
+    try {
+      return tokenEnvelope(
+        (
+          await request(target.endpoint, '/auth/token', {
+            method: 'POST',
+            form: {
+              grant_type: DEVICE_GRANT,
+              client_id: 'cli',
+              device_code: grant.device_code,
+              audience: 'admin',
+              device_token: deviceToken,
+              device_label: 'Zeroshot CLI',
+            },
+          })
+        ).body
+      );
+    } catch (error) {
+      const disposition = devicePollDisposition(error);
+      if (disposition === 'slow_down') {
+        intervalSeconds += 5;
+      }
+      if (disposition === 'expired') break;
+    }
+  }
+  throw new Error('device authorization expired before it was approved');
+}
+
+async function login(targetName, target) {
+  const grant = validateDeviceGrant(
+    (
+      await request(target.endpoint, '/auth/device/code', {
+        method: 'POST',
+        form: { client_id: 'cli' },
+      })
+    ).body
+  );
+  console.log(`Authorize this CLI in your browser:\n${grant.verification_uri_complete}`);
+  tryOpenBrowser(grant.verification_uri_complete);
+  const deviceToken = crypto.randomBytes(32).toString('hex');
+  const tokens = await pollDeviceAuthorization(target, grant, deviceToken);
+  storeRefreshToken(targetName, tokens.refresh_token);
+}
+
+async function exchangeCapsule(targetName, target, source) {
+  const tokens = tokenEnvelope(
+    (
+      await request(target.endpoint, '/auth/token', {
+        method: 'POST',
+        form: {
+          grant_type: 'refresh_token',
+          client_id: 'cli',
+          refresh_token: source.token,
+          audience: 'capsule',
+        },
+      })
+    ).body
+  );
+  if (source.persistent) storeRefreshToken(targetName, tokens.refresh_token);
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    persistent: source.persistent,
+  };
+}
+
+function capsuleSession(targetName, target, environment = process.env) {
+  return exchangeCapsule(targetName, target, loadRefreshToken(targetName, environment));
+}
+
+function rotateCapsuleSession(targetName, target, session) {
+  return exchangeCapsule(targetName, target, {
+    token: session.refreshToken,
+    persistent: session.persistent,
+  });
+}
+
+module.exports = { capsuleSession, login, rotateCapsuleSession, tokenEnvelope };

--- a/cli/hosted/auth.js
+++ b/cli/hosted/auth.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const crypto = require('node:crypto');
-const { spawn } = require('node:child_process');
 
 const { loadRefreshToken, storeRefreshToken } = require('./credential-store');
 const { HostedHttpError, request } = require('./http');
@@ -10,20 +9,6 @@ const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
 
 function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-function tryOpenBrowser(url) {
-  let command = 'xdg-open';
-  if (process.platform === 'darwin') command = 'open';
-  if (process.platform === 'win32') command = 'cmd';
-  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
-  try {
-    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
-    child.on('error', () => undefined);
-    child.unref();
-  } catch {
-    // The printed URL is the portable fallback.
-  }
 }
 
 function tokenEnvelope(value) {
@@ -102,7 +87,6 @@ async function login(targetName, target) {
     ).body
   );
   console.log(`Authorize this CLI in your browser:\n${grant.verification_uri_complete}`);
-  tryOpenBrowser(grant.verification_uri_complete);
   const deviceToken = crypto.randomBytes(32).toString('hex');
   const tokens = await pollDeviceAuthorization(target, grant, deviceToken);
   storeRefreshToken(targetName, tokens.refresh_token);

--- a/cli/hosted/credential-store.js
+++ b/cli/hosted/credential-store.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+
+const APPLICATION = 'zeroshot';
+
+function automationRefreshToken(environment = process.env) {
+  const value = environment.ZEROSHOT_TARGET_REFRESH_TOKEN;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function secretTool(args, options = {}) {
+  return execFileSync('secret-tool', args, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+    ...options,
+  });
+}
+
+function loadRefreshToken(targetName, environment = process.env) {
+  const automation = automationRefreshToken(environment);
+  if (automation) return { token: automation, persistent: false };
+  try {
+    const token = secretTool(['lookup', 'application', APPLICATION, 'target', targetName]).trim();
+    if (token) return { token, persistent: true };
+  } catch {
+    // Missing entry and unavailable Secret Service are handled by one actionable error.
+  }
+  throw new Error(
+    `target ${targetName} is not logged in; run "zeroshot target login ${targetName}" ` +
+      'or set ZEROSHOT_TARGET_REFRESH_TOKEN for one non-interactive run'
+  );
+}
+
+function storeRefreshToken(targetName, token) {
+  if (!token || typeof token !== 'string') throw new Error('refusing to store an empty token');
+  try {
+    secretTool(
+      [
+        'store',
+        `--label=Zeroshot target ${targetName}`,
+        'application',
+        APPLICATION,
+        'target',
+        targetName,
+      ],
+      { input: token }
+    );
+  } catch {
+    throw new Error(
+      'a Secret Service credential store is required for persistent target login; ' +
+        'install secret-tool/libsecret or use ZEROSHOT_TARGET_REFRESH_TOKEN for automation'
+    );
+  }
+}
+
+function removeRefreshToken(targetName) {
+  try {
+    secretTool(['clear', 'application', APPLICATION, 'target', targetName]);
+  } catch {
+    // Removing a target is idempotent with respect to an absent keyring entry.
+  }
+}
+
+module.exports = {
+  loadRefreshToken,
+  removeRefreshToken,
+  storeRefreshToken,
+};

--- a/cli/hosted/http.js
+++ b/cli/hosted/http.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { URL, URLSearchParams } = require('node:url');
+
+class HostedHttpError extends Error {
+  constructor(status, code, retryAfter) {
+    super(`Zero Cloud request failed (${status}${code ? `: ${code}` : ''})`);
+    this.name = 'HostedHttpError';
+    this.status = status;
+    this.code = code;
+    this.retryAfter = retryAfter;
+  }
+}
+
+function isLoopbackHttp(url) {
+  return url.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+}
+
+function encodeBody(options, headers) {
+  if (options.json !== undefined) {
+    headers['content-type'] = 'application/json';
+    return JSON.stringify(options.json);
+  }
+  if (options.form !== undefined) {
+    headers['content-type'] = 'application/x-www-form-urlencoded';
+    return new URLSearchParams(options.form).toString();
+  }
+  return undefined;
+}
+
+async function request(endpoint, pathname, options = {}) {
+  const url = new URL(pathname, `${endpoint}/`);
+  const headers = { accept: 'application/json', ...(options.headers || {}) };
+  if (isLoopbackHttp(url)) {
+    headers['x-forwarded-for'] = '127.0.0.1';
+  }
+  if (options.bearer) headers.authorization = `Bearer ${options.bearer}`;
+  const body = encodeBody(options, headers);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs || 15_000);
+  let response;
+  try {
+    response = await fetch(url, {
+      method: options.method || 'GET',
+      headers,
+      body,
+      redirect: 'error',
+      signal: options.signal || controller.signal,
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') throw new Error(`Zero Cloud request timed out: ${pathname}`);
+    throw new Error(`Zero Cloud is unreachable at ${endpoint}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+  const text = await response.text();
+  let value = null;
+  if (text) {
+    try {
+      value = JSON.parse(text);
+    } catch {
+      throw new Error(`Zero Cloud returned an invalid response (${response.status})`);
+    }
+  }
+  const accepted = options.accept || [200];
+  if (!accepted.includes(response.status)) {
+    let code = null;
+    if (typeof value?.code === 'string') code = value.code;
+    else if (typeof value?.error === 'string') code = value.error;
+    throw new HostedHttpError(response.status, code, response.headers.get('retry-after'));
+  }
+  return { status: response.status, body: value, headers: response.headers };
+}
+
+module.exports = { HostedHttpError, request };

--- a/cli/hosted/run.js
+++ b/cli/hosted/run.js
@@ -113,7 +113,7 @@ async function stdinText() {
 function readTaskFile(filename) {
   let descriptor;
   try {
-    descriptor = fs.openSync(filename, 'r');
+    descriptor = fs.openSync(filename, fs.constants.O_RDONLY | (fs.constants.O_NONBLOCK || 0));
   } catch (error) {
     if (['ENOENT', 'ENOTDIR', 'EISDIR'].includes(error.code)) return null;
     throw error;

--- a/cli/hosted/run.js
+++ b/cli/hosted/run.js
@@ -14,6 +14,7 @@ const DEFAULT_MODEL = 'openai/gpt-5.4';
 const PROTOCOL = 'openengine.cluster/v1';
 const WORKER = 'legacy.zeroshot.ship@1';
 const READY_TIMEOUT_MS = 10 * 60 * 1_000;
+const CAPSULE_SIZES = new Set(['tiny', 'small', 'standard', 'large']);
 
 function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -182,6 +183,9 @@ function validateHostedOptions(options) {
   }
   if (options.model !== undefined && !validModel(options.model)) {
     throw new Error('hosted runs require an exact provider/model slug');
+  }
+  if (!CAPSULE_SIZES.has(options.size || 'standard')) {
+    throw new Error('hosted runs require --size tiny, small, standard, or large');
   }
 }
 
@@ -413,7 +417,7 @@ async function runHosted(input, options) {
         method: 'POST',
         bearer: session.accessToken,
         headers: { 'idempotency-key': crypto.randomUUID() },
-        json: { label: 'zeroshot-cli' },
+        json: { label: 'zeroshot-cli', size: options.size || 'standard' },
         accept: [201],
       })
     ).body;

--- a/cli/hosted/run.js
+++ b/cli/hosted/run.js
@@ -49,10 +49,19 @@ function repositoryFromRemote(cwd = process.cwd()) {
   return match && validRepository(match[1]) ? match[1] : null;
 }
 
-function issueInput(value) {
+function isolationProfile(options = {}) {
+  return options.pr ? 'isolation.pr@1' : 'isolation.worktree@1';
+}
+
+function providerProfile(options = {}) {
+  return options.pr ? 'provider.codex-openrouter-pr@1' : 'provider.codex-openrouter@1';
+}
+
+function issueInput(value, options = {}) {
   const shorthand = value.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([1-9][0-9]*)$/);
   if (shorthand && validRepository(shorthand[1])) {
-    return { repository: shorthand[1], request: issueRequest(value) };
+    const canonicalIssue = `https://github.com/${shorthand[1]}/issues/${shorthand[2]}`;
+    return { repository: shorthand[1], request: issueRequest(canonicalIssue, options) };
   }
   let url;
   try {
@@ -63,26 +72,26 @@ function issueInput(value) {
   const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/issues\/([1-9][0-9]*)\/?$/);
   const repository = match ? `${match[1]}/${match[2]}` : '';
   if (url.hostname !== 'github.com' || !match || !validRepository(repository)) return null;
-  return { repository, request: issueRequest(value) };
+  return { repository, request: issueRequest(value, options) };
 }
 
-function issueRequest(issue) {
+function issueRequest(issue, options = {}) {
   return {
     source: 'issue',
     issue,
     artifacts: [],
-    isolationProfile: 'isolation.worktree@1',
-    providerProfile: 'provider.codex-openrouter@1',
+    isolationProfile: isolationProfile(options),
+    providerProfile: providerProfile(options),
   };
 }
 
-function promptRequest(prompt) {
+function promptRequest(prompt, options = {}) {
   return {
     source: 'prompt',
     prompt,
     artifacts: [],
-    isolationProfile: 'isolation.worktree@1',
-    providerProfile: 'provider.codex-openrouter@1',
+    isolationProfile: isolationProfile(options),
+    providerProfile: providerProfile(options),
   };
 }
 
@@ -101,7 +110,7 @@ async function stdinText() {
 }
 
 async function resolveInput(input, options) {
-  const explicitIssue = issueInput(input);
+  const explicitIssue = issueInput(input, options);
   if (explicitIssue) return explicitIssue;
   const repository =
     options.repository || process.env.ZEROSHOT_REPOSITORY || repositoryFromRemote();
@@ -111,16 +120,16 @@ async function resolveInput(input, options) {
         'ZEROSHOT_REPOSITORY, or run inside a GitHub checkout'
     );
   }
-  if (/^[1-9][0-9]*$/.test(input)) return { repository, request: issueRequest(input) };
-  if (input === '-') return { repository, request: promptRequest(await stdinText()) };
+  if (/^[1-9][0-9]*$/.test(input)) return { repository, request: issueRequest(input, options) };
+  if (input === '-') return { repository, request: promptRequest(await stdinText(), options) };
   const filename = path.resolve(input);
   if (fs.existsSync(filename) && fs.statSync(filename).isFile()) {
     const text = fs.readFileSync(filename, 'utf8').trim();
     if (!text) throw new Error(`hosted task file is empty: ${input}`);
-    return { repository, request: promptRequest(text) };
+    return { repository, request: promptRequest(text, options) };
   }
   if (!input.trim()) throw new Error('hosted task input is empty');
-  return { repository, request: promptRequest(input.trim()) };
+  return { repository, request: promptRequest(input.trim(), options) };
 }
 
 function githubToken(environment = process.env) {
@@ -151,7 +160,6 @@ function validateHostedOptions(options) {
     ['worktree', '--worktree'],
     ['dockerImage', '--docker-image'],
     ['strictSchema', '--strict-schema'],
-    ['pr', '--pr'],
     ['ship', '--ship'],
     ['prBase', '--pr-base'],
     ['mergeQueue', '--merge-queue'],

--- a/cli/hosted/run.js
+++ b/cli/hosted/run.js
@@ -110,6 +110,22 @@ async function stdinText() {
   return value;
 }
 
+function readTaskFile(filename) {
+  let descriptor;
+  try {
+    descriptor = fs.openSync(filename, 'r');
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR', 'EISDIR'].includes(error.code)) return null;
+    throw error;
+  }
+  try {
+    if (!fs.fstatSync(descriptor).isFile()) return null;
+    return fs.readFileSync(descriptor, 'utf8');
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
 async function resolveInput(input, options) {
   const explicitIssue = issueInput(input, options);
   if (explicitIssue) return explicitIssue;
@@ -124,8 +140,9 @@ async function resolveInput(input, options) {
   if (/^[1-9][0-9]*$/.test(input)) return { repository, request: issueRequest(input, options) };
   if (input === '-') return { repository, request: promptRequest(await stdinText(), options) };
   const filename = path.resolve(input);
-  if (fs.existsSync(filename) && fs.statSync(filename).isFile()) {
-    const text = fs.readFileSync(filename, 'utf8').trim();
+  const fileInput = readTaskFile(filename);
+  if (fileInput !== null) {
+    const text = fileInput.trim();
     if (!text) throw new Error(`hosted task file is empty: ${input}`);
     return { repository, request: promptRequest(text, options) };
   }

--- a/cli/hosted/run.js
+++ b/cli/hosted/run.js
@@ -1,0 +1,446 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { URL } = require('node:url');
+
+const { capsuleSession, rotateCapsuleSession } = require('./auth');
+const { HostedHttpError, request } = require('./http');
+const { getTarget } = require('./target-store');
+
+const DEFAULT_MODEL = 'openai/gpt-5.4';
+const PROTOCOL = 'openengine.cluster/v1';
+const WORKER = 'legacy.zeroshot.ship@1';
+const READY_TIMEOUT_MS = 10 * 60 * 1_000;
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function validRepository(value) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) return false;
+  return value.split('/').every((segment) => segment !== '.' && segment !== '..');
+}
+
+function validModel(value) {
+  return (
+    typeof value === 'string' &&
+    value.length <= 256 &&
+    /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(value)
+  );
+}
+
+function repositoryFromRemote(cwd = process.cwd()) {
+  let remote;
+  try {
+    remote = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+  const match = remote.match(
+    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https?:\/\/github\.com\/)([^/]+\/[^/]+?)(?:\.git)?$/
+  );
+  return match && validRepository(match[1]) ? match[1] : null;
+}
+
+function issueInput(value) {
+  const shorthand = value.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([1-9][0-9]*)$/);
+  if (shorthand && validRepository(shorthand[1])) {
+    return { repository: shorthand[1], request: issueRequest(value) };
+  }
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/issues\/([1-9][0-9]*)\/?$/);
+  const repository = match ? `${match[1]}/${match[2]}` : '';
+  if (url.hostname !== 'github.com' || !match || !validRepository(repository)) return null;
+  return { repository, request: issueRequest(value) };
+}
+
+function issueRequest(issue) {
+  return {
+    source: 'issue',
+    issue,
+    artifacts: [],
+    isolationProfile: 'isolation.worktree@1',
+    providerProfile: 'provider.codex-openrouter@1',
+  };
+}
+
+function promptRequest(prompt) {
+  return {
+    source: 'prompt',
+    prompt,
+    artifacts: [],
+    isolationProfile: 'isolation.worktree@1',
+    providerProfile: 'provider.codex-openrouter@1',
+  };
+}
+
+async function stdinText() {
+  if (process.stdin.isTTY) throw new Error('zeroshot run - requires piped input');
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of process.stdin) {
+    bytes += chunk.length;
+    if (bytes > 1024 * 1024) throw new Error('hosted task input exceeds 1 MiB');
+    chunks.push(chunk);
+  }
+  const value = Buffer.concat(chunks).toString('utf8').trim();
+  if (!value) throw new Error('hosted task input is empty');
+  return value;
+}
+
+async function resolveInput(input, options) {
+  const explicitIssue = issueInput(input);
+  if (explicitIssue) return explicitIssue;
+  const repository =
+    options.repository || process.env.ZEROSHOT_REPOSITORY || repositoryFromRemote();
+  if (!validRepository(repository || '')) {
+    throw new Error(
+      'hosted runs need a GitHub repository; use org/repo#123, --repository owner/name, ' +
+        'ZEROSHOT_REPOSITORY, or run inside a GitHub checkout'
+    );
+  }
+  if (/^[1-9][0-9]*$/.test(input)) return { repository, request: issueRequest(input) };
+  if (input === '-') return { repository, request: promptRequest(await stdinText()) };
+  const filename = path.resolve(input);
+  if (fs.existsSync(filename) && fs.statSync(filename).isFile()) {
+    const text = fs.readFileSync(filename, 'utf8').trim();
+    if (!text) throw new Error(`hosted task file is empty: ${input}`);
+    return { repository, request: promptRequest(text) };
+  }
+  if (!input.trim()) throw new Error('hosted task input is empty');
+  return { repository, request: promptRequest(input.trim()) };
+}
+
+function githubToken(environment = process.env) {
+  const configured = environment.GH_TOKEN || environment.GITHUB_TOKEN;
+  if (configured?.trim()) return configured.trim();
+  try {
+    const token = execFileSync('gh', ['auth', 'token'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (token) return token;
+  } catch {
+    // The actionable error below covers missing and unauthenticated gh alike.
+  }
+  throw new Error('hosted runs require GH_TOKEN/GITHUB_TOKEN or an authenticated gh CLI');
+}
+
+function providerKey(environment = process.env) {
+  const key = environment.OPENROUTER_API_KEY;
+  if (!key?.trim()) throw new Error('hosted Codex runs require OPENROUTER_API_KEY');
+  return key.trim();
+}
+
+function validateHostedOptions(options) {
+  const unsupported = [
+    ['config', '--config'],
+    ['docker', '--docker'],
+    ['worktree', '--worktree'],
+    ['dockerImage', '--docker-image'],
+    ['strictSchema', '--strict-schema'],
+    ['pr', '--pr'],
+    ['ship', '--ship'],
+    ['prBase', '--pr-base'],
+    ['mergeQueue', '--merge-queue'],
+    ['closeIssue', '--close-issue'],
+    ['workers', '--workers'],
+    ['gitlab', '--gitlab'],
+    ['jira', '--jira'],
+    ['devops', '--devops'],
+    ['linear', '--linear'],
+    ['detach', '--detach'],
+    ['mount', '--mount'],
+    ['containerHome', '--container-home'],
+  ];
+  const selected = unsupported
+    .filter(([name]) => options[name] !== undefined && options[name] !== false)
+    .map(([, flag]) => flag);
+  if (options.provider && options.provider !== 'codex') selected.push('--provider');
+  if (selected.length) {
+    throw new Error(`hosted runs do not support ${selected.join(', ')}`);
+  }
+  if (options.model !== undefined && !validModel(options.model)) {
+    throw new Error('hosted runs require an exact provider/model slug');
+  }
+}
+
+function organizationFromToken(token) {
+  const segments = token.split('.');
+  if (segments.length !== 3) throw new Error('Zero Cloud returned an invalid access token');
+  let claims;
+  try {
+    claims = JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('Zero Cloud returned an invalid access token');
+  }
+  if (typeof claims.org_id !== 'string' || !/^[0-9a-f-]{36}$/i.test(claims.org_id)) {
+    throw new Error('target login is not bound to an organization');
+  }
+  return claims.org_id;
+}
+
+async function waitForReady(target, organization, capsuleId, accessToken) {
+  const pathname = `/api/v1/orgs/${organization}/capsules/${capsuleId}`;
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  let lastState = 'provisioning';
+  while (Date.now() < deadline) {
+    const capsule = (await request(target.endpoint, pathname, { bearer: accessToken })).body;
+    lastState = capsule?.state;
+    if (lastState === 'ready') return;
+    if (['failed', 'terminated'].includes(lastState)) {
+      throw new Error(`capsule entered terminal state ${lastState} before it was ready`);
+    }
+    await delay(500);
+  }
+  throw new Error(`capsule did not become ready; last state was ${lastState}`);
+}
+
+async function mintAccess(target, capsuleId, accessToken) {
+  const pathname = `/api/v1/capsules/${capsuleId}/access`;
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      return (
+        await request(target.endpoint, pathname, {
+          method: 'POST',
+          bearer: accessToken,
+          json: { protocol: PROTOCOL },
+        })
+      ).body;
+    } catch (error) {
+      if (!(error instanceof HostedHttpError) || error.code !== 'capsule_not_ready') throw error;
+      await delay(500);
+    }
+  }
+  throw new Error('capsule access did not become ready');
+}
+
+function websocketUrl(target, advertised) {
+  const url = new URL(advertised);
+  if (new URL(target.endpoint).protocol === 'http:') {
+    const local = new URL(target.endpoint);
+    url.protocol = 'ws:';
+    url.host = local.host;
+  }
+  return url.toString();
+}
+
+function schemaDefinition(name) {
+  const schema = require('../../protocol/openengine-cluster/v1/worker.schema.json');
+  return payloadType(schema.$defs[name], schema.$defs);
+}
+
+function payloadType(schema, definitions) {
+  if (schema.$ref) {
+    const name = schema.$ref.split('/').pop();
+    return payloadType(definitions[name], definitions);
+  }
+  if (schema.enum) return { kind: 'enum', values: [...schema.enum].sort() };
+  const type = Array.isArray(schema.type)
+    ? schema.type.find((item) => item !== 'null')
+    : schema.type;
+  if (type === 'object') {
+    const required = new Set(schema.required || []);
+    const fields = {};
+    for (const name of Object.keys(schema.properties || {}).sort()) {
+      fields[name] = {
+        type: payloadType(schema.properties[name], definitions),
+        required: required.has(name),
+      };
+    }
+    return { kind: 'record', fields };
+  }
+  if (type === 'array') return { kind: 'array', items: payloadType(schema.items, definitions) };
+  if (['null', 'boolean', 'integer', 'number', 'string'].includes(type)) return { kind: type };
+  throw new Error('installed OECP worker schema cannot be converted to a graph contract');
+}
+
+function graph() {
+  const input = schemaDefinition('LegacyShipRequest');
+  const output = schemaDefinition('LegacyShipResult');
+  return {
+    initialInput: input,
+    policy: { default: 'deny', policy: 'policy.strict@1' },
+    profile: 'openengine.graph.single-worker/v1',
+    root: {
+      attempts: 1,
+      input,
+      inputBindings: [],
+      kind: 'step',
+      name: 'zeroshot',
+      output,
+      timeoutMs: 60 * 60 * 1_000,
+      worker: WORKER,
+      writeBindings: [],
+    },
+  };
+}
+
+function clusterLibrary() {
+  try {
+    return require('../../lib/cluster/index.cjs');
+  } catch (error) {
+    if (error?.code === 'MODULE_NOT_FOUND') {
+      throw new Error('OECP client is not built; run npm run build:cluster');
+    }
+    throw error;
+  }
+}
+
+async function watchRun(client, runId) {
+  const watch = await client.watch({ runId });
+  let outcome = null;
+  for await (const item of watch.stream) {
+    if (item.type === 'closed') throw new Error(`OECP watch closed early: ${item.reason}`);
+    const event = item.event;
+    if (event.type === 'node_begin') console.log(`Worker ${event.node.node} started`);
+    if (event.type === 'node_end') outcome = event.outcome;
+    if (event.type === 'finished') break;
+  }
+  await watch.stream.cancel();
+  return outcome;
+}
+
+async function applyRun(client, requestInput) {
+  const specification = graph();
+  const planned = await client.plan({ graph: specification });
+  if (!planned.ok) {
+    const detail = planned.diagnostics.map((item) => item.message).join('; ');
+    throw new Error(`OECP plan rejected the hosted graph${detail ? `: ${detail}` : ''}`);
+  }
+  const applied = await client.apply({
+    graph: specification,
+    input: requestInput,
+    idempotencyKey: crypto.randomUUID(),
+    ifGeneration: 0,
+  });
+  if (!applied.runId) throw new Error('OECP apply returned no run id');
+  console.log(`Run ${applied.runId} admitted`);
+  const outcome = await watchRun(client, applied.runId);
+  const final = await client.get({});
+  if (final.status.phase !== 'finished') throw new Error('OECP run did not reach finished');
+  if (!outcome) throw new Error('OECP run finished without a worker outcome');
+  if (outcome.status !== 'verified') {
+    throw new Error(`hosted worker failed (${outcome.code || outcome.status})`);
+  }
+  const result = outcome.output;
+  if (result?.summary) console.log(result.summary);
+  return result;
+}
+
+async function executeOecp(target, grant, requestInput) {
+  const WebSocket = require('ws');
+  const { ClusterClient, connect } = clusterLibrary();
+  const connection = await connect(websocketUrl(target, grant.websocket_url), {
+    webSocketFactory: (url, protocols) =>
+      new WebSocket(url, protocols || [], {
+        headers: { authorization: `Bearer ${grant.access_token}` },
+        perMessageDeflate: false,
+      }),
+  });
+  try {
+    return await applyRun(new ClusterClient(connection), requestInput);
+  } catch (error) {
+    const reason = error?.data?.details?.reason;
+    if (typeof reason === 'string' && reason) {
+      throw new Error(`${error.message}: ${reason}`, { cause: error });
+    }
+    throw error;
+  } finally {
+    await connection.close();
+  }
+}
+
+async function terminateCapsule(targetName, target, organization, capsuleId, session) {
+  const pathname = `/api/v1/orgs/${organization}/capsules/${capsuleId}`;
+  try {
+    await request(target.endpoint, pathname, {
+      method: 'DELETE',
+      bearer: session.accessToken,
+      accept: [202],
+    });
+    return session;
+  } catch (error) {
+    if (!(error instanceof HostedHttpError) || ![401, 403].includes(error.status)) throw error;
+  }
+  const rotated = await rotateCapsuleSession(targetName, target, session);
+  await request(target.endpoint, pathname, {
+    method: 'DELETE',
+    bearer: rotated.accessToken,
+    accept: [202],
+  });
+  return rotated;
+}
+
+async function runHosted(input, options) {
+  validateHostedOptions(options);
+  const targetName = options.target;
+  const target = getTarget(targetName);
+  const resolved = await resolveInput(input, options);
+  const credentials = {
+    githubToken: githubToken(),
+    openrouterApiKey: providerKey(),
+    repository: resolved.repository,
+    model: options.model || DEFAULT_MODEL,
+  };
+  let session = await capsuleSession(targetName, target);
+  const organization = organizationFromToken(session.accessToken);
+  let capsuleId = null;
+  try {
+    const created = (
+      await request(target.endpoint, `/api/v1/orgs/${organization}/capsules`, {
+        method: 'POST',
+        bearer: session.accessToken,
+        headers: { 'idempotency-key': crypto.randomUUID() },
+        json: { label: 'zeroshot-cli' },
+        accept: [201],
+      })
+    ).body;
+    capsuleId = created?.capsule_id;
+    if (typeof capsuleId !== 'string') throw new Error('Zero Cloud returned no capsule id');
+    console.log(`Capsule ${capsuleId} provisioning`);
+    await waitForReady(target, organization, capsuleId, session.accessToken);
+    console.log(`Capsule ${capsuleId} ready`);
+    const grant = await mintAccess(target, capsuleId, session.accessToken);
+    await request(target.endpoint, `/api/v1/capsules/${capsuleId}/credentials`, {
+      method: 'PUT',
+      bearer: grant.access_token,
+      json: credentials,
+      accept: [204],
+    });
+    return await executeOecp(target, grant, resolved.request);
+  } finally {
+    if (capsuleId) {
+      try {
+        await terminateCapsule(targetName, target, organization, capsuleId, session);
+        console.log(`Capsule ${capsuleId} termination requested`);
+      } catch (error) {
+        console.error(`Warning: capsule cleanup failed: ${error.message}`);
+      }
+    }
+  }
+}
+
+module.exports = {
+  graph,
+  issueInput,
+  payloadType,
+  repositoryFromRemote,
+  resolveInput,
+  runHosted,
+  validateHostedOptions,
+  websocketUrl,
+};

--- a/cli/hosted/target-command.js
+++ b/cli/hosted/target-command.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { login } = require('./auth');
+const { removeRefreshToken } = require('./credential-store');
+const { addTarget, getTarget, loadTargets, removeTarget } = require('./target-store');
+
+function registerTargetCommands(program) {
+  const target = program.command('target').description('Manage named Zero Cloud targets');
+  target
+    .command('add <name> <endpoint>')
+    .description('Add or update a Zero Cloud endpoint')
+    .action((name, endpoint) => {
+      const saved = addTarget(name, endpoint);
+      console.log(`${name}\t${saved.endpoint}`);
+    });
+  target
+    .command('list')
+    .description('List configured Zero Cloud targets')
+    .action(() => {
+      const entries = Object.entries(loadTargets().targets).sort(([left], [right]) =>
+        left.localeCompare(right)
+      );
+      for (const [name, configured] of entries) console.log(`${name}\t${configured.endpoint}`);
+    });
+  target
+    .command('login <name>')
+    .description('Authorize this CLI using the device flow')
+    .action(async (name) => {
+      await login(name, getTarget(name));
+      console.log(`Logged in to ${name}`);
+    });
+  target
+    .command('remove <name>')
+    .description('Remove a target and its stored login')
+    .action((name) => {
+      removeTarget(name);
+      removeRefreshToken(name);
+      console.log(`Removed ${name}`);
+    });
+}
+
+module.exports = { registerTargetCommands };

--- a/cli/hosted/target-store.js
+++ b/cli/hosted/target-store.js
@@ -44,14 +44,36 @@ function emptyStore() {
 
 function loadTargets(environment = process.env) {
   const filename = targetsFile(environment);
-  if (!fs.existsSync(filename)) return emptyStore();
-  const stat = fs.lstatSync(filename);
-  if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error(`target store is not a regular file: ${filename}`);
+  const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+  let descriptor;
+  try {
+    descriptor = fs.openSync(filename, flags);
+  } catch (error) {
+    if (error.code === 'ENOENT') return emptyStore();
+    if (error.code === 'ELOOP') {
+      throw new Error(`target store is not a regular file: ${filename}`);
+    }
+    throw error;
+  }
+  let contents;
+  try {
+    const descriptorStat = fs.fstatSync(descriptor);
+    const pathStat = fs.lstatSync(filename);
+    if (
+      !descriptorStat.isFile() ||
+      pathStat.isSymbolicLink() ||
+      descriptorStat.dev !== pathStat.dev ||
+      descriptorStat.ino !== pathStat.ino
+    ) {
+      throw new Error(`target store is not a regular file: ${filename}`);
+    }
+    contents = fs.readFileSync(descriptor, 'utf8');
+  } finally {
+    fs.closeSync(descriptor);
   }
   let parsed;
   try {
-    parsed = JSON.parse(fs.readFileSync(filename, 'utf8'));
+    parsed = JSON.parse(contents);
   } catch {
     throw new Error(`target store is not valid JSON: ${filename}`);
   }

--- a/cli/hosted/target-store.js
+++ b/cli/hosted/target-store.js
@@ -44,7 +44,8 @@ function emptyStore() {
 
 function loadTargets(environment = process.env) {
   const filename = targetsFile(environment);
-  const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+  const flags =
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0);
   let descriptor;
   try {
     descriptor = fs.openSync(filename, flags);

--- a/cli/hosted/target-store.js
+++ b/cli/hosted/target-store.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { URL } = require('node:url');
+
+const TARGET_NAME = /^[a-z][a-z0-9-]{0,31}$/;
+
+function targetsFile(environment = process.env) {
+  return environment.ZEROSHOT_TARGETS_FILE || path.join(os.homedir(), '.zeroshot', 'targets.json');
+}
+
+function normalizeTargetName(name) {
+  if (!TARGET_NAME.test(name)) {
+    throw new Error('target name must match [a-z][a-z0-9-]{0,31}');
+  }
+  return name;
+}
+
+function normalizeEndpoint(value) {
+  let endpoint;
+  try {
+    endpoint = new URL(value);
+  } catch {
+    throw new Error('target endpoint must be an absolute HTTP(S) URL');
+  }
+  if (
+    !['http:', 'https:'].includes(endpoint.protocol) ||
+    endpoint.username ||
+    endpoint.password ||
+    endpoint.search ||
+    endpoint.hash ||
+    !['', '/'].includes(endpoint.pathname)
+  ) {
+    throw new Error('target endpoint must be an HTTP(S) origin without credentials or a path');
+  }
+  return endpoint.origin;
+}
+
+function emptyStore() {
+  return { version: 1, targets: {} };
+}
+
+function loadTargets(environment = process.env) {
+  const filename = targetsFile(environment);
+  if (!fs.existsSync(filename)) return emptyStore();
+  const stat = fs.lstatSync(filename);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`target store is not a regular file: ${filename}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  } catch {
+    throw new Error(`target store is not valid JSON: ${filename}`);
+  }
+  if (
+    parsed?.version !== 1 ||
+    !parsed.targets ||
+    typeof parsed.targets !== 'object' ||
+    Array.isArray(parsed.targets)
+  ) {
+    throw new Error(`target store has an unsupported shape: ${filename}`);
+  }
+  const targets = {};
+  for (const [name, target] of Object.entries(parsed.targets)) {
+    targets[normalizeTargetName(name)] = { endpoint: normalizeEndpoint(target?.endpoint) };
+  }
+  return { version: 1, targets };
+}
+
+function saveTargets(store, environment = process.env) {
+  const filename = targetsFile(environment);
+  const directory = path.dirname(filename);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  const temporary = `${filename}.${process.pid}.${Date.now()}.tmp`;
+  const descriptor = fs.openSync(temporary, 'wx', 0o600);
+  try {
+    fs.writeFileSync(descriptor, `${JSON.stringify(store, null, 2)}\n`, 'utf8');
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  try {
+    fs.renameSync(temporary, filename);
+    fs.chmodSync(filename, 0o600);
+  } catch (error) {
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      // Preserve the original write failure.
+    }
+    throw error;
+  }
+}
+
+function addTarget(name, endpoint, environment = process.env) {
+  const targetName = normalizeTargetName(name);
+  const store = loadTargets(environment);
+  store.targets[targetName] = { endpoint: normalizeEndpoint(endpoint) };
+  saveTargets(store, environment);
+  return store.targets[targetName];
+}
+
+function getTarget(name, environment = process.env) {
+  const targetName = normalizeTargetName(name);
+  const target = loadTargets(environment).targets[targetName];
+  if (!target) throw new Error(`unknown target: ${targetName}`);
+  return target;
+}
+
+function removeTarget(name, environment = process.env) {
+  const targetName = normalizeTargetName(name);
+  const store = loadTargets(environment);
+  if (!store.targets[targetName]) throw new Error(`unknown target: ${targetName}`);
+  delete store.targets[targetName];
+  saveTargets(store, environment);
+}
+
+module.exports = {
+  addTarget,
+  getTarget,
+  loadTargets,
+  normalizeEndpoint,
+  normalizeTargetName,
+  removeTarget,
+  targetsFile,
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -101,6 +101,8 @@ const {
 const { checkBinDirOnPath, printPathWarning } = require('../lib/path-check');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
 const { EVENT_COPY, formatMergeStatus } = require('./event-copy');
+const { runHosted } = require('./hosted/run');
+const { registerTargetCommands } = require('./hosted/target-command');
 
 // =============================================================================
 // GLOBAL ERROR HANDLERS - Prevent silent process death
@@ -2585,6 +2587,8 @@ program
   .option('--workers <n>', 'Max sub-agents for worker to spawn in parallel', parseInt)
   .option('--provider <provider>', `Override all agents to use a provider (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Override all agent models (provider-specific model id)')
+  .option('--target <name>', 'Run in a capsule on a named Zero Cloud target')
+  .option('--repository <owner/name>', 'GitHub repository for a hosted prompt or numeric issue')
   .option(
     '--sim <mode>',
     'Token-free simulation gate for templates (off|fast|deep). Default: fast',
@@ -2640,6 +2644,10 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps), -N (Line
   )
   .action(async (inputArg, options) => {
     try {
+      if (options.target) {
+        await runHosted(inputArg, options);
+        return;
+      }
       // Normalize options (--ship → --pr → --worktree flags)
       normalizeRunOptions(options);
 
@@ -2821,6 +2829,8 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps), -N (Line
       process.exit(1);
     }
   });
+
+registerTargetCommands(program);
 
 // === TASK COMMANDS ===
 // Task run - single-agent background task

--- a/cli/index.js
+++ b/cli/index.js
@@ -2588,6 +2588,7 @@ program
   .option('--provider <provider>', `Override all agents to use a provider (${PROVIDER_CHOICES})`)
   .option('--model <model>', 'Override all agent models (provider-specific model id)')
   .option('--target <name>', 'Run in a capsule on a named Zero Cloud target')
+  .option('--size <tier>', 'Capsule size: tiny, small, standard, or large (default: standard)')
   .option('--repository <owner/name>', 'GitHub repository for a hosted prompt or numeric issue')
   .option(
     '--sim <mode>',
@@ -2647,6 +2648,9 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps), -N (Line
       if (options.target) {
         await runHosted(inputArg, options);
         return;
+      }
+      if (options.size !== undefined) {
+        throw new Error('--size requires --target');
       }
       // Normalize options (--ship → --pr → --worktree flags)
       normalizeRunOptions(options);
@@ -2855,11 +2859,7 @@ for (const mode of ['prove', 'verify', 'check']) {
     });
 }
 
-function assertRequestedWebSearchCliAvailable(
-  provider,
-  settings,
-  exists = commandExists
-) {
+function assertRequestedWebSearchCliAvailable(provider, settings, exists = commandExists) {
   const metadata = getProviderMetadata(provider);
   if (!metadata.settingsFields.includes('webSearch')) return;
   if (settings.providerSettings?.[provider]?.webSearch !== true) return;
@@ -2888,10 +2888,7 @@ taskCmd
     '-r, --resume <sessionId>',
     'Resume a specific provider session (Claude, Codex, or OpenCode)'
   )
-  .option(
-    '-c, --continue',
-    'Continue the most recent provider session (Claude or OpenCode)'
-  )
+  .option('-c, --continue', 'Continue the most recent provider session (Claude or OpenCode)')
   .option(
     '-o, --output-format <format>',
     'Output format: stream-json (default), text, json',
@@ -3868,9 +3865,8 @@ program
   .description('Output task ID for an internal spawn ownership token (machine-readable)')
   .action(async (token) => {
     try {
-      const { getTaskIdBySpawnToken } = await import(
-        '../task-lib/commands/get-task-id-by-spawn-token.js'
-      );
+      const { getTaskIdBySpawnToken } =
+        await import('../task-lib/commands/get-task-id-by-spawn-token.js');
       getTaskIdBySpawnToken(token);
     } catch (error) {
       console.error('Error resolving task spawn ownership:', error.message);

--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -2,7 +2,7 @@
 
 # The server and the existing Node worker ship together because OECP is the
 # in-capsule process boundary. Capsule allocation and termination remain owned
-# by Zero Cloud's runner/agent sidecars.
+# by Zero Cloud's control plane and capsule agent.
 FROM lukemathwalker/cargo-chef@sha256:4a51277f4e3e8e4643dd6384f6f6b2b3c8de9f074299cd0c19a80f3c29e8dd15 AS rust-builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./

--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# The server and the existing Node worker ship together because OECP is the
+# in-capsule process boundary. Capsule allocation and termination remain owned
+# by Zero Cloud's runner/agent sidecars.
+FROM lukemathwalker/cargo-chef@sha256:4a51277f4e3e8e4643dd6384f6f6b2b3c8de9f074299cd0c19a80f3c29e8dd15 AS rust-builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+COPY zeroshot-rust ./zeroshot-rust
+RUN cargo build --locked --release -p zeroshot-rust --bin zeroshot-oecp-server
+
+FROM node@sha256:235600a8101ab264e117b1768e925532262668dc9b581ef1dd7d96ced463b8e7 AS node-builder
+ARG CODEX_VERSION=0.146.0
+# Debian security package revisions intentionally follow the pinned base image's repositories.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends build-essential python3 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/zeroshot
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund \
+    && npm rebuild better-sqlite3 node-pty \
+    && npm install --global --no-audit --no-fund "@openai/codex@${CODEX_VERSION}"
+COPY . .
+
+FROM node@sha256:235600a8101ab264e117b1768e925532262668dc9b581ef1dd7d96ced463b8e7 AS runtime
+ARG ZEROSHOT_MIN_DISK_GB=10
+ENV ZEROSHOT_MIN_DISK_GB=${ZEROSHOT_MIN_DISK_GB}
+# Debian security package revisions intentionally follow the pinned base image's repositories.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends bash ca-certificates git gh tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && install -d -m 1777 /tmp \
+    && install -d -m 0750 -o node -g node /workspace
+COPY --from=node-builder --chown=node:node /opt/zeroshot /opt/zeroshot
+COPY --from=node-builder /usr/local/lib/node_modules/@openai /usr/local/lib/node_modules/@openai
+COPY --from=rust-builder /build/target/release/zeroshot-oecp-server /usr/local/bin/zeroshot-oecp-server
+RUN ln -s /opt/zeroshot/bin/zeroshot-cluster-worker.js /usr/local/bin/zeroshot-cluster-worker \
+    && ln -s /opt/zeroshot/cli/index.js /usr/local/bin/zeroshot \
+    && ln -s /usr/local/lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex
+USER node
+WORKDIR /workspace
+EXPOSE 8083 8084
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/zeroshot-oecp-server"]

--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -8,7 +8,13 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 COPY crates ./crates
 COPY zeroshot-rust ./zeroshot-rust
+RUN rustup component add --toolchain 1.96.0 rustfmt clippy
 RUN cargo build --locked --release -p zeroshot-rust --bin zeroshot-oecp-server
+
+# Keep a common repository guardrail runtime available without downloading a
+# second language toolchain after the capsule starts. The target repository
+# still owns its Python dependencies and Rust version through checked-in files.
+FROM python@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS python-runtime
 
 FROM node@sha256:235600a8101ab264e117b1768e925532262668dc9b581ef1dd7d96ced463b8e7 AS node-builder
 ARG CODEX_VERSION=0.146.0
@@ -36,10 +42,18 @@ RUN apt-get update \
     && install -d -m 0750 -o node -g node /workspace
 COPY --from=node-builder --chown=node:node /opt/zeroshot /opt/zeroshot
 COPY --from=node-builder /usr/local/lib/node_modules/@openai /usr/local/lib/node_modules/@openai
+COPY --from=python-runtime /usr/local /usr/local
+COPY --from=rust-builder --chown=node:node /usr/local/cargo/bin /usr/local/cargo/bin
+COPY --from=rust-builder --chown=node:node /usr/local/rustup /usr/local/rustup
 COPY --from=rust-builder /build/target/release/zeroshot-oecp-server /usr/local/bin/zeroshot-oecp-server
 RUN ln -s /opt/zeroshot/bin/zeroshot-cluster-worker.js /usr/local/bin/zeroshot-cluster-worker \
     && ln -s /opt/zeroshot/cli/index.js /usr/local/bin/zeroshot \
-    && ln -s /usr/local/lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex
+    && ln -s /usr/local/lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
+    && for command in cargo cargo-clippy cargo-fmt clippy-driver rustc rustdoc rustfmt rustup; do \
+        ln -s "/usr/local/cargo/bin/${command}" "/usr/local/bin/${command}"; \
+    done
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
 USER node
 WORKDIR /workspace
 EXPOSE 8083 8084

--- a/lib/cluster-worker/engine-adapter.js
+++ b/lib/cluster-worker/engine-adapter.js
@@ -11,9 +11,14 @@ function messageKey(message) {
 function terminalEventFromMessage(message) {
   const data = message.content?.data || {};
   if (message.topic === 'CLUSTER_COMPLETE') {
+    let prSummary = null;
+    if (typeof data.pr_url === 'string' && data.pr_url) {
+      const number = Number.isSafeInteger(data.pr_number) ? ` #${data.pr_number}` : '';
+      prSummary = `Pull request${number} created: ${data.pr_url}`;
+    }
     return {
       type: 'complete',
-      summary: data.reason || message.content?.text,
+      summary: prSummary || data.reason || message.content?.text,
       ...(Object.prototype.hasOwnProperty.call(data, 'result') ? { result: data.result } : {}),
       ...(Object.prototype.hasOwnProperty.call(data, 'artifacts')
         ? { artifacts: data.artifacts }

--- a/lib/cluster-worker/profiles.js
+++ b/lib/cluster-worker/profiles.js
@@ -25,6 +25,7 @@ const DEFAULT_PROVIDER_PROFILES = Object.freeze({
 });
 
 const HOSTED_CODEX_OPENROUTER_PROFILE = 'provider.codex-openrouter@1';
+const HOSTED_CODEX_OPENROUTER_PR_PROFILE = 'provider.codex-openrouter-pr@1';
 const DEFAULT_HOSTED_MODEL = 'openai/gpt-5.4';
 
 function providerProfilesFromEnvironment(environment = process.env) {
@@ -37,21 +38,26 @@ function providerProfilesFromEnvironment(environment = process.env) {
     level2: Object.freeze({ model, reasoningEffort: 'high' }),
     level3: Object.freeze({ model, reasoningEffort: 'xhigh' }),
   });
+  const hostedSettings = {
+    templateParams: { task_type: 'TASK' },
+    providerSettings: {
+      codex: {
+        defaultLevel: 'level2',
+        levelOverrides,
+      },
+    },
+  };
   return deepFreeze({
     ...DEFAULT_PROVIDER_PROFILES,
     [HOSTED_CODEX_OPENROUTER_PROFILE]: {
       configName: 'base-templates/single-worker',
       providerOverride: 'codex',
-      forceProvider: 'codex',
-      settings: {
-        templateParams: { task_type: 'TASK' },
-        providerSettings: {
-          codex: {
-            defaultLevel: 'level2',
-            levelOverrides,
-          },
-        },
-      },
+      settings: hostedSettings,
+    },
+    [HOSTED_CODEX_OPENROUTER_PR_PROFILE]: {
+      configName: 'base-templates/worker-validator',
+      providerOverride: 'codex',
+      settings: hostedSettings,
     },
   });
 }
@@ -110,6 +116,7 @@ module.exports = {
   DEFAULT_ISOLATION_PROFILES,
   DEFAULT_PROVIDER_PROFILES,
   HOSTED_CODEX_OPENROUTER_PROFILE,
+  HOSTED_CODEX_OPENROUTER_PR_PROFILE,
   createDeploymentProfileRegistry,
   providerProfilesFromEnvironment,
 };

--- a/lib/cluster-worker/profiles.js
+++ b/lib/cluster-worker/profiles.js
@@ -24,6 +24,38 @@ const DEFAULT_PROVIDER_PROFILES = Object.freeze({
   }),
 });
 
+const HOSTED_CODEX_OPENROUTER_PROFILE = 'provider.codex-openrouter@1';
+const DEFAULT_HOSTED_MODEL = 'openai/gpt-5.4';
+
+function providerProfilesFromEnvironment(environment = process.env) {
+  if (environment.ZEROSHOT_HOSTED_CODEX_OPENROUTER !== '1') {
+    return DEFAULT_PROVIDER_PROFILES;
+  }
+  const model = environment.ZEROSHOT_HOSTED_MODEL || DEFAULT_HOSTED_MODEL;
+  const levelOverrides = Object.freeze({
+    level1: Object.freeze({ model, reasoningEffort: 'medium' }),
+    level2: Object.freeze({ model, reasoningEffort: 'high' }),
+    level3: Object.freeze({ model, reasoningEffort: 'xhigh' }),
+  });
+  return deepFreeze({
+    ...DEFAULT_PROVIDER_PROFILES,
+    [HOSTED_CODEX_OPENROUTER_PROFILE]: {
+      configName: 'base-templates/single-worker',
+      providerOverride: 'codex',
+      forceProvider: 'codex',
+      settings: {
+        templateParams: { task_type: 'TASK' },
+        providerSettings: {
+          codex: {
+            defaultLevel: 'level2',
+            levelOverrides,
+          },
+        },
+      },
+    },
+  });
+}
+
 function own(map, key) {
   return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : null;
 }
@@ -38,7 +70,7 @@ function validateBounds(bounds) {
 
 function createDeploymentProfileRegistry(options = {}) {
   const isolationProfiles = options.isolationProfiles || DEFAULT_ISOLATION_PROFILES;
-  const providerProfiles = options.providerProfiles || DEFAULT_PROVIDER_PROFILES;
+  const providerProfiles = options.providerProfiles || providerProfilesFromEnvironment();
   const defaultBounds = { ...DEFAULT_BOUNDS, ...(options.bounds || {}) };
   validateBounds(defaultBounds);
   const bounds = deepFreeze(defaultBounds);
@@ -77,5 +109,7 @@ module.exports = {
   DEFAULT_BOUNDS,
   DEFAULT_ISOLATION_PROFILES,
   DEFAULT_PROVIDER_PROFILES,
+  HOSTED_CODEX_OPENROUTER_PROFILE,
   createDeploymentProfileRegistry,
+  providerProfilesFromEnvironment,
 };

--- a/lib/git-remote-utils.js
+++ b/lib/git-remote-utils.js
@@ -205,7 +205,7 @@ function detectGitContext(cwd = process.cwd()) {
 
     const supportedRemotes = new Map();
     for (const line of remoteOutput.split(/\r?\n/)) {
-      const match = line.match(/^(\S+)\s+(.+)\s+\(fetch\)$/);
+      const match = line.match(/^(\S+)\s+(.+?)\s+\(fetch\)(?:\s+\[[^\]\r\n]+\])?$/);
       if (!match) {
         continue;
       }

--- a/lib/start-cluster.js
+++ b/lib/start-cluster.js
@@ -176,17 +176,17 @@ function applyProviderOverrideToConfig(config, providerOverride, settings) {
   console.log(chalk.dim(`Provider override: ${providerOverride} (all agents)`));
 }
 
-function resolveParameterizedConfigFile(config) {
+function resolveParameterizedConfigFile(config, templateParams = {}) {
   if (!config?.params || Object.keys(config.params).length === 0) {
     return config;
   }
 
   const resolver = new TemplateResolver(path.join(PACKAGE_ROOT, 'cluster-templates'));
-  return resolver.resolveTemplate(config, {});
+  return resolver.resolveTemplate(config, templateParams);
 }
 
 function prepareClusterConfig(config, settings = {}, providerOverride) {
-  const prepared = resolveParameterizedConfigFile(config);
+  const prepared = resolveParameterizedConfigFile(config, settings.templateParams || {});
   ensureConfigProviderDefaults(prepared, settings);
   if (providerOverride) {
     applyProviderOverrideToConfig(prepared, providerOverride, settings);

--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -28,6 +28,7 @@ import { parseCodexEvent } from './codex-parser';
 
 const MODEL_CATALOG: Readonly<Record<string, ModelCatalogEntry>> = {
   'gpt-5.4': { rank: 2 },
+  'openai/gpt-5.4': { rank: 2 },
   'gpt-5.5': { rank: 3 },
   'gpt-5.6': { rank: 3 },
   'gpt-5.6-sol': { rank: 3 },

--- a/src/isolation-manager.js
+++ b/src/isolation-manager.js
@@ -29,6 +29,25 @@ const { provisionClaudeCredentials } = require('./claude-credentials');
 
 const DEFAULT_WORKTREE_SETUP_TIMEOUT_MS = 15 * 60 * 1000;
 const FRESH_BASE_REF_PREFIX = 'refs/zeroshot/base-fetch';
+const DEFAULT_MIN_DISK_GB = 10;
+
+function minimumDiskGigabytes(environment = process.env) {
+  const configured = environment.ZEROSHOT_MIN_DISK_GB;
+  if (configured === undefined) {
+    return DEFAULT_MIN_DISK_GB;
+  }
+
+  if (typeof configured !== 'string' || !/^[1-9][0-9]*$/.test(configured)) {
+    throw new Error('ZEROSHOT_MIN_DISK_GB must be an integer between 1 and 1000');
+  }
+
+  const minimum = Number(configured);
+  if (!Number.isSafeInteger(minimum) || minimum > 1000) {
+    throw new Error('ZEROSHOT_MIN_DISK_GB must be an integer between 1 and 1000');
+  }
+
+  return minimum;
+}
 
 function runSync(command, args, options = {}) {
   const timeout = options.timeout ?? 30000;
@@ -1576,7 +1595,7 @@ class IsolationManager {
     // Disk space guard: prevent worktree creation when disk is critically low.
     // Uses standalone gc module (no Orchestrator dependency — avoids circular require).
     const { gcOrphanedWorktrees, getDiskSpace, countOrphanedWorktrees } = require('./lib/gc');
-    const MIN_DISK_GB = 10;
+    const MIN_DISK_GB = minimumDiskGigabytes();
     const AUTO_GC_THRESHOLD_PERCENT = 80;
 
     const diskCheck = getDiskSpace(os.homedir());
@@ -1949,3 +1968,4 @@ class IsolationManager {
 }
 
 module.exports = IsolationManager;
+module.exports.minimumDiskGigabytes = minimumDiskGigabytes;

--- a/tests/cluster-worker/engine-adapter.test.js
+++ b/tests/cluster-worker/engine-adapter.test.js
@@ -114,6 +114,22 @@ describe('legacy cluster worker engine adapter', () => {
     );
   });
 
+  it('returns verified pull request identity in the bounded completion summary', () => {
+    assert.deepStrictEqual(
+      terminalEventFromMessage(
+        terminalMessage('CLUSTER_COMPLETE', {
+          reason: 'git-pusher-complete-verified',
+          pr_number: 321,
+          pr_url: 'https://github.com/the-open-engine/zeroshot/pull/321',
+        })
+      ),
+      {
+        type: 'complete',
+        summary: 'Pull request #321 created: https://github.com/the-open-engine/zeroshot/pull/321',
+      }
+    );
+  });
+
   it('subscribes before folding durable history and de-duplicates terminal truth', async () => {
     const complete = terminalMessage('CLUSTER_COMPLETE', { reason: 'done' });
     const state = harness([complete]);

--- a/tests/cluster-worker/hosted-profile.test.js
+++ b/tests/cluster-worker/hosted-profile.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const { describe, it } = require('mocha');
+const {
+  HOSTED_CODEX_OPENROUTER_PROFILE,
+  createDeploymentProfileRegistry,
+  providerProfilesFromEnvironment,
+} = require('../../lib/cluster-worker/profiles');
+const { prepareClusterConfig, resolveConfigPath } = require('../../lib/start-cluster');
+
+describe('hosted Codex/OpenRouter deployment profile', function () {
+  it('is absent unless the capsule host explicitly enables it', function () {
+    const profiles = providerProfilesFromEnvironment({});
+    assert.equal(profiles[HOSTED_CODEX_OPENROUTER_PROFILE], undefined);
+  });
+
+  it('pins the uploaded model across Zeroshot levels without carrying a key', function () {
+    const providerProfiles = providerProfilesFromEnvironment({
+      ZEROSHOT_HOSTED_CODEX_OPENROUTER: '1',
+      ZEROSHOT_HOSTED_MODEL: 'openai/gpt-5.4',
+    });
+    const registry = createDeploymentProfileRegistry({ providerProfiles });
+    const profile = registry.resolve('isolation.worktree@1', HOSTED_CODEX_OPENROUTER_PROFILE);
+
+    assert.equal(profile.provider.providerOverride, 'codex');
+    assert.equal(profile.provider.configName, 'base-templates/single-worker');
+    const config = prepareClusterConfig(
+      JSON.parse(fs.readFileSync(resolveConfigPath(profile.provider.configName), 'utf8')),
+      profile.provider.settings,
+      profile.provider.providerOverride
+    );
+    assert.match(config.agents[0].prompt.system, /TASK task/);
+    assert.deepEqual(
+      Object.values(profile.provider.settings.providerSettings.codex.levelOverrides).map(
+        ({ model }) => model
+      ),
+      ['openai/gpt-5.4', 'openai/gpt-5.4', 'openai/gpt-5.4']
+    );
+    assert.equal(JSON.stringify(profile).includes('apiKey'), false);
+  });
+});

--- a/tests/cluster-worker/hosted-profile.test.js
+++ b/tests/cluster-worker/hosted-profile.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const { describe, it } = require('mocha');
 const {
+  HOSTED_CODEX_OPENROUTER_PR_PROFILE,
   HOSTED_CODEX_OPENROUTER_PROFILE,
   createDeploymentProfileRegistry,
   providerProfilesFromEnvironment,
@@ -14,6 +15,30 @@ describe('hosted Codex/OpenRouter deployment profile', function () {
   it('is absent unless the capsule host explicitly enables it', function () {
     const profiles = providerProfilesFromEnvironment({});
     assert.equal(profiles[HOSTED_CODEX_OPENROUTER_PROFILE], undefined);
+    assert.equal(profiles[HOSTED_CODEX_OPENROUTER_PR_PROFILE], undefined);
+  });
+
+  it('uses the validated delivery template only for reviewed PR runs', function () {
+    const providerProfiles = providerProfilesFromEnvironment({
+      ZEROSHOT_HOSTED_CODEX_OPENROUTER: '1',
+      ZEROSHOT_HOSTED_MODEL: 'openai/gpt-5.4',
+    });
+    const registry = createDeploymentProfileRegistry({ providerProfiles });
+    const profile = registry.resolve('isolation.pr@1', HOSTED_CODEX_OPENROUTER_PR_PROFILE);
+
+    assert.equal(profile.plan.delivery, 'pr');
+    assert.equal(profile.provider.configName, 'base-templates/worker-validator');
+    assert.equal(profile.provider.forceProvider, undefined);
+    const config = prepareClusterConfig(
+      JSON.parse(fs.readFileSync(resolveConfigPath(profile.provider.configName), 'utf8')),
+      profile.provider.settings,
+      profile.provider.providerOverride
+    );
+    assert.deepEqual(
+      config.agents.map(({ id }) => id),
+      ['worker', 'validator']
+    );
+    assert.equal(JSON.stringify(profile).includes('apiKey'), false);
   });
 
   it('pins the uploaded model across Zeroshot levels without carrying a key', function () {
@@ -26,6 +51,7 @@ describe('hosted Codex/OpenRouter deployment profile', function () {
 
     assert.equal(profile.provider.providerOverride, 'codex');
     assert.equal(profile.provider.configName, 'base-templates/single-worker');
+    assert.equal(profile.provider.forceProvider, undefined);
     const config = prepareClusterConfig(
       JSON.parse(fs.readFileSync(resolveConfigPath(profile.provider.configName), 'utf8')),
       profile.provider.settings,

--- a/tests/unit/git-remote-utils.test.js
+++ b/tests/unit/git-remote-utils.test.js
@@ -264,6 +264,23 @@ function registerDetectGitContextTests() {
       );
     });
 
+    it('should detect a partial-clone remote with its fetch annotation', function () {
+      withGitRemotes(
+        {
+          origin: 'https://github.com/the-open-engine/zero-cloud.git',
+        },
+        (cwd) => {
+          execFileSync('git', ['config', 'remote.origin.promisor', 'true'], { cwd });
+          execFileSync('git', ['config', 'remote.origin.partialclonefilter', 'blob:none'], { cwd });
+
+          const result = detectGitContext(cwd);
+          assert.strictEqual(result.provider, 'github');
+          assert.strictEqual(result.fullRepo, 'the-open-engine/zero-cloud');
+          assert.strictEqual(result.remote, 'origin');
+        }
+      );
+    });
+
     it('should fail closed when multiple supported non-origin remotes are ambiguous', function () {
       withGitRemotes(
         {

--- a/tests/unit/hosted-target.test.js
+++ b/tests/unit/hosted-target.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert').strict;
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { describe, it } = require('mocha');
+
+const {
+  addTarget,
+  getTarget,
+  loadTargets,
+  removeTarget,
+} = require('../../cli/hosted/target-store');
+const { graph, issueInput, validateHostedOptions, websocketUrl } = require('../../cli/hosted/run');
+
+function fixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-hosted-target-'));
+  return {
+    directory,
+    environment: { ZEROSHOT_TARGETS_FILE: path.join(directory, 'targets.json') },
+  };
+}
+
+describe('hosted target CLI', function () {
+  it('persists endpoint metadata without credentials', function () {
+    const { directory, environment } = fixture();
+    try {
+      addTarget('local', 'http://127.0.0.1:8080/', environment);
+      assert.deepEqual(getTarget('local', environment), { endpoint: 'http://127.0.0.1:8080' });
+      assert.deepEqual(Object.keys(loadTargets(environment).targets), ['local']);
+      assert.equal(fs.statSync(environment.ZEROSHOT_TARGETS_FILE).mode & 0o777, 0o600);
+      assert.ok(!fs.readFileSync(environment.ZEROSHOT_TARGETS_FILE, 'utf8').includes('token'));
+      removeTarget('local', environment);
+      assert.deepEqual(loadTargets(environment).targets, {});
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects endpoints and names with ambiguous authority', function () {
+    const { directory, environment } = fixture();
+    try {
+      assert.throws(() => addTarget('../escape', 'https://cloud.example', environment));
+      assert.throws(() => addTarget('prod', 'https://user:secret@cloud.example', environment));
+      assert.throws(() => addTarget('prod', 'https://cloud.example/api', environment));
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the canonical single-worker facade for hosted issues', function () {
+    const issue = issueInput('the-open-engine/zeroshot#837');
+    assert.equal(issue.repository, 'the-open-engine/zeroshot');
+    assert.ok(!Object.hasOwn(issue.request, 'prompt'));
+    const specification = graph();
+    assert.equal(specification.profile, 'openengine.graph.single-worker/v1');
+    assert.equal(specification.root.worker, 'legacy.zeroshot.ship@1');
+    assert.equal(specification.root.input.fields.providerProfile.required, true);
+    assert.equal(specification.root.output.fields.summary.type.kind, 'string');
+  });
+
+  it('rejects repository path segments that Git would normalize', function () {
+    assert.equal(issueInput('../zeroshot#837'), null);
+    assert.equal(issueInput('the-open-engine/..#837'), null);
+    assert.equal(issueInput('https://github.com/../zeroshot/issues/837'), null);
+  });
+
+  it('routes localhost advertised wss access through the target', function () {
+    assert.equal(
+      websocketUrl(
+        { endpoint: 'http://127.0.0.1:49152' },
+        'wss://capsule.localtest.me/v1/capsules/example/oecp'
+      ),
+      'ws://127.0.0.1:49152/v1/capsules/example/oecp'
+    );
+  });
+
+  it('rejects local-only flags instead of silently ignoring them', function () {
+    assert.doesNotThrow(() => validateHostedOptions({ target: 'local', model: 'openai/gpt-5.4' }));
+    assert.doesNotThrow(() => validateHostedOptions({ target: 'local', provider: 'codex' }));
+    assert.throws(
+      () => validateHostedOptions({ target: 'local', docker: true, provider: 'claude' }),
+      /--docker, --provider/
+    );
+    assert.throws(
+      () => validateHostedOptions({ target: 'local', model: 'openai/gpt-5.4\n[model_providers]' }),
+      /provider\/model slug/
+    );
+  });
+});

--- a/tests/unit/hosted-target.test.js
+++ b/tests/unit/hosted-target.test.js
@@ -55,6 +55,18 @@ describe('hosted target CLI', function () {
     }
   });
 
+  it('rejects a symbolic-link target store', function () {
+    const { directory, environment } = fixture();
+    const regular = path.join(directory, 'regular.json');
+    try {
+      fs.writeFileSync(regular, '{"version":1,"targets":{}}');
+      fs.symlinkSync(regular, environment.ZEROSHOT_TARGETS_FILE);
+      assert.throws(() => loadTargets(environment), /not a regular file/);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('uses the canonical single-worker facade for hosted issues', function () {
     const issue = issueInput('the-open-engine/zeroshot#837');
     assert.equal(issue.repository, 'the-open-engine/zeroshot');
@@ -84,6 +96,18 @@ describe('hosted target CLI', function () {
       ).request.isolationProfile,
       'isolation.pr@1'
     );
+  });
+
+  it('reads a hosted prompt from one opened regular file', async function () {
+    const { directory } = fixture();
+    const prompt = path.join(directory, 'prompt.md');
+    try {
+      fs.writeFileSync(prompt, 'Implement the focused task.\n');
+      const resolved = await resolveInput(prompt, { repository: 'the-open-engine/zeroshot' });
+      assert.equal(resolved.request.prompt, 'Implement the focused task.');
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it('rejects repository path segments that Git would normalize', function () {

--- a/tests/unit/hosted-target.test.js
+++ b/tests/unit/hosted-target.test.js
@@ -12,7 +12,13 @@ const {
   loadTargets,
   removeTarget,
 } = require('../../cli/hosted/target-store');
-const { graph, issueInput, validateHostedOptions, websocketUrl } = require('../../cli/hosted/run');
+const {
+  graph,
+  issueInput,
+  resolveInput,
+  validateHostedOptions,
+  websocketUrl,
+} = require('../../cli/hosted/run');
 
 function fixture() {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-hosted-target-'));
@@ -52,12 +58,32 @@ describe('hosted target CLI', function () {
   it('uses the canonical single-worker facade for hosted issues', function () {
     const issue = issueInput('the-open-engine/zeroshot#837');
     assert.equal(issue.repository, 'the-open-engine/zeroshot');
+    assert.equal(issue.request.issue, 'https://github.com/the-open-engine/zeroshot/issues/837');
     assert.ok(!Object.hasOwn(issue.request, 'prompt'));
     const specification = graph();
     assert.equal(specification.profile, 'openengine.graph.single-worker/v1');
     assert.equal(specification.root.worker, 'legacy.zeroshot.ship@1');
     assert.equal(specification.root.input.fields.providerProfile.required, true);
     assert.equal(specification.root.output.fields.summary.type.kind, 'string');
+  });
+
+  it('selects reviewed PR delivery only when the hosted run requests it', async function () {
+    assert.equal(
+      (await resolveInput('the-open-engine/zeroshot#837', {})).request.isolationProfile,
+      'isolation.worktree@1'
+    );
+    const issuePr = await resolveInput('the-open-engine/zeroshot#837', { pr: true });
+    assert.equal(issuePr.request.isolationProfile, 'isolation.pr@1');
+    assert.equal(issuePr.request.providerProfile, 'provider.codex-openrouter-pr@1');
+    assert.equal(
+      (
+        await resolveInput('Implement the issue', {
+          pr: true,
+          repository: 'the-open-engine/zeroshot',
+        })
+      ).request.isolationProfile,
+      'isolation.pr@1'
+    );
   });
 
   it('rejects repository path segments that Git would normalize', function () {
@@ -78,6 +104,7 @@ describe('hosted target CLI', function () {
 
   it('rejects local-only flags instead of silently ignoring them', function () {
     assert.doesNotThrow(() => validateHostedOptions({ target: 'local', model: 'openai/gpt-5.4' }));
+    assert.doesNotThrow(() => validateHostedOptions({ target: 'local', pr: true }));
     assert.doesNotThrow(() => validateHostedOptions({ target: 'local', provider: 'codex' }));
     assert.throws(
       () => validateHostedOptions({ target: 'local', docker: true, provider: 'claude' }),

--- a/tests/unit/hosted-target.test.js
+++ b/tests/unit/hosted-target.test.js
@@ -106,6 +106,7 @@ describe('hosted target CLI', function () {
     assert.doesNotThrow(() => validateHostedOptions({ target: 'local', model: 'openai/gpt-5.4' }));
     assert.doesNotThrow(() => validateHostedOptions({ target: 'local', pr: true }));
     assert.doesNotThrow(() => validateHostedOptions({ target: 'local', provider: 'codex' }));
+    assert.doesNotThrow(() => validateHostedOptions({ target: 'local', size: 'standard' }));
     assert.throws(
       () => validateHostedOptions({ target: 'local', docker: true, provider: 'claude' }),
       /--docker, --provider/
@@ -113,6 +114,10 @@ describe('hosted target CLI', function () {
     assert.throws(
       () => validateHostedOptions({ target: 'local', model: 'openai/gpt-5.4\n[model_providers]' }),
       /provider\/model slug/
+    );
+    assert.throws(
+      () => validateHostedOptions({ target: 'local', size: 'xlarge' }),
+      /--size tiny, small, standard, or large/
     );
   });
 });

--- a/tests/unit/minimum-disk-space.test.js
+++ b/tests/unit/minimum-disk-space.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert');
+
+const { minimumDiskGigabytes } = require('../../src/isolation-manager');
+
+describe('minimum disk space configuration', function () {
+  it('preserves the 10 GB production default', function () {
+    assert.strictEqual(minimumDiskGigabytes({}), 10);
+  });
+
+  it('accepts a bounded positive integer override', function () {
+    assert.strictEqual(minimumDiskGigabytes({ ZEROSHOT_MIN_DISK_GB: '1' }), 1);
+    assert.strictEqual(minimumDiskGigabytes({ ZEROSHOT_MIN_DISK_GB: '1000' }), 1000);
+  });
+
+  for (const invalid of ['', '0', '-1', '1.5', '1e2', '1001', 'unlimited']) {
+    it(`rejects invalid value ${JSON.stringify(invalid)}`, function () {
+      assert.throws(
+        () => minimumDiskGigabytes({ ZEROSHOT_MIN_DISK_GB: invalid }),
+        /must be an integer between 1 and 1000/
+      );
+    });
+  }
+});

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -14,8 +14,13 @@ path = "src/lib.rs"
 name = "zeroshot-rust"
 path = "src/main.rs"
 
+[[bin]]
+name = "zeroshot-oecp-server"
+path = "src/bin/zeroshot-oecp-server.rs"
+
 [dependencies]
 async-trait.workspace = true
+axum.workspace = true
 fs2.workspace = true
 futures-util.workspace = true
 getrandom.workspace = true

--- a/zeroshot-rust/src/bin/zeroshot-oecp-server.rs
+++ b/zeroshot-rust/src/bin/zeroshot-oecp-server.rs
@@ -1,0 +1,32 @@
+use std::{error::Error, net::SocketAddr, sync::Arc};
+
+use tokio::net::TcpListener;
+use zeroshot_engine::hosted_oecp::{serve, HostedBackend, OECP_PORT};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    if std::env::args().nth(1).as_deref() == Some("--healthcheck") {
+        println!("zeroshot-oecp-server ready");
+        return Ok(());
+    }
+    let backend = Arc::new(HostedBackend::new());
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], OECP_PORT))).await?;
+    serve(listener, backend, shutdown_signal()).await?;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut terminate = signal(SignalKind::terminate()).expect("SIGTERM handler must install");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = terminate.recv() => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _result = tokio::signal::ctrl_c().await;
+}

--- a/zeroshot-rust/src/hosted_oecp.rs
+++ b/zeroshot-rust/src/hosted_oecp.rs
@@ -1,0 +1,14 @@
+//! Minimal hosted OECP adapter for the existing legacy Node worker.
+//!
+//! This process is a capsule workload. It deliberately owns neither capsule
+//! allocation nor capsule termination; its lifetime is the lifetime assigned by
+//! the capsule supervisor.
+
+mod backend;
+mod credentials;
+mod journal;
+mod server;
+mod worker;
+
+pub use backend::HostedBackend;
+pub use server::{serve, OECP_PORT};

--- a/zeroshot-rust/src/hosted_oecp/backend.rs
+++ b/zeroshot-rust/src/hosted_oecp/backend.rs
@@ -1,0 +1,768 @@
+use std::{
+    collections::BTreeMap,
+    sync::atomic::{AtomicU64, Ordering},
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    legacy_ship_request_payload_type, legacy_ship_result_payload_type, ApplyParams, ApplyResult,
+    ClusterStatus, Cursor, DiagnosticSeverity, DispatchState, Generation, GetParams, GetResult,
+    GraphDiagnostic, GraphDiagnosticCode, GraphNode, GraphProfile, GraphProfileSet, GraphSpec,
+    InitializeParams, InitializeResult, Labels, LegacyShipRequest, LegacyShipResult, LogLevel,
+    NodeAddress, NonEmptyVec, OperationalStatus, Phase, PlanParams, PlanResult, PositiveInteger,
+    RunId, ServerCapabilities, StopParams, StopResult, StructuralBounds, SubscriptionId,
+    TerminationWitness, WatchEvent, WatchParams, WatchResult, WorkerDescriptor, WorkerErrorCode,
+    WorkerOutcome, WorkerRef, GENERATION_CONFLICT, GRAPH_INVALID, IDEMPOTENCY_REUSE,
+    INTERNAL_ERROR_CODE, INVALID_PHASE, RUN_CONFLICT, SCHEMA_VIOLATION,
+};
+use openengine_cluster_server::{
+    watch::{
+        subscribe_and_stream, ObservationStore, SubscribeAndStreamRequest, WatchEventStream,
+        WatchHandle,
+    },
+    worker_registry::{check_graph_workers, WorkerRegistry, WorkerRegistryError},
+    BackendError, ClusterBackend, ConnectionContext,
+};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use super::{
+    credentials::{CredentialBundle, CredentialSlot},
+    journal::EventJournal,
+    worker::{WorkerClient, WorkerError},
+};
+
+static NEXT_RUN: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy)]
+struct LegacyRegistry;
+
+#[async_trait]
+impl WorkerRegistry for LegacyRegistry {
+    async fn resolve(&self, worker: &WorkerRef) -> Result<WorkerDescriptor, WorkerRegistryError> {
+        if worker.as_str() != "legacy.zeroshot.ship@1" {
+            return Err(WorkerRegistryError::NotFound {
+                worker: worker.clone(),
+            });
+        }
+        legacy_descriptor().map_err(|_| WorkerRegistryError::VersionUnavailable {
+            worker: worker.clone(),
+        })
+    }
+}
+
+struct HostedState {
+    graph: Option<GraphSpec>,
+    input: Option<Value>,
+    phase: Phase,
+    generation: Option<Generation>,
+    run_id: Option<RunId>,
+    at_cursor: Option<Cursor>,
+    committed: Option<ApplyParams>,
+    apply_result: Option<ApplyResult>,
+    stop_receipt: Option<(StopParams, StopResult)>,
+    worker: Option<Arc<WorkerClient>>,
+    finished: bool,
+}
+
+impl Default for HostedState {
+    fn default() -> Self {
+        Self {
+            graph: None,
+            input: None,
+            phase: Phase::Empty,
+            generation: None,
+            run_id: None,
+            at_cursor: None,
+            committed: None,
+            apply_result: None,
+            stop_receipt: None,
+            worker: None,
+            finished: false,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HostedBackend {
+    state: Arc<Mutex<HostedState>>,
+    credentials: CredentialSlot,
+    journal: Arc<EventJournal>,
+    next_subscription: Arc<AtomicU64>,
+}
+
+impl HostedBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HostedState::default())),
+            credentials: CredentialSlot::default(),
+            journal: Arc::new(EventJournal::new()),
+            next_subscription: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    pub async fn install_credentials(&self, bundle: CredentialBundle) -> Result<(), &'static str> {
+        if self.state.lock().await.phase != Phase::Empty {
+            return Err("credentials are frozen after admission begins");
+        }
+        let mut credentials = self.credentials.lock().await;
+        if credentials.is_some() {
+            return Err("credentials are already installed");
+        }
+        *credentials = Some(bundle);
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) {
+        let worker = self.state.lock().await.worker.clone();
+        if let Some(worker) = worker {
+            worker.terminate().await;
+        }
+    }
+
+    async fn verify(&self, graph: &GraphSpec) -> Result<PlanResult, BackendError> {
+        let diagnostics = single_worker_diagnostics(graph);
+        if !diagnostics.is_empty() {
+            return Ok(PlanResult {
+                ok: false,
+                diagnostics,
+                bounds: None,
+            });
+        }
+        if let Err(worker_diagnostics) = check_graph_workers(graph, &LegacyRegistry).await {
+            return Ok(PlanResult {
+                ok: false,
+                diagnostics: worker_diagnostics
+                    .into_iter()
+                    .map(|diagnostic| graph_diagnostic(diagnostic.message))
+                    .collect(),
+                bounds: None,
+            });
+        }
+        let GraphNode::Step(step) = &graph.root else {
+            return Err(BackendError::new(
+                INTERNAL_ERROR_CODE,
+                "validated single-worker graph lost its step root",
+            ));
+        };
+        let one = PositiveInteger::new(1)
+            .map_err(|error| BackendError::new(INTERNAL_ERROR_CODE, error.to_string()))?;
+        let order = NonEmptyVec::new(vec![step.name.clone()])
+            .map_err(|error| BackendError::new(INTERNAL_ERROR_CODE, error.to_string()))?;
+        Ok(PlanResult {
+            ok: true,
+            diagnostics: Vec::new(),
+            bounds: Some(StructuralBounds {
+                termination: TerminationWitness::Acyclic { order },
+                max_node_executions: one,
+                peak_concurrency: one,
+                attempts_per_node: BTreeMap::from([(step.name.clone(), one)]),
+            }),
+        })
+    }
+
+    async fn publish(&self, run_id: RunId, event: WatchEvent) -> Cursor {
+        let cursor = self.journal.publish(run_id, event).await;
+        self.state.lock().await.at_cursor = Some(cursor.clone());
+        cursor
+    }
+
+    async fn settle(&self, receipt: Result<Value, WorkerError>) {
+        let (run_id, node) = {
+            let mut state = self.state.lock().await;
+            if state.finished {
+                return;
+            }
+            state.finished = true;
+            state.phase = Phase::Finished;
+            let Some(run_id) = state.run_id.clone() else {
+                return;
+            };
+            let Some(graph) = state.graph.clone() else {
+                return;
+            };
+            (run_id, graph.root.name().clone())
+        };
+        let outcome = worker_outcome(receipt);
+        self.publish(
+            run_id.clone(),
+            WatchEvent::NodeEnd {
+                node: NodeAddress {
+                    node,
+                    attempt: PositiveInteger::new(1).expect("one is positive"),
+                },
+                outcome,
+            },
+        )
+        .await;
+        let final_status = self.status().await;
+        self.publish(
+            run_id,
+            WatchEvent::Finished {
+                final_status,
+                stop_mode: None,
+            },
+        )
+        .await;
+    }
+
+    async fn status(&self) -> ClusterStatus {
+        let state = self.state.lock().await;
+        status_from(&state)
+    }
+
+    async fn begin_run(
+        &self,
+        params: ApplyParams,
+        credentials: CredentialBundle,
+    ) -> Result<ApplyResult, BackendError> {
+        let request = params
+            .input
+            .clone()
+            .ok_or_else(|| schema_error("committed apply requires input"))?;
+        serde_json::from_value::<LegacyShipRequest>(request.clone())
+            .map_err(|_| schema_error("input does not match the legacy Zeroshot request"))?;
+        let worker = WorkerClient::spawn(&credentials)
+            .await
+            .map_err(worker_backend_error)?;
+        worker
+            .start(request.clone())
+            .await
+            .map_err(worker_backend_error)?;
+        let (run_id, graph, result) = {
+            let mut state = self.state.lock().await;
+            let generation = Generation::new(1).expect("one is a safe generation");
+            let run_id = new_run_id();
+            state.graph = Some(params.graph.clone());
+            state.input = Some(request.clone());
+            state.phase = Phase::Running;
+            state.generation = Some(generation);
+            state.run_id = Some(run_id.clone());
+            state.worker = Some(Arc::clone(&worker));
+            let result = ApplyResult {
+                generation: Some(generation),
+                run_id: Some(run_id.clone()),
+                phase: Phase::Running,
+                deduped: false,
+                diff: None,
+            };
+            state.committed = Some(params);
+            state.apply_result = Some(result.clone());
+            (
+                run_id,
+                state.graph.clone().expect("graph was stored"),
+                result,
+            )
+        };
+        let running = self.status().await;
+        self.publish(
+            run_id.clone(),
+            WatchEvent::Phase {
+                status: running,
+                admission: Some(Box::new(openengine_cluster_protocol::AdmissionTransition {
+                    run_id: run_id.clone(),
+                    spec: graph,
+                    seed_input: request.clone(),
+                })),
+            },
+        )
+        .await;
+        self.publish(
+            run_id,
+            WatchEvent::NodeBegin {
+                node: NodeAddress {
+                    node: result_node(&self.state).await,
+                    attempt: PositiveInteger::new(1).expect("one is positive"),
+                },
+                input: request,
+            },
+        )
+        .await;
+        let backend = self.clone();
+        tokio::spawn(async move {
+            backend.settle(worker.result().await).await;
+        });
+        Ok(result)
+    }
+}
+
+fn single_worker_diagnostics(graph: &GraphSpec) -> Vec<GraphDiagnostic> {
+    let mut messages = Vec::new();
+    if graph.profile != GraphProfile::SingleWorker {
+        messages.push("hosted Zeroshot accepts only openengine.graph.single-worker/v1");
+    }
+    let GraphNode::Step(step) = &graph.root else {
+        messages.push("single-worker graphs require exactly one step root");
+        return messages.into_iter().map(graph_diagnostic).collect();
+    };
+    if step.worker.as_str() != "legacy.zeroshot.ship@1" {
+        messages.push("single-worker graphs require legacy.zeroshot.ship@1");
+    }
+    let input = legacy_ship_request_payload_type();
+    if graph.initial_input != input || step.input != input {
+        messages.push("graph and worker input must use the canonical legacy Zeroshot request");
+    }
+    if step.output != legacy_ship_result_payload_type() {
+        messages.push("worker output must use the canonical legacy Zeroshot result");
+    }
+    if !step.input_bindings.is_empty() || !step.write_bindings.is_empty() {
+        messages.push("single-worker facade graphs cannot contain data bindings");
+    }
+    if step.attempts.get() != 1 {
+        messages.push("minimal hosted execution supports exactly one worker attempt");
+    }
+    if graph.policy.policy.as_str() != "policy.strict@1" {
+        messages.push("hosted Zeroshot requires policy.strict@1");
+    }
+    messages.into_iter().map(graph_diagnostic).collect()
+}
+
+fn graph_diagnostic(message: impl Into<String>) -> GraphDiagnostic {
+    GraphDiagnostic {
+        severity: DiagnosticSeverity::Error,
+        code: GraphDiagnosticCode::InvalidGraphShape,
+        message: message.into(),
+        path: Vec::new(),
+        related_nodes: Vec::new(),
+    }
+}
+
+impl Default for HostedBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for HostedBackend {
+    async fn initialize(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        let graph_profiles = GraphProfileSet::new(vec![GraphProfile::SingleWorker])
+            .map_err(|error| BackendError::new(INTERNAL_ERROR_CODE, error.to_string()))?;
+        Ok(InitializeResult::new(
+            ServerCapabilities {
+                graph_profiles,
+                logs: false,
+                agent_attach: false,
+            },
+            self.status().await,
+        ))
+    }
+
+    async fn plan(
+        &self,
+        _context: &ConnectionContext,
+        params: PlanParams,
+    ) -> Result<PlanResult, BackendError> {
+        self.verify(&params.graph).await
+    }
+
+    async fn apply(
+        &self,
+        _context: &ConnectionContext,
+        params: ApplyParams,
+    ) -> Result<ApplyResult, BackendError> {
+        validate_apply(&params)?;
+        let planned = self.verify(&params.graph).await?;
+        if !planned.ok {
+            return Err(BackendError::application(
+                GRAPH_INVALID,
+                "Graph verification failed",
+                Some(json!({ "diagnostics": planned.diagnostics })),
+            ));
+        }
+        if params.dry_run {
+            let state = self.state.lock().await;
+            return Ok(ApplyResult {
+                generation: state.generation,
+                run_id: state.run_id.clone(),
+                phase: state.phase,
+                deduped: false,
+                diff: None,
+            });
+        }
+        {
+            let mut state = self.state.lock().await;
+            if let Some(committed) = &state.committed {
+                if committed == &params {
+                    let mut replayed = state
+                        .apply_result
+                        .clone()
+                        .ok_or_else(|| BackendError::new(INTERNAL_ERROR_CODE, "missing receipt"))?;
+                    replayed.deduped = true;
+                    return Ok(replayed);
+                }
+                return Err(BackendError::application(
+                    RUN_CONFLICT,
+                    "This capsule already admitted its one OECP run",
+                    None,
+                ));
+            }
+            if state.phase != Phase::Empty {
+                return Err(BackendError::application(
+                    RUN_CONFLICT,
+                    "Another apply is already being admitted",
+                    None,
+                ));
+            }
+            precheck_generation(params.if_generation, state.generation)?;
+            params
+                .graph
+                .initial_input
+                .validate_value(params.input.as_ref().expect("validated committed input"))
+                .map_err(|error| schema_error(&error.to_string()))?;
+            state.phase = Phase::Admitting;
+        }
+        let credentials = self.credentials.lock().await.clone().ok_or_else(|| {
+            BackendError::application(
+                "CREDENTIALS_REQUIRED",
+                "Capsule credentials must be installed before apply",
+                None,
+            )
+        });
+        match credentials {
+            Ok(credentials) => match self.begin_run(params, credentials).await {
+                Ok(result) => Ok(result),
+                Err(error) => {
+                    self.state.lock().await.phase = Phase::Empty;
+                    Err(error)
+                }
+            },
+            Err(error) => {
+                self.state.lock().await.phase = Phase::Empty;
+                Err(error)
+            }
+        }
+    }
+
+    async fn get(
+        &self,
+        _context: &ConnectionContext,
+        params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        let state = self.state.lock().await;
+        if let Some(requested) = params.at_cursor {
+            if state.at_cursor.as_ref() != Some(&requested) {
+                return Err(BackendError::application(
+                    INVALID_PHASE,
+                    "Requested cursor is not available",
+                    Some(json!({ "currentCursor": state.at_cursor })),
+                ));
+            }
+        }
+        Ok(GetResult {
+            spec: state.graph.clone(),
+            status: status_from(&state),
+            at_cursor: state.at_cursor.clone(),
+        })
+    }
+
+    async fn stop(
+        &self,
+        _context: &ConnectionContext,
+        params: StopParams,
+    ) -> Result<StopResult, BackendError> {
+        let worker = {
+            let state = self.state.lock().await;
+            if let Some((committed, result)) = &state.stop_receipt {
+                if committed == &params {
+                    let mut replayed = result.clone();
+                    replayed.deduped = true;
+                    return Ok(replayed);
+                }
+                return Err(BackendError::application(
+                    IDEMPOTENCY_REUSE,
+                    "Stop idempotency key was reused with different parameters",
+                    None,
+                ));
+            }
+            if state.generation != Some(params.if_generation) {
+                return Err(generation_error(state.generation));
+            }
+            state.worker.clone().ok_or_else(|| {
+                BackendError::application(INVALID_PHASE, "No running worker exists", None)
+            })?
+        };
+        let receipt = worker.stop().await;
+        self.settle(receipt).await;
+        let mut state = self.state.lock().await;
+        let generation = state.generation.expect("stop validated generation");
+        let run_id = state.run_id.clone().expect("stop validated run");
+        let at_cursor = state
+            .at_cursor
+            .clone()
+            .unwrap_or_else(|| Cursor::new("event-0"));
+        let result = StopResult {
+            generation,
+            run_id,
+            phase: state.phase,
+            accepted_mode: params.mode,
+            effective_mode: params.mode,
+            operational: operational(state.phase),
+            at_cursor,
+            deduped: false,
+        };
+        state.stop_receipt = Some((params, result.clone()));
+        Ok(result)
+    }
+
+    async fn watch(
+        &self,
+        _context: &ConnectionContext,
+        params: WatchParams,
+        queue_capacity: usize,
+    ) -> Result<(WatchResult, WatchEventStream, WatchHandle), BackendError> {
+        let store: Arc<dyn ObservationStore> =
+            Arc::clone(&self.journal) as Arc<dyn ObservationStore>;
+        subscribe_and_stream(
+            &store,
+            SubscribeAndStreamRequest {
+                subscription_id: SubscriptionId::new(format!(
+                    "watch-{}",
+                    self.next_subscription.fetch_add(1, Ordering::Relaxed)
+                )),
+                params,
+                queue_capacity,
+            },
+            |_| BackendError::application("NOT_FOUND", "Run does not exist", None),
+        )
+        .await
+    }
+}
+
+fn validate_apply(params: &ApplyParams) -> Result<(), BackendError> {
+    if params.dry_run {
+        if params.idempotency_key.is_some() || params.input.is_some() {
+            return Err(schema_error(
+                "dry-run apply must omit idempotencyKey and input",
+            ));
+        }
+    } else if params.idempotency_key.is_none() || params.input.is_none() {
+        return Err(schema_error(
+            "committed apply requires idempotencyKey and input",
+        ));
+    }
+    Ok(())
+}
+
+fn precheck_generation(
+    expected: Option<Generation>,
+    current: Option<Generation>,
+) -> Result<(), BackendError> {
+    if expected.is_none() || expected.is_some_and(|value| value.get() == 0 && current.is_none()) {
+        Ok(())
+    } else {
+        Err(generation_error(current))
+    }
+}
+
+fn generation_error(current: Option<Generation>) -> BackendError {
+    BackendError::application(
+        GENERATION_CONFLICT,
+        "Generation precondition failed",
+        Some(json!({ "currentGeneration": current })),
+    )
+}
+
+fn schema_error(reason: &str) -> BackendError {
+    BackendError::invalid_params(
+        SCHEMA_VIOLATION,
+        "Admission parameters violate the schema",
+        Some(json!({ "reason": reason })),
+    )
+}
+
+fn worker_backend_error(error: WorkerError) -> BackendError {
+    BackendError::application(
+        error.code,
+        "Legacy Zeroshot worker failed",
+        Some(json!({ "reason": error.message })),
+    )
+}
+
+fn worker_outcome(receipt: Result<Value, WorkerError>) -> WorkerOutcome {
+    match receipt {
+        Ok(receipt) if receipt.get("state").and_then(Value::as_str) == Some("completed") => {
+            let result = receipt.get("result").cloned().unwrap_or(Value::Null);
+            match serde_json::from_value::<LegacyShipResult>(result.clone()) {
+                Ok(result_contract) => WorkerOutcome::Verified {
+                    output: result,
+                    artifacts: result_contract.artifacts,
+                },
+                Err(_) => WorkerOutcome::malformed(),
+            }
+        }
+        Ok(receipt) => receipt
+            .get("outcome")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_else(|| WorkerOutcome::declared_failure(WorkerErrorCode::Crash)),
+        Err(_) => WorkerOutcome::declared_failure(WorkerErrorCode::Crash),
+    }
+}
+
+fn status_from(state: &HostedState) -> ClusterStatus {
+    ClusterStatus {
+        phase: state.phase,
+        observed_generation: state.generation,
+        current_run_id: state.run_id.clone(),
+        at_cursor: state.at_cursor.clone(),
+        operational: (state.phase != Phase::Empty).then(|| operational(state.phase)),
+    }
+}
+
+fn operational(phase: Phase) -> OperationalStatus {
+    let terminal = phase == Phase::Finished;
+    OperationalStatus {
+        labels: Labels::default(),
+        log_level: LogLevel::Info,
+        dispatch_state: if terminal {
+            DispatchState::Stopped
+        } else {
+            DispatchState::Active
+        },
+        stop_mode: None,
+        in_flight: u32::from(!terminal),
+    }
+}
+
+async fn result_node(state: &Mutex<HostedState>) -> openengine_cluster_protocol::NodeName {
+    state
+        .lock()
+        .await
+        .graph
+        .as_ref()
+        .expect("run graph exists")
+        .root
+        .name()
+        .clone()
+}
+
+fn new_run_id() -> RunId {
+    let time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let sequence = NEXT_RUN.fetch_add(1, Ordering::Relaxed);
+    RunId::new(format!("hosted-{time:x}-{sequence:x}"))
+}
+
+fn legacy_descriptor() -> Result<WorkerDescriptor, serde_json::Error> {
+    serde_json::from_value(json!({
+        "worker": "legacy.zeroshot.ship@1",
+        "graphProfiles": ["openengine.graph.single-worker/v1"],
+        "binding": {
+            "protocol": "legacy_zeroshot",
+            "version": "1",
+            "profile": "legacy.zeroshot.ship/v1"
+        },
+        "contract": {
+            "input": serde_json::to_value(legacy_ship_request_payload_type())?,
+            "output": serde_json::to_value(legacy_ship_result_payload_type())?,
+            "verifier": null,
+            "errors": ["timeout", "crash", "malformed", "refusal"]
+        },
+        "capabilityPolicy": {
+            "autonomy": "strict",
+            "permissionPolicy": "policy.strict@1"
+        },
+        "artifactProfile": {
+            "allowedTypeIds": ["openengine.result@1"],
+            "allowedMediaTypes": ["application/json"],
+            "minimumRedaction": "internal"
+        },
+        "credentialRequirements": []
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_protocol::{
+        legacy_ship_request_payload_type, legacy_ship_result_payload_type, GraphProfile, GraphSpec,
+    };
+    use serde_json::json;
+
+    use super::{single_worker_diagnostics, HostedBackend};
+
+    fn graph(profile: GraphProfile, worker: &str) -> GraphSpec {
+        serde_json::from_value(json!({
+            "profile": profile,
+            "initialInput": legacy_ship_request_payload_type(),
+            "policy": { "policy": "policy.strict@1", "default": "deny" },
+            "root": {
+                "kind": "step",
+                "name": "zeroshot",
+                "worker": worker,
+                "input": legacy_ship_request_payload_type(),
+                "output": legacy_ship_result_payload_type(),
+                "inputBindings": [],
+                "writeBindings": [],
+                "timeoutMs": 3_600_000,
+                "attempts": 1
+            }
+        }))
+        .expect("hosted graph fixture must be valid protocol syntax")
+    }
+
+    #[tokio::test]
+    async fn canonical_single_worker_graph_has_fixed_structural_bounds() {
+        let graph = graph(GraphProfile::SingleWorker, "legacy.zeroshot.ship@1");
+        let planned = HostedBackend::new()
+            .verify(&graph)
+            .await
+            .expect("canonical graph must verify");
+
+        assert!(planned.ok);
+        assert!(planned.diagnostics.is_empty());
+        let bounds = planned.bounds.expect("accepted graph must have bounds");
+        assert_eq!(bounds.max_node_executions.get(), 1);
+        assert_eq!(bounds.peak_concurrency.get(), 1);
+        assert_eq!(bounds.attempts_per_node.len(), 1);
+    }
+
+    #[test]
+    fn broader_profiles_and_workers_are_rejected_at_the_facade() {
+        let full = graph(GraphProfile::Full, "legacy.zeroshot.ship@1");
+        let unsupported = graph(GraphProfile::SingleWorker, "example.worker@1");
+
+        let full_messages = single_worker_diagnostics(&full)
+            .into_iter()
+            .map(|diagnostic| diagnostic.message)
+            .collect::<Vec<_>>();
+        let worker_messages = single_worker_diagnostics(&unsupported)
+            .into_iter()
+            .map(|diagnostic| diagnostic.message)
+            .collect::<Vec<_>>();
+
+        assert!(
+            full_messages
+                .iter()
+                .any(|message| message.contains("single-worker/v1"))
+        );
+        assert!(
+            worker_messages
+                .iter()
+                .any(|message| message.contains("legacy.zeroshot.ship@1"))
+        );
+    }
+
+    #[test]
+    fn facade_rejects_noncanonical_contracts_before_worker_resolution() {
+        let mut graph = graph(GraphProfile::SingleWorker, "legacy.zeroshot.ship@1");
+        graph.initial_input = serde_json::from_value(json!({ "kind": "string" }))
+            .expect("string is a valid payload type");
+
+        let messages = single_worker_diagnostics(&graph)
+            .into_iter()
+            .map(|diagnostic| diagnostic.message)
+            .collect::<Vec<_>>();
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("canonical legacy Zeroshot request"));
+    }
+}

--- a/zeroshot-rust/src/hosted_oecp/credentials.rs
+++ b/zeroshot-rust/src/hosted_oecp/credentials.rs
@@ -58,44 +58,84 @@ impl CredentialBundle {
             .env("HOME", RUNTIME_ROOT)
             .env("CODEX_HOME", format!("{RUNTIME_ROOT}/codex"))
             .env("TMPDIR", format!("{RUNTIME_ROOT}/tmp"))
-            .env("GIT_TERMINAL_PROMPT", "0");
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", format!("{RUNTIME_ROOT}/git-askpass.sh"));
     }
 
     pub async fn prepare_workspace(&self) -> Result<(), String> {
         write_runtime_files(&self.model).await?;
-        if Path::new(&format!("{REPOSITORY_ROOT}/.git")).exists() {
-            return Ok(());
-        }
-        if Path::new(REPOSITORY_ROOT).exists() {
-            fs::remove_dir_all(REPOSITORY_ROOT)
+        if !Path::new(&format!("{REPOSITORY_ROOT}/.git")).exists() {
+            if Path::new(REPOSITORY_ROOT).exists() {
+                fs::remove_dir_all(REPOSITORY_ROOT)
+                    .await
+                    .map_err(|error| format!("remove incomplete repository clone: {error}"))?;
+            }
+            fs::create_dir_all("/workspace")
                 .await
-                .map_err(|error| format!("remove incomplete repository clone: {error}"))?;
+                .map_err(|error| format!("create workspace: {error}"))?;
+            let mut command = Command::new("git");
+            command.args([
+                "clone",
+                "--filter=blob:none",
+                &format!("https://github.com/{}.git", self.repository),
+                REPOSITORY_ROOT,
+            ]);
+            self.apply_to(&mut command);
+            run(&mut command, "git clone").await?;
         }
-        fs::create_dir_all("/workspace")
-            .await
-            .map_err(|error| format!("create workspace: {error}"))?;
+        configure_git_identity(self).await
+    }
+}
+
+async fn configure_git_identity(credentials: &CredentialBundle) -> Result<(), String> {
+    let mut identity_command = Command::new("gh");
+    identity_command.args(["api", "user", "--jq", "[.login, (.id|tostring)] | @tsv"]);
+    credentials.apply_to(&mut identity_command);
+    let output = run(&mut identity_command, "GitHub identity lookup").await?;
+    let (name, email) = github_identity(&String::from_utf8_lossy(&output))?;
+
+    for (key, value) in [("user.name", name.as_str()), ("user.email", email.as_str())] {
         let mut command = Command::new("git");
-        command.args([
-            "clone",
-            "--filter=blob:none",
-            &format!("https://github.com/{}.git", self.repository),
-            REPOSITORY_ROOT,
-        ]);
-        self.apply_to(&mut command);
-        command.env("GIT_ASKPASS", format!("{RUNTIME_ROOT}/git-askpass.sh"));
-        let output = command
-            .output()
-            .await
-            .map_err(|error| format!("start git clone: {error}"))?;
-        if output.status.success() {
-            Ok(())
-        } else {
-            Err(format!(
-                "git clone failed with status {}: {}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr).trim()
-            ))
-        }
+        command.args(["-C", REPOSITORY_ROOT, "config", "--local", key, value]);
+        credentials.apply_to(&mut command);
+        run(&mut command, "git identity configuration").await?;
+    }
+    Ok(())
+}
+
+fn github_identity(value: &str) -> Result<(String, String), String> {
+    let (login, id) = value
+        .trim()
+        .split_once('\t')
+        .ok_or_else(|| "GitHub identity lookup returned an invalid response".to_owned())?;
+    if login.is_empty()
+        || !login
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        || id.is_empty()
+        || !id.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err("GitHub identity lookup returned an invalid response".to_owned());
+    }
+    Ok((
+        login.to_owned(),
+        format!("{id}+{login}@users.noreply.github.com"),
+    ))
+}
+
+async fn run(command: &mut Command, operation: &str) -> Result<Vec<u8>, String> {
+    let output = command
+        .output()
+        .await
+        .map_err(|error| format!("start {operation}: {error}"))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(format!(
+            "{operation} failed with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
     }
 }
 
@@ -203,7 +243,9 @@ pub type CredentialSlot = Arc<Mutex<Option<CredentialBundle>>>;
 
 #[cfg(test)]
 mod tests {
-    use super::CredentialBundle;
+    use std::collections::BTreeMap;
+
+    use super::{github_identity, CredentialBundle, RUNTIME_ROOT};
     use crate::hosted_oecp::HostedBackend;
 
     fn bundle() -> CredentialBundle {
@@ -233,6 +275,40 @@ mod tests {
         let mut invalid = bundle();
         invalid.model = "openai/gpt-5.4\napproval_policy = \"never\"".to_owned();
         assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn worker_environment_keeps_noninteractive_git_auth_for_pushes() {
+        let mut command = tokio::process::Command::new("true");
+        bundle().apply_to(&mut command);
+        let environment = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(key, value)| {
+                Some((key.to_str()?.to_owned(), value?.to_str()?.to_owned()))
+            })
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            environment.get("GIT_ASKPASS").map(String::as_str),
+            Some(&*format!("{RUNTIME_ROOT}/git-askpass.sh"))
+        );
+        assert_eq!(
+            environment.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+            Some("0")
+        );
+    }
+
+    #[test]
+    fn github_identity_uses_the_authenticated_accounts_noreply_address() {
+        assert_eq!(
+            github_identity("zeroshot-user\t12345\n"),
+            Ok((
+                "zeroshot-user".to_owned(),
+                "12345+zeroshot-user@users.noreply.github.com".to_owned()
+            ))
+        );
+        assert!(github_identity("bad login\t12345").is_err());
+        assert!(github_identity("zeroshot-user\tnot-an-id").is_err());
     }
 
     #[tokio::test]

--- a/zeroshot-rust/src/hosted_oecp/credentials.rs
+++ b/zeroshot-rust/src/hosted_oecp/credentials.rs
@@ -1,0 +1,247 @@
+use std::{path::Path, sync::Arc};
+
+use axum::{
+    extract::{DefaultBodyLimit, State},
+    http::StatusCode,
+    routing::put,
+    Json, Router,
+};
+use serde::Deserialize;
+use tokio::{fs, process::Command, sync::Mutex};
+
+use super::backend::HostedBackend;
+
+pub const CREDENTIAL_PORT: u16 = 8_084;
+const MAX_SECRET_BYTES: usize = 16 * 1024;
+const DEFAULT_MODEL: &str = "openai/gpt-5.4";
+const RUNTIME_ROOT: &str = "/workspace/.zeroshot-runtime";
+const REPOSITORY_ROOT: &str = "/workspace/repository";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct CredentialBundle {
+    github_token: String,
+    openrouter_api_key: String,
+    repository: String,
+    #[serde(default = "default_model")]
+    model: String,
+}
+
+fn default_model() -> String {
+    DEFAULT_MODEL.to_owned()
+}
+
+impl CredentialBundle {
+    fn validate(&self) -> Result<(), &'static str> {
+        if self.github_token.trim().is_empty() || self.github_token.len() > 4_096 {
+            return Err("githubToken must be nonempty and at most 4096 bytes");
+        }
+        if self.openrouter_api_key.trim().is_empty() || self.openrouter_api_key.len() > 4_096 {
+            return Err("openrouterApiKey must be nonempty and at most 4096 bytes");
+        }
+        if !valid_repository(&self.repository) {
+            return Err("repository must have the form owner/name");
+        }
+        if !valid_model(&self.model) {
+            return Err("model must be an exact provider/model slug");
+        }
+        Ok(())
+    }
+
+    pub fn apply_to(&self, command: &mut Command) {
+        command
+            .env("GH_TOKEN", &self.github_token)
+            .env("GITHUB_TOKEN", &self.github_token)
+            .env("OPENROUTER_API_KEY", &self.openrouter_api_key)
+            .env("ZEROSHOT_HOSTED_CODEX_OPENROUTER", "1")
+            .env("ZEROSHOT_HOSTED_MODEL", &self.model)
+            .env("HOME", RUNTIME_ROOT)
+            .env("CODEX_HOME", format!("{RUNTIME_ROOT}/codex"))
+            .env("TMPDIR", format!("{RUNTIME_ROOT}/tmp"))
+            .env("GIT_TERMINAL_PROMPT", "0");
+    }
+
+    pub async fn prepare_workspace(&self) -> Result<(), String> {
+        write_runtime_files(&self.model).await?;
+        if Path::new(&format!("{REPOSITORY_ROOT}/.git")).exists() {
+            return Ok(());
+        }
+        if Path::new(REPOSITORY_ROOT).exists() {
+            fs::remove_dir_all(REPOSITORY_ROOT)
+                .await
+                .map_err(|error| format!("remove incomplete repository clone: {error}"))?;
+        }
+        fs::create_dir_all("/workspace")
+            .await
+            .map_err(|error| format!("create workspace: {error}"))?;
+        let mut command = Command::new("git");
+        command.args([
+            "clone",
+            "--filter=blob:none",
+            &format!("https://github.com/{}.git", self.repository),
+            REPOSITORY_ROOT,
+        ]);
+        self.apply_to(&mut command);
+        command.env("GIT_ASKPASS", format!("{RUNTIME_ROOT}/git-askpass.sh"));
+        let output = command
+            .output()
+            .await
+            .map_err(|error| format!("start git clone: {error}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(format!(
+                "git clone failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ))
+        }
+    }
+}
+
+fn valid_repository(value: &str) -> bool {
+    let mut parts = value.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let name = parts.next().unwrap_or_default();
+    !owner.is_empty()
+        && !name.is_empty()
+        && !matches!(owner, "." | "..")
+        && !matches!(name, "." | "..")
+        && parts.next().is_none()
+        && owner.bytes().all(valid_repo_byte)
+        && name.bytes().all(valid_repo_byte)
+}
+
+fn valid_model(value: &str) -> bool {
+    if value.len() > 256 {
+        return false;
+    }
+    let Some((provider, model)) = value.split_once('/') else {
+        return false;
+    };
+    provider
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_alphanumeric)
+        && model
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && !model.contains('/')
+        && provider
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && model
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'))
+}
+
+fn valid_repo_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
+}
+
+async fn write_runtime_files(model: &str) -> Result<(), String> {
+    fs::create_dir_all(format!("{RUNTIME_ROOT}/codex"))
+        .await
+        .map_err(|error| format!("create Codex runtime directory: {error}"))?;
+    fs::create_dir_all(format!("{RUNTIME_ROOT}/tmp"))
+        .await
+        .map_err(|error| format!("create temporary runtime directory: {error}"))?;
+    let escaped_model = model.replace('\\', "\\\\").replace('"', "\\\"");
+    let config = format!(
+        "model_provider = \"openrouter\"\nmodel = \"{escaped_model}\"\n\
+         model_reasoning_effort = \"high\"\napproval_policy = \"never\"\n\
+         sandbox_mode = \"danger-full-access\"\nweb_search = \"disabled\"\n\n\
+         [model_providers.openrouter]\nname = \"OpenRouter\"\n\
+         base_url = \"https://openrouter.ai/api/v1\"\nenv_key = \"OPENROUTER_API_KEY\"\n\
+         wire_api = \"responses\"\n\n[projects.\"{REPOSITORY_ROOT}\"]\ntrust_level = \"trusted\"\n"
+    );
+    fs::write(format!("{RUNTIME_ROOT}/codex/config.toml"), config)
+        .await
+        .map_err(|error| format!("write Codex runtime config: {error}"))?;
+    fs::write(
+        format!("{RUNTIME_ROOT}/git-askpass.sh"),
+        "#!/bin/sh\ncase \"$1\" in\n  *Username*) printf '%s\\n' x-access-token ;;\n  *) printf '%s\\n' \"$GH_TOKEN\" ;;\nesac\n",
+    )
+    .await
+    .map_err(|error| format!("write git credential helper: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(
+            format!("{RUNTIME_ROOT}/git-askpass.sh"),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .await
+        .map_err(|error| format!("protect git credential helper: {error}"))?;
+    }
+    Ok(())
+}
+
+pub fn router(backend: Arc<HostedBackend>) -> Router {
+    Router::new()
+        .route("/internal/credentials", put(install))
+        .layer(DefaultBodyLimit::max(MAX_SECRET_BYTES))
+        .with_state(backend)
+}
+
+async fn install(
+    State(backend): State<Arc<HostedBackend>>,
+    Json(bundle): Json<CredentialBundle>,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    bundle
+        .validate()
+        .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+    backend
+        .install_credentials(bundle)
+        .await
+        .map_err(|message| (StatusCode::CONFLICT, message))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub type CredentialSlot = Arc<Mutex<Option<CredentialBundle>>>;
+
+#[cfg(test)]
+mod tests {
+    use super::CredentialBundle;
+    use crate::hosted_oecp::HostedBackend;
+
+    fn bundle() -> CredentialBundle {
+        CredentialBundle {
+            github_token: "github".to_owned(),
+            openrouter_api_key: "openrouter".to_owned(),
+            repository: "the-open-engine/zeroshot".to_owned(),
+            model: "openai/gpt-5.4".to_owned(),
+        }
+    }
+
+    #[test]
+    fn credential_contract_is_closed_and_bounded() {
+        assert!(bundle().validate().is_ok());
+        let mut invalid = bundle();
+        invalid.repository = "owner/repo/extra".to_owned();
+        assert!(invalid.validate().is_err());
+        let mut invalid = bundle();
+        invalid.repository = "../repo".to_owned();
+        assert!(invalid.validate().is_err());
+        let mut invalid = bundle();
+        invalid.repository = "owner/..".to_owned();
+        assert!(invalid.validate().is_err());
+        let mut invalid = bundle();
+        invalid.model = "model-without-provider".to_owned();
+        assert!(invalid.validate().is_err());
+        let mut invalid = bundle();
+        invalid.model = "openai/gpt-5.4\napproval_policy = \"never\"".to_owned();
+        assert!(invalid.validate().is_err());
+    }
+
+    #[tokio::test]
+    async fn credentials_can_only_be_installed_once() {
+        let backend = HostedBackend::new();
+        assert!(backend.install_credentials(bundle()).await.is_ok());
+        assert_eq!(
+            backend.install_credentials(bundle()).await,
+            Err("credentials are already installed")
+        );
+    }
+}

--- a/zeroshot-rust/src/hosted_oecp/journal.rs
+++ b/zeroshot-rust/src/hosted_oecp/journal.rs
@@ -1,0 +1,118 @@
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{Cursor, RunId, WatchEvent};
+use openengine_cluster_server::{
+    admission::StoreError,
+    watch::{
+        ObservationStore, PublicEventRecord, ReplayPageRequest, ResolvedSubscription,
+        SubscribeRequest,
+    },
+};
+use tokio::sync::{mpsc, Mutex};
+
+#[derive(Default)]
+struct JournalState {
+    run_id: Option<RunId>,
+    history: Vec<PublicEventRecord>,
+    live: Vec<(mpsc::Sender<PublicEventRecord>, Arc<AtomicBool>)>,
+}
+
+pub struct EventJournal {
+    sequence: AtomicU64,
+    state: Mutex<JournalState>,
+}
+
+impl EventJournal {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            sequence: AtomicU64::new(1),
+            state: Mutex::new(JournalState::default()),
+        }
+    }
+
+    pub async fn publish(&self, run_id: RunId, event: WatchEvent) -> Cursor {
+        let cursor = Cursor::new(format!(
+            "event-{}",
+            self.sequence.fetch_add(1, Ordering::Relaxed)
+        ));
+        let record = PublicEventRecord {
+            run_id: run_id.clone(),
+            cursor: cursor.clone(),
+            event,
+        };
+        let mut state = self.state.lock().await;
+        state.run_id = Some(run_id);
+        state.history.push(record.clone());
+        state.live.retain(
+            |(sender, overflowed)| match sender.try_send(record.clone()) {
+                Ok(()) => true,
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    overflowed.store(true, Ordering::Release);
+                    false
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => false,
+            },
+        );
+        cursor
+    }
+}
+
+#[async_trait]
+impl ObservationStore for EventJournal {
+    async fn subscribe(
+        &self,
+        request: SubscribeRequest,
+        queue_capacity: usize,
+    ) -> Result<ResolvedSubscription, StoreError> {
+        let mut state = self.state.lock().await;
+        if let (Some(requested), Some(current)) = (&request.run_id, &state.run_id) {
+            if requested != current {
+                return Err(StoreError::UnknownRun);
+            }
+        }
+        let replay_through = state.history.last().map(|record| record.cursor.clone());
+        let (sender, receiver) = mpsc::channel(queue_capacity.max(1));
+        let overflowed = Arc::new(AtomicBool::new(false));
+        state.live.push((sender, Arc::clone(&overflowed)));
+        Ok(ResolvedSubscription {
+            run_id: state.run_id.clone(),
+            at_cursor: replay_through.clone(),
+            resume_after: request.from_cursor,
+            replay_through,
+            receiver,
+            overflowed,
+        })
+    }
+
+    async fn replay_page(
+        &self,
+        request: ReplayPageRequest<'_>,
+    ) -> Result<Vec<PublicEventRecord>, StoreError> {
+        let state = self.state.lock().await;
+        if state.run_id.as_ref() != Some(request.run_id) {
+            return Err(StoreError::UnknownRun);
+        }
+        let start = match request.after {
+            Some(after) => state
+                .history
+                .iter()
+                .position(|record| &record.cursor == after)
+                .map_or(0, |index| index + 1),
+            None => 0,
+        };
+        let mut page = Vec::new();
+        for record in state.history.iter().skip(start) {
+            let reached_tail = &record.cursor == request.through;
+            page.push(record.clone());
+            if page.len() >= request.limit || reached_tail {
+                break;
+            }
+        }
+        Ok(page)
+    }
+}

--- a/zeroshot-rust/src/hosted_oecp/server.rs
+++ b/zeroshot-rust/src/hosted_oecp/server.rs
@@ -1,0 +1,186 @@
+use std::{
+    collections::BTreeMap,
+    future::{Future, IntoFuture},
+    io,
+    net::{Ipv4Addr, SocketAddr},
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use openengine_cluster_server::{
+    admission::CancellationSignal,
+    identity::{
+        BindingAttributes, ConnectionBinding, ConnectionIdentity, ConnectionIdentityConfig,
+        PrincipalId, StaticConnectionIdentityResolver, SystemConnectionTime, TenantId,
+    },
+    websocket::{serve_websocket, websocket_config},
+};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Semaphore,
+    task::JoinSet,
+};
+use tokio_tungstenite::{
+    accept_hdr_async_with_config,
+    tungstenite::{
+        handshake::server::{ErrorResponse, Request, Response},
+        http::StatusCode,
+    },
+};
+
+use super::{
+    backend::HostedBackend,
+    credentials::{router as credential_router, CREDENTIAL_PORT},
+};
+
+pub const OECP_PORT: u16 = 8_083;
+const OECP_PATH: &str = "/oecp";
+const ACTIVE_CONNECTION_CAPACITY: usize = 32;
+const CAPSULE_ID_HEADER: &str = "x-zero-capsule-id";
+const ORGANIZATION_ID_HEADER: &str = "x-zero-organization-id";
+const ACTOR_HANDLE_HEADER: &str = "x-zero-actor-handle";
+const GRANT_EXPIRY_HEADER: &str = "x-capsule-grant-expires-at";
+
+pub async fn serve<F>(
+    listener: TcpListener,
+    backend: Arc<HostedBackend>,
+    shutdown: F,
+) -> io::Result<()>
+where
+    F: Future<Output = ()>,
+{
+    let credential_listener =
+        TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, CREDENTIAL_PORT))).await?;
+    let credential_server =
+        axum::serve(credential_listener, credential_router(Arc::clone(&backend))).into_future();
+    tokio::pin!(credential_server);
+    let capacity = Arc::new(Semaphore::new(ACTIVE_CONNECTION_CAPACITY));
+    let mut connections = JoinSet::new();
+    tokio::pin!(shutdown);
+    loop {
+        tokio::select! {
+            () = &mut shutdown => break,
+            result = &mut credential_server => return result,
+            completed = connections.join_next(), if !connections.is_empty() => {
+                match completed {
+                    Some(Ok(Ok(()))) | Some(Ok(Err(_))) | None => {}
+                    Some(Err(error)) => return Err(io::Error::other(error)),
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, _peer) = accepted?;
+                let Ok(permit) = Arc::clone(&capacity).try_acquire_owned() else {
+                    continue;
+                };
+                let backend = Arc::clone(&backend);
+                connections.spawn(async move {
+                    let _permit = permit;
+                    serve_connection(stream, backend).await
+                });
+            }
+        }
+    }
+    connections.abort_all();
+    while connections.join_next().await.is_some() {}
+    backend.shutdown().await;
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+async fn serve_connection(stream: TcpStream, backend: Arc<HostedBackend>) -> io::Result<()> {
+    let identity = Arc::new(Mutex::new(None));
+    let captured = Arc::clone(&identity);
+    let websocket = accept_hdr_async_with_config(
+        stream,
+        move |request: &Request, response: Response| {
+            let resolved = resolve_identity(request).map_err(handshake_error)?;
+            let Ok(mut slot) = captured.lock() else {
+                return Err(handshake_error((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "identity capture failed",
+                )));
+            };
+            *slot = Some(resolved);
+            Ok(response)
+        },
+        Some(websocket_config()),
+    )
+    .await
+    .map_err(io::Error::other)?;
+    let resolved = identity
+        .lock()
+        .map_err(|_| io::Error::other("identity capture was poisoned"))?
+        .take()
+        .ok_or_else(|| io::Error::other("identity was not captured"))?;
+    let binding = ConnectionBinding::new(
+        backend,
+        StaticConnectionIdentityResolver::new(resolved),
+        SystemConnectionTime,
+        CancellationSignal::default(),
+    );
+    serve_websocket(binding, websocket).await
+}
+
+fn resolve_identity(request: &Request) -> Result<ConnectionIdentity, (StatusCode, &'static str)> {
+    if request.uri().path() != OECP_PATH {
+        return Err((StatusCode::NOT_FOUND, "unknown OECP route"));
+    }
+    if request.headers().contains_key("authorization") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "public authorization reached the capsule runtime",
+        ));
+    }
+    let capsule_id = one_header(request, CAPSULE_ID_HEADER)?;
+    let organization_id = one_header(request, ORGANIZATION_ID_HEADER)?;
+    let actor_handle = one_header(request, ACTOR_HANDLE_HEADER)?;
+    let expires_at = one_header(request, GRANT_EXPIRY_HEADER)?
+        .parse::<u64>()
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid grant expiry"))?;
+    if expires_at <= unix_seconds() {
+        return Err((StatusCode::UNAUTHORIZED, "expired runtime identity"));
+    }
+    let expires_at_ms = expires_at
+        .checked_mul(1_000)
+        .ok_or((StatusCode::BAD_REQUEST, "invalid grant expiry"))?;
+    let attributes = BindingAttributes::new(BTreeMap::from([(
+        "capsule_id".to_owned(),
+        capsule_id.to_owned(),
+    )]));
+    Ok(ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new(actor_handle),
+        tenant: TenantId::new(organization_id),
+        issued_at_ms: None,
+        expires_at_ms,
+        binding_attributes: attributes,
+    }))
+}
+
+fn one_header<'a>(
+    request: &'a Request,
+    name: &'static str,
+) -> Result<&'a str, (StatusCode, &'static str)> {
+    let mut values = request.headers().get_all(name).iter();
+    let value = values
+        .next()
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or((StatusCode::BAD_REQUEST, "missing runtime identity"))?;
+    if values.next().is_some() {
+        return Err((StatusCode::BAD_REQUEST, "ambiguous runtime identity"));
+    }
+    Ok(value)
+}
+
+fn handshake_error((status, message): (StatusCode, &'static str)) -> ErrorResponse {
+    let mut response = ErrorResponse::new(Some(message.to_owned()));
+    *response.status_mut() = status;
+    response
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/zeroshot-rust/src/hosted_oecp/worker.rs
+++ b/zeroshot-rust/src/hosted_oecp/worker.rs
@@ -1,0 +1,186 @@
+use std::{collections::BTreeMap, io, process::Stdio, sync::Arc};
+
+use serde_json::{json, Value};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, Command},
+    sync::{oneshot, Mutex},
+};
+
+use super::credentials::CredentialBundle;
+
+type Pending = Arc<Mutex<BTreeMap<u64, oneshot::Sender<Result<Value, WorkerError>>>>>;
+
+#[derive(Clone, Debug)]
+pub struct WorkerError {
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for WorkerError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for WorkerError {}
+
+pub struct WorkerClient {
+    child: Mutex<Child>,
+    input: Mutex<ChildStdin>,
+    pending: Pending,
+    next_id: Mutex<u64>,
+}
+
+impl WorkerClient {
+    pub async fn spawn(credentials: &CredentialBundle) -> Result<Arc<Self>, WorkerError> {
+        credentials
+            .prepare_workspace()
+            .await
+            .map_err(|message| worker_error("WORKSPACE_PREPARATION", message))?;
+        let binary = std::env::var("ZEROSHOT_CLUSTER_WORKER_BIN")
+            .unwrap_or_else(|_| "zeroshot-cluster-worker".to_owned());
+        let mut command = Command::new(binary);
+        command
+            .current_dir("/workspace/repository")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        credentials.apply_to(&mut command);
+        let mut child = command
+            .spawn()
+            .map_err(|error| worker_error("WORKER_START", error.to_string()))?;
+        let input = child
+            .stdin
+            .take()
+            .ok_or_else(|| worker_error("WORKER_START", "worker stdin was unavailable"))?;
+        let output = child
+            .stdout
+            .take()
+            .ok_or_else(|| worker_error("WORKER_START", "worker stdout was unavailable"))?;
+        let pending = Pending::default();
+        tokio::spawn(read_responses(output, Arc::clone(&pending)));
+        Ok(Arc::new(Self {
+            child: Mutex::new(child),
+            input: Mutex::new(input),
+            pending,
+            next_id: Mutex::new(1),
+        }))
+    }
+
+    pub async fn start(&self, request: Value) -> Result<Value, WorkerError> {
+        self.call("start", json!({ "request": request })).await
+    }
+
+    pub async fn result(&self) -> Result<Value, WorkerError> {
+        self.call("result", json!({})).await
+    }
+
+    pub async fn stop(&self) -> Result<Value, WorkerError> {
+        self.call("stop", json!({})).await
+    }
+
+    async fn call(&self, method: &str, params: Value) -> Result<Value, WorkerError> {
+        let id = {
+            let mut next = self.next_id.lock().await;
+            let id = *next;
+            *next = next.saturating_add(1);
+            id
+        };
+        let (sender, receiver) = oneshot::channel();
+        self.pending.lock().await.insert(id, sender);
+        let frame = serde_json::to_vec(&json!({ "id": id, "method": method, "params": params }))
+            .map_err(|error| worker_error("WORKER_PROTOCOL", error.to_string()))?;
+        let write = async {
+            let mut input = self.input.lock().await;
+            input.write_all(&frame).await?;
+            input.write_all(b"\n").await?;
+            input.flush().await
+        }
+        .await;
+        if let Err(error) = write {
+            self.pending.lock().await.remove(&id);
+            return Err(worker_error("WORKER_IO", error.to_string()));
+        }
+        receiver
+            .await
+            .map_err(|_| worker_error("WORKER_EXITED", "worker response channel closed"))?
+    }
+
+    pub async fn terminate(&self) {
+        let mut child = self.child.lock().await;
+        let _result = child.kill().await;
+    }
+}
+
+async fn read_responses(output: tokio::process::ChildStdout, pending: Pending) {
+    let mut lines = BufReader::new(output).lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => route_response(&line, &pending).await,
+            Ok(None) | Err(_) => {
+                fail_pending(&pending, worker_error("WORKER_EXITED", "worker exited")).await;
+                return;
+            }
+        }
+    }
+}
+
+async fn route_response(line: &str, pending: &Pending) {
+    let Ok(frame) = serde_json::from_str::<Value>(line) else {
+        fail_pending(
+            pending,
+            worker_error("WORKER_PROTOCOL", "worker emitted malformed JSON"),
+        )
+        .await;
+        return;
+    };
+    if frame.get("type").and_then(Value::as_str) != Some("response") {
+        return;
+    }
+    let Some(id) = frame.get("id").and_then(Value::as_u64) else {
+        return;
+    };
+    let Some(sender) = pending.lock().await.remove(&id) else {
+        return;
+    };
+    let response = if frame.get("ok").and_then(Value::as_bool) == Some(true) {
+        Ok(frame.get("result").cloned().unwrap_or(Value::Null))
+    } else {
+        let error = frame.get("error").unwrap_or(&Value::Null);
+        Err(WorkerError {
+            code: error
+                .get("code")
+                .and_then(Value::as_str)
+                .unwrap_or("WORKER_ERROR")
+                .to_owned(),
+            message: error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("worker command failed")
+                .to_owned(),
+        })
+    };
+    let _result = sender.send(response);
+}
+
+async fn fail_pending(pending: &Pending, error: WorkerError) {
+    let senders = std::mem::take(&mut *pending.lock().await);
+    for sender in senders.into_values() {
+        let _result = sender.send(Err(error.clone()));
+    }
+}
+
+fn worker_error(code: &str, message: impl Into<String>) -> WorkerError {
+    WorkerError {
+        code: code.to_owned(),
+        message: message.into(),
+    }
+}
+
+impl From<io::Error> for WorkerError {
+    fn from(error: io::Error) -> Self {
+        worker_error("WORKER_IO", error.to_string())
+    }
+}

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod daemon_discovery;
 pub mod daemon_listener;
 pub mod execution;
 pub mod full_v1_reducer;
+pub mod hosted_oecp;
 pub mod issue_provider;
 pub mod product_errors;
 mod provider_value;

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -123,6 +123,7 @@ fn workspace_metadata_preserves_package_lib_and_bin_identity() {
         })
         .collect::<BTreeSet<_>>();
     for required in [
+        ("zeroshot-oecp-server".to_owned(), "bin".to_owned()),
         ("zeroshot-rust".to_owned(), "bin".to_owned()),
         ("zeroshot_engine".to_owned(), "lib".to_owned()),
         ("architecture".to_owned(), "test".to_owned()),
@@ -152,6 +153,7 @@ fn workspace_metadata_preserves_package_lib_and_bin_identity() {
             .cloned()
             .collect::<BTreeSet<_>>(),
         BTreeSet::from([
+            ("zeroshot-oecp-server".to_owned(), "bin".to_owned()),
             ("zeroshot-rust".to_owned(), "bin".to_owned()),
             ("zeroshot_engine".to_owned(), "lib".to_owned()),
         ]),
@@ -699,6 +701,7 @@ fn product_modules_require_issue_authorization() {
         BTreeSet::from([
             "artifact_store",
             "artifact_store.rs",
+            "bin",
             "cluster_ledger",
             "cluster_ledger.rs",
             "daemon_auth.rs",
@@ -709,6 +712,8 @@ fn product_modules_require_issue_authorization() {
             "fault",
             "fault.rs",
             "full_v1_reducer.rs",
+            "hosted_oecp",
+            "hosted_oecp.rs",
             "issue_provider",
             "issue_provider.rs",
             "lib.rs",


### PR DESCRIPTION
Adds the minimal in-capsule OECP server and hosted Zero Cloud CLI path.

- runs the existing Zeroshot worker behind the canonical OECP protocol
- supports credential upload and reviewed PR delivery
- adds optional capsule sizing with a `standard` default
- includes protocol, hosted CLI, and container contract coverage

Validated end to end from private zero-cloud issue #21 through code, commit, push, and PR creation (the-open-engine/zero-cloud#29).