### PR TITLE
fix: harden long-running provider output workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -801,9 +801,22 @@ Provider task ownership: task watchers persist an owned termination boundary wit
 Codex JSONL is streamed losslessly into the task log instead of buffering an unbounded physical
 record in the watcher. Provider-session inspection is fixed-bound, and agent log framing replaces
 any record over 1 MiB with a byte-count/SHA-256 receipt before broadcast; the local lane also stores
-only that receipt in agent output while the complete record remains in the task log. Never restore
-whole-record watcher buffering or publish an oversized provider record directly into control-plane
-state.
+only that receipt in agent output while the complete record remains in the task log. Local and
+isolated followers retain a bounded complete-record tail for parsing and diagnostics, stop live
+`AGENT_OUTPUT` publication at cumulative byte/record limits, and publish that bounded tail once at
+terminal settlement. Isolated settlement re-reads only a fixed-size file tail; the raw task log is
+the sole complete-output authority. Never restore whole-record watcher buffering, cumulative output
+strings, whole-log terminal reads, or unbounded provider records/events in control-plane state.
+The SQLite ledger additionally keeps one cluster-wide newest tail of non-replayable
+`AGENT_OUTPUT` (8 MiB / 8192 exported messages) and a persisted deterministic omission receipt;
+live delivery is unchanged, while control and explicitly replayable messages are never compacted.
+Writable opens reconcile pre-budget or stale compaction state one cluster per transaction. JSON
+export verifies actual compactable row counts/bytes and streams rows in the same readonly snapshot;
+legacy writers therefore cannot race a verified export, and inconsistent snapshots receive only
+bounded repair attempts. A persisted high-water allocator assigns explicit message rowids, so
+deleting compacted output can never reuse a sequence already returned to a caller; later readonly
+exports and cursors remain bounded and monotonic. JSON export must iterate ledger rows directly to
+its destination instead of materializing the whole ledger or pretty-printed document in memory.
 POSIX providers run in a dedicated process group; Windows providers use the exact root PID with
 `taskkill /T`. Recovery must terminate that recorded boundary before retrying work. Command cleanup
 ownership is persisted with the task and may run only after that boundary is confirmed terminal.
@@ -929,6 +942,9 @@ Classifies tasks on Complexity x TaskType, routes to parameterized templates.
 | DEBUG    | Fix broken code       |
 
 Base templates: `single-worker`, `worker-validator`, `debug-workflow`, `full-workflow`.
+An exact whole-value `{{param}}` placeholder preserves the parameter's JSON type; placeholders
+embedded in surrounding text stringify their values. Keep numeric workflow controls typed through
+dynamic template loading.
 
 ## Isolation Modes
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -3295,21 +3295,18 @@ program
         throw new Error(`Cluster ${clusterId} not found (no DB file)`);
       }
 
-      const ledger = new Ledger(dbPath);
-      const messages = ledger.getAll(clusterId);
-      ledger.close();
-
       // JSON export
       if (options.format === 'json') {
-        const data = JSON.stringify({ cluster_id: clusterId, messages }, null, 2);
+        exportClusterJson(dbPath, clusterId, options.output || null);
         if (options.output) {
-          require('fs').writeFileSync(options.output, data, 'utf8');
           console.log(`Exported to ${options.output}`);
-        } else {
-          console.log(data);
         }
         return;
       }
+
+      const ledger = new Ledger(dbPath);
+      const messages = ledger.getAll(clusterId);
+      ledger.close();
 
       // Terminal-style export (for markdown and pdf)
       const terminalOutput = renderMessagesToTerminal(clusterId, messages);
@@ -6065,6 +6062,35 @@ async function handleNoArgumentInvocation({
     outputHelp();
   }
   return true;
+}
+
+function tryExportClusterJsonSnapshot(dbPath, clusterId, outputPath) {
+  const Ledger = require('../src/ledger');
+  const { streamClusterJsonExport } = require('./json-export');
+  const ledger = new Ledger(dbPath, { readonly: true });
+  try {
+    return ledger.withReadSnapshot(() => {
+      if (ledger.needsAgentOutputReconciliation(clusterId)) return false;
+      streamClusterJsonExport({ ledger, clusterId, outputPath });
+      return true;
+    });
+  } finally {
+    ledger.close();
+  }
+}
+
+function exportClusterJson(dbPath, clusterId, outputPath) {
+  const Ledger = require('../src/ledger');
+  const maxReconciliationAttempts = 3;
+  for (let attempt = 0; attempt <= maxReconciliationAttempts; attempt += 1) {
+    if (tryExportClusterJsonSnapshot(dbPath, clusterId, outputPath)) return;
+    if (attempt === maxReconciliationAttempts) break;
+    const reconciliationLedger = new Ledger(dbPath);
+    reconciliationLedger.close();
+  }
+  throw new Error(
+    `Cluster ${clusterId} output changed during ${maxReconciliationAttempts} reconciliation attempts`
+  );
 }
 
 // Main entry point

--- a/cli/json-export.js
+++ b/cli/json-export.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+
+function indentJson(value, spaces) {
+  const prefix = ' '.repeat(spaces);
+  return JSON.stringify(value, null, 2)
+    .split('\n')
+    .map((line) => `${prefix}${line}`)
+    .join('\n');
+}
+
+function writeAll(fd, value) {
+  const bytes = Buffer.from(value);
+  let offset = 0;
+  while (offset < bytes.length) {
+    const written = fs.writeSync(fd, bytes, offset, bytes.length - offset);
+    if (!Number.isInteger(written) || written <= 0) {
+      throw new Error('JSON export destination stopped accepting bytes');
+    }
+    offset += written;
+  }
+}
+
+function createDestination(outputPath, stdout) {
+  if (outputPath) {
+    const fd = fs.openSync(outputPath, 'w');
+    return {
+      close: () => fs.closeSync(fd),
+      write: (value) => writeAll(fd, value),
+    };
+  }
+
+  if (Number.isInteger(stdout.fd)) {
+    return {
+      close() {},
+      write: (value) => writeAll(stdout.fd, value),
+    };
+  }
+
+  return {
+    close() {},
+    write: (value) => stdout.write(value),
+  };
+}
+
+function streamClusterJsonExport({
+  ledger,
+  clusterId,
+  outputPath = null,
+  stdout = process.stdout,
+}) {
+  const destination = createDestination(outputPath, stdout);
+  const iterator = ledger.iterateAll(clusterId);
+  try {
+    destination.write(`{\n  "cluster_id": ${JSON.stringify(clusterId)},\n  "messages": `);
+    let current = iterator.next();
+    if (current.done) {
+      destination.write('[]\n}\n');
+      return;
+    }
+
+    destination.write('[\n');
+    while (!current.done) {
+      destination.write(indentJson(current.value, 4));
+      current = iterator.next();
+      destination.write(current.done ? '\n' : ',\n');
+    }
+    destination.write('  ]\n}\n');
+  } finally {
+    try {
+      if (typeof iterator.return === 'function') iterator.return();
+    } finally {
+      destination.close();
+    }
+  }
+}
+
+module.exports = { streamClusterJsonExport };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -60,6 +60,11 @@ const {
 } = require('./structured-output-error');
 const TASK_TERMINAL_STATUSES = new Set(['completed', 'failed', 'killed', 'stale']);
 const MAX_CONTROL_PLANE_RECORD_BYTES = 1024 * 1024;
