### PR TITLE
fix(recovery): preserve trusted Codex routes

### DIFF
--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -255,7 +255,9 @@ function assertStructuredOutputRecoveryFeatures(options: BuildProviderCommandOpt
   const missing = [
     ['--sandbox', features.supportsSandbox],
     ['--ephemeral', features.supportsEphemeral],
-    ['--ignore-user-config', features.supportsIgnoreUserConfig],
+    ...(options.trustIsolatedCodexProfile === true
+      ? []
+      : [['--ignore-user-config', features.supportsIgnoreUserConfig] as const]),
     ['--ignore-rules', features.supportsIgnoreRules],
     ['--strict-config', features.supportsStrictConfig],
     ['--config', features.supportsConfigOverride],
@@ -284,17 +286,11 @@ function buildStructuredOutputRecoveryCommand(
   const args = [...spec.args];
   const prompt = args.pop();
   if (prompt === undefined) throw new Error('Codex recovery command is missing its prompt');
-  args.push(
-    '--sandbox',
-    'read-only',
-    '--ephemeral',
-    '--ignore-user-config',
-    '--ignore-rules',
-    '--strict-config',
-    '--config',
-    'web_search="disabled"',
-    prompt
-  );
+  args.push('--sandbox', 'read-only', '--ephemeral');
+  if (options.trustIsolatedCodexProfile !== true) {
+    args.push('--ignore-user-config');
+  }
+  args.push('--ignore-rules', '--strict-config', '--config', 'web_search="disabled"', prompt);
   return { ...spec, args };
 }
 

--- a/src/agent-cli-provider/provider-registry.ts
+++ b/src/agent-cli-provider/provider-registry.ts
@@ -276,9 +276,9 @@ export const providerRegistry = [
     authInstructions: 'codex login',
     credentialPaths: ['~/.config/codex', '~/.codex'],
     credentialEnvKeys: codexAdapter.credentialEnvKeys,
-    settingsFields: ['webSearch'],
-    settingsDefaults: { webSearch: false },
-    settingsValidator: (settings): string | null => validateWebSearchSettings('codex', settings),
+    settingsFields: ['webSearch', 'trustIsolatedRecoveryProfile'],
+    settingsDefaults: { webSearch: false, trustIsolatedRecoveryProfile: false },
+    settingsValidator: validateCodexSettings,
     capabilities: {
       ...STANDARD_CAPABILITIES,
       jsonSchema: true,
@@ -661,6 +661,18 @@ export const providerRegistry = [
     adapter: copilotAdapter,
   },
 ] as const satisfies readonly ProviderRegistryEntry[];
+
+function validateCodexSettings(settings: Record<string, unknown>): string | null {
+  const webSearchError = validateWebSearchSettings('codex', settings);
+  if (webSearchError) return webSearchError;
+  if (
+    settings.trustIsolatedRecoveryProfile === undefined ||
+    typeof settings.trustIsolatedRecoveryProfile === 'boolean'
+  ) {
+    return null;
+  }
+  return 'providerSettings.codex.trustIsolatedRecoveryProfile must be a boolean';
+}
 
 function validateWebSearchSettings(
   provider: 'codex' | 'opencode',

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -54,16 +54,12 @@ import type {
 
 type UnknownFunction = (...args: readonly unknown[]) => unknown;
 
-interface CommandParts {
-  readonly command: string;
-  readonly args: readonly string[];
-}
-
 interface RuntimeProviderSettings {
   readonly defaultLevel?: ModelLevel;
   readonly levelOverrides: LevelOverrides;
   readonly gateway?: GatewayBuildOptions;
   readonly webSearch?: boolean;
+  readonly trustIsolatedRecoveryProfile?: boolean;
 }
 
 interface RuntimeCommandContext {
@@ -428,7 +424,6 @@ function ompExecutionContext(
   throw new Error('options.executionContext must be "host", "detached", "docker", or "benchmark".');
 }
 
-
 function ompSdkOutputContract(
   options: BuildProviderCommandOptions
 ):
@@ -664,7 +659,7 @@ export function probeRuntimeProviderCli(
   const requested = registryEntry.settingsFields.includes('webSearch')
     ? runtimeProviderSettings(settings, adapter.id, process.cwd()).webSearch === true
     : false;
-  const helpCommand = runtimeHelpCommand(adapter.id);
+  const helpCommand = resolveProviderCommand(adapter.id);
   const commandAvailable =
     evidence === undefined
       ? booleanResult(commandExistsFn(helpCommand.command))
@@ -735,6 +730,10 @@ function buildRuntimeOptions(
     cliFeatures: runtime.cliFeatures,
   };
   const resolved = { ...baseResolved };
+  delete resolved.trustIsolatedCodexProfile;
+  if (baseOptions.structuredOutputRecovery && adapter.id === 'codex') {
+    resolved.trustIsolatedCodexProfile = providerSettings.trustIsolatedRecoveryProfile === true;
+  }
   if (baseOptions.structuredOutputRecovery) {
     delete resolved.resumeSessionId;
     delete resolved.continueSession;
@@ -870,6 +869,10 @@ function runtimeProviderSettings(
     providerSettings.webSearch,
     `settings.providerSettings.${provider}.webSearch`
   );
+  const trustIsolatedRecoveryProfile = optionalBoolean(
+    providerSettings.trustIsolatedRecoveryProfile,
+    `settings.providerSettings.${provider}.trustIsolatedRecoveryProfile`
+  );
   const gateway =
     provider === 'gateway'
       ? normalizeGatewayBuildOptions(providerSettings, 'settings.providerSettings.gateway', cwd)
@@ -878,12 +881,9 @@ function runtimeProviderSettings(
     levelOverrides,
     ...(gateway === undefined ? {} : { gateway }),
     ...(webSearch === undefined ? {} : { webSearch }),
+    ...(trustIsolatedRecoveryProfile === undefined ? {} : { trustIsolatedRecoveryProfile }),
   };
   return defaultLevel === undefined ? base : { ...base, defaultLevel };
-}
-
-function runtimeHelpCommand(provider: ProviderId): CommandParts {
-  return resolveProviderCommand(provider);
 }
 
 function probeGatewayProvider(

--- a/src/agent-cli-provider/types.ts
+++ b/src/agent-cli-provider/types.ts
@@ -468,6 +468,8 @@ export interface BuildProviderCommandOptions {
   readonly mcpConfig?: readonly string[];
   /** Internal profile for provider-neutral structured-output correction turns. */
   readonly structuredOutputRecovery?: boolean;
+  /** Preserve a caller-isolated CODEX_HOME profile during Codex recovery. */
+  readonly trustIsolatedCodexProfile?: boolean;
 }
 
 export interface TextEvent {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -25,6 +25,10 @@ const { calculateRateLimitDelay, isRateLimitError } = require('./rate-limit-back
 const { updateAgentProviderSession } = require('./provider-session');
 const { rebuildProviderSessionAfterCommit } = require('./agent-task-executor');
 const {
+  buildStructuredOutputClusterFailure,
+  isStructuredOutputInvalidError,
+} = require('./structured-output-error');
+const {
   commitRecordedOwnership,
   markCleanupRequired,
 } = require('../../task-lib/omp-session-ownership.js');
@@ -735,6 +739,7 @@ async function handleFinalFailure(agent, triggeringMessage, error, maxRetries) {
   const failureAttempts = error?.terminationAttempts ?? maxRetries;
   const unsupportedCapability =
     error?.code === 'unsupported-capability' && error?.permanent === true;
+  const structuredOutputInvalid = isStructuredOutputInvalidError(error);
   console.error(`
 ${'='.repeat(80)}`);
   console.error(`🔴🔴🔴 MAX RETRIES EXHAUSTED - AGENT: ${agent.id} 🔴🔴🔴`);
@@ -810,6 +815,9 @@ ${'='.repeat(80)}`);
     });
   }
 
+  if (structuredOutputInvalid) {
+    agent._publish(buildStructuredOutputClusterFailure(agent, error));
+  }
   if (unsupportedCapability) {
     agent._publish({
       topic: 'CLUSTER_FAILED',
@@ -880,6 +888,7 @@ ${'='.repeat(80)}`);
           capability: error.capability,
         }
       : {}),
+    ...(structuredOutputInvalid ? { code: error.code, details: error.details ?? null } : {}),
     timestamp: Date.now(),
   };
 
@@ -910,6 +919,7 @@ ${'='.repeat(80)}`);
               capability: error.capability,
             }
           : {}),
+        ...(structuredOutputInvalid ? { code: error.code, details: error.details ?? null } : {}),
         hookFailureContext: error.message.includes('Hook uses result')
           ? {
               taskId: agent.currentTaskId || 'UNKNOWN',
@@ -936,7 +946,7 @@ ${'='.repeat(80)}`);
     orchestrator: agent.orchestrator,
   });
 
-  if (!error?.terminationExhausted && !unsupportedCapability) {
+  if (!error?.terminationExhausted && !unsupportedCapability && !structuredOutputInvalid) {
     agent.state = 'idle';
   }
 }

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -52,6 +52,10 @@ const {
   validateCompletedResumeIdentity,
 } = require('./provider-session');
 const { extractClaudeVertexModelError } = require('./output-extraction');
+const {
+  createStructuredOutputInvalidError,
+  isStructuredOutputInvalidError,
+} = require('./structured-output-error');
 const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -1412,6 +1416,7 @@ async function evaluateStructuredSuccess({ agent, taskId, state, success, allowR
     return { success: true, error: null };
   } catch (error) {
     if (
+      isStructuredOutputInvalidError(error) ||
       isNestedLifecycleError(error) ||
       error?.permanent === true ||
       error?.recoveryAbort === true
@@ -2858,7 +2863,10 @@ async function parseResultOutput(agent, output, { allowRecovery = true } = {}) {
   const schema = agent.config.jsonSchema;
   if (!schema) {
     if (parsed) return parsed;
-    throw new Error(`Agent ${agent.id} output missing required JSON block`);
+    throw createStructuredOutputInvalidError(
+      `Agent ${agent.id} output missing required JSON block`,
+      'missing_json'
+    );
   }
 
   const { createStructuredOutputValidator, reformatOutput } = require('./output-reformatter');
@@ -2911,7 +2919,12 @@ async function parseResultOutput(agent, output, { allowRecovery = true } = {}) {
       throw new Error('Task execution failed - no output');
     }
     const recoveryDetail = recovery?.lastError ? ` Recovery exhausted: ${recovery.lastError}.` : '';
-    throw new Error(`Agent ${agent.id} output missing required JSON block.${recoveryDetail}`);
+    throw createStructuredOutputInvalidError(
+      `Agent ${agent.id} output missing required JSON block.${recoveryDetail}`,
+      'missing_json',
+      directValidation,
+      recovery
+    );
   }
 
   if (!allowRecovery) {
@@ -2921,12 +2934,16 @@ async function parseResultOutput(agent, output, { allowRecovery = true } = {}) {
 
   const errorDetail = directValidation?.error || 'unknown schema error';
   const message = `Agent ${agent.id} output failed JSON schema validation: ${errorDetail}`;
-  if (agent.role === 'validator') {
-    throw new Error(
-      recovery?.status === 'exhausted'
-        ? `${message}. Recovery exhausted after ${recovery.attempts} attempts: ${recovery.lastError}`
-        : message
+  if (recovery?.status === 'exhausted') {
+    throw createStructuredOutputInvalidError(
+      `${message}. Recovery exhausted after ${recovery.attempts} attempts: ${recovery.lastError}`,
+      'schema_validation',
+      directValidation,
+      recovery
     );
+  }
+  if (agent.role === 'validator') {
+    throw new Error(message);
   }
 
   console.warn(`⚠️  ${message}`);

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2934,7 +2934,8 @@ async function parseResultOutput(agent, output, { allowRecovery = true } = {}) {
 
   const errorDetail = directValidation?.error || 'unknown schema error';
   const message = `Agent ${agent.id} output failed JSON schema validation: ${errorDetail}`;
-  if (recovery?.status === 'exhausted') {
+  const terminalStructuredRole = ['planner', 'conductor', 'validator'].includes(agent.role);
+  if (recovery?.status === 'exhausted' && terminalStructuredRole) {
     throw createStructuredOutputInvalidError(
       `${message}. Recovery exhausted after ${recovery.attempts} attempts: ${recovery.lastError}`,
       'schema_validation',

--- a/src/agent/structured-output-error.js
+++ b/src/agent/structured-output-error.js
@@ -1,0 +1,42 @@
+const STRUCTURED_OUTPUT_INVALID_CODE = 'STRUCTURED_OUTPUT_INVALID';
+
+function createStructuredOutputInvalidError(message, kind, validation = null, recovery = null) {
+  const error = new Error(message);
+  error.code = STRUCTURED_OUTPUT_INVALID_CODE;
+  error.details = {
+    kind,
+    validationError: validation?.error ?? null,
+    recoveryAttempts: recovery?.status === 'exhausted' ? recovery.attempts : 0,
+    recoveryError: recovery?.status === 'exhausted' ? recovery.lastError : null,
+  };
+  return error;
+}
+
+function isStructuredOutputInvalidError(error) {
+  return error?.code === STRUCTURED_OUTPUT_INVALID_CODE;
+}
+
+function buildStructuredOutputClusterFailure(agent, error) {
+  return {
+    topic: 'CLUSTER_FAILED',
+    receiver: 'broadcast',
+    content: {
+      text: `Cluster failed: structured output is invalid for ${agent.id} - ${error.message}`,
+      data: {
+        reason: 'structured_output_invalid',
+        agentId: agent.id,
+        role: agent.role,
+        code: error.code,
+        details: error.details ?? null,
+        error: error.message,
+      },
+    },
+  };
+}
+
+module.exports = {
+  STRUCTURED_OUTPUT_INVALID_CODE,
+  createStructuredOutputInvalidError,
+  isStructuredOutputInvalidError,
+  buildStructuredOutputClusterFailure,
+};

--- a/tests/agent-cli-provider/parity.test.js
+++ b/tests/agent-cli-provider/parity.test.js
@@ -1067,6 +1067,58 @@ test('eligible adapters build restricted provider-owned recovery commands', () =
   }
 });
 
+test('Codex recovery trusts only an explicitly configured isolated profile', () => {
+  const cliFeatures = {
+    supportsSandbox: true,
+    supportsEphemeral: true,
+    supportsIgnoreUserConfig: false,
+    supportsIgnoreRules: true,
+    supportsStrictConfig: true,
+    supportsConfigOverride: true,
+  };
+
+  withTempSettings({ providerSettings: { codex: {} } }, () => {
+    assert.throws(
+      () =>
+        helper.prepareSingleAgentProviderCommand({
+          provider: 'codex',
+          context: 'repair this output',
+          options: { structuredOutputRecovery: true, cliFeatures },
+        }),
+      /--ignore-user-config/
+    );
+  });
+
+  withTempSettings({ providerSettings: { codex: { trustIsolatedRecoveryProfile: true } } }, () => {
+    const prepared = helper.prepareSingleAgentProviderCommand({
+      provider: 'codex',
+      context: 'repair this output',
+      options: {
+        structuredOutputRecovery: true,
+        resumeSessionId: 'must-not-survive',
+        cliFeatures,
+      },
+    });
+    const { args } = prepared.commandSpec;
+    assert.equal(prepared.options.trustIsolatedCodexProfile, true);
+    assert.equal(args.includes('--ignore-user-config'), false);
+    assert.ok(args.includes('--sandbox'));
+    assert.ok(args.includes('read-only'));
+    assert.ok(args.includes('--ephemeral'));
+    assert.ok(args.includes('--ignore-rules'));
+    assert.ok(args.includes('--strict-config'));
+    assert.ok(args.includes('web_search="disabled"'));
+    assert.equal(args.includes('resume'), false);
+
+    const ordinary = helper.prepareSingleAgentProviderCommand({
+      provider: 'codex',
+      context: 'ordinary turn',
+      options: { cliFeatures },
+    });
+    assert.equal(ordinary.options.trustIsolatedCodexProfile, undefined);
+  });
+});
+
 test('eligible adapters fail closed without recovery safety evidence', () => {
   for (const provider of ['claude', 'codex', 'gemini', 'opencode']) {
     assert.throws(

--- a/tests/fixtures/fake-codex-recovery.js
+++ b/tests/fixtures/fake-codex-recovery.js
@@ -31,7 +31,12 @@ if (action === 'hang') {
   console.error('simulated provider process death');
   process.exit(17);
 } else {
-  const message = action === 'malformed' ? 'completed without json' : '{"done":true}';
+  const message =
+    action === 'malformed'
+      ? 'completed without json'
+      : action === 'schema-invalid'
+        ? '{"done":"invalid"}'
+        : '{"done":true}';
   if (isRecovery && process.env.FAKE_CODEX_EMIT_SESSION === '1') {
     console.log(JSON.stringify({ type: 'thread.started', thread_id: `thread-${count}` }));
   }

--- a/tests/fixtures/run-stuck-recovery.js
+++ b/tests/fixtures/run-stuck-recovery.js
@@ -30,6 +30,7 @@ async function main() {
 
   const cluster = orchestrator.getCluster(started.id);
   const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+  const messages = cluster.messageBus.getAll(started.id);
   const lifecycle = cluster.messageBus
     .query({
       cluster_id: started.id,
@@ -47,8 +48,12 @@ async function main() {
         state: orchestrator.getStatus(started.id).state,
         configuredRole: config.agents[0].role,
         lifecycle,
-        topics: cluster.messageBus.getAll(started.id).map((message) => message.topic),
+        topics: messages.map((message) => message.topic),
         completionData: completion?.content?.data || null,
+        clusterFailures: messages
+          .filter((message) => message.topic === 'CLUSTER_FAILED')
+          .map((message) => message.content.data),
+        failureInfo: registry[started.id].failureInfo || null,
         agentState: registry[started.id].agentStates[0],
         tasks: Object.fromEntries(
           Object.entries(loadTasks()).map(([id, task]) => [

--- a/tests/helpers/stuck-recovery-fixture.js
+++ b/tests/helpers/stuck-recovery-fixture.js
@@ -134,9 +134,12 @@ async function runInProcessRecovery() {
   }
 }
 
-async function runStructuredOutputRecovery() {
+async function runStructuredOutputRecovery({
+  initialAction = 'malformed',
+  recoveryAction = 'success',
+} = {}) {
   const fixture = setupFixture({
-    actions: ['malformed'],
+    actions: [initialAction],
     maxRetries: 1,
     timeout: 20000,
     staleDuration: 15000,
@@ -151,7 +154,7 @@ async function runStructuredOutputRecovery() {
           ...fixture.env,
           RECOVERY_CONFIG: fixture.configFile,
           RECOVERY_STORAGE_DIR: fixture.storage,
-          FAKE_CODEX_RECOVERY_ACTION: 'success',
+          FAKE_CODEX_RECOVERY_ACTION: recoveryAction,
           FAKE_CODEX_EMIT_SESSION: '1',
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -2839,4 +2839,26 @@ describe('Codex planner structured-output recovery', function () {
       true,
     ]);
   });
+
+  it('stops a planner with one typed cluster failure after recovery exhaustion', async function () {
+    const result = await runStructuredOutputRecovery({
+      initialAction: 'schema-invalid',
+      recoveryAction: 'schema-invalid',
+    });
+
+    assert.strictEqual(result.state, 'stopped', JSON.stringify(result, null, 2));
+    assert.strictEqual(result.configuredRole, 'planner');
+    assert.strictEqual(result.fakeCount, '4', JSON.stringify(result, null, 2));
+    assert.strictEqual(result.lifecycle.includes('TASK_COMPLETED'), false);
+    assert.strictEqual(result.lifecycle.filter((event) => event === 'TASK_FAILED').length, 1);
+    assert.strictEqual(result.topics.includes('CLUSTER_COMPLETE'), false);
+    assert.strictEqual(result.topics.includes('AGENT_ERROR'), true);
+    assert.strictEqual(result.clusterFailures.length, 1);
+    assert.strictEqual(result.clusterFailures[0].reason, 'structured_output_invalid');
+    assert.strictEqual(result.clusterFailures[0].code, 'STRUCTURED_OUTPUT_INVALID');
+    assert.strictEqual(result.clusterFailures[0].details.kind, 'schema_validation');
+    assert.strictEqual(result.clusterFailures[0].details.recoveryAttempts, 3);
+    assert.strictEqual(result.failureInfo.code, 'STRUCTURED_OUTPUT_INVALID');
+    assert.deepStrictEqual(result.failureInfo.details, result.clusterFailures[0].details);
+  });
 });

--- a/tests/output-reformatter.test.js
+++ b/tests/output-reformatter.test.js
@@ -399,17 +399,17 @@ describe('Output Reformatter', function () {
     assert.match(runReformat.firstCall.args[0], /required property.*plan/);
   });
 
-  it('retains the original invalid object for non-validators after exhaustion and warns once', async function () {
+  it('rejects the original invalid object after recovery exhaustion', async function () {
     const published = [];
     const runReformat = sinon.stub().resolves({ success: true, output: 'invalid' });
     const agent = recoveryAgent({ provider: 'codex', runReformat, published });
 
-    const result = await parseResultOutput(agent, JSON.stringify({ wrong: true }));
-
-    assert.deepEqual(result, {});
+    await assert.rejects(
+      parseResultOutput(agent, JSON.stringify({ wrong: true })),
+      (error) => error.code === 'STRUCTURED_OUTPUT_INVALID'
+    );
     assert.equal(runReformat.callCount, DEFAULT_MAX_ATTEMPTS);
-    assert.equal(published.length, 1);
-    assert.equal(published[0].topic, 'AGENT_SCHEMA_WARNING');
+    assert.equal(published.length, 0);
   });
 
   it('keeps validators strict after the same three-attempt exhaustion', async function () {

--- a/tests/parse-result-output.test.js
+++ b/tests/parse-result-output.test.js
@@ -48,6 +48,7 @@ describe('parseResultOutput', function () {
   defineGeminiProviderTests();
   defineEdgeCaseTests();
   defineSchemaValidationTests();
+  defineStructuredOutputFailureTests();
   defineRegressionTests();
 });
 
@@ -321,12 +322,12 @@ function defineSchemaValidationTests() {
       await assert.rejects(() => parseResultOutput(agent, output), /failed JSON schema validation/);
     });
 
-    it('should warn but not throw for non-validator role with invalid schema', async function () {
+    it('should warn but not throw for non-validator roles without recovery support', async function () {
       const warnings = [];
       const agent = {
         ...createMockAgent({
-          provider: 'claude',
-          role: 'conductor', // Not validator - should warn, not throw
+          provider: 'gateway',
+          role: 'conductor',
         }),
         _publish: (msg) => {
           if (msg.topic === 'AGENT_SCHEMA_WARNING') {
@@ -343,6 +344,63 @@ function defineSchemaValidationTests() {
       // Should NOT throw, but should publish warning
       const result = await parseResultOutput(agent, output);
       assert.strictEqual(result.complexity, 'SIMPLE');
+    });
+  });
+}
+
+function defineStructuredOutputFailureTests() {
+  describe('Structured output failures', function () {
+    it('tags missing JSON after recovery exhaustion', async function () {
+      let recoveryAttempts = 0;
+      const agent = {
+        ...createMockAgent({ provider: 'codex', role: 'planner' }),
+        _spawnClaudeTask() {
+          recoveryAttempts += 1;
+          return Promise.resolve({ success: true, output: 'still not JSON' });
+        },
+      };
+
+      await assert.rejects(
+        () => parseResultOutput(agent, 'completed without JSON'),
+        (error) => {
+          assert.strictEqual(error.code, 'STRUCTURED_OUTPUT_INVALID');
+          assert.strictEqual(error.details.kind, 'missing_json');
+          assert.strictEqual(error.details.recoveryAttempts, 3);
+          return true;
+        }
+      );
+      assert.strictEqual(recoveryAttempts, 3);
+    });
+
+    it('tags schema-invalid recovery exhaustion for planner output', async function () {
+      let recoveryAttempts = 0;
+      const agent = {
+        ...createMockAgent({
+          provider: 'codex',
+          role: 'planner',
+          jsonSchema: {
+            type: 'object',
+            properties: { score: { type: 'number' } },
+            required: ['score'],
+          },
+        }),
+        _spawnClaudeTask() {
+          recoveryAttempts += 1;
+          return Promise.resolve({ success: true, output: '{"score":"invalid"}' });
+        },
+      };
+
+      await assert.rejects(
+        () => parseResultOutput(agent, '{"score":"invalid"}'),
+        (error) => {
+          assert.strictEqual(error.code, 'STRUCTURED_OUTPUT_INVALID');
+          assert.strictEqual(error.details.kind, 'schema_validation');
+          assert.strictEqual(error.details.recoveryAttempts, 3);
+          assert.match(error.details.validationError, /number/);
+          return true;
+        }
+      );
+      assert.strictEqual(recoveryAttempts, 3);
     });
   });
 }

--- a/tests/settings-providers.test.js
+++ b/tests/settings-providers.test.js
@@ -108,12 +108,19 @@ describe('Provider settings', function () {
     }, /reasoningEffort overrides are only supported/);
   });
 
-  it('declares strict default-off web search only for Codex and OpenCode', function () {
-    assert.strictEqual(getProvider('codex').getDefaultSettings().webSearch, false);
+  it('declares secure default-off Codex and OpenCode provider features', function () {
+    const codexDefaults = getProvider('codex').getDefaultSettings();
+    assert.deepStrictEqual(
+      {
+        webSearch: codexDefaults.webSearch,
+        trustIsolatedRecoveryProfile: codexDefaults.trustIsolatedRecoveryProfile,
+      },
+      { webSearch: false, trustIsolatedRecoveryProfile: false }
+    );
     assert.strictEqual(getProvider('opencode').getDefaultSettings().webSearch, false);
     assert.strictEqual(
       validateSetting('providerSettings', {
-        codex: { webSearch: true },
+        codex: { webSearch: true, trustIsolatedRecoveryProfile: true },
         opencode: { webSearch: false },
       }),
       null
@@ -123,21 +130,29 @@ describe('Provider settings', function () {
       /providerSettings\.codex\.webSearch must be a boolean/
     );
     assert.match(
+      validateSetting('providerSettings', {
+        codex: { trustIsolatedRecoveryProfile: 'yes' },
+      }),
+      /providerSettings\.codex\.trustIsolatedRecoveryProfile must be a boolean/
+    );
+    assert.match(
       validateSetting('providerSettings', { claude: { webSearch: true } }),
       /Unknown provider setting: providerSettings\.claude\.webSearch/
     );
   });
 
-  it('round-trips web search through settings mutation and reads', function () {
+  it('round-trips Codex and OpenCode feature settings through mutation and reads', function () {
     process.env.ZEROSHOT_SETTINGS_FILE = settingsFile;
     fs.writeFileSync(settingsFile, '{}', 'utf8');
     try {
       mutateSettings((settings) => {
         settings.providerSettings.codex.webSearch = true;
+        settings.providerSettings.codex.trustIsolatedRecoveryProfile = true;
         settings.providerSettings.opencode.webSearch = true;
       });
       const settings = loadSettings();
       assert.strictEqual(settings.providerSettings.codex.webSearch, true);
+      assert.strictEqual(settings.providerSettings.codex.trustIsolatedRecoveryProfile, true);
       assert.strictEqual(settings.providerSettings.opencode.webSearch, true);
     } finally {
       delete process.env.ZEROSHOT_SETTINGS_FILE;


### PR DESCRIPTION
## Summary

- preserve job-private Codex provider routing during structured-output recovery only when `providerSettings.codex.trustIsolatedRecoveryProfile` is explicitly enabled
- keep `--ignore-user-config` as the secure default and retain every other recovery restriction
- tag exhausted missing-JSON and schema-validation failures with `STRUCTURED_OUTPUT_INVALID`
- publish one terminal `CLUSTER_FAILED` event instead of leaving planner/conductor clusters idle

Fixes #949
Fixes #950

## Verification

- `npm test`: 2637 passed, 18 pending
- `npm run typecheck:agent-cli-provider`
- `npm run build:agent-cli-provider`
- `node --test tests/agent-cli-provider/parity.test.js`
- focused settings, parser, and orchestrator recovery tests
- changed files pass Prettier
- ESLint: 0 errors (existing warnings only)
- `npm run opcore:check`
- `opcore-zero check --repo . --changed --json`: clean