### PR TITLE
test: isolate task-store home across Mocha workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1112,6 +1112,8 @@ npm run test
 Mocha config: `.mocharc.cjs` applies defaults; passing explicit `*.test.js` files on the CLI skips the default `tests/**/*.test.js` spec.
 The Mocha bootstrap isolates unit tests from live `ZEROSHOT_*` run options and user settings;
 tests must not depend on ambient cluster state or `~/.zeroshot/settings.json`.
+`ZEROSHOT_HOME` is immutable inside a Mocha worker because `task-lib/config.js` caches the task-store
+root at module load; alternate-home scenarios must run in an isolated child process.
 
 Workers are now explicitly ordered to treat every `VALIDATION_RESULT` line as non-negotiable law before typing again. Failing to read and address each validator complaint before claiming completion will be rejected automatically.
 

--- a/tests/mocha-setup.js
+++ b/tests/mocha-setup.js
@@ -13,6 +13,7 @@ const fallbackSettingsFile = path.join(
   `zeroshot-mocha-settings-${process.pid}-${crypto.randomUUID()}.json`
 );
 const testSettingsFile = inheritedSettingsFile || fallbackSettingsFile;
+const taskStoreHome = process.env.ZEROSHOT_HOME;
 const ambientRunVariables = [
   'ZEROSHOT_CLOSE_ISSUE',
   'ZEROSHOT_CLAUDE_MCP_CONFIG_FILE',
@@ -35,6 +36,20 @@ const ambientRunVariables = [
   'ZEROSHOT_WORKTREE',
 ];
 
+function assertStableTaskStoreHome() {
+  if (process.env.ZEROSHOT_HOME === taskStoreHome) return;
+
+  if (taskStoreHome === undefined) {
+    delete process.env.ZEROSHOT_HOME;
+  } else {
+    process.env.ZEROSHOT_HOME = taskStoreHome;
+  }
+  throw new Error(
+    'Tests must not mutate ZEROSHOT_HOME in a shared Mocha worker. ' +
+      'task-lib/config.js caches the task-store root; run alternate-home scenarios in a child process.'
+  );
+}
+
 function restoreTestEnvironment() {
   for (const variable of ambientRunVariables) {
     delete process.env[variable];
@@ -47,7 +62,11 @@ function restoreTestEnvironment() {
 restoreTestEnvironment();
 
 exports.mochaHooks = {
-  beforeEach: restoreTestEnvironment,
+  beforeEach() {
+    assertStableTaskStoreHome();
+    restoreTestEnvironment();
+  },
+  afterEach: assertStableTaskStoreHome,
   afterAll() {
     if (!inheritedSettingsFile) {
       fs.rmSync(fallbackSettingsFile, { force: true });

--- a/tests/unit/guidance-delivery.test.js
+++ b/tests/unit/guidance-delivery.test.js
@@ -2,8 +2,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-guidance-'));
-process.env.ZEROSHOT_HOME = tempHome;
+const storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-guidance-'));
+
+// task-lib/config.js binds ZEROSHOT_HOME when its module is loaded. Mocha reuses parallel workers,
+// so changing that process-global root here would split later tests from their spawned children.
 
 const assert = require('assert');
 
@@ -36,7 +38,7 @@ describe('Guidance delivery', function () {
     orchestrator = new Orchestrator({
       quiet: true,
       skipLoad: true,
-      storageDir: path.join(tempHome, 'clusters'),
+      storageDir: path.join(storageRoot, 'clusters'),
     });
 
     agent = new AgentWrapper(
@@ -63,7 +65,7 @@ describe('Guidance delivery', function () {
   });
 
   after(() => {
-    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(storageRoot, { recursive: true, force: true });
   });
 
   it('publishes unsupported delivery metadata when no live socket is available', async () => {


### PR DESCRIPTION
## Summary

- stop `guidance-delivery.test.js` from rebinding the process-wide task-store home
- fail fast if any Mocha test mutates `ZEROSHOT_HOME` inside a reused worker
- document the isolated-child convention for alternate task-store homes

## Root cause

`task-lib/config.js` resolves and caches the task-store root at module load. `guidance-delivery.test.js` changed `ZEROSHOT_HOME` at file scope and deleted that directory after its suite. When Mocha later reused the same parallel worker for `agent-stuck-recovery.test.js`, the parent retained an SQLite connection to the removed store while spawned children recreated a different store at the same pathname. The parent therefore never observed durable child rows, producing the exact five recovery failures from runs 30775508954 and 30776282990. Worker assignment made the defect nondeterministic.

Deterministic pre-fix reproduction:

```
npx c8 node tests/run-tests.js --jobs 1 tests/unit/guidance-delivery.test.js tests/agent-stuck-recovery.test.js
# 5 failing: exact Agent stuck-task recovery set
```

## Testing

- same ordered coverage command after fix: 17 passing
- ordered pair repeated 5 times: 5/5 green
- `npm run test:coverage`: 2514 passing, 18 pending
- `npm run test:e2e`: 25 passing
- `npm run test:slow -- --jobs 1`: 133 passing, 37 pending (serialized locally because high shared-workstation disk pressure triggers cross-worker auto-GC)
- CI-equivalent protocol, Rust fmt/clippy/tests, audit, lint, dupcheck, typecheck, and provider-helper checks passed

## Related

Follow-up to #911 and failed downstream run 30776282990.

## Checklist

- [x] Tests pass
- [x] Documentation updated
- [x] Follows commit guidelines