+const MAX_CONTROL_PLANE_OUTPUT_BYTES = 2 * 1024 * 1024;
+const MAX_CONTROL_PLANE_OUTPUT_RECORDS = 1024;
+const MAX_LIVE_OUTPUT_BYTES = 512 * 1024;
+const MAX_LIVE_OUTPUT_RECORDS = 512;
+const CONTROL_PLANE_OMISSION_MARKER_BYTES = 1024;
 const LOG_READ_CHUNK_BYTES = 64 * 1024;
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
@@ -1222,8 +1227,8 @@ async function waitForTaskReady(agent, taskId, maxRetries = 10, delayMs = 200) {
 const MAX_STATUS_FAILURES = 30;
 
 function createLogFollowState() {
-  return {
-    output: '',
+  const state = {
+    controlPlaneOutput: createControlPlaneOutputState(),
     logFilePath: null,
     lastSize: 0,
     pollInterval: null,
@@ -1233,6 +1238,175 @@ function createLogFollowState() {
     logDecoder: new StringDecoder('utf8'),
     consecutiveExecFailures: 0,
   };
+  defineControlPlaneOutputAccessor(state, 'output');
+  return state;
+}
+
+function createControlPlaneOutputState(options = {}) {
+  const maxBytes = options.maxBytes || MAX_CONTROL_PLANE_OUTPUT_BYTES;
+  const maxRecords = options.maxRecords || MAX_CONTROL_PLANE_OUTPUT_RECORDS;
+  const liveByteLimit = options.liveByteLimit || MAX_LIVE_OUTPUT_BYTES;
+  const liveRecordLimit = options.liveRecordLimit || MAX_LIVE_OUTPUT_RECORDS;
+  if (maxBytes <= CONTROL_PLANE_OMISSION_MARKER_BYTES || maxRecords < 1) {
+    throw new Error('Control-plane output bounds must retain space for at least one record');
+  }
+  return {
+    records: [],
+    head: 0,
+    byteLength: 0,
+    maxBytes,
+    maxRecords,
+    liveByteLimit,
+    liveRecordLimit,
+    liveBytes: 0,
+    liveRecords: 0,
+    nextSequence: 0,
+    lastLiveSequence: -1,
+    liveSuppressed: false,
+    terminalFlushed: false,
+    omittedBytes: 0,
+    omittedRecords: 0,
+    omittedDigest: createHash('sha256'),
+    prefixOmitted: false,
+  };
+}
+
+function defineControlPlaneOutputAccessor(state, property) {
+  Object.defineProperty(state, property, {
+    configurable: true,
+    enumerable: true,
+    get: () => snapshotControlPlaneOutput(state.controlPlaneOutput),
+  });
+}
+
+function ensureControlPlaneOutputState(state = {}) {
+  if (state.controlPlaneOutput) return state;
+  let existingOutput = '';
+  if (typeof state.output === 'string') {
+    existingOutput = state.output;
+  } else if (typeof state.fullOutput === 'string') {
+    existingOutput = state.fullOutput;
+  }
+  state.controlPlaneOutput = createControlPlaneOutputState();
+  if (Object.hasOwn(state, 'output')) delete state.output;
+  if (Object.hasOwn(state, 'fullOutput')) delete state.fullOutput;
+  defineControlPlaneOutputAccessor(state, 'output');
+  if (existingOutput) {
+    replayCompleteLogContent(existingOutput, (content) =>
+      appendControlPlaneRecord(state.controlPlaneOutput, {
+        content,
+        timestamp: Date.now(),
+        type: isValidJsonLine(content) ? 'json' : 'text',
+      })
+    );
+  }
+  return state;
+}
+
+function retainedControlPlaneRecords(outputState) {
+  return outputState.records.slice(outputState.head);
+}
+
+function compactControlPlaneRecords(outputState) {
+  if (outputState.head >= 64 && outputState.head * 2 >= outputState.records.length) {
+    outputState.records = outputState.records.slice(outputState.head);
+    outputState.head = 0;
+  }
+}
+
+function omitOldestControlPlaneRecord(outputState) {
+  const record = outputState.records[outputState.head++];
+  outputState.byteLength -= record.byteLength;
+  outputState.omittedBytes += record.byteLength;
+  outputState.omittedRecords++;
+  outputState.omittedDigest.update(record.text);
+  compactControlPlaneRecords(outputState);
+}
+
+function appendControlPlaneRecord(outputState, { content, timestamp, type }) {
+  const text = `${content}\n`;
+  const record = {
+    sequence: outputState.nextSequence++,
+    content,
+    timestamp,
+    type,
+    text,
+    byteLength: Buffer.byteLength(text),
+  };
+  outputState.records.push(record);
+  outputState.byteLength += record.byteLength;
+
+  const payloadLimit = outputState.maxBytes - CONTROL_PLANE_OMISSION_MARKER_BYTES;
+  while (
+    outputState.byteLength > payloadLimit ||
+    outputState.records.length - outputState.head > outputState.maxRecords
+  ) {
+    omitOldestControlPlaneRecord(outputState);
+  }
+  return record;
+}
+
+function controlPlaneOmissionRecord(outputState) {
+  if (!outputState.prefixOmitted && outputState.omittedRecords === 0) return null;
+  const digest = outputState.omittedRecords
+    ? `, sha256=${outputState.omittedDigest.copy().digest('hex')}`
+    : '';
+  const known = outputState.omittedRecords
+    ? `records=${outputState.omittedRecords}, byte_length=${outputState.omittedBytes}${digest}`
+    : 'byte_length=unknown';
+  const content =
+    `[ZEROSHOT] Earlier provider output omitted from the bounded control-plane tail (${known}). ` +
+    'Complete output remains in the task log.';
+  return {
+    content,
+    timestamp: Date.now(),
+    type: 'text',
+    text: `${content}\n`,
+    byteLength: Buffer.byteLength(`${content}\n`),
+  };
+}
+
+function snapshotControlPlaneOutput(outputState) {
+  const omission = controlPlaneOmissionRecord(outputState);
+  const records = retainedControlPlaneRecords(outputState);
+  return `${omission ? omission.text : ''}${records.map((record) => record.text).join('')}`;
+}
+
+function resetControlPlaneTail(outputState, { prefixOmitted = false } = {}) {
+  outputState.records = [];
+  outputState.head = 0;
+  outputState.byteLength = 0;
+  outputState.omittedBytes = 0;
+  outputState.omittedRecords = 0;
+  outputState.omittedDigest = createHash('sha256');
+  outputState.prefixOmitted = prefixOmitted;
+}
+
+function publishLiveControlPlaneRecord(outputState, record, publish) {
+  if (
+    outputState.liveSuppressed ||
+    outputState.liveBytes + record.byteLength > outputState.liveByteLimit ||
+    outputState.liveRecords + 1 > outputState.liveRecordLimit
+  ) {
+    outputState.liveSuppressed = true;
+    return;
+  }
+  publish(record);
+  outputState.liveBytes += record.byteLength;
+  outputState.liveRecords++;
+  outputState.lastLiveSequence = record.sequence;
+}
+
+function flushTerminalControlPlaneOutput(outputState, publish) {
+  if (outputState.terminalFlushed) return;
+  outputState.terminalFlushed = true;
+  if (outputState.liveSuppressed) {
+    const omission = controlPlaneOmissionRecord(outputState);
+    if (omission) publish(omission);
+  }
+  for (const record of retainedControlPlaneRecords(outputState)) {
+    if (record.sequence > outputState.lastLiveSequence) publish(record);
+  }
 }
 
 function createLogRecordBuffer() {
@@ -1289,7 +1463,27 @@ function isValidJsonLine(content) {
   }
 }
 
+function publishAgentOutputRecord(agent, providerName, record) {
+  agent._publish({
+    topic: 'AGENT_OUTPUT',
+    receiver: 'broadcast',
+    metadata: buildRawLogOnlyMetadata(),
+    timestamp: record.timestamp,
+    content: {
+      data: {
+        type: record.type,
+        line: record.content,
+        agent: agent.id,
+        role: agent.role,
+        iteration: agent.iteration,
+        provider: providerName,
+      },
+    },
+  });
+}
+
 function broadcastAgentLine({ agent, providerName, state, line }) {
+  const followerState = ensureControlPlaneOutputState(state);
   if (!line.trim()) return;
 
   const { timestamp, content } = parseTimestampedLine(line);
@@ -1298,29 +1492,26 @@ function broadcastAgentLine({ agent, providerName, state, line }) {
   }
 
   const isValidJson = isValidJsonLine(content);
-  state.output += content + '\n';
+  const record = appendControlPlaneRecord(followerState.controlPlaneOutput, {
+    content,
+    timestamp,
+    type: isValidJson ? 'json' : 'text',
+  });
 
-  if (!state.nested) {
+  if (!followerState.nested) {
     agent.lastOutputTime = Date.now();
   }
 
-  agent._publish({
-    topic: 'AGENT_OUTPUT',
-    receiver: 'broadcast',
-    metadata: buildRawLogOnlyMetadata(),
-    timestamp,
-    content: {
-      text: content,
-      data: {
-        type: isValidJson ? 'json' : 'text',
-        line: content,
-        agent: agent.id,
-        role: agent.role,
-        iteration: agent.iteration,
-        provider: providerName,
-      },
-    },
-  });
+  publishLiveControlPlaneRecord(followerState.controlPlaneOutput, record, (item) =>
+    publishAgentOutputRecord(agent, providerName, item)
+  );
+}
+
+function flushAgentOutput(agent, providerName, state) {
+  const followerState = ensureControlPlaneOutputState(state);
+  flushTerminalControlPlaneOutput(followerState.controlPlaneOutput, (record) =>
+    publishAgentOutputRecord(agent, providerName, record)
+  );
 }
 
 function appendLogRecordFragment(buffer, fragment) {
@@ -1616,7 +1807,29 @@ function finalizeLogFollow(agent, state) {
   }
 }
 
-function handleStatusExecError({ agent, state, ctPath, taskId, error, stderr, resolve }) {
+function settleHostStatusFailure({ agent, providerName, state, resolve, text, data, error }) {
+  if (state.resolved) return;
+  state.resolved = true;
+  finalizeLogFollow(agent, state);
+  flushAgentOutput(agent, providerName, state);
+  agent._publish({
+    topic: 'AGENT_ERROR',
+    receiver: 'broadcast',
+    content: { text, data },
+  });
+  resolve({ success: false, output: state.output, error });
+}
+
+function handleStatusExecError({
+  agent,
+  providerName,
+  state,
+  ctPath,
+  taskId,
+  error,
+  stderr,
+  resolve,
+}) {
   if (!error) {
     return false;
   }
@@ -1641,30 +1854,20 @@ function handleStatusExecError({ agent, state, ctPath, taskId, error, stderr, re
       `[Agent ${agent.id}] ⚠️ Task ${taskId} not found - will restart to ensure completion`
     );
 
-    if (!state.resolved) {
-      state.resolved = true;
-      finalizeLogFollow(agent, state);
-
-      agent._publish({
-        topic: 'AGENT_ERROR',
-        receiver: 'broadcast',
-        content: {
-          text: `Task ${taskId} not found - restarting for safety`,
-          data: {
-            taskId,
-            error: 'task_not_found',
-            role: agent.role,
-            iteration: agent.iteration,
-          },
-        },
-      });
-
-      resolve({
-        success: false,
-        output: state.output,
-        error: `Task not found - restarting for safety`,
-      });
-    }
+    settleHostStatusFailure({
+      agent,
+      providerName,
+      state,
+      resolve,
+      text: `Task ${taskId} not found - restarting for safety`,
+      data: {
+        taskId,
+        error: 'task_not_found',
+        role: agent.role,
+        iteration: agent.iteration,
+      },
+      error: 'Task not found - restarting for safety',
+    });
 
     return true;
   }
@@ -1682,31 +1885,21 @@ function handleStatusExecError({ agent, state, ctPath, taskId, error, stderr, re
   console.error(`  Stderr: ${stderr || 'none'}`);
   console.error(`  This may indicate zeroshot is not in PATH or task storage is corrupted.`);
 
-  if (!state.resolved) {
-    state.resolved = true;
-    finalizeLogFollow(agent, state);
-
-    agent._publish({
-      topic: 'AGENT_ERROR',
-      receiver: 'broadcast',
-      content: {
-        text: `Task ${taskId} polling failed after ${MAX_STATUS_FAILURES} consecutive failures`,
-        data: {
-          taskId,
-          error: 'polling_timeout',
-          attempts: state.consecutiveExecFailures,
-          role: agent.role,
-          iteration: agent.iteration,
-        },
-      },
-    });
-
-    resolve({
-      success: false,
-      output: state.output,
-      error: `Status polling failed ${MAX_STATUS_FAILURES} times - task may not exist`,
-    });
-  }
+  settleHostStatusFailure({
+    agent,
+    providerName,
+    state,
+    resolve,
+    text: `Task ${taskId} polling failed after ${MAX_STATUS_FAILURES} consecutive failures`,
+    data: {
+      taskId,
+      error: 'polling_timeout',
+      attempts: state.consecutiveExecFailures,
+      role: agent.role,
+      iteration: agent.iteration,
+    },
+    error: `Status polling failed ${MAX_STATUS_FAILURES} times - task may not exist`,
+  });
 
   return true;
 }
@@ -1761,6 +1954,7 @@ function handleStatusCompletion({
     state.resolved = true;
 
     finalizeLogFollow(agent, state);
+    flushAgentOutput(agent, providerName, state);
 
     buildCompletionResult({
       agent,
@@ -1783,6 +1977,7 @@ function buildKillHandler({ agent, taskId, state, providerName, resolve }) {
       if (state.resolved) return;
       state.resolved = true;
       finalizeLogFollow(agent, state);
+      flushAgentOutput(agent, providerName, state);
       if (!state.nested) {
         agent._stopLivenessCheck();
       }
@@ -1842,7 +2037,18 @@ function createLogFollower({
         (error, stdout, stderr) => {
           if (state.resolved) return;
 
-          if (handleStatusExecError({ agent, state, ctPath, taskId, error, stderr, resolve })) {
+          if (
+            handleStatusExecError({
+              agent,
+              providerName,
+              state,
+              ctPath,
+              taskId,
+              error,
+              stderr,
+              resolve,
+            })
+          ) {
             return;
           }
 
@@ -2283,7 +2489,7 @@ async function spawnClaudeTaskIsolatedExecution(agent, context, options = {}) {
  * - Result: 10-20% overall latency reduction
  */
 function createIsolatedLogState(skipStructuredResultCheck = false, nested = false) {
-  return {
+  const state = {
     taskExited: false,
     resolved: false,
     terminationPromise: null,
@@ -2291,8 +2497,10 @@ function createIsolatedLogState(skipStructuredResultCheck = false, nested = fals
     durableTaskStatus: null,
     lifecycleHandle: null,
     logFilePath: null,
-    fullOutput: '',
+    controlPlaneOutput: createControlPlaneOutputState(),
     tailProcess: null,
+    rawBytesSeen: 0,
+    ignoreTailOutput: false,
     statusCheckInterval: null,
     timeoutTimer: null,
     lineBuffer: createLogRecordBuffer(),
@@ -2300,6 +2508,9 @@ function createIsolatedLogState(skipStructuredResultCheck = false, nested = fals
     skipStructuredResultCheck,
     nested,
   };
+  defineControlPlaneOutputAccessor(state, 'output');
+  defineControlPlaneOutputAccessor(state, 'fullOutput');
+  return state;
 }
 
 function buildIsolatedCleanup(state) {
@@ -2422,6 +2633,41 @@ async function resolveIsolatedLogFilePath(manager, clusterId, taskId, state) {
   return state.logFilePath;
 }
 
+async function captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, state) {
+  stopIsolatedTailForSettlement(state);
+  const sizeResult = await manager.execInContainer(clusterId, [
+    'sh',
+    '-c',
+    `wc -c < "${logFilePath}" 2>/dev/null || echo 0`,
+  ]);
+  const fileSize = Number.parseInt(sizeResult.stdout.trim(), 10);
+  const missingBytes = Number.isSafeInteger(fileSize)
+    ? Math.max(0, fileSize - state.rawBytesSeen)
+    : 0;
+
+  if (missingBytes > 0) {
+    const readBytes = Math.min(missingBytes, MAX_CONTROL_PLANE_OUTPUT_BYTES);
+    const finalReadResult = await manager.execInContainer(clusterId, [
+      'sh',
+      '-c',
+      `tail -c ${readBytes} "${logFilePath}" 2>/dev/null || echo ""`,
+    ]);
+    if (finalReadResult.code === 0 && finalReadResult.stdout) {
+      if (missingBytes > readBytes) {
+        resetControlPlaneTail(state.controlPlaneOutput, { prefixOmitted: true });
+        state.lineBuffer = createLogRecordBuffer();
+      }
+      appendIsolatedContent(state, finalReadResult.stdout, (line) =>
+        retainIsolatedLine(state, line)
+      );
+    }
+  }
+
+  if (state.lineBuffer.byteLength > 0) {
+    completeLogRecord(state.lineBuffer, (line) => retainIsolatedLine(state, line), true);
+  }
+}
+
 function settleIsolatedTerminalStatus({
   agent,
   manager,
@@ -2434,7 +2680,6 @@ function settleIsolatedTerminalStatus({
   cleanup,
   resolve,
   reject,
-  onLine,
 }) {
   if (state.resolved) return Promise.resolve();
   if (state.terminalSettlementPromise) return state.terminalSettlementPromise;
@@ -2448,17 +2693,9 @@ function settleIsolatedTerminalStatus({
     const logFilePath = await resolveIsolatedLogFilePath(manager, clusterId, taskId, state);
     await new Promise((settle) => setTimeout(settle, 200));
     if (state.resolved) return;
-    const finalReadResult = await manager.execInContainer(clusterId, [
-      'sh',
-      '-c',
-      `cat "${logFilePath}" 2>/dev/null || echo ""`,
-    ]);
+    await captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, state);
     if (state.resolved) return;
-
-    if (finalReadResult.code === 0 && finalReadResult.stdout) {
-      state.fullOutput = finalReadResult.stdout;
-      replayCompleteLogContent(state.fullOutput, onLine);
-    }
+    flushIsolatedOutput(agent, providerName, taskId, state);
 
     const vertexModelError =
       providerName === 'claude'
@@ -2542,9 +2779,9 @@ function buildIsolatedLifecycleHandle({
   cleanup,
   resolve,
   reject,
-  onLine,
 }) {
-  const settleCancellation = (reason, details) =>
+  const settleCancellation = (reason, details) => {
+    flushIsolatedOutput(agent, providerName, taskId, state);
     settleIsolatedFollower({
       agent,
       state,
@@ -2559,6 +2796,7 @@ function buildIsolatedLifecycleHandle({
         tokenUsage: extractTokenUsage(state.fullOutput, providerName),
       },
     });
+  };
   const terminate = (reason = 'Task killed', details = {}) => {
     if (state.durableTaskTerminal) {
       if (state.nested) settleCancellation(reason, details);
@@ -2590,7 +2828,6 @@ function buildIsolatedLifecycleHandle({
           cleanup,
           resolve,
           reject,
-          onLine,
         });
         return termination;
       }
@@ -2618,11 +2855,14 @@ function buildIsolatedLifecycleHandle({
   };
 }
 
-function broadcastIsolatedLine({ agent, providerName, taskId, state, line }) {
+function parseIsolatedLogLine(line) {
   const timestampMatch = line.match(/^\[(\d{4}-\d{2}-\d{2}T[^\]]+)\]\s*(.*)$/);
   const timestamp = timestampMatch ? new Date(timestampMatch[1]).getTime() : Date.now();
   const content = timestampMatch ? timestampMatch[2] : line;
+  return { timestamp, content };
+}
 
+function publishIsolatedOutputRecord(agent, providerName, taskId, record) {
   agent.messageBus.publish({
     cluster_id: agent.cluster.id,
     topic: 'AGENT_OUTPUT',
@@ -2630,18 +2870,42 @@ function broadcastIsolatedLine({ agent, providerName, taskId, state, line }) {
     metadata: buildRawLogOnlyMetadata(),
     content: {
       data: {
-        line: content,
+        line: record.content,
         taskId,
         iteration: agent.iteration,
         provider: providerName,
       },
     },
-    timestamp,
+    timestamp: record.timestamp,
   });
+}
 
-  if (!state?.nested) {
+function retainIsolatedLine(state, line) {
+  const { timestamp, content } = parseIsolatedLogLine(line);
+  return appendControlPlaneRecord(state.controlPlaneOutput, {
+    content,
+    timestamp,
+    type: isValidJsonLine(content) ? 'json' : 'text',
+  });
+}
+
+function broadcastIsolatedLine({ agent, providerName, taskId, state, line }) {
+  const followerState = ensureControlPlaneOutputState(state);
+  const record = retainIsolatedLine(followerState, line);
+  publishLiveControlPlaneRecord(followerState.controlPlaneOutput, record, (item) =>
+    publishIsolatedOutputRecord(agent, providerName, taskId, item)
+  );
+
+  if (!followerState.nested) {
     agent.lastOutputTime = Date.now();
   }
+}
+
+function flushIsolatedOutput(agent, providerName, taskId, state) {
+  const followerState = ensureControlPlaneOutputState(state);
+  flushTerminalControlPlaneOutput(followerState.controlPlaneOutput, (record) =>
+    publishIsolatedOutputRecord(agent, providerName, taskId, record)
+  );
 }
 
 function appendIsolatedContent(state, content, onLine) {
@@ -2650,9 +2914,20 @@ function appendIsolatedContent(state, content, onLine) {
 
 function consumeIsolatedTailChunk(state, data, onLine) {
   const chunk = typeof data === 'string' ? data : state.tailDecoder.write(data);
-  if (!chunk) return;
-  state.fullOutput += chunk;
+  if (!chunk || state.ignoreTailOutput) return;
+  state.rawBytesSeen += Buffer.byteLength(chunk);
   appendIsolatedContent(state, chunk, onLine);
+}
+
+function stopIsolatedTailForSettlement(state) {
+  state.ignoreTailOutput = true;
+  if (!state.tailProcess) return;
+  try {
+    state.tailProcess.kill('SIGTERM');
+  } catch {
+    // Ignore - process may already be dead.
+  }
+  state.tailProcess = null;
 }
 
 function startIsolatedTail({ agent, manager, clusterId, logFilePath, state, onLine }) {
@@ -2696,7 +2971,6 @@ async function checkIsolatedStatus({
   cleanup,
   resolve,
   reject,
-  onLine,
 }) {
   if (state.taskExited) return;
 
@@ -2749,7 +3023,6 @@ async function checkIsolatedStatus({
     cleanup,
     resolve,
     reject,
-    onLine,
   });
 }
 
@@ -2764,7 +3037,6 @@ function startIsolatedStatusChecks({
   cleanup,
   resolve,
   reject,
-  onLine,
 }) {
   state.statusCheckInterval = setInterval(() => {
     checkIsolatedStatus({
@@ -2778,7 +3050,6 @@ function startIsolatedStatusChecks({
       cleanup,
       resolve,
       reject,
-      onLine,
     }).catch((statusErr) => {
       agent._log(`[${agent.id}] Status check error (will retry): ${statusErr.message}`);
     });
@@ -2812,7 +3083,6 @@ function followClaudeTaskLogsIsolated(agent, taskId, options = {}) {
       cleanup,
       resolve,
       reject,
-      onLine,
     });
     // Only register the lifecycle handle on the agent for top-level tasks.
     if (!options.nested) {
@@ -2883,7 +3153,6 @@ function followClaudeTaskLogsIsolated(agent, taskId, options = {}) {
           cleanup,
           resolve,
           reject,
-          onLine,
         });
 
         if (agent.timeout > 0 && !agent.enableLivenessCheck && !options.nested) {
@@ -3167,7 +3436,19 @@ module.exports = {
   buildTaskRunArgs,
   rebuildProviderSessionAfterCommit,
   killTask,
+  createLogFollowState,
+  createIsolatedLogState,
+  createControlPlaneOutputState,
+  appendControlPlaneRecord,
   createLogRecordBuffer,
   appendContentToBuffer,
   consumeIsolatedTailChunk,
+  flushAgentOutput,
+  flushIsolatedOutput,
+  CONTROL_PLANE_OUTPUT_LIMITS: Object.freeze({
+    maxBytes: MAX_CONTROL_PLANE_OUTPUT_BYTES,
+    maxRecords: MAX_CONTROL_PLANE_OUTPUT_RECORDS,
+    liveBytes: MAX_LIVE_OUTPUT_BYTES,
+    liveRecords: MAX_LIVE_OUTPUT_RECORDS,
+  }),
 };

--- a/src/ledger.js
+++ b/src/ledger.js
@@ -1,7 +1,8 @@
 /**
- * Ledger - Immutable event log for multi-agent coordination
+ * Ledger - Durable event log for multi-agent coordination
  *
  * Provides:
+ * - Immutable control/replayable messages plus a bounded newest tail of raw AGENT_OUTPUT
  * - SQLite-backed message storage with indexes
  * - Query API for message retrieval
  * - In-memory cache for recent queries
@@ -16,9 +17,14 @@ const {
   USER_GUIDANCE_AGENT,
   USER_GUIDANCE_CLUSTER,
 } = require('./guidance-topics');
+const { isReplayableMessage } = require('./agent/context-replay-policy');
 const { messageSequenceFromSql, messageSequenceToSql } = require('./ledger-sequence');
 
 const MESSAGE_SEQUENCE_SELECT = 'CAST(rowid AS TEXT) AS sequence';
+const AGENT_OUTPUT_EXPORT_MAX_BYTES = 8 * 1024 * 1024;
+const AGENT_OUTPUT_EXPORT_MAX_MESSAGES = 8192;
+const EMPTY_OMISSION_DIGEST = '0'.repeat(64);
+const AGENT_OUTPUT_RECEIPT_SENDER = 'zeroshot';
 
 class Ledger extends EventEmitter {
   constructor(dbPath = ':memory:', options = {}) {
@@ -87,16 +93,40 @@ class Ledger extends EventEmitter {
       CREATE INDEX IF NOT EXISTS idx_cluster_sender ON messages(cluster_id, sender);
       CREATE INDEX IF NOT EXISTS idx_cluster_topic ON messages(cluster_id, topic);
       CREATE INDEX IF NOT EXISTS idx_cluster_timestamp ON messages(cluster_id, timestamp);
+
+      CREATE TABLE IF NOT EXISTS agent_output_compaction (
+        cluster_id TEXT PRIMARY KEY,
+        receipt_message_id TEXT,
+        first_omitted_timestamp INTEGER,
+        omitted_messages INTEGER NOT NULL DEFAULT 0,
+        omitted_export_bytes INTEGER NOT NULL DEFAULT 0,
+        omission_digest TEXT NOT NULL,
+        retained_messages INTEGER NOT NULL DEFAULT 0,
+        retained_export_bytes INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS ledger_sequence (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        value INTEGER NOT NULL
+      );
+      INSERT OR IGNORE INTO ledger_sequence (singleton, value) VALUES (1, 0);
+      UPDATE ledger_sequence
+      SET value = MAX(value, COALESCE((SELECT MAX(rowid) FROM messages), 0))
+      WHERE singleton = 1;
     `);
 
     this._prepareStatements();
     this._loadLastTimestamp();
+    this._reconcileAgentOutput();
   }
 
   _prepareStatements() {
     const insert = this.db.prepare(`
-        INSERT INTO messages (id, timestamp, topic, sender, receiver, content_text, content_data, metadata, cluster_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO messages (
+          rowid, id, timestamp, topic, sender, receiver,
+          content_text, content_data, metadata, cluster_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
     insert.safeIntegers(true);
 
@@ -111,7 +141,92 @@ class Ledger extends EventEmitter {
         `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages WHERE cluster_id = ?` +
           ` ORDER BY timestamp ASC, rowid ASC`
       ),
+
+      agentOutputRows: this.db.prepare(
+        `SELECT ${MESSAGE_SEQUENCE_SELECT}, * FROM messages` +
+          ` WHERE cluster_id = ? AND topic = 'AGENT_OUTPUT' ORDER BY timestamp ASC, rowid ASC`
+      ),
     };
+
+    if (!this.readonly) {
+      const nextSequence = this.db.prepare(`
+        UPDATE ledger_sequence
+        SET value = MAX(value, COALESCE((SELECT MAX(rowid) FROM messages), 0)) + 1
+        WHERE singleton = 1
+          AND value < 9223372036854775807
+          AND COALESCE((SELECT MAX(rowid) FROM messages), 0) < 9223372036854775807
+        RETURNING value
+      `);
+      nextSequence.safeIntegers(true);
+      this.stmts.nextSequence = nextSequence;
+      this._prepareAgentOutputCompactionStatements();
+    }
+  }
+
+  _prepareAgentOutputCompactionStatements() {
+    this.compactionStmts = {
+      get: this.db.prepare('SELECT * FROM agent_output_compaction WHERE cluster_id = ?'),
+      insert: this.db.prepare(`
+        INSERT INTO agent_output_compaction (
+          cluster_id, receipt_message_id, first_omitted_timestamp,
+          omitted_messages, omitted_export_bytes, omission_digest,
+          retained_messages, retained_export_bytes
+        ) VALUES (?, NULL, NULL, 0, 0, ?, ?, ?)
+      `),
+      update: this.db.prepare(`
+        UPDATE agent_output_compaction
+        SET receipt_message_id = ?, first_omitted_timestamp = ?, omitted_messages = ?,
+            omitted_export_bytes = ?, omission_digest = ?, retained_messages = ?,
+            retained_export_bytes = ?
+        WHERE cluster_id = ?
+      `),
+      deleteMessage: this.db.prepare('DELETE FROM messages WHERE id = ?'),
+      updateReceipt: this.db.prepare(`
+        UPDATE messages SET content_data = ?, metadata = ? WHERE id = ?
+      `),
+      receiptExists: this.db.prepare('SELECT 1 FROM messages WHERE id = ?'),
+      agentOutputClusterIds: this.db.prepare(`
+        SELECT cluster_id FROM agent_output_compaction
+        UNION
+        SELECT cluster_id FROM messages WHERE topic = 'AGENT_OUTPUT'
+      `),
+      deleteState: this.db.prepare('DELETE FROM agent_output_compaction'),
+    };
+  }
+
+  _reconcileAgentOutput() {
+    const clusterIds = this.compactionStmts.agentOutputClusterIds
+      .all()
+      .map((row) => row.cluster_id);
+    const reconcileCluster = this.db.transaction((clusterId) => {
+      const measured = this._measureCompactableAgentOutput(clusterId);
+      let state = this.compactionStmts.get.get(clusterId);
+      if (!state) {
+        if (measured.retained_messages === 0) return;
+        state = this._createCompactionState(clusterId, measured);
+      } else if (
+        state.retained_messages !== measured.retained_messages ||
+        state.retained_export_bytes !== measured.retained_export_bytes
+      ) {
+        state.retained_messages = measured.retained_messages;
+        state.retained_export_bytes = measured.retained_export_bytes;
+        this._updateCompactionState(state);
+      }
+      const receiptMissing =
+        state.omitted_messages > 0 &&
+        (!state.receipt_message_id ||
+          !this.compactionStmts.receiptExists.get(state.receipt_message_id));
+      if (
+        receiptMissing ||
+        state.retained_export_bytes > AGENT_OUTPUT_EXPORT_MAX_BYTES ||
+        state.retained_messages > AGENT_OUTPUT_EXPORT_MAX_MESSAGES
+      ) {
+        this._compactAgentOutput(clusterId);
+      }
+    });
+    for (const clusterId of clusterIds) {
+      reconcileCluster.immediate(clusterId);
+    }
   }
 
   _loadLastTimestamp() {
@@ -119,6 +234,191 @@ class Ledger extends EventEmitter {
     if (row && Number.isFinite(row.max_timestamp)) {
       this._lastTimestamp = row.max_timestamp;
     }
+  }
+
+  _insertRecord(record) {
+    const allocated = this.stmts.nextSequence.get();
+    if (!allocated) {
+      throw new RangeError('Ledger message sequence exhausted the SQLite rowid range');
+    }
+    this.stmts.insert.run(
+      allocated.value,
+      record.id,
+      record.timestamp,
+      record.topic,
+      record.sender,
+      record.receiver,
+      record.content_text,
+      record.content_data,
+      record.metadata,
+      record.cluster_id
+    );
+    record.sequence = messageSequenceFromSql(allocated.value);
+    return this._deserializeMessage(record);
+  }
+
+  _recordExportBytes(record) {
+    return Buffer.byteLength(JSON.stringify(this._deserializeMessage(record)));
+  }
+
+  _isCompactableAgentOutput(record) {
+    if (record.topic !== 'AGENT_OUTPUT') return false;
+    const message = this._deserializeMessage(record);
+    return message.metadata?.compactionReceipt !== true && !isReplayableMessage(message);
+  }
+
+  _measureCompactableAgentOutput(clusterId) {
+    let retainedMessages = 0;
+    let retainedExportBytes = 0;
+    for (const row of this.stmts.agentOutputRows.iterate(clusterId)) {
+      if (!this._isCompactableAgentOutput(row)) continue;
+      retainedMessages += 1;
+      retainedExportBytes += this._recordExportBytes(row);
+    }
+    return {
+      retained_messages: retainedMessages,
+      retained_export_bytes: retainedExportBytes,
+    };
+  }
+
+  _createCompactionState(clusterId, measured = this._measureCompactableAgentOutput(clusterId)) {
+    this.compactionStmts.insert.run(
+      clusterId,
+      EMPTY_OMISSION_DIGEST,
+      measured.retained_messages,
+      measured.retained_export_bytes
+    );
+    return this.compactionStmts.get.get(clusterId);
+  }
+
+  _updateCompactionState(state) {
+    this.compactionStmts.update.run(
+      state.receipt_message_id,
+      state.first_omitted_timestamp,
+      state.omitted_messages,
+      state.omitted_export_bytes,
+      state.omission_digest,
+      state.retained_messages,
+      state.retained_export_bytes,
+      state.cluster_id
+    );
+  }
+
+  _oldestCompactableAgentOutput(clusterId) {
+    for (const row of this.stmts.agentOutputRows.iterate(clusterId)) {
+      if (this._isCompactableAgentOutput(row)) return row;
+    }
+    return null;
+  }
+
+  _nextOmissionDigest(previousDigest, record) {
+    const hash = crypto.createHash('sha256');
+    hash.update(Buffer.from(previousDigest, 'hex'));
+    const exportedMessage = Buffer.from(JSON.stringify(this._deserializeMessage(record)));
+    const length = Buffer.allocUnsafe(8);
+    length.writeBigUInt64BE(BigInt(exportedMessage.length));
+    hash.update(length);
+    hash.update(exportedMessage);
+    return hash.digest('hex');
+  }
+
+  _agentOutputReceiptRecord(state) {
+    const line =
+      `[ZEROSHOT] Earlier raw provider output omitted from the durable control-plane tail ` +
+      `(messages=${state.omitted_messages}, export_bytes=${state.omitted_export_bytes}, ` +
+      `sha256_chain=${state.omission_digest}). The newest output is retained within ` +
+      `${AGENT_OUTPUT_EXPORT_MAX_BYTES} exported bytes and ` +
+      `${AGENT_OUTPUT_EXPORT_MAX_MESSAGES} messages. Complete output remains in task logs.`;
+    return {
+      id:
+        state.receipt_message_id ||
+        `agent_output_receipt_${crypto.createHash('sha256').update(state.cluster_id).digest('hex').slice(0, 24)}`,
+      timestamp: state.first_omitted_timestamp,
+      topic: 'AGENT_OUTPUT',
+      sender: AGENT_OUTPUT_RECEIPT_SENDER,
+      receiver: 'broadcast',
+      content_text: null,
+      content_data: JSON.stringify({
+        type: 'output_omission',
+        line,
+        omittedMessages: state.omitted_messages,
+        omittedExportBytes: state.omitted_export_bytes,
+        sha256Chain: state.omission_digest,
+        retainedExportByteLimit: AGENT_OUTPUT_EXPORT_MAX_BYTES,
+        retainedMessageLimit: AGENT_OUTPUT_EXPORT_MAX_MESSAGES,
+        completeOutputAuthority: 'task_logs',
+      }),
+      metadata: JSON.stringify({
+        compactionReceipt: true,
+        contextSafe: false,
+        replayPolicy: 'raw_log_only',
+      }),
+      cluster_id: state.cluster_id,
+    };
+  }
+
+  _persistAgentOutputReceipt(state) {
+    const receipt = this._agentOutputReceiptRecord(state);
+    const updated = state.receipt_message_id
+      ? this.compactionStmts.updateReceipt.run(receipt.content_data, receipt.metadata, receipt.id)
+      : { changes: 0 };
+    if (updated.changes === 0) {
+      this._insertRecord(receipt);
+    }
+    state.receipt_message_id = receipt.id;
+  }
+
+  _compactAgentOutput(clusterId) {
+    const state = this.compactionStmts.get.get(clusterId) || this._createCompactionState(clusterId);
+    while (
+      state.retained_export_bytes > AGENT_OUTPUT_EXPORT_MAX_BYTES ||
+      state.retained_messages > AGENT_OUTPUT_EXPORT_MAX_MESSAGES
+    ) {
+      const oldest = this._oldestCompactableAgentOutput(clusterId);
+      if (!oldest) break;
+      const exportBytes = this._recordExportBytes(oldest);
+      state.first_omitted_timestamp ??= oldest.timestamp;
+      state.omitted_messages += 1;
+      state.omitted_export_bytes += exportBytes;
+      state.omission_digest = this._nextOmissionDigest(state.omission_digest, oldest);
+      state.retained_messages -= 1;
+      state.retained_export_bytes -= exportBytes;
+      if (
+        !state.receipt_message_id ||
+        !this.compactionStmts.receiptExists.get(state.receipt_message_id)
+      ) {
+        this._persistAgentOutputReceipt(state);
+      }
+      this.compactionStmts.deleteMessage.run(oldest.id);
+    }
+    if (state.omitted_messages > 0) {
+      this._persistAgentOutputReceipt(state);
+    }
+    this._updateCompactionState(state);
+  }
+
+  _insertAndCompact(record) {
+    const fullMessage = this._insertRecord(record);
+    if (this._isCompactableAgentOutput(record)) {
+      const state = this.compactionStmts.get.get(record.cluster_id);
+      if (state) {
+        state.retained_messages += 1;
+        state.retained_export_bytes += this._recordExportBytes(record);
+        this._updateCompactionState(state);
+      }
+      this._compactAgentOutput(record.cluster_id);
+    }
+    return fullMessage;
+  }
+
+  _appendRecord(record) {
+    const compactable = this._isCompactableAgentOutput(record);
+    if (!this._appendRecordTxn) {
+      this._appendRecordTxn = this.db.transaction((item, compact) =>
+        compact ? this._insertAndCompact(item) : this._insertRecord(item)
+      );
+    }
+    return this._appendRecordTxn(record, compactable);
   }
 
   /**
@@ -154,18 +454,7 @@ class Ledger extends EventEmitter {
     };
 
     try {
-      const insertResult = this.stmts.insert.run(
-        record.id,
-        record.timestamp,
-        record.topic,
-        record.sender,
-        record.receiver,
-        record.content_text,
-        record.content_data,
-        record.metadata,
-        record.cluster_id
-      );
-      record.sequence = messageSequenceFromSql(insertResult.lastInsertRowid);
+      const fullMessage = this._appendRecord(record);
 
       // Invalidate cache
       this.cache.clear();
@@ -173,7 +462,6 @@ class Ledger extends EventEmitter {
       this._lastTimestamp = Math.max(this._lastTimestamp, timestamp);
 
       // Emit event for subscriptions
-      const fullMessage = this._deserializeMessage(record);
       this.emit('message', fullMessage);
       this.emit(`topic:${message.topic}`, fullMessage);
 
@@ -229,20 +517,7 @@ class Ledger extends EventEmitter {
           cluster_id: message.cluster_id,
         };
 
-        const insertResult = this.stmts.insert.run(
-          record.id,
-          record.timestamp,
-          record.topic,
-          record.sender,
-          record.receiver,
-          record.content_text,
-          record.content_data,
-          record.metadata,
-          record.cluster_id
-        );
-        record.sequence = messageSequenceFromSql(insertResult.lastInsertRowid);
-
-        results.push(this._deserializeMessage(record));
+        results.push(this._insertAndCompact(record));
       }
 
       return { results, baseTimestamp };
@@ -547,6 +822,54 @@ class Ledger extends EventEmitter {
   }
 
   /**
+   * Iterate over all cluster messages without materializing the complete ledger.
+   * @param {String} cluster_id - Cluster ID
+   * @yields {Object} One deserialized message at a time
+   */
+  *iterateAll(cluster_id) {
+    for (const row of this.stmts.getAll.iterate(cluster_id)) {
+      yield this._deserializeMessage(row);
+    }
+  }
+
+  /**
+   * Run synchronous reads against one stable SQLite snapshot.
+   * @param {Function} callback - Work to perform inside the snapshot
+   * @returns {*} The callback result
+   */
+  withReadSnapshot(callback) {
+    return this.db.transaction(callback).deferred();
+  }
+
+  /**
+   * Return whether a legacy cluster requires one writable compaction pass.
+   * This preflight is read-only and does not acquire a writer lock.
+   * @param {String} cluster_id - Cluster ID
+   * @returns {Boolean} True when actual raw output disagrees with durable budget state
+   */
+  needsAgentOutputReconciliation(cluster_id) {
+    const hasCompactionTable = this.db
+      .prepare(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_output_compaction'"
+      )
+      .get();
+    const state =
+      hasCompactionTable &&
+      this.db.prepare('SELECT * FROM agent_output_compaction WHERE cluster_id = ?').get(cluster_id);
+    const measured = this._measureCompactableAgentOutput(cluster_id);
+    if (!state) return measured.retained_messages > 0;
+    if (
+      state.retained_messages !== measured.retained_messages ||
+      state.retained_export_bytes !== measured.retained_export_bytes
+    ) {
+      return true;
+    }
+    if (state.omitted_messages === 0) return false;
+    if (!state.receipt_message_id) return true;
+    return !this.db.prepare('SELECT 1 FROM messages WHERE id = ?').get(state.receipt_message_id);
+  }
+
+  /**
    * Get aggregated token usage by agent role
    * Queries TOKEN_USAGE messages and sums tokens per role
    * @param {String} cluster_id - Cluster ID
@@ -811,9 +1134,19 @@ class Ledger extends EventEmitter {
    * Clear all messages (for testing)
    */
   clear() {
-    this.db.exec('DELETE FROM messages');
+    this.db.transaction(() => {
+      this.db.exec('DELETE FROM messages');
+      if (this.compactionStmts) {
+        this.compactionStmts.deleteState.run();
+      }
+    })();
     this.cache.clear();
   }
 }
+
+Ledger.AGENT_OUTPUT_EXPORT_LIMITS = Object.freeze({
+  maxBytes: AGENT_OUTPUT_EXPORT_MAX_BYTES,
+  maxMessages: AGENT_OUTPUT_EXPORT_MAX_MESSAGES,
+});
 
 module.exports = Ledger;

--- a/src/template-resolver.js
+++ b/src/template-resolver.js
@@ -327,6 +327,11 @@ class TemplateResolver {
    * @returns {any}
    */
   _resolveString(str, params) {
+    const exactPlaceholder = str.match(/^\{\{(\w+)\}\}$/);
+    if (exactPlaceholder && params[exactPlaceholder[1]] !== undefined) {
+      return JSON.parse(JSON.stringify(params[exactPlaceholder[1]]));
+    }
+
     // Handle simple {{param}} substitutions
     let result = str.replace(
       /\{\{(\w+)\}\}/g,

--- a/task-lib/watcher-output-runtime.js
+++ b/task-lib/watcher-output-runtime.js
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { createHash } from 'crypto';
 import { StringDecoder } from 'string_decoder';
 import {
   detectProviderFatalError,
@@ -11,6 +12,7 @@ import { terminateProcess } from './process-termination.js';
 export const COMMAND_CLEANUP_UNINITIALIZED = Symbol('command-cleanup-uninitialized');
 
 const MAX_CODEX_CONTROL_RECORD_BYTES = 64 * 1024;
+const MAX_WATCHER_CONTROL_RECORD_BYTES = 1024 * 1024;
 
 export function spawnWatcherProvider(command, finalArgs, options) {
   return spawn(command, finalArgs, {
@@ -33,12 +35,6 @@ export async function terminateWatcherProvider(providerProcess, options = {}) {
     return false;
   }
   return result.terminated;
-}
-
-function splitBufferLines(buffer, chunk) {
-  const nextBuffer = buffer + chunk;
-  const lines = nextBuffer.split('\n');
-  return { lines: lines.slice(0, -1), remaining: lines.at(-1) || '' };
 }
 
 function createCodexOutputPassthrough({ log, captureProviderSession }) {
@@ -102,6 +98,98 @@ function createCodexOutputPassthrough({ log, captureProviderSession }) {
       if (!atLineStart) {
         finishLine();
         log('\n');
+      }
+    },
+  };
+}
+
+function createBoundedLinePassthrough({ log, handleLine, deferRawUntilOverflow = false }) {
+  const decoder = new StringDecoder('utf8');
+  let atLineStart = true;
+  let lineTimestamp = null;
+  let byteLength = 0;
+  let inspectable = true;
+  let inspectionParts = [];
+  let digest = createHash('sha256');
+  let rawOverflowStreaming = false;
+
+  function inspectPart(part) {
+    if (!part) return;
+    byteLength += Buffer.byteLength(part);
+    digest.update(part);
+    if (!inspectable) {
+      if (deferRawUntilOverflow && log) log(part);
+      return;
+    }
+    if (byteLength > MAX_WATCHER_CONTROL_RECORD_BYTES) {
+      if (deferRawUntilOverflow && log) {
+        log(`[${lineTimestamp}]${inspectionParts.join('')}${part}`);
+        rawOverflowStreaming = true;
+      }
+      inspectable = false;
+      inspectionParts = [];
+      return;
+    }
+    inspectionParts.push(part);
+  }
+
+  function finishLine() {
+    const oversized = !inspectable;
+    const line = inspectable
+      ? inspectionParts.join('')
+      : `[ZEROSHOT] Provider output record retained in task log but omitted from watcher inspection ` +
+        `(byte_length=${byteLength}, sha256=${digest.digest('hex')})`;
+    handleLine(line, lineTimestamp || Date.now(), { oversized });
+    atLineStart = true;
+    lineTimestamp = null;
+    byteLength = 0;
+    inspectable = true;
+    inspectionParts = [];
+    digest = createHash('sha256');
+    rawOverflowStreaming = false;
+  }
+
+  function appendRaw(logged, ...parts) {
+    if (log && !deferRawUntilOverflow) logged.push(...parts);
+  }
+
+  function writeText(text) {
+    if (!text) return;
+    const logged = [];
+    let offset = 0;
+    while (offset < text.length) {
+      if (atLineStart) {
+        lineTimestamp = Date.now();
+        appendRaw(logged, `[${lineTimestamp}]`);
+        atLineStart = false;
+      }
+      const newline = text.indexOf('\n', offset);
+      if (newline === -1) {
+        const part = text.slice(offset);
+        inspectPart(part);
+        appendRaw(logged, part);
+        break;
+      }
+      const part = text.slice(offset, newline);
+      inspectPart(part);
+      appendRaw(logged, part, '\n');
+      if (deferRawUntilOverflow && rawOverflowStreaming && log) log('\n');
+      finishLine();
+      offset = newline + 1;
+    }
+    if (log && logged.length > 0) log(logged.join(''));
+  }
+
+  return {
+    consume(chunk) {
+      writeText(typeof chunk === 'string' ? chunk : decoder.write(chunk));
+    },
+    flush() {
+      writeText(decoder.end());
+      if (!atLineStart) {
+        if (deferRawUntilOverflow && rawOverflowStreaming && log) log('\n');
+        finishLine();
+        if (log && !deferRawUntilOverflow) log('\n');
       }
     },
   };
@@ -260,6 +348,21 @@ export function createWatcherOutputRuntime({
   const captureProviderSession = providerSessionCapture?.captureLine || (() => {});
   const codexOutputPassthrough =
     providerName === 'codex' ? createCodexOutputPassthrough({ log, captureProviderSession }) : null;
+  const outputPassthrough = codexOutputPassthrough
+    ? null
+    : createBoundedLinePassthrough({
+        log,
+        deferRawUntilOverflow: silentJsonMode,
+        handleLine: (line, timestamp, { oversized }) =>
+          handleOutputLine(line, timestamp, {
+            alreadyLogged: !silentJsonMode,
+            oversized,
+          }),
+      });
+  const stderrPassthrough = createBoundedLinePassthrough({
+    log,
+    handleLine: (line, timestamp) => maybeHandleFatalError(line, timestamp),
+  });
 
   function maybeHandleFatalError(line, timestamp) {
     if (fatalError) return false;
@@ -288,56 +391,38 @@ export function createWatcherOutputRuntime({
     }
   }
 
-  function handleOutputLine(line, timestamp) {
+  function handleOutputLine(line, timestamp, { alreadyLogged = false, oversized = false } = {}) {
+    if (silentJsonMode && oversized) {
+      fatalError =
+        `Provider structured output exceeded the ${MAX_WATCHER_CONTROL_RECORD_BYTES}-byte ` +
+        'watcher inspection limit; complete output remains in the task log';
+      log(`[${timestamp}][FATAL] ${fatalError}\n`);
+      stopProvider(timestamp);
+      return;
+    }
     captureProviderSession(line);
     if (silentJsonMode && !line.trim()) return;
     maybeHandleFatalError(line, timestamp);
     if (captureStreamingError(line, timestamp)) return;
     if (silentJsonMode) {
       maybeCaptureStructuredOutput(line);
-    } else {
+    } else if (!alreadyLogged) {
       log(`[${timestamp}]${line}\n`);
     }
   }
 
-  function consumeOutput(buffer, chunk) {
+  function consumeOutput(_buffer, chunk) {
     if (codexOutputPassthrough) {
       codexOutputPassthrough.consume(chunk);
-      return '';
-    }
-    const timestamp = Date.now();
-    const { lines, remaining } = splitBufferLines(buffer, chunk.toString());
-    for (const line of lines) handleOutputLine(line, timestamp);
-    return remaining;
-  }
-
-  function consumeStderr(buffer, chunk) {
-    const timestamp = Date.now();
-    const { lines, remaining } = splitBufferLines(buffer, chunk.toString());
-    for (const line of lines) log(`[${timestamp}]${line}\n`);
-    return remaining;
-  }
-
-  function flushOutput(buffer, timestamp) {
-    if (!buffer.trim()) return;
-    captureProviderSession(buffer);
-    if (!enableRecovery) {
-      if (!silentJsonMode) log(`[${timestamp}]${buffer}\n`);
-      return;
-    }
-    maybeHandleFatalError(buffer, timestamp);
-    if (captureStreamingError(buffer, timestamp)) return;
-    if (silentJsonMode) {
-      maybeCaptureStructuredOutput(buffer);
     } else {
-      log(`[${timestamp}]${buffer}\n`);
+      outputPassthrough.consume(chunk);
     }
+    return '';
   }
 
-  function flushStderr(buffer, timestamp) {
-    if (!buffer.trim()) return;
-    maybeHandleFatalError(buffer, timestamp);
-    log(`[${timestamp}]${buffer}\n`);
+  function consumeStderr(_buffer, chunk) {
+    stderrPassthrough.consume(chunk);
+    return '';
   }
 
   function attemptRecovery(code, timestamp) {
@@ -357,14 +442,14 @@ export function createWatcherOutputRuntime({
     return recovered;
   }
 
-  function complete({ code, signal, outputBuffer, stderrBuffer = null }) {
+  function complete({ code, signal, stderrBuffer = null }) {
     const timestamp = Date.now();
     if (codexOutputPassthrough) {
       codexOutputPassthrough.flush();
     } else {
-      flushOutput(outputBuffer, timestamp);
+      outputPassthrough.flush();
     }
-    if (stderrBuffer !== null) flushStderr(stderrBuffer, timestamp);
+    if (stderrBuffer !== null) stderrPassthrough.flush();
     const recovered = attemptRecovery(code, timestamp);
     const sessionIdentityError = providerSessionCapture?.getCompletionError() || null;
     if (silentJsonMode && finalResultJson) log(`${finalResultJson}\n`);

--- a/tests/agent-task-not-found.test.js
+++ b/tests/agent-task-not-found.test.js
@@ -80,6 +80,9 @@ describe('Agent Task Not Found - Fail-Safe Restart', () => {
     assert.ok(functionMatch, 'Should find handleStatusExecError function');
 
     const functionBody = functionMatch[0];
+    const settlementBody = sourceCode.match(
+      /function settleHostStatusFailure\([^)]*\)\s*{[\s\S]*?^}/m
+    )[0];
 
     // Verify it has a dedicated "not found" check BEFORE the retry counter
     const notFoundCheckIndex = functionBody.indexOf('ID not found');
@@ -94,12 +97,12 @@ describe('Agent Task Not Found - Fail-Safe Restart', () => {
     const notFoundSection = functionBody.substring(notFoundCheckIndex, retryCounterIndex);
 
     assert.ok(
-      notFoundSection.includes('resolve('),
+      notFoundSection.includes('settleHostStatusFailure(') && settlementBody.includes('resolve('),
       'Should call resolve() immediately when task not found'
     );
 
     assert.ok(
-      notFoundSection.includes('success: false'),
+      settlementBody.includes('success: false'),
       'Should resolve with success: false when task not found'
     );
 
@@ -115,6 +118,9 @@ describe('Agent Task Not Found - Fail-Safe Restart', () => {
     );
 
     const functionBody = functionMatch[0];
+    const settlementBody = sourceCode.match(
+      /function settleHostStatusFailure\([^)]*\)\s*{[\s\S]*?^}/m
+    )[0];
 
     // Find the "not found" section
     const notFoundStart = functionBody.indexOf('ID not found');
@@ -123,7 +129,9 @@ describe('Agent Task Not Found - Fail-Safe Restart', () => {
 
     // Verify it publishes an error event
     assert.ok(
-      notFoundSection.includes('_publish') && notFoundSection.includes('AGENT_ERROR'),
+      notFoundSection.includes('settleHostStatusFailure(') &&
+        settlementBody.includes('_publish') &&
+        settlementBody.includes('AGENT_ERROR'),
       'Should publish AGENT_ERROR event when task not found'
     );
 

--- a/tests/bounded-provider-output.test.js
+++ b/tests/bounded-provider-output.test.js
@@ -3,8 +3,11 @@ const { createHash } = require('crypto');
 const { StringDecoder } = require('string_decoder');
 
 const {
+  CONTROL_PLANE_OUTPUT_LIMITS,
   appendContentToBuffer,
+  broadcastIsolatedLine,
   consumeIsolatedTailChunk,
+  createIsolatedLogState,
   createLogRecordBuffer,
 } = require('../src/agent/agent-task-executor');
 
@@ -53,7 +56,114 @@ describe('bounded provider output transport', function () {
     assert.deepStrictEqual(inspected, [records[0], records[2]]);
     assert.strictEqual(completion.status, 'completed');
   });
+});
 
+describe('bounded generic provider output transport', function () {
+  it('streams oversized non-Codex stdout and stderr lines without cumulative buffering', async function () {
+    const { createWatcherOutputRuntime } = await import('../task-lib/watcher-output-runtime.js');
+    const logged = [];
+    const inspected = [];
+    const runtime = createWatcherOutputRuntime({
+      config: { outputFormat: 'text' },
+      providerName: 'claude',
+      log: (value) => logged.push(value),
+      stopProvider() {},
+      providerSessionCapture: {
+        captureLine: (line) => inspected.push(line),
+        getCompletionError: () => null,
+        getCompletionUpdate: () => ({}),
+      },
+    });
+    const stdout = `stdout-${'🙂'.repeat(300_000)}-end`;
+    const stderr = `stderr-${'z'.repeat(2 * 1024 * 1024)}-end`;
+    for (const [consume, value] of [
+      [runtime.consumeOutput, stdout],
+      [runtime.consumeStderr, stderr],
+    ]) {
+      const encoded = Buffer.from(`${value}\n`);
+      let buffer = '';
+      for (let offset = 0; offset < encoded.length; offset += 4093) {
+        buffer = consume(buffer, encoded.subarray(offset, offset + 4093));
+        assert.strictEqual(buffer, '');
+      }
+    }
+    runtime.complete({ code: 0, signal: null, outputBuffer: '', stderrBuffer: '' });
+
+    const raw = logged.join('').replace(/^\[\d{13}\]/gm, '');
+    const expected = `${stdout}\n${stderr}\n`;
+    const streamed = raw.slice(0, expected.length);
+    assert.strictEqual(Buffer.byteLength(streamed), Buffer.byteLength(expected));
+    assert.strictEqual(
+      createHash('sha256').update(streamed).digest('hex'),
+      createHash('sha256').update(expected).digest('hex')
+    );
+    assert.match(inspected[0], /omitted from watcher inspection/);
+    assert.match(raw.slice(expected.length), /Finished:.*Exit code: 0, Signal: null/s);
+  });
+});
+
+describe('bounded silent structured output transport', function () {
+  it('preserves bounded Claude structured output larger than 64 KiB', async function () {
+    const { createWatcherOutputRuntime } = await import('../task-lib/watcher-output-runtime.js');
+    const logged = [];
+    const runtime = createWatcherOutputRuntime({
+      config: {
+        outputFormat: 'json',
+        jsonSchema: { type: 'object' },
+        silentJsonOutput: true,
+      },
+      providerName: 'claude',
+      log: (value) => logged.push(value),
+      stopProvider() {},
+    });
+    const record = JSON.stringify({
+      structured_output: { summary: 's'.repeat(128 * 1024), result: 'complete' },
+    });
+    const encoded = Buffer.from(`${record}\n`);
+    let buffer = '';
+    for (let offset = 0; offset < encoded.length; offset += 4093) {
+      buffer = runtime.consumeOutput(buffer, encoded.subarray(offset, offset + 4093));
+    }
+    const completion = runtime.complete({ code: 0, signal: null, outputBuffer: buffer });
+
+    assert.strictEqual(logged.join(''), `${record}\n`);
+    assert.strictEqual(completion.status, 'completed');
+  });
+
+  it('fails oversized silent structured output while preserving its raw bytes', async function () {
+    const { createWatcherOutputRuntime } = await import('../task-lib/watcher-output-runtime.js');
+    const logged = [];
+    let stopCalls = 0;
+    const runtime = createWatcherOutputRuntime({
+      config: {
+        outputFormat: 'json',
+        jsonSchema: { type: 'object' },
+        silentJsonOutput: true,
+      },
+      providerName: 'claude',
+      log: (value) => logged.push(value),
+      stopProvider: () => {
+        stopCalls += 1;
+      },
+    });
+    const record = JSON.stringify({ structured_output: { result: 'x'.repeat(2 * 1024 * 1024) } });
+    const encoded = Buffer.from(`${record}\n`);
+    let buffer = '';
+    for (let offset = 0; offset < encoded.length; offset += 4093) {
+      buffer = runtime.consumeOutput(buffer, encoded.subarray(offset, offset + 4093));
+    }
+    const completion = runtime.complete({ code: 0, signal: null, outputBuffer: buffer });
+
+    const raw = logged.join('').replace(/^\[\d{13}\]/gm, '');
+    assert.strictEqual(raw.slice(0, record.length + 1), `${record}\n`);
+    assert.match(raw.slice(record.length + 1), /\[FATAL\].*inspection limit/);
+    assert.strictEqual(stopCalls, 1);
+    assert.strictEqual(completion.status, 'failed');
+    assert.match(completion.error, /inspection limit/);
+  });
+});
+
+describe('bounded control-plane record transport', function () {
   it('replaces an oversized conductor record with a stable receipt and resumes at the next line', function () {
     const timestamp = '[1777777777777]';
     const oversized = `${timestamp}${'x'.repeat(2 * 1024 * 1024)}`;
@@ -83,17 +193,22 @@ describe('isolated bounded provider output transport', function () {
     const next = `${timestamp}{"type":"turn.completed"}`;
     const input = `${oversized}\n${next}\n`;
     const encoded = Buffer.from(input);
-    const state = {
-      fullOutput: '',
-      lineBuffer: createLogRecordBuffer(),
-      tailDecoder: new StringDecoder('utf8'),
-    };
+    const state = createIsolatedLogState();
+    state.tailDecoder = new StringDecoder('utf8');
     const lines = [];
+    const published = [];
+    const agent = {
+      id: 'isolated-worker',
+      iteration: 1,
+      cluster: { id: 'cluster-1' },
+      messageBus: { publish: (message) => published.push(message) },
+    };
 
     for (let offset = 0; offset < encoded.length; offset += 4093) {
-      consumeIsolatedTailChunk(state, encoded.subarray(offset, offset + 4093), (line) =>
-        lines.push(line)
-      );
+      consumeIsolatedTailChunk(state, encoded.subarray(offset, offset + 4093), (line) => {
+        lines.push(line);
+        broadcastIsolatedLine({ agent, providerName: 'codex', taskId: 'task-1', state, line });
+      });
     }
 
     const expectedDigest = createHash('sha256').update(oversized).digest('hex');
@@ -102,6 +217,9 @@ describe('isolated bounded provider output transport', function () {
         `(byte_length=${Buffer.byteLength(oversized)}, sha256=${expectedDigest})`,
       next,
     ]);
-    assert.strictEqual(state.fullOutput, input);
+    assert.match(state.fullOutput, /Provider output record retained in task log/);
+    assert.match(state.fullOutput, /turn\.completed/);
+    assert.ok(Buffer.byteLength(state.fullOutput) <= CONTROL_PLANE_OUTPUT_LIMITS.maxBytes);
+    assert.strictEqual(published.length, 2);
   });
 });

--- a/tests/cluster-output-export-budget.test.js
+++ b/tests/cluster-output-export-budget.test.js
@@ -1,0 +1,298 @@
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Database = require('better-sqlite3');
+
+const { streamClusterJsonExport } = require('../cli/json-export');
+const Ledger = require('../src/ledger');
+const MessageBus = require('../src/message-bus');
+
+const EXPORT_LIMIT = 64 * 1024 * 1024;
+const CLI_PATH = path.resolve(__dirname, '..', 'cli', 'index.js');
+const RAW_METADATA = { contextSafe: false, replayPolicy: 'raw_log_only' };
+
+const rawOutput = (id, line) => ({
+  id,
+  cluster_id: 'sequence-reservation',
+  topic: 'AGENT_OUTPUT',
+  sender: 'worker',
+  metadata: RAW_METADATA,
+  content: { data: { line } },
+});
+
+function extendDigest(previousDigest, message) {
+  const messageBytes = Buffer.from(JSON.stringify(message));
+  const length = Buffer.allocUnsafe(8);
+  length.writeBigUInt64BE(BigInt(messageBytes.length));
+  return createHash('sha256')
+    .update(Buffer.from(previousDigest, 'hex'))
+    .update(length)
+    .update(messageBytes)
+    .digest('hex');
+}
+
+function insertLegacyMessage(insert, message) {
+  const contentData = message.content?.data ? JSON.stringify(message.content.data) : null;
+  const metadata = message.metadata ? JSON.stringify(message.metadata) : null;
+  const result = insert.run(
+    message.id,
+    message.timestamp,
+    message.topic,
+    message.sender,
+    'broadcast',
+    message.content?.text || null,
+    contentData,
+    metadata,
+    message.cluster_id
+  );
+  const exported = {
+    id: message.id,
+    sequence: String(result.lastInsertRowid),
+    timestamp: message.timestamp,
+    topic: message.topic,
+    sender: message.sender,
+    receiver: 'broadcast',
+    cluster_id: message.cluster_id,
+  };
+  if (message.content) exported.content = message.content;
+  if (message.metadata) exported.metadata = message.metadata;
+  return exported;
+}
+
+function createLegacyDatabase(databasePath, clusterId) {
+  const database = new Database(databasePath);
+  database.exec(`CREATE TABLE messages (
+    id TEXT PRIMARY KEY, timestamp INTEGER NOT NULL, topic TEXT NOT NULL,
+    sender TEXT NOT NULL, receiver TEXT NOT NULL, content_text TEXT,
+    content_data TEXT, metadata TEXT, cluster_id TEXT NOT NULL
+  )`);
+  const insert = database.prepare('INSERT INTO messages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+  const payload = 'x'.repeat(1024 * 1024);
+  const digestPrefixes = [];
+  let digest = '0'.repeat(64);
+  let timestamp = 1800000000000;
+  const add = (id, topic, content, metadata) =>
+    insertLegacyMessage(insert, {
+      id,
+      timestamp: timestamp++,
+      topic,
+      sender: 'worker',
+      cluster_id: clusterId,
+      content,
+      metadata,
+    });
+  const insertAll = database.transaction(() => {
+    for (let record = 0; record < 66; record += 1) {
+      const output = add(
+        `raw-${record}`,
+        'AGENT_OUTPUT',
+        { data: { line: `initial:${record}:${payload}`, record, type: 'text' } },
+        RAW_METADATA
+      );
+      digest = extendDigest(digest, output);
+      digestPrefixes.push(digest);
+      if (record < 24) {
+        add(`control-${record}`, 'EXECUTION_FINISHED', { data: { execution: record } });
+        add(
+          `context-${record}`,
+          'AGENT_OUTPUT',
+          { text: `context-safe-${record}` },
+          { contextSafe: true, replayPolicy: 'context' }
+        );
+      }
+    }
+  });
+  insertAll();
+  return {
+    database,
+    digestPrefixes,
+    insertStale(count) {
+      database.transaction(() => {
+        for (let record = 0; record < count; record += 1) {
+          const output = add(
+            `stale-${digestPrefixes.length}`,
+            'AGENT_OUTPUT',
+            { data: { line: `stale:${record}:${payload}`, record, type: 'text' } },
+            RAW_METADATA
+          );
+          digest = extendDigest(digest, output);
+          digestPrefixes.push(digest);
+        }
+      })();
+    },
+  };
+}
+
+function runCliExport(homeDir, clusterId, outputPath) {
+  const result = spawnSync(
+    process.execPath,
+    [CLI_PATH, 'export', clusterId, '--format', 'json', '--output', outputPath],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: homeDir, NODE_OPTIONS: '--max-old-space-size=128' },
+      timeout: 30000,
+    }
+  );
+  assert.strictEqual(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+}
+
+function findReceipt(ledger, clusterId) {
+  return [...ledger.iterateAll(clusterId)].find((row) => row.metadata?.compactionReceipt);
+}
+
+function runLegacyUpgradeStress() {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-legacy-output-'));
+  const clusterId = 'legacy-output-stress';
+  const databaseDir = path.join(homeDir, '.zeroshot');
+  fs.mkdirSync(databaseDir);
+  const databasePath = path.join(databaseDir, `${clusterId}.db`);
+  const exportPath = path.join(homeDir, 'export.json');
+  const legacy = createLegacyDatabase(databasePath, clusterId);
+  try {
+    assert.ok(fs.statSync(databasePath).size > EXPORT_LIMIT);
+    runCliExport(homeDir, clusterId, exportPath);
+    const directExport = JSON.parse(fs.readFileSync(exportPath, 'utf8'));
+    let ledger = new Ledger(databasePath, { readonly: true });
+    const directCount = ledger.readSnapshot(clusterId).messageCount;
+    const directReceipt = findReceipt(ledger, clusterId);
+    assert.ok(fs.statSync(exportPath).size < EXPORT_LIMIT);
+    assert.strictEqual(directExport.messages.length, directCount);
+    assert.strictEqual(
+      directReceipt.content.data.sha256Chain,
+      legacy.digestPrefixes[directReceipt.content.data.omittedMessages - 1]
+    );
+    ledger.close();
+
+    ledger = new Ledger(databasePath, { readonly: true });
+    ledger.withReadSnapshot(() => {
+      assert.strictEqual(ledger.needsAgentOutputReconciliation(clusterId), false);
+      legacy.insertStale(1);
+      assert.strictEqual(legacy.database.pragma('journal_mode', { simple: true }), 'wal');
+      streamClusterJsonExport({ ledger, clusterId, outputPath: exportPath });
+    });
+    ledger.close();
+    assert.strictEqual(JSON.parse(fs.readFileSync(exportPath)).messages.length, directCount);
+    legacy.insertStale(59);
+    runCliExport(homeDir, clusterId, exportPath);
+    const repaired = JSON.parse(fs.readFileSync(exportPath));
+    ledger = new Ledger(databasePath, { readonly: true });
+    const repairedCount = ledger.readSnapshot(clusterId).messageCount;
+    const repairedReceipt = findReceipt(ledger, clusterId);
+    assert.ok(fs.statSync(exportPath).size < EXPORT_LIMIT);
+    assert.strictEqual(repaired.messages.length, repairedCount);
+    assert.strictEqual(
+      repairedReceipt.content.data.sha256Chain,
+      legacy.digestPrefixes[repairedReceipt.content.data.omittedMessages - 1]
+    );
+    ledger.close();
+    runCliExport(homeDir, clusterId, exportPath);
+    assert.strictEqual(JSON.parse(fs.readFileSync(exportPath)).messages.length, repairedCount);
+
+    ledger = new Ledger(databasePath);
+    const messageBus = new MessageBus(ledger);
+    let liveOutput = 0;
+    const unsubscribe = messageBus.subscribeTopic('AGENT_OUTPUT', () => (liveOutput += 1));
+    messageBus.publish({
+      cluster_id: clusterId,
+      topic: 'AGENT_OUTPUT',
+      sender: 'worker',
+      metadata: RAW_METADATA,
+      content: { data: { line: 'newest-live-terminal', type: 'text' } },
+    });
+    assert.strictEqual(liveOutput, 1);
+    const messageCount = ledger.readSnapshot(clusterId).messageCount;
+    unsubscribe();
+    messageBus.close();
+
+    runCliExport(homeDir, clusterId, exportPath);
+    const exported = JSON.parse(fs.readFileSync(exportPath, 'utf8'));
+    assert.ok(fs.statSync(exportPath).size < EXPORT_LIMIT);
+    assert.strictEqual(exported.messages.length, messageCount);
+    assert.strictEqual(
+      exported.messages.filter((row) => row.topic === 'EXECUTION_FINISHED').length,
+      24
+    );
+    assert.strictEqual(exported.messages.filter((row) => row.metadata?.contextSafe).length, 24);
+    assert.ok(exported.messages.some((row) => row.content?.data?.line === 'newest-live-terminal'));
+  } finally {
+    legacy.database.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+function runSinkFailureRegression() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-export-sink-'));
+  const ledger = new Ledger(':memory:');
+  ledger.append({ cluster_id: 'sink', topic: 'CONTROL', sender: 'worker', content: { text: 'x' } });
+  const iterator = ledger.iterateAll('sink');
+  const lifecycle = [];
+  ledger.iterateAll = () => ({
+    next: () => iterator.next(),
+    return: () => {
+      lifecycle.push('iterator');
+      return iterator.return();
+    },
+  });
+  const originalWrite = fs.writeSync;
+  const originalClose = fs.closeSync;
+  let writes = 0;
+  fs.writeSync = (...args) => {
+    if ((writes += 1) === 3) throw new Error('injected sink failure');
+    return originalWrite(...args);
+  };
+  fs.closeSync = (...args) => {
+    lifecycle.push('destination');
+    return originalClose(...args);
+  };
+  try {
+    assert.throws(
+      () =>
+        streamClusterJsonExport({ ledger, clusterId: 'sink', outputPath: path.join(tempDir, 'x') }),
+      /injected sink failure/
+    );
+  } finally {
+    fs.writeSync = originalWrite;
+    fs.closeSync = originalClose;
+  }
+  ledger.close();
+  lifecycle.push('ledger');
+  assert.deepStrictEqual(lifecycle, ['iterator', 'destination', 'ledger']);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+function runSequenceReservationRegression() {
+  const ledger = new Ledger(':memory:');
+  const oversized = 'o'.repeat(Ledger.AGENT_OUTPUT_EXPORT_LIMITS.maxBytes + 1024);
+  const sequences = [
+    ledger.append(rawOutput('oversized-first', oversized)).sequence,
+    ledger.append(rawOutput('oversized-second', oversized)).sequence,
+    ...ledger
+      .batchAppend([
+        rawOutput('oversized-batch', oversized),
+        rawOutput('small-batch', 'batch-terminal'),
+      ])
+      .map((row) => row.sequence),
+    ledger.append(rawOutput('small-final', 'final-terminal')).sequence,
+  ];
+  assert.strictEqual(new Set(sequences).size, sequences.length);
+  for (let index = 1; index < sequences.length; index += 1) {
+    assert.ok(BigInt(sequences[index]) > BigInt(sequences[index - 1]));
+  }
+  const afterFirst = ledger.query({ cluster_id: 'sequence-reservation', afterId: sequences[0] });
+  const receipt = afterFirst.find((row) => row.metadata?.compactionReceipt);
+  assert.deepStrictEqual(
+    afterFirst.map((row) => row.sequence),
+    [receipt.sequence, sequences[3], sequences[4]]
+  );
+  ledger.close();
+}
+
+describe('cluster-wide provider-output export budget', function () {
+  this.timeout(120000);
+  it('reconciles and exports a >64 MiB legacy ledger under 128 MiB', runLegacyUpgradeStress);
+  it('closes export resources in order on sink failure', runSinkFailureRegression);
+  it('never reuses deleted oversized output sequences', runSequenceReservationRegression);
+});

--- a/tests/cumulative-provider-output.test.js
+++ b/tests/cumulative-provider-output.test.js
@@ -1,0 +1,227 @@
+const assert = require('assert');
+
+const {
+  CONTROL_PLANE_OUTPUT_LIMITS,
+  appendControlPlaneRecord,
+  broadcastAgentLine,
+  broadcastIsolatedLine,
+  buildCompletionResult,
+  createIsolatedLogState,
+  createLogFollowState,
+  flushAgentOutput,
+  flushIsolatedOutput,
+} = require('../src/agent/agent-task-executor');
+
+function makeAgent(messages, outputFormat = 'json') {
+  return {
+    id: 'stress-worker',
+    role: 'implementation',
+    iteration: 1,
+    config: { outputFormat, cwd: process.cwd() },
+    _publish: (message) => messages.push(message),
+    _parseResultOutput: (output) => {
+      for (const line of output.trim().split('\n').reverse()) {
+        try {
+          const parsed = JSON.parse(line);
+          if (parsed.structured_output) return parsed.structured_output;
+        } catch {
+          // Continue through non-JSON diagnostic lines.
+        }
+      }
+      throw new Error('missing structured output');
+    },
+  };
+}
+
+function broadcastStressRecords({ agent, state, count = 5000 }) {
+  const payload = 'x'.repeat(2048);
+  for (let index = 0; index < count; index++) {
+    broadcastAgentLine({
+      agent,
+      providerName: 'codex',
+      state,
+      line: `[1777777777777]${JSON.stringify({ type: 'item.completed', index, payload })}`,
+    });
+  }
+}
+
+function assertControlPlaneIsBounded(messages, output) {
+  const publishedBytes = messages.reduce(
+    (total, message) => total + Buffer.byteLength(message.content.data.line),
+    0
+  );
+  assert.ok(Buffer.byteLength(output) <= CONTROL_PLANE_OUTPUT_LIMITS.maxBytes);
+  assert.ok(
+    publishedBytes <= CONTROL_PLANE_OUTPUT_LIMITS.liveBytes + CONTROL_PLANE_OUTPUT_LIMITS.maxBytes
+  );
+  assert.ok(
+    messages.length <=
+      CONTROL_PLANE_OUTPUT_LIMITS.liveRecords + CONTROL_PLANE_OUTPUT_LIMITS.maxRecords + 1
+  );
+}
+
+describe('bounded cumulative provider output', function () {
+  it('retains the terminal structured result after many small records', async function () {
+    const messages = [];
+    const agent = makeAgent(messages);
+    const state = createLogFollowState();
+    broadcastStressRecords({ agent, state });
+    broadcastAgentLine({
+      agent,
+      providerName: 'codex',
+      state,
+      line: `[1777777777777]${JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        structured_output: { answer: 'terminal-success' },
+      })}`,
+    });
+    flushAgentOutput(agent, 'codex', state);
+
+    const result = await buildCompletionResult({
+      agent,
+      taskId: 'stress-success',
+      providerName: 'codex',
+      state,
+      stdout: 'Status: completed',
+      success: true,
+      taskInfo: null,
+    });
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.parsedResult, { answer: 'terminal-success' });
+    assert.match(result.output, /Earlier provider output omitted/);
+    assert.ok(messages.some((message) => message.content.data.line.includes('terminal-success')));
+    assert.ok(messages.every((message) => message.content.text === undefined));
+    assertControlPlaneIsBounded(messages, result.output);
+  });
+
+  it('retains provider failure diagnostics after many small records', async function () {
+    const messages = [];
+    const agent = makeAgent(messages, 'text');
+    const state = createLogFollowState();
+    broadcastStressRecords({ agent, state });
+    broadcastAgentLine({
+      agent,
+      providerName: 'codex',
+      state,
+      line: '[1777777777777]Error: provider exploded after prolonged output',
+    });
+    flushAgentOutput(agent, 'codex', state);
+    const result = await buildCompletionResult({
+      agent,
+      taskId: 'stress-failure',
+      providerName: 'codex',
+      state,
+      stdout: 'Status: failed',
+      success: false,
+      taskInfo: null,
+    });
+    assert.strictEqual(result.success, false);
+    assert.match(result.output, /provider exploded after prolonged output/);
+    assert.match(result.error, /provider exploded after prolonged output/);
+    assertControlPlaneIsBounded(messages, result.output);
+  });
+
+  it('bounds isolated success and failure tails', function () {
+    for (const terminal of ['isolated-terminal-success', 'Error: isolated provider exploded']) {
+      const state = createIsolatedLogState();
+      const published = [];
+      const agent = {
+        id: 'isolated-stress-worker',
+        iteration: 1,
+        cluster: { id: 'cluster-1' },
+        messageBus: { publish: (message) => published.push(message) },
+      };
+      const payload = 'y'.repeat(2048);
+      for (let index = 0; index < 5000; index++) {
+        broadcastIsolatedLine({
+          agent,
+          providerName: 'codex',
+          taskId: 'isolated-stress',
+          state,
+          line: JSON.stringify({ type: 'item.completed', index, payload }),
+        });
+      }
+      broadcastIsolatedLine({
+        agent,
+        providerName: 'codex',
+        taskId: 'isolated-stress',
+        state,
+        line: terminal,
+      });
+      flushIsolatedOutput(agent, 'codex', 'isolated-stress', state);
+      assert.ok(Buffer.byteLength(state.fullOutput) <= CONTROL_PLANE_OUTPUT_LIMITS.maxBytes);
+      assert.match(state.fullOutput, /Earlier provider output omitted/);
+      assert.ok(state.fullOutput.includes(terminal));
+      assert.ok(published.some((message) => message.content.data.line.includes(terminal)));
+    }
+  });
+});
+
+describe('bounded terminal output drain', function () {
+  it('drains just-over-limit records exactly once', function () {
+    const messages = [];
+    const agent = makeAgent(messages, 'text');
+    const state = createLogFollowState();
+    broadcastStressRecords({ agent, state, count: 300 });
+    assert.strictEqual(state.controlPlaneOutput.liveSuppressed, true);
+    flushAgentOutput(agent, 'codex', state);
+    flushAgentOutput(agent, 'codex', state);
+    const indexes = messages
+      .map((message) => {
+        try {
+          return JSON.parse(message.content.data.line).index;
+        } catch {
+          return null;
+        }
+      })
+      .filter(Number.isInteger);
+    assert.deepStrictEqual(
+      indexes,
+      Array.from({ length: 300 }, (_, index) => index)
+    );
+  });
+
+  it('publishes a small record captured only during terminal drain', function () {
+    const messages = [];
+    const agent = makeAgent(messages, 'text');
+    const state = createLogFollowState();
+    appendControlPlaneRecord(state.controlPlaneOutput, {
+      content: 'final record captured during terminal drain',
+      timestamp: 1777777777777,
+      type: 'text',
+    });
+    flushAgentOutput(agent, 'codex', state);
+    assert.strictEqual(messages.length, 1);
+    assert.strictEqual(
+      messages[0].content.data.line,
+      'final record captured during terminal drain'
+    );
+  });
+
+  it('keeps 112 MiB of small-record output bounded in 128 MiB heaps', function () {
+    const messages = [];
+    const agent = makeAgent(messages, 'text');
+    const state = createLogFollowState();
+    const payload = 'm'.repeat(64 * 1024);
+    const recordCount = 1792;
+    for (let index = 0; index < recordCount; index++) {
+      broadcastAgentLine({
+        agent,
+        providerName: 'codex',
+        state,
+        line: `[1777777777777]${index}:${payload}`,
+      });
+    }
+    broadcastAgentLine({
+      agent,
+      providerName: 'codex',
+      state,
+      line: '[1777777777777]terminal-after-112-mib',
+    });
+    flushAgentOutput(agent, 'codex', state);
+    assert.ok(recordCount * Buffer.byteLength(payload) >= 112 * 1024 * 1024);
+    assert.match(state.output, /terminal-after-112-mib/);
+    assertControlPlaneIsBounded(messages, state.output);
+  });
+});

--- a/tests/e2e/codex-terminal-stress.test.js
+++ b/tests/e2e/codex-terminal-stress.test.js
@@ -1,0 +1,171 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Database = require('better-sqlite3');
+
+const { setupE2ERepo, cleanupE2ERepo, runZeroshot } = require('./helpers/e2e-harness');
+
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'codex-terminal-stress-config.json');
+const FAKE_CODEX_PATH = path.resolve(__dirname, '..', 'fixtures', 'fake-codex-terminal-stress.js');
+const STRESS_BYTES = 12 * 1024 * 1024;
+const MAX_EXPORTED_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024;
+const BENCHMARK_AGENT_FIELDS = [
+  'currentTask',
+  'currentTaskId',
+  'id',
+  'iteration',
+  'maxIterations',
+  'model',
+  'modelSpec',
+  'pid',
+  'provider',
+  'role',
+  'state',
+];
+
+function assertBenchmarkAgentContract(agent) {
+  assert.deepStrictEqual(Object.keys(agent).sort(), BENCHMARK_AGENT_FIELDS);
+  for (const name of ['id', 'role', 'state']) {
+    assert.ok(typeof agent[name] === 'string' && agent[name], `${name} must be nonempty text`);
+  }
+  for (const name of ['iteration', 'maxIterations']) {
+    assert.ok(Number.isInteger(agent[name]) && agent[name] >= 0, `${name} must be nonnegative`);
+  }
+  for (const name of ['model', 'provider', 'currentTaskId']) {
+    assert.ok(
+      agent[name] === null || typeof agent[name] === 'string',
+      `${name} must be optional text`
+    );
+  }
+  assert.strictEqual(typeof agent.currentTask, 'boolean');
+  assert.ok(agent.pid === null || (Number.isInteger(agent.pid) && agent.pid > 1));
+  assert.ok(agent.modelSpec && typeof agent.modelSpec === 'object');
+  assert.ok(
+    Object.keys(agent.modelSpec).every((name) =>
+      ['level', 'model', 'reasoningEffort'].includes(name)
+    )
+  );
+  assert.ok(
+    Object.values(agent.modelSpec).every((value) => value === null || typeof value === 'string')
+  );
+}
+
+function readTaskLog(homeDir) {
+  const storePath = path.join(homeDir, '.claude-zeroshot', 'store.db');
+  const database = new Database(storePath, { readonly: true, fileMustExist: true });
+  try {
+    const tasks = database.prepare('SELECT status, error, log_file FROM tasks').all();
+    assert.strictEqual(tasks.length, 1, `expected one real provider task, got ${tasks.length}`);
+    assert.strictEqual(tasks[0].status, 'completed', tasks[0].error || 'task did not complete');
+    return fs.readFileSync(tasks[0].log_file, 'utf8');
+  } finally {
+    database.close();
+  }
+}
+
+function extractProviderOutput(rawLog) {
+  const lines = rawLog.replaceAll('\r\n', '\n').split('\n');
+  const normalized = lines.map((line) => line.replace(/^\[\d{13}\]/, ''));
+  const start = normalized.findIndex((line) => line.includes('"type":"thread.started"'));
+  const end = normalized.findIndex(
+    (line, index) => index >= start && line.includes('"type":"turn.completed"')
+  );
+  assert.ok(start >= 0, 'raw task log must contain the first provider record');
+  assert.ok(end >= start, 'raw task log must contain the terminal provider record');
+  return `${normalized.slice(start, end + 1).join('\n')}\n`;
+}
+
+describe('e2e: Codex compressed terminal stress', function () {
+  this.timeout(90000);
+
+  let env;
+  let issueDir;
+
+  beforeEach(() => {
+    env = setupE2ERepo();
+    issueDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-terminal-stress-'));
+    fs.symlinkSync(FAKE_CODEX_PATH, path.join(env.binDir, 'codex'));
+  });
+
+  afterEach(() => {
+    cleanupE2ERepo(env);
+    fs.rmSync(issueDir, { recursive: true, force: true });
+  });
+
+  it('bounds the control plane while preserving the raw log and terminal export', function () {
+    const issuePath = path.join(issueDir, 'task.md');
+    const expectedOutputPath = path.join(issueDir, 'expected-provider-output.jsonl');
+    const exportPath = path.join(issueDir, 'cluster-export.json');
+    fs.writeFileSync(issuePath, '# Synthetic terminal stress\n');
+
+    const clusterId = 'e2e-codex-terminal-stress';
+    const run = runZeroshot(
+      env,
+      [
+        'run',
+        issuePath,
+        '--config',
+        CONFIG_PATH,
+        '--provider',
+        'codex',
+        '--model',
+        'gpt-5.6-luna',
+        '--strict-schema',
+        '--sim',
+        'off',
+      ],
+      {
+        ZEROSHOT_CLUSTER_ID: clusterId,
+        FAKE_CODEX_EXPECTED_OUTPUT: expectedOutputPath,
+        FAKE_CODEX_STRESS_BYTES: String(STRESS_BYTES),
+      }
+    );
+    assert.strictEqual(run.status, 0, `STDOUT:\n${run.stdout}\nSTDERR:\n${run.stderr}`);
+
+    const rawLog = readTaskLog(env.homeDir);
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8');
+    assert.ok(Buffer.byteLength(expectedOutput) > STRESS_BYTES);
+    assert.strictEqual(extractProviderOutput(rawLog), expectedOutput);
+
+    const statusResult = runZeroshot(env, ['status', clusterId, '--json']);
+    assert.strictEqual(
+      statusResult.status,
+      0,
+      `STDOUT:\n${statusResult.stdout}\nSTDERR:\n${statusResult.stderr}`
+    );
+    const status = JSON.parse(statusResult.stdout);
+    assert.strictEqual(status.state, 'stopped');
+    assert.strictEqual(status.isZombie, false);
+    assert.strictEqual(status.pid, null);
+    assert.ok(Array.isArray(status.agents) && status.agents.length === 2);
+    status.agents.forEach(assertBenchmarkAgentContract);
+
+    const exportResult = runZeroshot(env, [
+      'export',
+      clusterId,
+      '--format',
+      'json',
+      '--output',
+      exportPath,
+    ]);
+    assert.strictEqual(exportResult.status, 0, exportResult.stderr);
+    const exported = JSON.parse(fs.readFileSync(exportPath, 'utf8'));
+    assert.strictEqual(exported.cluster_id, clusterId);
+    assert.strictEqual(exported.messages.length, status.messageCount);
+    assert.strictEqual(
+      exported.messages.filter((message) =>
+        ['CLUSTER_COMPLETE', 'CLUSTER_FAILED'].includes(message.topic)
+      ).length,
+      1
+    );
+
+    const exportedAgentOutputBytes = exported.messages
+      .filter((message) => message.topic === 'AGENT_OUTPUT')
+      .reduce((total, message) => total + Buffer.byteLength(JSON.stringify(message)), 0);
+    assert.ok(
+      exportedAgentOutputBytes <= MAX_EXPORTED_AGENT_OUTPUT_BYTES,
+      `control-plane agent output was ${exportedAgentOutputBytes} bytes`
+    );
+  });
+});

--- a/tests/e2e/fixtures/codex-terminal-stress-config.json
+++ b/tests/e2e/fixtures/codex-terminal-stress-config.json
@@ -1,0 +1,26 @@
+{
+  "defaultProvider": "codex",
+  "agents": [
+    {
+      "id": "worker",
+      "role": "implementation",
+      "modelLevel": "level1",
+      "reasoningEffort": "max",
+      "timeout": 0,
+      "triggers": [{ "topic": "ISSUE_OPENED", "action": "execute_task" }],
+      "prompt": "Complete the synthetic terminal stress task.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": { "topic": "TASK_COMPLETE", "content": { "text": "Done" } }
+        }
+      }
+    },
+    {
+      "id": "completion-detector",
+      "role": "orchestrator",
+      "timeout": 0,
+      "triggers": [{ "topic": "TASK_COMPLETE", "action": "stop_cluster" }]
+    }
+  ]
+}

--- a/tests/fixtures/fake-codex-terminal-stress.js
+++ b/tests/fixtures/fake-codex-terminal-stress.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+function writeChunked(buffer) {
+  return new Promise((resolve, reject) => {
+    let offset = 0;
+    const writeNext = () => {
+      while (offset < buffer.length) {
+        const next = Math.min(buffer.length, offset + 4093);
+        if (!process.stdout.write(buffer.subarray(offset, next))) {
+          offset = next;
+          process.stdout.once('drain', writeNext);
+          return;
+        }
+        offset = next;
+      }
+      resolve();
+    };
+    process.stdout.on('error', reject);
+    writeNext();
+  });
+}
+
+function providerOutput() {
+  const targetBytes = Number(process.env.FAKE_CODEX_STRESS_BYTES || 12 * 1024 * 1024);
+  const recordPayload = 'medium-output-🌍'.repeat(2048);
+  const lines = [JSON.stringify({ type: 'thread.started', thread_id: 'fake-stress-thread' })];
+  let outputBytes = Buffer.byteLength(lines[0]) + 1;
+  let index = 0;
+
+  while (outputBytes < targetBytes) {
+    const line = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: `command-${index}`,
+        type: 'command_execution',
+        command: `stress-command-${index}`,
+        aggregated_output: `${recordPayload}:${index}`,
+        exit_code: 0,
+      },
+    });
+    lines.push(line);
+    outputBytes += Buffer.byteLength(line) + 1;
+    index += 1;
+  }
+
+  lines.push(
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'oversized-command',
+        type: 'command_execution',
+        command: 'oversized-command',
+        aggregated_output: 'oversized-output'.repeat(96 * 1024),
+        exit_code: 0,
+      },
+    })
+  );
+  lines.push(
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        type: 'agent_message',
+        text: JSON.stringify({
+          summary: 'Synthetic terminal stress completed',
+          result: 'UTF-8 and final structured output survived 🌍',
+        }),
+      },
+    })
+  );
+  lines.push(
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 0, output_tokens: 0 },
+    })
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  if (process.argv.includes('--version')) {
+    process.stdout.write('codex-cli 0.147.0\n');
+    return;
+  }
+  if (process.argv.includes('--help')) {
+    process.stdout.write(
+      'codex exec --json --output-schema -m -C --config --skip-git-repo-check ' +
+        '--sandbox --ephemeral --ignore-user-config --ignore-rules --strict-config resume\n'
+    );
+    return;
+  }
+
+  const output = providerOutput();
+  const expectedPath = process.env.FAKE_CODEX_EXPECTED_OUTPUT;
+  if (!expectedPath) throw new Error('FAKE_CODEX_EXPECTED_OUTPUT is required');
+  fs.writeFileSync(expectedPath, output);
+  await writeChunked(Buffer.from(output));
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tests/helpers/isolated-task-recovery-fixture.js
+++ b/tests/helpers/isolated-task-recovery-fixture.js
@@ -37,6 +37,7 @@ function createIsolationManager({
   unverifiableKillAttempts = 0,
   terminalStatusOnKill = null,
 } = {}) {
+  const providerOutput = '{"summary":"done","result":"ok"}\n';
   const commands = [];
   let taskStatus = status;
   let remainingKillCommandFailures = killCommandFailures;
@@ -104,8 +105,11 @@ function createIsolationManager({
           stderr: '',
         };
       }
-      if (commandText.includes('cat')) {
-        return { code: 0, stdout: '{"summary":"done","result":"ok"}\n', stderr: '' };
+      if (commandText.includes('wc -c')) {
+        return { code: 0, stdout: `${Buffer.byteLength(providerOutput)}\n`, stderr: '' };
+      }
+      if (commandText.includes('tail -c')) {
+        return { code: 0, stdout: providerOutput, stderr: '' };
       }
       throw new Error(`Unexpected isolated command: ${command.join(' ')}`);
     },

--- a/tests/isolated-task-launch-recovery.test.js
+++ b/tests/isolated-task-launch-recovery.test.js
@@ -7,6 +7,7 @@ const {
   killTask,
   spawnClaudeTaskIsolated,
 } = require('../src/agent/agent-task-executor');
+const { createStructuredOutputInvalidError } = require('../src/agent/structured-output-error');
 
 const { serializeTaskStartupError } = require('../src/task-startup-error');
 const OWNERSHIP_ENV = 'ZEROSHOT_TASK_SPAWN_OWNERSHIP_TOKEN';
@@ -333,6 +334,7 @@ describe('Isolated terminal cleanup recovery', function () {
 
   it('retains a terminal follower until persisted cleanup recovery succeeds', async function () {
     const commands = [];
+    const providerOutput = '{"summary":"done","result":"ok"}\n';
     let cleanupPending = true;
     let cleanupAttempts = 0;
     const manager = {
@@ -364,10 +366,17 @@ describe('Isolated terminal cleanup recovery', function () {
           cleanupPending = false;
           return Promise.resolve({ code: 0, stdout: 'cleanup recovered\n', stderr: '' });
         }
-        if (commandText.includes('cat')) {
+        if (commandText.includes('wc -c')) {
           return Promise.resolve({
             code: 0,
-            stdout: '{"summary":"done","result":"ok"}\n',
+            stdout: `${Buffer.byteLength(providerOutput)}\n`,
+            stderr: '',
+          });
+        }
+        if (commandText.includes('tail -c')) {
+          return Promise.resolve({
+            code: 0,
+            stdout: providerOutput,
             stderr: '',
           });
         }
@@ -414,6 +423,8 @@ describe('Isolated terminal cleanup recovery', function () {
   it('validates stale isolated output without launching recovery', async function () {
     this.timeout(5000);
     let parserOptions;
+    const published = [];
+    const providerOutput = '{"wrong":true}\n';
     const manager = {
       spawnInContainer() {
         return createProcess();
@@ -426,8 +437,15 @@ describe('Isolated terminal cleanup recovery', function () {
         if (commandText.includes('status')) {
           return Promise.resolve({ code: 0, stdout: 'Status: stale\n', stderr: '' });
         }
-        if (commandText.includes('cat')) {
-          return Promise.resolve({ code: 0, stdout: '{"wrong":true}\n', stderr: '' });
+        if (commandText.includes('wc -c')) {
+          return Promise.resolve({
+            code: 0,
+            stdout: `${Buffer.byteLength(providerOutput)}\n`,
+            stderr: '',
+          });
+        }
+        if (commandText.includes('tail -c')) {
+          return Promise.resolve({ code: 0, stdout: providerOutput, stderr: '' });
         }
         throw new Error(`Unexpected command: ${commandText}`);
       },
@@ -451,20 +469,24 @@ describe('Isolated terminal cleanup recovery', function () {
       timeout: 0,
       enableLivenessCheck: false,
       quiet: true,
-      messageBus: { publish() {} },
+      messageBus: { publish: (message) => published.push(message) },
       _resolveProvider: () => 'codex',
       _parseResultOutput(_output, options) {
         parserOptions = options;
-        return Promise.reject(new Error('stale schema-invalid output'));
+        return Promise.reject(
+          createStructuredOutputInvalidError('stale schema-invalid output', 'schema')
+        );
       },
       _stopLivenessCheck() {},
       _log() {},
     };
 
-    const result = await followClaudeTaskLogsIsolated(agent, agent.currentTaskId);
+    await assert.rejects(
+      followClaudeTaskLogsIsolated(agent, agent.currentTaskId),
+      /stale schema-invalid output/
+    );
 
     assert.deepStrictEqual(parserOptions, { allowRecovery: false });
-    assert.strictEqual(result.success, false);
-    assert.match(result.error, /stale schema-invalid output/);
+    assert.ok(published.some((message) => message.content.data.line.includes('wrong')));
   });
 });

--- a/tests/opencode-nested-model-provenance.test.js
+++ b/tests/opencode-nested-model-provenance.test.js
@@ -258,6 +258,7 @@ describe('Isolated opencode structured-output recovery', function () {
       properties: { plan: { type: 'string' } },
       required: ['plan'],
     };
+    const recoveredOutput = opencodeTextEvent({ plan: 'isolated recovery' });
     const spawnedCommands = [];
     let spawnCount = 0;
     const manager = {
@@ -288,10 +289,17 @@ describe('Isolated opencode structured-output recovery', function () {
         if (rendered.includes('zeroshot status')) {
           return Promise.resolve({ code: 0, stdout: 'Status: completed\n', stderr: '' });
         }
-        if (rendered.includes('cat "/tmp/reformat.log"')) {
+        if (rendered.includes('wc -c < "/tmp/reformat.log"')) {
           return Promise.resolve({
             code: 0,
-            stdout: opencodeTextEvent({ plan: 'isolated recovery' }),
+            stdout: `${Buffer.byteLength(recoveredOutput)}\n`,
+            stderr: '',
+          });
+        }
+        if (rendered.includes('tail -c') && rendered.includes('"/tmp/reformat.log"')) {
+          return Promise.resolve({
+            code: 0,
+            stdout: recoveredOutput,
             stderr: '',
           });
         }
@@ -712,6 +720,7 @@ describe('Isolated opencode structured-output recovery', function () {
     let finalReadCount = 0;
     let spawnCount = 0;
     let tailKills = 0;
+    const lateOutput = opencodeTextEvent({ plan: 'too late' });
     const manager = {
       getContainerEnvironmentValue() {
         return null;
@@ -740,7 +749,11 @@ describe('Isolated opencode structured-output recovery', function () {
         if (rendered.includes('zeroshot status')) {
           return Promise.resolve({ code: 0, stdout: 'Status: completed\n', stderr: '' });
         }
-        if (rendered.includes('cat "/tmp/terminal-drain.log"')) {
+        if (rendered.includes('wc -c < "/tmp/terminal-drain.log"')) {
+          const stdout = `${Buffer.byteLength(lateOutput)}\n`;
+          return Promise.resolve({ code: 0, stdout, stderr: '' });
+        }
+        if (rendered.includes('tail -c') && rendered.includes('"/tmp/terminal-drain.log"')) {
           finalReadCount++;
           return new Promise((resolve) => {
             resolveFinalRead = resolve;
@@ -794,7 +807,7 @@ describe('Isolated opencode structured-output recovery', function () {
     assert.strictEqual(tailKills, 1);
     assert.strictEqual(agent.nestedExecutions.size, 0);
 
-    resolveFinalRead({ code: 0, stdout: opencodeTextEvent({ plan: 'too late' }), stderr: '' });
+    resolveFinalRead({ code: 0, stdout: lateOutput, stderr: '' });
     await new Promise((resolve) => setImmediate(resolve));
     assert.strictEqual(finalReadCount, 1);
     assert.strictEqual(spawnCount, 2);

--- a/tests/template-resolver-typed-values.test.js
+++ b/tests/template-resolver-typed-values.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const path = require('path');
+
+const { DEFAULT_MAX_ITERATIONS } = require('../src/agent/agent-config');
+const { getConfig } = require('../src/config-router');
+const TemplateResolver = require('../src/template-resolver');
+
+describe('TemplateResolver typed placeholders', function () {
+  const templatesDir = path.join(__dirname, '..', 'cluster-templates');
+  const resolver = new TemplateResolver(templatesDir);
+
+  it('preserves exact JSON types while embedded values remain strings', function () {
+    const resolved = resolver.resolveTemplate(
+      {
+        params: {
+          count: {},
+          enabled: {},
+          settings: {},
+        },
+        exact: {
+          count: '{{count}}',
+          enabled: '{{enabled}}',
+          settings: '{{settings}}',
+        },
+        embedded: 'count={{count}}, enabled={{enabled}}',
+      },
+      {
+        count: 7,
+        enabled: false,
+        settings: { retries: 2, labels: ['fast', 'local'] },
+      }
+    );
+
+    assert.strictEqual(resolved.exact.count, 7);
+    assert.strictEqual(typeof resolved.exact.count, 'number');
+    assert.strictEqual(resolved.exact.enabled, false);
+    assert.strictEqual(typeof resolved.exact.enabled, 'boolean');
+    assert.deepStrictEqual(resolved.exact.settings, {
+      retries: 2,
+      labels: ['fast', 'local'],
+    });
+    assert.strictEqual(typeof resolved.exact.settings, 'object');
+    assert.strictEqual(resolved.embedded, 'count=7, enabled=false');
+    assert.strictEqual(typeof resolved.embedded, 'string');
+  });
+
+  for (const [complexity, taskType, agentId] of [
+    ['SIMPLE', 'TASK', 'worker'],
+    ['STANDARD', 'TASK', 'worker'],
+    ['SIMPLE', 'DEBUG', 'fixer'],
+  ]) {
+    it(`preserves numeric maxIterations for ${complexity} ${taskType}`, function () {
+      const { base, params } = getConfig(complexity, taskType);
+      const resolved = resolver.resolve(base, params);
+      const agent = resolved.agents.find((candidate) => candidate.id === agentId);
+
+      assert.ok(agent, `${agentId} should be present`);
+      assert.strictEqual(agent.maxIterations, DEFAULT_MAX_ITERATIONS);
+      assert.strictEqual(typeof agent.maxIterations, 'number');
+    });
+  }
+});

--- a/tests/unit/start-cluster-config.test.js
+++ b/tests/unit/start-cluster-config.test.js
@@ -48,7 +48,7 @@ describe('start-cluster config loading', function () {
     assert.strictEqual(config.params, undefined);
     assert.strictEqual(config.defaultProvider, 'claude');
     assert.strictEqual(config.agents[0].modelLevel, 'level3');
-    assert.strictEqual(config.agents[0].timeout, '0');
+    assert.strictEqual(config.agents[0].timeout, 0);
     assert.strictEqual(config.agents[0].prompt.system, 'Plan a TASK');
   });
 });


### PR DESCRIPTION
## Summary

- preserve native JSON types for exact whole-value template placeholders while retaining string interpolation for embedded placeholders
- keep complete provider bytes in task logs while bounding watcher inspection, local/isolated control-plane tails, cumulative live publication, and terminal drain
- replace isolated whole-log terminal reads with byte-counted bounded tail catch-up and flush terminal output before structured-result parsing
- enforce a durable cluster-wide budget for non-replayable `AGENT_OUTPUT`, with deterministic omission receipts and monotonic persisted message sequences
- stream JSON exports under a stable read snapshot, reconcile legacy or stale compaction state, and fail after bounded repair attempts instead of emitting an oversized/unverified artifact

## Why

Long-running tasks could remain bounded per physical record yet still accumulate unbounded memory and export state across thousands of smaller records or repeated executions. A typed template placeholder could also turn numeric workflow controls into strings, surfacing only when dynamically loaded agents were inspected late in a run.

This change makes the raw task log the complete-output authority and keeps the control plane/export deliberately bounded without dropping terminal diagnostics or replayable control context.

## Validation

- `npm test` — 2,753 passing, 18 pending
- `npm run test:e2e` — 26 passing
- 128 MiB heap stress: 112 MiB cumulative provider output, oversized physical JSONL, repeated cluster executions, direct export of untouched/stale >64 MiB legacy ledgers
- exact stale pre-upgrade writer repro: second direct export remains ~7.34 MiB after 60 additional 1 MiB implicit inserts
- forced perpetual-staleness export fails in <1s after three repairs without creating/truncating the destination
- `npm run lint` — 0 errors (repository baseline warnings only)
- `npm run typecheck`
- `npm run audit:production`
- `npm run opcore:check`
- `opcore check --changed`
- changed-file Prettier and `git diff --check`
- `npm pack --dry-run --json` — 1,011 files, package build successful
- release preflight — patch from v6.34.1

Follow-up hardening to #965.

Fixes #966