### PR TITLE
fix: patch brace-expansion in hosted OECP image

### DIFF
--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -10,9 +10,12 @@ FROM docker.io/library/node:22-bookworm-slim@sha256:f32b81066cde10a75dbac9664609
 WORKDIR /opt/node-runtime
 COPY docker/zeroshot-oecp/package.json docker/zeroshot-oecp/package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund \
-    && npm install brace-expansion@5.0.8 --no-save --ignore-scripts --no-audit --no-fund \
+    && npm install brace-expansion@5.0.9 --no-save --ignore-scripts --no-audit --no-fund \
     && cp -r node_modules/brace-expansion/. node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion/ \
-    && rm -rf node_modules/brace-expansion
+    && rm -rf node_modules/brace-expansion \
+    && node -e "const pkg = require( \
+      './node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion/package.json'); \
+      if (pkg.version !== '5.0.9') throw new Error('expected brace-expansion@5.0.9, got ' + pkg.version)"
 
 FROM docker.io/instructure/tini:v0.19.0@sha256:0f9ccf2e54d010735ad691ebe670e256a3820fe8b92c28101194c68ee1216092 AS tini
 

--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -9,7 +9,10 @@ RUN cargo build --locked --release -p zeroshot-rust --bin zeroshot-oecp-server
 FROM docker.io/library/node:22-bookworm-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46 AS node-deps
 WORKDIR /opt/node-runtime
 COPY docker/zeroshot-oecp/package.json docker/zeroshot-oecp/package-lock.json ./
-RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund \
+    && npm install brace-expansion@5.0.8 --no-save --ignore-scripts --no-audit --no-fund \
+    && cp -r node_modules/brace-expansion/. node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion/ \
+    && rm -rf node_modules/brace-expansion
 
 FROM docker.io/instructure/tini:v0.19.0@sha256:0f9ccf2e54d010735ad691ebe670e256a3820fe8b92c28101194c68ee1216092 AS tini
 

--- a/docker/zeroshot-oecp/build-manifest.json
+++ b/docker/zeroshot-oecp/build-manifest.json
@@ -8,12 +8,8 @@
   "protocol": {
     "version": "openengine.cluster/v1",
     "route": "/oecp",
-    "graphProfiles": [
-      "openengine.graph.single-worker/v1"
-    ],
-    "workerProfiles": [
-      "legacy.zeroshot.ship@1"
-    ]
+    "graphProfiles": ["openengine.graph.single-worker/v1"],
+    "workerProfiles": ["legacy.zeroshot.ship@1"]
   },
   "runtime": {
     "supervisor": {
@@ -62,10 +58,10 @@
     "clippy.toml": "3c652ff2949df903bd0b80c8f14a7196ff9ad1e12841ddb614d080c4a03d1aa2",
     "crates": "a2f7c3bb65eb2b150647b00aab00f510ea67356dd08990e1bb9afa626b8bac9e",
     "docker/zeroshot-oecp/.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
-    "docker/zeroshot-oecp/Dockerfile": "5a18451b5fc7f41d4bfe84ddf88df64c3b194d1e0085540b82b281e5493d15f9",
+    "docker/zeroshot-oecp/Dockerfile": "8c36654fcaec00488ccba2bf93261761a28467481ccc31e400d7cd2740c2a571",
     "docker/zeroshot-oecp/Dockerfile.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
-    "docker/zeroshot-oecp/package-lock.json": "3f98c36741fb197cb75e2eb921173b33bf291724bfe1babc13bc250e94f9e1d4",
-    "docker/zeroshot-oecp/package.json": "3015b31b75d38d930a768d532e5b809e01c37f4f91076075367649614ca280b5",
+    "docker/zeroshot-oecp/package-lock.json": "5711bf91423b0095adda9e149699ae5ab3ae631e93284da88fc635eab78e8f9b",
+    "docker/zeroshot-oecp/package.json": "c940926d527e0f8a7acc435ef4866574ffb0743e6696ee4370bee9213469403a",
     "lib/agent-cli-provider": "665ea5edab232eb718a685005828ab8fdccf2c72d6c20c1baee594ad39ce3a68",
     "lib/provider-detection.js": "8a57242a38aa2da62912fc525af9995f61c8e84724e715342c765e5bf15e7893",
     "lib/cluster-worker/contracts.js": "a8c97f5ef0e3e5b8caef4acf7f7a2efd2a71019c6b08a3066c2078246c19b455",
@@ -98,10 +94,10 @@
     "zeroshot-rust/hosted-node": "8d3a7d9d38d8f4cd0fdb5bef2e38dbf0d030b2b2e56e24b02d7a02020ea355c8",
     "zeroshot-rust/src": "9b4a67bcf9fffac122b92fcbdcbdd2d25a82903c0149b183a4e6a4528167cb1a"
   },
-  "imageInputsDigest": "010248943dcf38d1eca4b205e744d568a37947c20ab9b49fd5c47e949032ba3e",
+  "imageInputsDigest": "69858a76f1c1d8279795b2a76d497c06a0c7e91de8d3cac150852ecac38171b3",
   "rollback": {
     "policy": "remove-or-restore-private-digest",
     "stableReleasesUntouched": true
   },
-  "manifestDigest": "60b01863b74231dd58ec5d9e316c6b4cac35d6a79e0bb29a6b1be2b0344889ef"
+  "manifestDigest": "01e3aad31c2d36d58480a3814b598193a2bdf3c646418d2de05d3992c5d86028"
 }

