### PR TITLE
fix: bound oversized provider output records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,6 +798,12 @@ that receipt against the cluster ID, then removes only the derived container nam
 temporary directories. Never persist or honor caller-selected cleanup paths for this boundary.
 
 Provider task ownership: task watchers persist an owned termination boundary with each active task.
+Codex JSONL is streamed losslessly into the task log instead of buffering an unbounded physical
+record in the watcher. Provider-session inspection is fixed-bound, and agent log framing replaces
+any record over 1 MiB with a byte-count/SHA-256 receipt before broadcast; the local lane also stores
+only that receipt in agent output while the complete record remains in the task log. Never restore
+whole-record watcher buffering or publish an oversized provider record directly into control-plane
+state.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -11,8 +11,10 @@
  */
 
 const { spawn, spawnSync } = require('child_process');
+const { createHash } = require('crypto');
 const path = require('path');
 const fs = require('fs');
+const { StringDecoder } = require('string_decoder');
 const { getNestedExecutionRegistry, TaskExecutionHandle } = require('./task-execution-handle');
 const os = require('os');
 const { parseProviderChunk, getProvider } = require('../providers');
@@ -57,6 +59,8 @@ const {
   isStructuredOutputInvalidError,
 } = require('./structured-output-error');
 const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
+const MAX_CONTROL_PLANE_RECORD_BYTES = 1024 * 1024;
+const LOG_READ_CHUNK_BYTES = 64 * 1024;
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
   if (timeout <= 0) {
@@ -1225,8 +1229,17 @@ function createLogFollowState() {
     pollInterval: null,
     statusCheckInterval: null,
     resolved: false,
-    lineBuffer: '',
+    lineBuffer: createLogRecordBuffer(),
+    logDecoder: new StringDecoder('utf8'),
     consecutiveExecFailures: 0,
+  };
+}
+
+function createLogRecordBuffer() {
+  return {
+    byteLength: 0,
+    fragments: [],
+    oversized: null,
   };
 }
 
@@ -1310,15 +1323,82 @@ function broadcastAgentLine({ agent, providerName, state, line }) {
   });
 }
 
