### PR TITLE
fix: remove package managers from hosted OECP runtime

### DIFF
--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -22,7 +22,11 @@ FROM docker.io/instructure/tini:v0.19.0@sha256:0f9ccf2e54d010735ad691ebe670e256a
 FROM docker.io/library/node:22-bookworm-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46 AS runtime
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f -- /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+        /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm /usr/local/bin/pnpx \
+    && rm -rf -- /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+        /opt/yarn-v1.22.22
 ARG BUILD_MANIFEST_DIGEST
 LABEL org.opencontainers.image.title="zeroshot-oecp-private" \
       org.opencontainers.image.description="Unpublished legacy single-worker capsule runtime" \

--- a/docker/zeroshot-oecp/build-manifest.json
+++ b/docker/zeroshot-oecp/build-manifest.json
@@ -62,7 +62,7 @@
     "clippy.toml": "3c652ff2949df903bd0b80c8f14a7196ff9ad1e12841ddb614d080c4a03d1aa2",
     "crates": "a2f7c3bb65eb2b150647b00aab00f510ea67356dd08990e1bb9afa626b8bac9e",
     "docker/zeroshot-oecp/.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
-    "docker/zeroshot-oecp/Dockerfile": "8c36654fcaec00488ccba2bf93261761a28467481ccc31e400d7cd2740c2a571",
+    "docker/zeroshot-oecp/Dockerfile": "9e50d74c15acaa885c5693a05bacc3f42a6929c4872b65e39602273745c39ab2",
     "docker/zeroshot-oecp/Dockerfile.dockerignore": "ea747fa7c0886f9a13a0f15fcb747cf61033850f002e2746d43f713835fc1dfd",
     "docker/zeroshot-oecp/package-lock.json": "5711bf91423b0095adda9e149699ae5ab3ae631e93284da88fc635eab78e8f9b",
     "docker/zeroshot-oecp/package.json": "c940926d527e0f8a7acc435ef4866574ffb0743e6696ee4370bee9213469403a",
@@ -84,7 +84,7 @@
     "lib/run-plan.js": "c70bae45c113ff7a25a9c8696756fc3799104b01a8dba957d4d0eaf3a55d8a27",
     "package-lock.json": "b75c87f09360a76e5630698fba03ecd6127b486e94b6d98b99b0ff3974dce967",
     "package.json": "521c013acc0eb3436648321a0eba277eeaced52b7fc8462a0d46a11034eb28e6",
-    "scripts/hosted-oecp-image-commands.js": "cee0efa9a9ddf0cc3ce19829ea403dc0bbf74185d8ec2236acd866c53be3313d",
+    "scripts/hosted-oecp-image-commands.js": "eeca1152aac68c5ff5243a46f4d900eb2ded118be73ce300902b3ed5869667cb",
     "scripts/hosted-oecp-image-smoke.js": "33a764499ada23b5fd27bf2f2bee5cf3ff0ff727f5800a2621fc1507e82e18eb",
     "scripts/hosted-oecp-image.js": "bb75c266037febaaf1a617b139134dce1ba0d831d4583cab8c05146a354632a9",
     "scripts/hosted-oecp-manifest.js": "874932d3fd566f8c18326d1b3efe54f8d9313237904a5d5b5b1b8c275093affa",
@@ -98,10 +98,10 @@
     "zeroshot-rust/hosted-node": "8d3a7d9d38d8f4cd0fdb5bef2e38dbf0d030b2b2e56e24b02d7a02020ea355c8",
     "zeroshot-rust/src": "9b4a67bcf9fffac122b92fcbdcbdd2d25a82903c0149b183a4e6a4528167cb1a"
   },
-  "imageInputsDigest": "69858a76f1c1d8279795b2a76d497c06a0c7e91de8d3cac150852ecac38171b3",
+  "imageInputsDigest": "3d635f26ac8f400d908c170f65528bc05b5a03ee9f9e990736f461104cf872eb",
   "rollback": {
     "policy": "remove-or-restore-private-digest",
     "stableReleasesUntouched": true
   },