--- a/docker/zeroshot-oecp/build-manifest.json
+++ b/docker/zeroshot-oecp/build-manifest.json
@@ -8,8 +8,12 @@
   "protocol": {
     "version": "openengine.cluster/v1",
     "route": "/oecp",
-    "graphProfiles": ["openengine.graph.single-worker/v1"],
-    "workerProfiles": ["legacy.zeroshot.ship@1"]
+    "graphProfiles": [
+      "openengine.graph.single-worker/v1"
+    ],
+    "workerProfiles": [
+      "legacy.zeroshot.ship@1"
+    ]
   },
   "runtime": {
     "supervisor": {
@@ -58,11 +62,11 @@
     "clippy.toml": "3c652ff2949df903bd0b80c8f14a7196ff9ad1e12841ddb614d080c4a03d1aa2",
     "crates": "a2f7c3bb65eb2b150647b00aab00f510ea67356dd08990e1bb9afa626b8bac9e",
     "docker/zeroshot-oecp/.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
-    "docker/zeroshot-oecp/Dockerfile": "499a58c84e503fa8a2652e78f00c2ebbba015c7abc5add1f9772589cde15d06e",
+    "docker/zeroshot-oecp/Dockerfile": "5a18451b5fc7f41d4bfe84ddf88df64c3b194d1e0085540b82b281e5493d15f9",
     "docker/zeroshot-oecp/Dockerfile.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
-    "docker/zeroshot-oecp/package-lock.json": "70b56078784e0e835bc45fbf8dc0ae88d5b195402a957cdd3ed9891951055749",
-    "docker/zeroshot-oecp/package.json": "83eeeb4df59be148d962232a99e98744011ab747ace52da79378d0fca211d1b0",
-    "lib/agent-cli-provider": "629c3e514cd4f1bef6d0172e27b48017c869365f0a73f019228374c0acfa045a",
+    "docker/zeroshot-oecp/package-lock.json": "3f98c36741fb197cb75e2eb921173b33bf291724bfe1babc13bc250e94f9e1d4",
+    "docker/zeroshot-oecp/package.json": "3015b31b75d38d930a768d532e5b809e01c37f4f91076075367649614ca280b5",
+    "lib/agent-cli-provider": "665ea5edab232eb718a685005828ab8fdccf2c72d6c20c1baee594ad39ce3a68",
     "lib/provider-detection.js": "8a57242a38aa2da62912fc525af9995f61c8e84724e715342c765e5bf15e7893",
     "lib/cluster-worker/contracts.js": "a8c97f5ef0e3e5b8caef4acf7f7a2efd2a71019c6b08a3066c2078246c19b455",
     "lib/cluster-worker/engine-adapter-common.js": "4183281e75530b9a064f11f3c97e5355e85d29e23096a93735ad470ef7343f80",
@@ -78,8 +82,8 @@
     "lib/cluster-worker/terminal-normalizer.js": "99720fa379ebef7397a98b4b29eaa5b0043814aa8b7c15254d045ed329529343",
     "lib/cluster-worker/worker-internals.js": "db5d7d2f23f07f74aef7d029d1a0ee36ec9317a9f06ba0a5e7d2f15947cbab92",
     "lib/run-plan.js": "c70bae45c113ff7a25a9c8696756fc3799104b01a8dba957d4d0eaf3a55d8a27",
-    "package-lock.json": "68123774904f4012bd4098ebcb1793001caced20f8540de6d66ea4eedcadfdbb",
-    "package.json": "9bfb3c816ab933b6ee65d655add4b90e7c9ebd6fe129f63ffe3edd9995cc5028",
+    "package-lock.json": "b75c87f09360a76e5630698fba03ecd6127b486e94b6d98b99b0ff3974dce967",
+    "package.json": "521c013acc0eb3436648321a0eba277eeaced52b7fc8462a0d46a11034eb28e6",
     "scripts/hosted-oecp-image-commands.js": "cee0efa9a9ddf0cc3ce19829ea403dc0bbf74185d8ec2236acd866c53be3313d",
     "scripts/hosted-oecp-image-smoke.js": "33a764499ada23b5fd27bf2f2bee5cf3ff0ff727f5800a2621fc1507e82e18eb",
     "scripts/hosted-oecp-image.js": "bb75c266037febaaf1a617b139134dce1ba0d831d4583cab8c05146a354632a9",
@@ -94,10 +98,10 @@
     "zeroshot-rust/hosted-node": "8d3a7d9d38d8f4cd0fdb5bef2e38dbf0d030b2b2e56e24b02d7a02020ea355c8",
     "zeroshot-rust/src": "9b4a67bcf9fffac122b92fcbdcbdd2d25a82903c0149b183a4e6a4528167cb1a"
   },
-  "imageInputsDigest": "957871f456494612d32de62c15749abf0b1603b778a45f99a5236094a566e43b",
+  "imageInputsDigest": "010248943dcf38d1eca4b205e744d568a37947c20ab9b49fd5c47e949032ba3e",
   "rollback": {
     "policy": "remove-or-restore-private-digest",
     "stableReleasesUntouched": true
   },
-  "manifestDigest": "95205734fd7d8739c6c5d409881fe11296c38e0cc89fdc9f1ea5e46da67fb034"
+  "manifestDigest": "60b01863b74231dd58ec5d9e316c6b4cac35d6a79e0bb29a6b1be2b0344889ef"
 }

