### PR TITLE
fix: make liveness watchdog opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Operational rules and references for automated agents working on this repo. Inst
 - Curated notes live at `docs/releases/vX.Y.Z.md`. Recovery may operate only from an immutable
   `vX.Y.Z` tag whose exact commit is an ancestor of `main`, and it must never overwrite an existing
   npm version or GitHub Release.
+- Provider output-silence liveness checks are opt-in (`enableLivenessCheck: true`). Recovery tests
+  that exercise stale-agent termination must enable the watchdog explicitly.
 
 Worker git operations are allowed only with isolation (`--worktree`, `--docker`, `--pr`, `--ship`). They are forbidden without isolation.
 

--- a/src/agent/agent-config.js
+++ b/src/agent/agent-config.js
@@ -21,12 +21,10 @@ const DEFAULT_MAX_ITERATIONS = 100;
 // Use positive number for timeout in milliseconds
 const DEFAULT_TIMEOUT = 0;
 
-// Stale detection - ENABLED by default using multi-indicator analysis (safe from false positives)
-// Multi-indicator approach checks: process state, CPU usage, context switches, network I/O
-// Only flags as stuck when ALL indicators show inactivity (score >= 3.5)
-// Single-indicator detection (just output freshness) was too risky - this is safe.
+// Output-silence detection is opt-in because healthy provider operations may be quiet for
+// longer than the stale threshold. Explicit task timeouts remain independently supported.
 const DEFAULT_STALE_DURATION_MS = 30 * 60 * 1000; // 30 minutes before triggering analysis
-const DEFAULT_LIVENESS_CHECK_ENABLED = true; // Safe with multi-indicator detection
+const DEFAULT_LIVENESS_CHECK_ENABLED = false;
 
 function applyOutputDefaults(config) {
   // CRITICAL: Enforce JSON schema output by default to prevent parse failures and crashes

--- a/tests/agent-liveness-config.test.js
+++ b/tests/agent-liveness-config.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const {
+  DEFAULT_LIVENESS_CHECK_ENABLED,
+  validateAgentConfig,
+} = require('../src/agent/agent-config');
+
+describe('agent liveness configuration', function () {
+  it('does not impose an output-silence timeout by default', function () {
+    const config = validateAgentConfig({
+      id: 'unbounded-agent',
+      role: 'implementation',
+      timeout: 0,
+      triggers: [],
+    });
+
+    assert.strictEqual(DEFAULT_LIVENESS_CHECK_ENABLED, false);
+    assert.strictEqual(config.timeout, 0);
+    assert.strictEqual(config.enableLivenessCheck, false);
+  });
+
+  it('preserves explicit liveness watchdog opt-in', function () {
+    const config = validateAgentConfig({
+      id: 'watched-agent',
+      role: 'implementation',
+      timeout: 0,
+      staleDuration: 5000,
+      enableLivenessCheck: true,
+      triggers: [],
+    });
+
+    assert.strictEqual(config.enableLivenessCheck, true);
+    assert.strictEqual(config.staleDuration, 5000);
+  });
+});

--- a/tests/helpers/stuck-recovery-fixture.js
+++ b/tests/helpers/stuck-recovery-fixture.js
@@ -23,6 +23,7 @@ function workerConfig(maxRetries, timeout, staleDuration = 1500, role = 'impleme
           required: ['done'],
         },
         staleDuration,
+        enableLivenessCheck: true,
         timeout,
         maxRetries,
         triggers: [{ topic: 'ISSUE_OPENED', action: 'execute_task' }],


### PR DESCRIPTION
Closes #961.

## What changed

- Disable the output-silence liveness watchdog by default.
- Preserve the existing watchdog behavior for agents that explicitly set `enableLivenessCheck: true`.
- Add regression coverage for the unbounded default and explicit opt-in.

## Root cause

`timeout: 0` is documented as no timeout, but agent configuration independently enabled a 30-minute liveness watchdog. Although comments described multi-indicator process analysis, the termination path uses output age alone and can kill a healthy provider during a long silent operation.

## Impact

Unbounded tasks no longer acquire a hidden output-silence timeout. Operators can still opt into the existing watchdog and configure `staleDuration` when that policy is appropriate.

## Validation

- `npm test`: 2730 passing, 18 pending
- Focused liveness and stuck-recovery suite: 16 passing
- `npm run lint`: 0 errors
- Pre-commit and pre-push TypeScript checks passed
- `npm run opcore:check`: passed
- Changed files pass Prettier

The repository-wide Prettier check currently reports existing drift in unrelated files; this change does not modify those files.