### PR TITLE
fix(hosted): make target tests self-contained

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typecheck:agent-cli-provider": "tsc --project tsconfig.agent-cli-provider.json",
     "typecheck:hosted-target": "tsc --project tsconfig.hosted-target.json",
     "typecheck:hosted-session": "tsc --project tsconfig.hosted-session.json",
-    "test:hosted-target": "npm run build:cluster && node --test tests/hosted-target/*.test.ts",
+    "test:hosted-target": "npm run build:cluster && npm run build:target && node --test tests/hosted-target/*.test.ts",
     "test:target": "npm run build:agent-cli-provider && npm run build:target && node --test tests/target/*.test.ts",
     "typecheck:target": "tsc --project tsconfig.target.json",
     "typecheck:cluster": "tsc --project tsconfig.cluster.json",


### PR DESCRIPTION
## Problem
`test:hosted-target` builds the cluster projection, whose build script removes `lib/target`, but the test helper imports `lib/target/index.js`.

## Change
Run `build:target` after `build:cluster` inside the hosted-target test command.

## Verification
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run test:hosted-target` (45 passed)
- `npm run test:target` (58 passed)