--- a/docker/zeroshot-oecp/build-manifest.json
+++ b/docker/zeroshot-oecp/build-manifest.json
@@ -8,8 +8,12 @@
   "protocol": {
     "version": "openengine.cluster/v1",
     "route": "/oecp",
-    "graphProfiles": ["openengine.graph.single-worker/v1"],
-    "workerProfiles": ["legacy.zeroshot.ship@1"]
+    "graphProfiles": [
+      "openengine.graph.single-worker/v1"
+    ],
+    "workerProfiles": [
+      "legacy.zeroshot.ship@1"
+    ]
   },
   "runtime": {
     "supervisor": {

--- a/docker/zeroshot-oecp/package-lock.json
+++ b/docker/zeroshot-oecp/package-lock.json
@@ -72,9 +72,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -87,9 +84,6 @@
       "integrity": "sha512-Xbhc7X/QK+EsjJsJf4p3U4gp+2kWuU+c1DhQ9Gm0uXpWpdMSDAblXj99vhusK/9fOHobqlBGSf3fw29Wxf0SbA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -104,9 +98,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -119,9 +110,6 @@
       "integrity": "sha512-QcJqUFBdWgAGvUU2YF04DAOixuzG4LKBg29lhVoT/EQ0rJmVcz6dOLH6QzD/xrrAQ4HgoOAVFyMeY2NN2d2wbQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -658,7 +646,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -774,9 +762,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,9 +777,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -812,9 +794,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -831,9 +810,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,9 +825,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2049,9 +2022,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -2067,9 +2037,6 @@
       "integrity": "sha512-QK3oMtAn9dIv+1u1kx0xNpZNtZxdI+uZVIyLl7myp+Oh2Uj8BLagVv6a7uP0cDphO3TgfIdlvpepCe5MIcx0fw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -2087,9 +2054,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -2105,9 +2069,6 @@
       "integrity": "sha512-YMaJaeBGbArGAFYel+yFaFW/0rFgh0Oqki2f2mUtlonTX/xHr8EB4+mTnMJkHYMFy4gOTC3OtSEEe1NaW/cBXQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,

--- a/docker/zeroshot-oecp/package-lock.json
+++ b/docker/zeroshot-oecp/package-lock.json
@@ -14,6 +14,9 @@
         "@google/gemini-cli": "0.53.1",
         "@openai/codex": "0.146.0",
         "ajv": "8.18.0"
+      },
+      "overrides": {
+        "brace-expansion": "5.0.8"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -72,6 +75,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -84,6 +90,9 @@
       "integrity": "sha512-Xbhc7X/QK+EsjJsJf4p3U4gp+2kWuU+c1DhQ9Gm0uXpWpdMSDAblXj99vhusK/9fOHobqlBGSf3fw29Wxf0SbA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -98,6 +107,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -110,6 +122,9 @@
       "integrity": "sha512-QcJqUFBdWgAGvUU2YF04DAOixuzG4LKBg29lhVoT/EQ0rJmVcz6dOLH6QzD/xrrAQ4HgoOAVFyMeY2NN2d2wbQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -646,7 +661,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -762,6 +777,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -777,6 +795,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -794,6 +815,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -810,6 +834,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -825,6 +852,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1163,15 +1193,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -2022,6 +2052,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -2037,6 +2070,9 @@
       "integrity": "sha512-QK3oMtAn9dIv+1u1kx0xNpZNtZxdI+uZVIyLl7myp+Oh2Uj8BLagVv6a7uP0cDphO3TgfIdlvpepCe5MIcx0fw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -2054,6 +2090,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -2069,6 +2108,9 @@
       "integrity": "sha512-YMaJaeBGbArGAFYel+yFaFW/0rFgh0Oqki2f2mUtlonTX/xHr8EB4+mTnMJkHYMFy4gOTC3OtSEEe1NaW/cBXQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,

--- a/docker/zeroshot-oecp/package-lock.json
+++ b/docker/zeroshot-oecp/package-lock.json
@@ -16,7 +16,7 @@
         "ajv": "8.18.0"
       },
       "overrides": {
-        "brace-expansion": "5.0.8"
+        "brace-expansion": "5.0.9"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -1193,9 +1193,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/docker/zeroshot-oecp/package.json
+++ b/docker/zeroshot-oecp/package.json
@@ -9,5 +9,8 @@
     "@google/gemini-cli": "0.53.1",
     "@openai/codex": "0.146.0",
     "ajv": "8.18.0"
+  },
+  "overrides": {
+    "brace-expansion": "5.0.8"
   }
 }