-  "manifestDigest": "01e3aad31c2d36d58480a3814b598193a2bdf3c646418d2de05d3992c5d86028"
+  "manifestDigest": "c7e260a377c22a557df26b779fbc09327053760379ac4b1904c4098e41526b63"
 }

--- a/scripts/hosted-oecp-image-commands.js
+++ b/scripts/hosted-oecp-image-commands.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { isDeepStrictEqual } = require('util');
 const { ROOT, check } = require('./hosted-oecp-manifest');
 
 const DOCKERFILE = path.join(ROOT, 'docker', 'zeroshot-oecp', 'Dockerfile');
@@ -82,6 +83,15 @@ function validTag(reference) {
 const RUNTIME_INSPECTION_SCRIPT = `
 'use strict';
 const fs = require('fs');
+const present = (target) => {
+  try {
+    fs.lstatSync(target);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+};
 const ownership = (target) => {
   const stat = fs.statSync(target);
   return { uid: stat.uid, gid: stat.gid, mode: (stat.mode & 0o777).toString(8).padStart(3, '0') };
@@ -100,6 +110,18 @@ process.stdout.write(JSON.stringify({
     '/opt/zeroshot/src/target',
     '/opt/zeroshot/lib/cluster-worker/engine-adapter.js',
   ].filter((target) => fs.existsSync(target)),
+  packageManagerPaths: {
+    '/usr/local/bin/npm': present('/usr/local/bin/npm'),
+    '/usr/local/bin/npx': present('/usr/local/bin/npx'),
+    '/usr/local/bin/corepack': present('/usr/local/bin/corepack'),
+    '/usr/local/bin/yarn': present('/usr/local/bin/yarn'),
+    '/usr/local/bin/yarnpkg': present('/usr/local/bin/yarnpkg'),
+    '/usr/local/bin/pnpm': present('/usr/local/bin/pnpm'),
+    '/usr/local/bin/pnpx': present('/usr/local/bin/pnpx'),
+    '/usr/local/lib/node_modules/npm': present('/usr/local/lib/node_modules/npm'),
+    '/usr/local/lib/node_modules/corepack': present('/usr/local/lib/node_modules/corepack'),
+    '/opt/yarn-v1.22.22': present('/opt/yarn-v1.22.22'),
+  },
   runtimeModules: {
     engineStart: fs.existsSync('/opt/zeroshot/lib/cluster-worker/engine-start.js'),
     runtimeDependencies: fs.existsSync('/opt/zeroshot/lib/cluster-worker/runtime-dependencies.js'),
@@ -164,9 +186,25 @@ function validateRuntimePermissions(runtime) {
   }
 }
 
+const EXPECTED_PACKAGE_MANAGER_PATHS = Object.freeze({
+  '/usr/local/bin/npm': false,
+  '/usr/local/bin/npx': false,
+  '/usr/local/bin/corepack': false,
+  '/usr/local/bin/yarn': false,
+  '/usr/local/bin/yarnpkg': false,
+  '/usr/local/bin/pnpm': false,
+  '/usr/local/bin/pnpx': false,
+  '/usr/local/lib/node_modules/npm': false,
+  '/usr/local/lib/node_modules/corepack': false,
+  '/opt/yarn-v1.22.22': false,
+});
+
 function validateRuntimeContents(runtime) {
   if (!Array.isArray(runtime.forbiddenPresent) || runtime.forbiddenPresent.length > 0) {
     throw new Error('Hosted image contains a forbidden runtime path');
+  }
+  if (!isDeepStrictEqual(runtime.packageManagerPaths, EXPECTED_PACKAGE_MANAGER_PATHS)) {
+    throw new Error('Hosted image package manager paths are invalid');
   }
   if (
     runtime.runtimeModules?.engineStart !== true ||

--- a/tests/unit/hosted-oecp-image.test.js
+++ b/tests/unit/hosted-oecp-image.test.js
@@ -12,6 +12,23 @@ const {
   validateContextAllowlist,
 } = require('../../scripts/hosted-oecp-manifest');
 
+const packageManagerPaths = [
+  '/usr/local/bin/npm',
+  '/usr/local/bin/npx',
+  '/usr/local/bin/corepack',
+  '/usr/local/bin/yarn',
+  '/usr/local/bin/yarnpkg',
+  '/usr/local/bin/pnpm',
+  '/usr/local/bin/pnpx',
+  '/usr/local/lib/node_modules/npm',
+  '/usr/local/lib/node_modules/corepack',
+  '/opt/yarn-v1.22.22',
+];
+
+function absentPackageManagerPaths() {
+  return Object.fromEntries(packageManagerPaths.map((path) => [path, false]));
+}
+
 function imageMetadata(manifestDigest) {
   return {
     User: '0:0',
@@ -35,12 +52,34 @@ function runtimeInspection() {
     workspace: { uid: 10002, gid: 10002, mode: '770' },
     controlRoot: { uid: 1000, gid: 10002, mode: '700' },
     forbiddenPresent: [],
+    packageManagerPaths: absentPackageManagerPaths(),
     runtimeModules: { engineStart: true, runtimeDependencies: true },
     serverExecutable: true,
     tiniExecutable: true,
     gitExecutable: true,
     ajvVersion: '8.18.0',
   };
+}
+
+function registerPackageManagerInspectionTest() {
+  it('requires an exact absent package manager path inspection', function () {
+    const expectedPaths = absentPackageManagerPaths();
+    assert.deepStrictEqual(runtimeInspection().packageManagerPaths, expectedPaths);
+
+    for (const target of packageManagerPaths) {
+      const present = runtimeInspection();
+      present.packageManagerPaths[target] = true;
+      assert.throws(() => validateRuntimeInspection(present), /package manager paths are invalid/);
+    }
+
+    const missing = runtimeInspection();
+    delete missing.packageManagerPaths['/usr/local/bin/npm'];
+    assert.throws(() => validateRuntimeInspection(missing), /package manager paths are invalid/);
+
+    const extra = runtimeInspection();
+    extra.packageManagerPaths['/usr/local/bin/bun'] = false;
+    assert.throws(() => validateRuntimeInspection(extra), /package manager paths are invalid/);
+  });
 }
 
 describe('hosted OECP image contracts', function () {
@@ -84,6 +123,8 @@ describe('hosted OECP image contracts', function () {
     missingModule.runtimeModules.runtimeDependencies = false;
     assert.throws(() => validateRuntimeInspection(missingModule), /required runtime module/);
   });
+
+  registerPackageManagerInspectionTest();
 
   it('records immutable image identities and enforces deny-all allowlist parity', function () {
     const manifest = createManifest();


### PR DESCRIPTION
Closes #942

## Summary
- remove npm, npx, Corepack, Yarn, and their runtime trees after image dependency installation
- fail image inspection if any fixed package-manager path remains, including dangling shims
- preserve Node and installed provider executable resolution

## Verification
- `npx mocha tests/unit/hosted-oecp-image.test.js`
- `npx eslint scripts/hosted-oecp-image-commands.js tests/unit/hosted-oecp-image.test.js`
- `opcore-zero check --repo . --changed --json`
- `opcore-zero check --repo . --staged --json`
- `node scripts/hosted-oecp-image.js check`
- image build and inspect passed for `zeroshot-oecp:issue942`
- direct runtime inspection confirmed all package-manager shims/trees absent
- provider symlinks resolve inside `/opt/zeroshot/node_modules`
- targeted Trivy image scan returned no CVE-2026-14257 or CVE-2026-69152 findings