-function appendContentToBuffer(state, content, onLine) {
-  state.lineBuffer += content;
-  const lines = state.lineBuffer.split('\n');
-
-  for (let i = 0; i < lines.length - 1; i++) {
-    onLine(lines[i]);
+function appendLogRecordFragment(buffer, fragment) {
+  const fragmentBytes = Buffer.byteLength(fragment);
+  buffer.byteLength += fragmentBytes;
+  if (buffer.oversized) {
+    buffer.oversized.digest.update(fragment);
+    return;
+  }
+  if (buffer.byteLength <= MAX_CONTROL_PLANE_RECORD_BYTES) {
+    buffer.fragments.push(fragment);
+    return;
   }
 
-  state.lineBuffer = lines[lines.length - 1];
+  const retainedPrefix = buffer.fragments.join('');
+  const prefixProbe = `${retainedPrefix}${fragment.slice(0, Math.max(0, 32 - retainedPrefix.length))}`;
+  const timestampPrefix = prefixProbe.match(/^\[\d{13}\]/)?.[0] || '';
+  const digest = createHash('sha256');
+  for (const retained of buffer.fragments) digest.update(retained);
+  digest.update(fragment);
+  buffer.fragments = [];
+  buffer.oversized = { digest, timestampPrefix };
+}
+
+function completeLogRecord(buffer, onLine, skipEmpty = false) {
+  let line;
+  if (buffer.oversized) {
+    const digest = buffer.oversized.digest.digest('hex');
+    line =
+      `${buffer.oversized.timestampPrefix}[ZEROSHOT] Provider output record retained in task log ` +
+      `but omitted from the control plane (byte_length=${buffer.byteLength}, sha256=${digest})`;
+  } else {
+    line = buffer.fragments.join('');
+  }
+  buffer.byteLength = 0;
+  buffer.fragments = [];
+  buffer.oversized = null;
+  if (!skipEmpty || line.trim()) onLine(line);
+}
+
+function appendContentToBuffer(state, content, onLine, skipEmpty = false) {
+  let offset = 0;
+  while (offset < content.length) {
+    const newline = content.indexOf('\n', offset);
+    if (newline === -1) {
+      appendLogRecordFragment(state.lineBuffer, content.slice(offset));
+      return;
+    }
+    appendLogRecordFragment(state.lineBuffer, content.slice(offset, newline));
+    completeLogRecord(state.lineBuffer, onLine, skipEmpty);
+    offset = newline + 1;
+  }
+}
+
+function replayCompleteLogContent(content, onLine) {
+  const replayState = { lineBuffer: createLogRecordBuffer() };
+  appendContentToBuffer(replayState, content, onLine, true);
+  if (replayState.lineBuffer.byteLength > 0) {
+    completeLogRecord(replayState.lineBuffer, onLine, true);
+  }
+}
+
+function readLogFileDelta({ fsModule, logFilePath, state, currentSize, onNewContent }) {
+  const fd = fsModule.openSync(logFilePath, 'r');
+  try {
+    let offset = state.lastSize;
+    const buffer = Buffer.allocUnsafe(LOG_READ_CHUNK_BYTES);
+    while (offset < currentSize) {
+      const requested = Math.min(buffer.length, currentSize - offset);
+      const bytesRead = fsModule.readSync(fd, buffer, 0, requested, offset);
+      if (bytesRead === 0) break;
+      onNewContent(state.logDecoder.write(buffer.subarray(0, bytesRead)));
+      offset += bytesRead;
+    }
+    state.lastSize = offset;
+  } finally {
+    fsModule.closeSync(fd);
+  }
 }
 
 function pollLogFileForUpdates({ agent, fsModule, ctPath, taskId, state, onNewContent }) {
@@ -1340,13 +1420,13 @@ function pollLogFileForUpdates({ agent, fsModule, ctPath, taskId, state, onNewCo
     const currentSize = stats.size;
 
     if (currentSize > state.lastSize) {
-      const fd = fsModule.openSync(state.logFilePath, 'r');
-      const buffer = Buffer.alloc(currentSize - state.lastSize);
-      fsModule.readSync(fd, buffer, 0, buffer.length, state.lastSize);
-      fsModule.closeSync(fd);
-
-      onNewContent(buffer.toString('utf-8'));
-      state.lastSize = currentSize;
+      readLogFileDelta({
+        fsModule,
+        logFilePath: state.logFilePath,
+        state,
+        currentSize,
+        onNewContent,
+      });
     }
   } catch (err) {
     const error = /** @type {Error} */ (err);
@@ -2215,7 +2295,7 @@ function createIsolatedLogState(skipStructuredResultCheck = false, nested = fals
     tailProcess: null,
     statusCheckInterval: null,
     timeoutTimer: null,
-    lineBuffer: '',
+    lineBuffer: createLogRecordBuffer(),
     skipStructuredResultCheck,
     nested,
   };
@@ -2376,9 +2456,7 @@ function settleIsolatedTerminalStatus({
 
     if (finalReadResult.code === 0 && finalReadResult.stdout) {
       state.fullOutput = finalReadResult.stdout;
-      for (const line of state.fullOutput.split('\n')) {
-        if (line.trim()) onLine(line);
-      }
+      replayCompleteLogContent(state.fullOutput, onLine);
     }
 
     const vertexModelError =
@@ -2566,16 +2644,7 @@ function broadcastIsolatedLine({ agent, providerName, taskId, state, line }) {
 }
 
 function appendIsolatedContent(state, content, onLine) {
-  state.lineBuffer += content;
-  const lines = state.lineBuffer.split('\n');
-
-  for (let i = 0; i < lines.length - 1; i++) {
-    if (lines[i].trim()) {
-      onLine(lines[i]);
-    }
-  }
-
-  state.lineBuffer = lines[lines.length - 1];
+  appendContentToBuffer(state, content, onLine, true);
 }
 
 function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLine }) {
@@ -3091,4 +3160,6 @@ module.exports = {
   buildTaskRunArgs,
   rebuildProviderSessionAfterCommit,
   killTask,
+  createLogRecordBuffer,
+  appendContentToBuffer,
 };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -2296,6 +2296,7 @@ function createIsolatedLogState(skipStructuredResultCheck = false, nested = fals
     statusCheckInterval: null,
     timeoutTimer: null,
     lineBuffer: createLogRecordBuffer(),
+    tailDecoder: new StringDecoder('utf8'),
     skipStructuredResultCheck,
     nested,
   };
@@ -2647,6 +2648,13 @@ function appendIsolatedContent(state, content, onLine) {
   appendContentToBuffer(state, content, onLine, true);
 }
 
+function consumeIsolatedTailChunk(state, data, onLine) {
+  const chunk = typeof data === 'string' ? data : state.tailDecoder.write(data);
+  if (!chunk) return;
+  state.fullOutput += chunk;
+  appendIsolatedContent(state, chunk, onLine);
+}
+
 function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLine }) {
   state.tailProcess = manager.spawnInContainer(clusterId, [
     'sh',
@@ -2655,9 +2663,7 @@ function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLi
   ]);
 
   state.tailProcess.stdout.on('data', (data) => {
-    const chunk = data.toString();
-    state.fullOutput += chunk;
-    appendIsolatedContent(state, chunk, onLine);
+    consumeIsolatedTailChunk(state, data, onLine);
   });
 
   state.tailProcess.stderr.on('data', (data) => {
@@ -2668,6 +2674,7 @@ function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLi
   });
 
   state.tailProcess.on('close', (exitCode) => {
+    consumeIsolatedTailChunk(state, state.tailDecoder.end(), onLine);
     if (!state.taskExited) {
       agent._log(`[${agent.id}] tail process exited with code ${exitCode}`);
     }
@@ -3162,4 +3169,5 @@ module.exports = {
   killTask,
   createLogRecordBuffer,
   appendContentToBuffer,
+  consumeIsolatedTailChunk,
 };

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { StringDecoder } from 'string_decoder';
 import {
   detectProviderFatalError,
   detectProviderStreamingModeError,
@@ -8,6 +9,8 @@ import {
 import { terminateProcess } from './process-termination.js';
 
 export const COMMAND_CLEANUP_UNINITIALIZED = Symbol('command-cleanup-uninitialized');
+
+const MAX_CODEX_CONTROL_RECORD_BYTES = 64 * 1024;
 
 export function spawnWatcherProvider(command, finalArgs, options) {
   return spawn(command, finalArgs, {
@@ -36,6 +39,72 @@ function splitBufferLines(buffer, chunk) {
   const nextBuffer = buffer + chunk;
   const lines = nextBuffer.split('\n');
   return { lines: lines.slice(0, -1), remaining: lines.at(-1) || '' };
+}
+
+function createCodexOutputPassthrough({ log, captureProviderSession }) {
+  const decoder = new StringDecoder('utf8');
+  let atLineStart = true;
+  let inspectable = true;
+  let inspectionBytes = 0;
+  let inspectionParts = [];
+
+  function inspectPart(part) {
+    if (!inspectable || !part) return;
+    inspectionBytes += Buffer.byteLength(part);
+    if (inspectionBytes > MAX_CODEX_CONTROL_RECORD_BYTES) {
+      inspectable = false;
+      inspectionParts = [];
+      return;
+    }
+    inspectionParts.push(part);
+  }
+
+  function finishLine() {
+    if (inspectable) captureProviderSession(inspectionParts.join(''));
+    atLineStart = true;
+    inspectable = true;
+    inspectionBytes = 0;
+    inspectionParts = [];
+  }
+
+  function writeText(text, timestamp) {
+    if (!text) return;
+    const logged = [];
+    let offset = 0;
+    while (offset < text.length) {
+      if (atLineStart) {
+        logged.push(`[${timestamp}]`);
+        atLineStart = false;
+      }
+      const newline = text.indexOf('\n', offset);
+      if (newline === -1) {
+        const part = text.slice(offset);
+        inspectPart(part);
+        logged.push(part);
+        break;
+      }
+      const part = text.slice(offset, newline);
+      inspectPart(part);
+      logged.push(part, '\n');
+      finishLine();
+      offset = newline + 1;
+    }
+    log(logged.join(''));
+  }
+
+  return {
+    consume(chunk) {
+      const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+      writeText(text, Date.now());
+    },
+    flush() {
+      writeText(decoder.end(), Date.now());
+      if (!atLineStart) {
+        finishLine();
+        log('\n');
+      }
+    },
+  };
 }
 
 export function resolveWatcherCommand(config, commandSpec, fallbackArgs, normalizeProviderName) {
@@ -189,6 +258,8 @@ export function createWatcherOutputRuntime({
   let streamingModeError = null;
   let fatalError = null;
   const captureProviderSession = providerSessionCapture?.captureLine || (() => {});
+  const codexOutputPassthrough =
+    providerName === 'codex' ? createCodexOutputPassthrough({ log, captureProviderSession }) : null;
 
   function maybeHandleFatalError(line, timestamp) {
     if (fatalError) return false;
@@ -230,6 +301,10 @@ export function createWatcherOutputRuntime({
   }
 
   function consumeOutput(buffer, chunk) {
+    if (codexOutputPassthrough) {
+      codexOutputPassthrough.consume(chunk);
+      return '';
+    }
     const timestamp = Date.now();
     const { lines, remaining } = splitBufferLines(buffer, chunk.toString());
     for (const line of lines) handleOutputLine(line, timestamp);
@@ -284,7 +359,11 @@ export function createWatcherOutputRuntime({
 
   function complete({ code, signal, outputBuffer, stderrBuffer = null }) {
     const timestamp = Date.now();
-    flushOutput(outputBuffer, timestamp);
+    if (codexOutputPassthrough) {
+      codexOutputPassthrough.flush();
+    } else {
+      flushOutput(outputBuffer, timestamp);
+    }
     if (stderrBuffer !== null) flushStderr(stderrBuffer, timestamp);
     const recovered = attemptRecovery(code, timestamp);
     const sessionIdentityError = providerSessionCapture?.getCompletionError() || null;

--- a/tests/bounded-provider-output.test.js
+++ b/tests/bounded-provider-output.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const { createHash } = require('crypto');
+
+const {
+  appendContentToBuffer,
+  createLogRecordBuffer,
+} = require('../src/agent/agent-task-executor');
+
+describe('bounded provider output transport', function () {
+  it('streams a large Codex JSONL record to the raw log without retaining it in the watcher', async function () {
+    const { createWatcherOutputRuntime } = await import('../task-lib/watcher-output-runtime.js');
+    const logged = [];
+    const inspected = [];
+    const runtime = createWatcherOutputRuntime({
+      config: { outputFormat: 'text' },
+      providerName: 'codex',
+      log: (value) => logged.push(value),
+      stopProvider() {},
+      providerSessionCapture: {
+        captureLine: (line) => inspected.push(line),
+        getCompletionError: () => null,
+        getCompletionUpdate: () => ({}),
+      },
+    });
+    const largeText = `before-${'🙂'.repeat(300_000)}-after`;
+    const records = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'session-1' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'command_execution', aggregated_output: largeText },
+      }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 2 } }),
+    ];
+    const expected = `${records.join('\n')}\n`;
+    const encoded = Buffer.from(expected);
+    let buffer = '';
+    for (let offset = 0; offset < encoded.length; offset += 4093) {
+      buffer = runtime.consumeOutput(buffer, encoded.subarray(offset, offset + 4093));
+      assert.strictEqual(buffer, '');
+    }
+    const completion = runtime.complete({ code: 0, signal: null, outputBuffer: buffer });
+
+    const raw = logged.join('').replace(/^\[\d{13}\]/gm, '');
+    const streamed = raw.slice(0, expected.length);
+    assert.strictEqual(Buffer.byteLength(streamed), Buffer.byteLength(expected));
+    assert.strictEqual(
+      createHash('sha256').update(streamed).digest('hex'),
+      createHash('sha256').update(expected).digest('hex')
+    );
+    assert.match(raw.slice(expected.length), /Finished:.*Exit code: 0, Signal: null/s);
+    assert.deepStrictEqual(inspected, [records[0], records[2]]);
+    assert.strictEqual(completion.status, 'completed');
+  });
+
+  it('replaces an oversized conductor record with a stable receipt and resumes at the next line', function () {
+    const timestamp = '[1777777777777]';
+    const oversized = `${timestamp}${'x'.repeat(2 * 1024 * 1024)}`;
+    const next = `${timestamp}{"type":"turn.completed"}`;
+    const input = `${oversized}\n${next}\n`;
+    const state = { lineBuffer: createLogRecordBuffer() };
+    const lines = [];
+
+    for (let offset = 0; offset < input.length; offset += 8191) {
+      appendContentToBuffer(state, input.slice(offset, offset + 8191), (line) => lines.push(line));
+    }
+
+    const expectedDigest = createHash('sha256').update(oversized).digest('hex');
+    assert.deepStrictEqual(lines, [
+      `${timestamp}[ZEROSHOT] Provider output record retained in task log but omitted from the control plane ` +
+        `(byte_length=${Buffer.byteLength(oversized)}, sha256=${expectedDigest})`,
+      next,
+    ]);
+    assert.deepStrictEqual(state.lineBuffer, createLogRecordBuffer());
+  });
+});

--- a/tests/bounded-provider-output.test.js
+++ b/tests/bounded-provider-output.test.js
@@ -1,8 +1,10 @@
 const assert = require('assert');
 const { createHash } = require('crypto');
+const { StringDecoder } = require('string_decoder');
 
 const {
   appendContentToBuffer,
+  consumeIsolatedTailChunk,
   createLogRecordBuffer,
 } = require('../src/agent/agent-task-executor');
 
@@ -71,5 +73,35 @@ describe('bounded provider output transport', function () {
       next,
     ]);
     assert.deepStrictEqual(state.lineBuffer, createLogRecordBuffer());
+  });
+});
+
+describe('isolated bounded provider output transport', function () {
+  it('preserves isolated receipt hashes when UTF-8 characters span stdout chunks', function () {
+    const timestamp = '[1777777777777]';
+    const oversized = `${timestamp}${'🙂'.repeat(300_000)}`;
+    const next = `${timestamp}{"type":"turn.completed"}`;
+    const input = `${oversized}\n${next}\n`;
+    const encoded = Buffer.from(input);
+    const state = {
+      fullOutput: '',
+      lineBuffer: createLogRecordBuffer(),
+      tailDecoder: new StringDecoder('utf8'),
+    };
+    const lines = [];
+
+    for (let offset = 0; offset < encoded.length; offset += 4093) {
+      consumeIsolatedTailChunk(state, encoded.subarray(offset, offset + 4093), (line) =>
+        lines.push(line)
+      );
+    }
+
+    const expectedDigest = createHash('sha256').update(oversized).digest('hex');
+    assert.deepStrictEqual(lines, [
+      `${timestamp}[ZEROSHOT] Provider output record retained in task log but omitted from the control plane ` +
+        `(byte_length=${Buffer.byteLength(oversized)}, sha256=${expectedDigest})`,
+      next,
+    ]);
+    assert.strictEqual(state.fullOutput, input);
   });
 });


### PR DESCRIPTION
## Summary

- stream Codex JSONL directly into the raw task log without accumulating an unbounded physical line in the watcher
- inspect only bounded records for provider-session identity
- read task-log growth in fixed-size chunks and replace control-plane records over 1 MiB with a byte-count/SHA-256 receipt
- apply the same bound to host, isolated, and isolated final-replay paths
- add multibyte stress tests for 1.2 MB and 2 MB records

## Root cause

A command matched a checked-in minified source map stored as one very large physical line. The watcher repeatedly rebuilt its entire partial-line buffer for every PTY chunk, producing quadratic copying and memory growth. The conductor then attempted to retain and broadcast the same full record, adding another unbounded control-plane path. The watcher died and left the cluster in a zombie state.

## Impact

The complete provider output remains losslessly available in the raw task log. Normal records continue through the control plane unchanged. Oversized records are represented there by a compact receipt containing their exact byte length and SHA-256 digest, so a large tool result cannot take down task supervision.

## Validation

- `npm test` — 2,736 passing, 18 pending
- `npm run check` — zero errors
- `npm run opcore:check`
- `opcore-zero check --repo . --staged --json`
- `opcore-zero sense --repo . --staged --json`
- `npm run audit:production`
- `npm run release:preflight`
- `npm pack --dry-run --json`
- Prettier and targeted oversized-output stress tests