--- a/docker/zeroshot-oecp/package.json
+++ b/docker/zeroshot-oecp/package.json
@@ -11,6 +11,6 @@
     "ajv": "8.18.0"
   },
   "overrides": {
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }


### PR DESCRIPTION
## Summary

Patch the nested `brace-expansion` installation used by `@earendil-works/pi-coding-agent` from 5.0.6 to 5.0.9 in the private hosted OECP image.

## Security

- Fixes CVE-2026-14257, addressed in the 5.x line by 5.0.8.
- Also incorporates 5.0.9, which addresses CVE-2026-69152 affecting 5.0.8.
- Affected path: `docker/zeroshot-oecp/package-lock.json` through Pi's nested `minimatch` dependency.
- Presence was confirmed; runtime reachability was not.

## Root cause

`@earendil-works/pi-coding-agent@0.80.3` ships its own `npm-shrinkwrap.json`. `npm ci` respects that shrinkwrap, so a root override alone does not replace the installed nested 5.0.6 package.

The image build therefore installs the exact patched release with lifecycle scripts disabled, copies it over Pi's shrinkwrap-owned nested package, removes the temporary top-level copy, and asserts the final installed version.

## Changes

- `docker/zeroshot-oecp/package.json`: declare the 5.0.9 override.
- `docker/zeroshot-oecp/package-lock.json`: record the patched resolution and integrity.
- `docker/zeroshot-oecp/Dockerfile`: replace the shrinkwrap-owned installation and assert version 5.0.9.
- `docker/zeroshot-oecp/build-manifest.json`: regenerate image input digests.

The unpublished hosted OECP runtime remains private and otherwise unchanged.