### PR TITLE
fix: persist provider terminal failures safely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -807,6 +807,12 @@ isolated followers retain a bounded complete-record tail for parsing and diagnos
 terminal settlement. Isolated settlement re-reads only a fixed-size file tail; the raw task log is
 the sole complete-output authority. Never restore whole-record watcher buffering, cumulative output
 strings, whole-log terminal reads, or unbounded provider records/events in control-plane state.
+Provider terminal failures are parsed from the newest typed terminal event before generic status
+text. Raw provider diagnostics remain task-log-only; `AGENT_OUTPUT`, `failureInfo`, `AGENT_ERROR`,
+and `CLUSTER_FAILED` retain only a synthesized error plus provider/event/category/retryability and
+byte-length/SHA-256 receipt. Final critical-agent exhaustion installs `failureInfo` before emitting
+exactly one durable `CLUSTER_FAILED`; the legacy `AGENT_ERROR` stop fallback must not initiate a
+second stop after that terminal topic already exists.
 The SQLite ledger additionally keeps one cluster-wide newest tail of non-replayable
 `AGENT_OUTPUT` (8 MiB / 8192 exported messages) and a persisted deterministic omission receipt;
 live delivery is unchanged, while control and explicitly replayable messages are never compacted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -812,7 +812,8 @@ text. Raw provider diagnostics remain task-log-only; `AGENT_OUTPUT`, `failureInf
 and `CLUSTER_FAILED` retain only a synthesized error plus provider/event/category/retryability and
 byte-length/SHA-256 receipt. Final critical-agent exhaustion installs `failureInfo` before emitting
 exactly one durable `CLUSTER_FAILED`; the legacy `AGENT_ERROR` stop fallback must not initiate a
-second stop after that terminal topic already exists.
+second stop after that terminal topic exists in the current run, while prior-run failures must not
+suppress terminalization after resume.
 The SQLite ledger additionally keeps one cluster-wide newest tail of non-replayable
 `AGENT_OUTPUT` (8 MiB / 8192 exported messages) and a persisted deterministic omission receipt;
 live delivery is unchanged, while control and explicitly replayable messages are never compacted.

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -24,6 +24,7 @@ const { findPlatformMismatchReason } = require('./validation-platform');
 const { calculateRateLimitDelay, isRateLimitError } = require('./rate-limit-backoff');
 const { updateAgentProviderSession } = require('./provider-session');
 const { rebuildProviderSessionAfterCommit } = require('./agent-task-executor');
+const providerFailures = require('./provider-terminal-failure');
 const {
   buildStructuredOutputClusterFailure,
   isStructuredOutputInvalidError,
@@ -660,6 +661,7 @@ async function runTaskAttempt(agent, triggeringMessage) {
     error.code = result.code || result.errorType || null;
     error.taskId = result.taskId || null;
     error.vertexModelError = result.vertexModelError || null;
+    providerFailures.decorateError(error, result.providerFailure);
     throw error;
   }
 
@@ -872,25 +874,24 @@ ${'='.repeat(80)}`);
     });
   }
 
-  // Save failure info to cluster for resume capability
-  agent.cluster.failureInfo = {
-    ...(error?.terminationExhausted ? agent.cluster.failureInfo : {}),
-    agentId: agent.id,
-    taskId: error?.taskId || agent.currentTaskId,
-    iteration: agent.iteration,
-    error: error.message,
+  const workerFailure = providerFailures.workerFailure(error);
+  // Install failure truth first: synchronous listeners may immediately persist a stop.
+  agent.cluster.failureInfo = providerFailures.buildFinalFailureInfo({
+    agent,
+    error,
     attempts: failureAttempts,
-    ...(unsupportedCapability
-      ? {
-          code: error.code,
-          permanent: true,
-          provider: error.provider,
-          capability: error.capability,
-        }
-      : {}),
-    ...(structuredOutputInvalid ? { code: error.code, details: error.details ?? null } : {}),
-    timestamp: Date.now(),
-  };
+    worker: workerFailure,
+    unsupportedCapability,
+    structuredOutputInvalid,
+  });
+  providerFailures.publishCriticalFailure({
+    agent,
+    error,
+    attempts: failureAttempts,
+    worker: workerFailure,
+    unsupportedCapability,
+    structuredOutputInvalid,
+  });
 
   // Publish error to message bus for visibility in logs
   agent._publish({
@@ -900,7 +901,7 @@ ${'='.repeat(80)}`);
       text: `Task execution failed after ${failureAttempts} attempts: ${error.message}`,
       data: {
         error: error.message,
-        stack: error.stack,
+        stack: error?.provider ? undefined : error.stack,
         hookFailure: error?.hookFailure === true,
         restartExhausted: error?.restartExhausted === true,
         terminationExhausted: error?.terminationExhausted === true,
@@ -911,6 +912,10 @@ ${'='.repeat(80)}`);
         iteration: agent.iteration,
         taskId: error?.taskId || agent.currentTaskId,
         attempts: failureAttempts,
+        ...providerFailures.receiptFields(error),
+        ...(error?.provider
+          ? { workerCode: workerFailure.code, workerReason: workerFailure.reason }
+          : {}),
         ...(unsupportedCapability
           ? {
               code: error.code,

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -797,6 +797,16 @@ ${'='.repeat(80)}`);
 
   // Non-validator agents: publish error and stop
   agent.state = 'error';
+  const workerFailure = providerFailures.workerFailure(error);
+  // Synchronous terminal listeners must see the final failure truth before persisting a stop.
+  agent.cluster.failureInfo = providerFailures.buildFinalFailureInfo({
+    agent,
+    error,
+    attempts: failureAttempts,
+    worker: workerFailure,
+    unsupportedCapability,
+    structuredOutputInvalid,
+  });
 
   // Hook failure: fail the whole cluster so it gets stopped + persisted (prevents deadlocked "running" clusters).
   if (error?.hookFailure) {
@@ -874,16 +884,6 @@ ${'='.repeat(80)}`);
     });
   }
 
-  const workerFailure = providerFailures.workerFailure(error);
-  // Install failure truth first: synchronous listeners may immediately persist a stop.
-  agent.cluster.failureInfo = providerFailures.buildFinalFailureInfo({
-    agent,
-    error,
-    attempts: failureAttempts,
-    worker: workerFailure,
-    unsupportedCapability,
-    structuredOutputInvalid,
-  });
   providerFailures.publishCriticalFailure({
     agent,
     error,

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -55,6 +55,10 @@ const {
 } = require('./provider-session');
 const { extractClaudeVertexModelError } = require('./output-extraction');
 const {
+  extractProviderFailure,
+  redactTerminalFailureForControlPlane,
+} = require('./provider-terminal-failure');
+const {
   createStructuredOutputInvalidError,
   isStructuredOutputInvalidError,
 } = require('./structured-output-error');
@@ -66,6 +70,8 @@ const MAX_LIVE_OUTPUT_BYTES = 512 * 1024;
 const MAX_LIVE_OUTPUT_RECORDS = 512;
 const CONTROL_PLANE_OMISSION_MARKER_BYTES = 1024;
 const LOG_READ_CHUNK_BYTES = 64 * 1024;
+const MAX_FAILURE_ERROR_BYTES = 4096;
+const FAILURE_ERROR_TRUNCATION_SUFFIX = '… [truncated]';
 function runCommandWithTimeout(command, args, options = {}, callback = null) {
   const timeout = options.timeout ?? 30000;
   if (timeout <= 0) {
@@ -175,6 +181,22 @@ function buildClaudeEnv(modelSpec, options = {}) {
 function sanitizeErrorMessage(error) {
   if (!error) return null;
 
+  const original = String(error);
+  const suffixBytes = Buffer.byteLength(FAILURE_ERROR_TRUNCATION_SUFFIX);
+  const contentBudget = MAX_FAILURE_ERROR_BYTES - suffixBytes;
+  let boundedError = original;
+  if (Buffer.byteLength(original) > MAX_FAILURE_ERROR_BYTES) {
+    let bytes = 0;
+    let prefix = '';
+    for (const character of original) {
+      const characterBytes = Buffer.byteLength(character);
+      if (bytes + characterBytes > contentBudget) break;
+      prefix += character;
+      bytes += characterBytes;
+    }
+    boundedError = `${prefix}${FAILURE_ERROR_TRUNCATION_SUFFIX}`;
+  }
+
   // Patterns that look like TypeScript type annotations (not real error messages)
   const typeAnnotationPatterns = [
     /^string\s*\|\s*null$/i,
@@ -187,7 +209,7 @@ function sanitizeErrorMessage(error) {
     /^[A-Z][a-zA-Z]*\s*\|\s*(?:null|undefined)$/, // e.g., "Error | null"
   ];
 
-  const trimmedError = error.trim();
+  const trimmedError = boundedError.trim();
 
   // Check if it's a union type like "string | number | boolean" (ReDoS-safe approach)
   const unionParts = trimmedError.split(/\s*\|\s*/);
@@ -196,14 +218,16 @@ function sanitizeErrorMessage(error) {
   for (const pattern of typeAnnotationPatterns) {
     if (pattern.test(trimmedError) || isUnionType) {
       console.warn(
-        `[agent-task-executor] WARNING: Error message looks like a TypeScript type annotation: "${error}". ` +
+        `[agent-task-executor] WARNING: Error message looks like a TypeScript type annotation: "${boundedError}". ` +
           `This indicates corrupted data. Replacing with generic error.`
       );
-      return `Task failed with corrupted error data (original: "${error}")`;
+      return sanitizeErrorMessage(
+        `Task failed with corrupted error data (original: "${boundedError}")`
+      );
     }
   }
 
-  return error;
+  return boundedError;
 }
 
 function safeTail(text, maxChars) {
@@ -295,6 +319,30 @@ function logNoMessagesReturned({ taskId, output, statusOutput, debug }) {
   console.error('[AgentTaskExecutor] Claude CLI returned no messages', payload);
 }
 
+function extractKnownCliFailure({ fullOutput, taskId, statusOutput, debug }) {
+  if (fullOutput.includes('exceeds maximum allowed size') || fullOutput.includes('256KB')) {
+    return sanitizeErrorMessage(
+      `FILE TOO LARGE (Claude Code 256KB limit). ` +
+        `Use offset and limit parameters when reading large files. ` +
+        `Example: Read tool with offset=0, limit=1000 to read first 1000 lines.`
+    );
+  }
+  if (fullOutput.includes('only prompt commands are supported in streaming mode')) {
+    return sanitizeErrorMessage(
+      `STREAMING MODE ERROR: Agent tried to use interactive tools in streaming mode. ` +
+        `This usually happens with AskUserQuestion or interactive prompts. ` +
+        `Zeroshot agents must run non-interactively.`
+    );
+  }
+  if (fullOutput.includes('No messages returned')) {
+    logNoMessagesReturned({ taskId, output: fullOutput, statusOutput, debug });
+    return sanitizeErrorMessage(
+      `Claude CLI returned no messages. This is usually transient; retry the task or resume the cluster.`
+    );
+  }
+  return null;
+}
+
 /**
  * Extract error context from task output.
  * Shared by both isolated and non-isolated modes.
@@ -307,7 +355,15 @@ function logNoMessagesReturned({ taskId, output, statusOutput, debug }) {
  * @param {Object} [params.debug] - Additional debug context for logging
  * @returns {string|null} Sanitized error context or null if extraction failed
  */
-function extractErrorContext({ output, statusOutput, taskId, isNotFound = false, debug }) {
+function extractErrorContext({
+  output,
+  statusOutput,
+  taskId,
+  isNotFound = false,
+  providerName = getDefaultProviderId(),
+  providerFailure = null,
+  debug,
+}) {
   // Task not found - explicit error
   if (isNotFound) {
     return sanitizeErrorMessage(`Task ${taskId} not found (may have crashed or been killed)`);
@@ -321,37 +377,15 @@ function extractErrorContext({ output, statusOutput, taskId, isNotFound = false,
     }
   }
 
-  // KNOWN CLAUDE CODE LIMITATIONS - detect and provide actionable guidance
+  const terminalFailure = providerFailure || extractProviderFailure(output, providerName);
+  if (terminalFailure) {
+    return sanitizeErrorMessage(terminalFailure.error);
+  }
+
   const fullOutput = output || '';
+  const knownFailure = extractKnownCliFailure({ fullOutput, taskId, statusOutput, debug });
+  if (knownFailure) return knownFailure;
 
-  // 256KB file limit error
-  if (fullOutput.includes('exceeds maximum allowed size') || fullOutput.includes('256KB')) {
-    return sanitizeErrorMessage(
-      `FILE TOO LARGE (Claude Code 256KB limit). ` +
-        `Use offset and limit parameters when reading large files. ` +
-        `Example: Read tool with offset=0, limit=1000 to read first 1000 lines.`
-    );
-  }
-
-  // Streaming mode error (interactive tools in non-interactive mode)
-  if (fullOutput.includes('only prompt commands are supported in streaming mode')) {
-    return sanitizeErrorMessage(
-      `STREAMING MODE ERROR: Agent tried to use interactive tools in streaming mode. ` +
-        `This usually happens with AskUserQuestion or interactive prompts. ` +
-        `Zeroshot agents must run non-interactively.`
-    );
-  }
-
-  // Claude CLI transient failure: no messages returned
-  if (fullOutput.includes('No messages returned')) {
-    logNoMessagesReturned({ taskId, output: fullOutput, statusOutput, debug });
-    return sanitizeErrorMessage(
-      `Claude CLI returned no messages. This is usually transient; retry the task or resume the cluster.`
-    );
-  }
-
-  // NEVER TRUNCATE OUTPUT - truncation corrupts structured JSON and causes false "crash" status
-  // If output is too verbose, that's a prompt problem - fix the prompts, not the data
   const trimmedOutput = (output || '').trim();
   if (!trimmedOutput) {
     return sanitizeErrorMessage(
@@ -1490,10 +1524,15 @@ function broadcastAgentLine({ agent, providerName, state, line }) {
   if (shouldSkipLogLine(content)) {
     return;
   }
+  const controlPlaneContent = redactTerminalFailureForControlPlane(
+    followerState,
+    providerName,
+    content
+  );
 
-  const isValidJson = isValidJsonLine(content);
+  const isValidJson = isValidJsonLine(controlPlaneContent);
   const record = appendControlPlaneRecord(followerState.controlPlaneOutput, {
-    content,
+    content: controlPlaneContent,
     timestamp,
     type: isValidJson ? 'json' : 'text',
   });
@@ -1703,11 +1742,13 @@ async function evaluateStructuredSuccess({ agent, taskId, state, success, allowR
   }
 }
 
-function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
+function buildFailureContext({ agent, taskId, providerName, state, stdout, providerFailure }) {
   return extractErrorContext({
     output: state.output,
     statusOutput: stdout,
     taskId,
+    providerName,
+    providerFailure,
     debug: {
       agentId: agent.id,
       providerName,
@@ -1718,6 +1759,19 @@ function buildFailureContext({ agent, taskId, providerName, state, stdout }) {
       logFilePath: state.logFilePath || null,
     },
   });
+}
+
+function resolveCompletionFailure({ classified, agent, taskId, providerName, state, stdout }) {
+  if (classified.success) return { providerFailure: null, errorContext: classified.error };
+  const providerFailure =
+    state.providerFailure || extractProviderFailure(state.output, providerName);
+  return {
+    providerFailure,
+    errorContext:
+      providerFailure?.error ||
+      classified.error ||
+      buildFailureContext({ agent, taskId, providerName, state, stdout, providerFailure }),
+  };
 }
 
 async function buildCompletionResult({
@@ -1753,10 +1807,14 @@ async function buildCompletionResult({
   if (vertexModelError) {
     classified.success = false;
   }
-  let errorContext = classified.error;
-  if (!errorContext && !classified.success) {
-    errorContext = buildFailureContext({ agent, taskId, providerName, state, stdout });
-  }
+  const { providerFailure, errorContext } = resolveCompletionFailure({
+    classified,
+    agent,
+    taskId,
+    providerName,
+    state,
+    stdout,
+  });
 
   return {
     success: classified.success,
@@ -1772,6 +1830,7 @@ async function buildCompletionResult({
       taskInfo,
       logicalSuccess: classified.success,
     }),
+    providerFailure,
     vertexModelError,
   };
 }
@@ -2633,7 +2692,13 @@ async function resolveIsolatedLogFilePath(manager, clusterId, taskId, state) {
   return state.logFilePath;
 }
 
-async function captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, state) {
+async function captureIsolatedFinalOutputTail(
+  manager,
+  clusterId,
+  logFilePath,
+  state,
+  providerName
+) {
   stopIsolatedTailForSettlement(state);
   const sizeResult = await manager.execInContainer(clusterId, [
     'sh',
@@ -2658,14 +2723,56 @@ async function captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, s
         state.lineBuffer = createLogRecordBuffer();
       }
       appendIsolatedContent(state, finalReadResult.stdout, (line) =>
-        retainIsolatedLine(state, line)
+        retainIsolatedLine(state, providerName, line)
       );
     }
   }
 
   if (state.lineBuffer.byteLength > 0) {
-    completeLogRecord(state.lineBuffer, (line) => retainIsolatedLine(state, line), true);
+    completeLogRecord(
+      state.lineBuffer,
+      (line) => retainIsolatedLine(state, providerName, line),
+      true
+    );
   }
+}
+
+function resolveIsolatedFailure({
+  success,
+  structuredError,
+  agent,
+  taskId,
+  providerName,
+  state,
+  status,
+  isNotFound,
+  clusterId,
+  logFilePath,
+}) {
+  if (success) return { providerFailure: null, errorContext: structuredError };
+  const providerFailure =
+    state.providerFailure || extractProviderFailure(state.fullOutput, providerName);
+  const errorContext =
+    providerFailure?.error ||
+    structuredError ||
+    extractErrorContext({
+      output: state.fullOutput,
+      statusOutput: status ? `Status: ${status}` : '',
+      taskId,
+      isNotFound,
+      providerName,
+      debug: {
+        agentId: agent.id,
+        providerName,
+        pid: agent.processPid,
+        cwd: agent.config.cwd || process.cwd(),
+        worktreePath: agent.worktree?.path || null,
+        isolation: true,
+        clusterId,
+        logFilePath,
+      },
+    });
+  return { providerFailure, errorContext };
 }
 
 function settleIsolatedTerminalStatus({
@@ -2693,7 +2800,7 @@ function settleIsolatedTerminalStatus({
     const logFilePath = await resolveIsolatedLogFilePath(manager, clusterId, taskId, state);
     await new Promise((settle) => setTimeout(settle, 200));
     if (state.resolved) return;
-    await captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, state);
+    await captureIsolatedFinalOutputTail(manager, clusterId, logFilePath, state, providerName);
     if (state.resolved) return;
     flushIsolatedOutput(agent, providerName, taskId, state);
 
@@ -2720,26 +2827,18 @@ function settleIsolatedTerminalStatus({
       success = evaluated.success;
       structuredError = evaluated.error;
     }
-    const errorContext =
-      structuredError ||
-      (!success
-        ? extractErrorContext({
-            output: state.fullOutput,
-            statusOutput: status ? `Status: ${status}` : '',
-            taskId,
-            isNotFound,
-            debug: {
-              agentId: agent.id,
-              providerName,
-              pid: agent.processPid,
-              cwd: agent.config.cwd || process.cwd(),
-              worktreePath: agent.worktree?.path || null,
-              isolation: true,
-              clusterId,
-              logFilePath,
-            },
-          })
-        : null);
+    const { providerFailure, errorContext } = resolveIsolatedFailure({
+      success,
+      structuredError,
+      agent,
+      taskId,
+      providerName,
+      state,
+      status,
+      isNotFound,
+      clusterId,
+      logFilePath,
+    });
     let parsedResult = null;
     if (success && !state.skipStructuredResultCheck && !vertexModelError) {
       parsedResult = staleCandidate
@@ -2759,6 +2858,7 @@ function settleIsolatedTerminalStatus({
         parsedResult,
         error: errorContext,
         tokenUsage: extractTokenUsage(state.fullOutput, providerName),
+        providerFailure,
         vertexModelError,
       },
     });
@@ -2880,18 +2980,19 @@ function publishIsolatedOutputRecord(agent, providerName, taskId, record) {
   });
 }
 
-function retainIsolatedLine(state, line) {
+function retainIsolatedLine(state, providerName, line) {
   const { timestamp, content } = parseIsolatedLogLine(line);
+  const controlPlaneContent = redactTerminalFailureForControlPlane(state, providerName, content);
   return appendControlPlaneRecord(state.controlPlaneOutput, {
-    content,
+    content: controlPlaneContent,
     timestamp,
-    type: isValidJsonLine(content) ? 'json' : 'text',
+    type: isValidJsonLine(controlPlaneContent) ? 'json' : 'text',
   });
 }
 
 function broadcastIsolatedLine({ agent, providerName, taskId, state, line }) {
   const followerState = ensureControlPlaneOutputState(state);
-  const record = retainIsolatedLine(followerState, line);
+  const record = retainIsolatedLine(followerState, providerName, line);
   publishLiveControlPlaneRecord(followerState.controlPlaneOutput, record, (item) =>
     publishIsolatedOutputRecord(agent, providerName, taskId, item)
   );

--- a/src/agent/output-extraction.js
+++ b/src/agent/output-extraction.js
@@ -16,7 +16,50 @@
  * 4. Direct JSON parse of entire output
  */
 
+const { createHash } = require('node:crypto');
 const { parseProviderChunk } = require('../providers');
+
+const MAX_CLI_ERROR_BYTES = 4096;
+const CLI_ERROR_TRUNCATION_SUFFIX = '… [truncated]';
+
+function truncateUtf8(text, maxBytes = MAX_CLI_ERROR_BYTES) {
+  if (Buffer.byteLength(text) <= maxBytes) return text;
+
+  const suffixBytes = Buffer.byteLength(CLI_ERROR_TRUNCATION_SUFFIX);
+  const contentBudget = Math.max(0, maxBytes - suffixBytes);
+  let bytes = 0;
+  let truncated = '';
+  for (const character of text) {
+    const characterBytes = Buffer.byteLength(character);
+    if (bytes + characterBytes > contentBudget) break;
+    truncated += character;
+    bytes += characterBytes;
+  }
+  return `${truncated}${CLI_ERROR_TRUNCATION_SUFFIX}`;
+}
+
+function primitiveErrorText(value) {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+    ? String(value)
+    : '';
+}
+
+function cliErrorDetail(value, fallback) {
+  const candidate = Array.isArray(value)
+    ? value
+        .map(primitiveErrorText)
+        .filter((message) => message.trim())
+        .join('; ')
+    : primitiveErrorText(value);
+  const raw = candidate.trim() ? candidate : fallback;
+  return {
+    error: truncateUtf8(raw.trim()),
+    diagnostic: {
+      byteLength: Buffer.byteLength(raw),
+      sha256: createHash('sha256').update(raw).digest('hex'),
+    },
+  };
+}
 
 /**
  * Strip timestamp prefix from log lines.
@@ -308,58 +351,85 @@ function extractClaudeVertexModelError(output, { useVertex = false } = {}) {
  * @param {string} providerName - Active provider whose terminal errors may be inspected
  * @returns {{error: string, provider: string}|null} Error info or null
  */
-function extractCliError(output, providerName = 'claude') {
+function claudeFailureFromObject(obj) {
+  if (obj.type !== 'result') return null;
+  if (obj.is_error === true) {
+    const detail = cliErrorDetail(
+      Array.isArray(obj.errors) ? obj.errors : obj.error || obj.result,
+      'Unknown CLI error'
+    );
+    return { ...detail, provider: 'claude' };
+  }
+  if (obj.subtype !== 'error') return null;
+  return {
+    ...cliErrorDetail(obj.error || obj.result, 'CLI returned error'),
+    provider: 'claude',
+  };
+}
+
+function codexFailureFromObject(obj) {
+  if (obj.type !== 'turn.failed') return null;
+  return {
+    ...cliErrorDetail(obj.error?.message || obj.error?.code || obj.error, 'Turn failed'),
+    provider: 'codex',
+  };
+}
+
+function geminiFailureFromObject(obj) {
+  const geminiFailure =
+    (obj.type === 'result' && obj.status === 'error') ||
+    (obj.type === 'error' && obj.severity === 'error');
+  if (!geminiFailure) return null;
+  return {
+    ...cliErrorDetail(obj.error?.message || obj.message, 'Gemini CLI error'),
+    provider: 'gemini',
+  };
+}
+
+function opencodeFailureFromObject(obj) {
+  if (obj.type !== 'session.error' && obj.type !== 'error') return null;
+  return {
+    ...cliErrorDetail(
+      obj.error?.data?.message || obj.error?.message || obj.error?.name,
+      'Session error'
+    ),
+    provider: 'opencode',
+  };
+}
+
+function failureFromProviderObject(obj, providerName) {
+  if (providerName === 'claude') return claudeFailureFromObject(obj);
+  if (providerName === 'codex') return codexFailureFromObject(obj);
+  if (providerName === 'gemini') return geminiFailureFromObject(obj);
+  if (providerName === 'opencode') return opencodeFailureFromObject(obj);
+  return null;
+}
+
+function extractCliFailure(output, providerName = 'claude') {
   if (!output || typeof output !== 'string') return null;
 
   const lines = output.split('\n');
+  // Codex terminal truth is a turn.failed record at the newest end of JSONL output.
+  // Search it newest-first so a preserved terminal tail wins over older provider chatter.
+  if (providerName === 'codex') lines.reverse();
 
   for (const line of lines) {
     const content = stripTimestamp(line);
     if (!content.startsWith('{')) continue;
-
-    let obj;
     try {
-      obj = JSON.parse(content);
+      const failure = failureFromProviderObject(JSON.parse(content), providerName);
+      if (failure) return failure;
     } catch {
-      continue;
-    }
-
-    if (providerName === 'claude' && obj.type === 'result' && obj.is_error === true) {
-      const errorMsg = Array.isArray(obj.errors)
-        ? obj.errors.join('; ')
-        : obj.error || obj.result || 'Unknown CLI error';
-      return { error: errorMsg, provider: 'claude' };
-    }
-
-    if (providerName === 'claude' && obj.type === 'result' && obj.subtype === 'error') {
-      const errorMsg = obj.error || obj.result || 'CLI returned error';
-      return { error: errorMsg, provider: 'claude' };
-    }
-
-    if (providerName === 'codex' && obj.type === 'turn.failed') {
-      const errorMsg = obj.error?.message || obj.error || 'Turn failed';
-      return { error: errorMsg, provider: 'codex' };
-    }
-
-    if (
-      providerName === 'gemini' &&
-      ((obj.type === 'result' && obj.status === 'error') ||
-        (obj.type === 'error' && obj.severity === 'error'))
-    ) {
-      return {
-        error: obj.error?.message || obj.message || 'Gemini CLI error',
-        provider: 'gemini',
-      };
-    }
-
-    if (providerName === 'opencode' && (obj.type === 'session.error' || obj.type === 'error')) {
-      const errorMsg =
-        obj.error?.data?.message || obj.error?.message || obj.error?.name || 'Session error';
-      return { error: errorMsg, provider: 'opencode' };
+      // Ignore non-JSON output lines.
     }
   }
 
   return null;
+}
+
+function extractCliError(output, providerName = 'claude') {
+  const failure = extractCliFailure(output, providerName);
+  return failure ? { error: failure.error, provider: failure.provider } : null;
 }
 
 /**
@@ -419,8 +489,10 @@ function extractJsonFromOutput(output, providerName = 'claude') {
 }
 
 module.exports = {
+  MAX_CLI_ERROR_BYTES,
   extractJsonFromOutput,
   extractModelTextFromOutput,
+  extractCliFailure,
   extractCliError,
   extractClaudeVertexModelError,
   extractFromResultWrapper,

--- a/src/agent/provider-terminal-failure.js
+++ b/src/agent/provider-terminal-failure.js
@@ -1,0 +1,186 @@
+// @ts-nocheck
+
+const { getProvider } = require('../providers');
+const { extractCliFailure } = require('./output-extraction');
+
+function categoryForProviderFailure(error, classification) {
+  const isPermanent = classification.retryable === false;
+  const authenticationPattern =
+    /(?:invalid[_ -]?api[_ -]?key|api[_ -]?key.*invalid|unauthori[sz]ed|forbidden|authentication|permission denied)/i;
+  if (isPermanent && authenticationPattern.test(error)) return 'authentication';
+
+  const quotaPattern = /(?:insufficient[_ -]?quota|quota exceeded|resource_exhausted)/i;
+  if (isPermanent && quotaPattern.test(error)) return 'quota';
+  if (isPermanent) return 'permanent';
+  return classification.kind === 'unknown-retryable' ? 'unknown' : 'transient';
+}
+
+function classifyProviderFailure(providerName, error) {
+  let rawClassification = { retryable: true, kind: 'unknown-retryable' };
+  try {
+    rawClassification = getProvider(providerName).adapter.classifyError(new Error(error));
+  } catch {
+    // Extraction remains available if a provider adapter cannot be loaded.
+  }
+  return {
+    retryable: rawClassification?.retryable !== false,
+    kind:
+      typeof rawClassification?.kind === 'string' ? rawClassification.kind : 'unknown-retryable',
+  };
+}
+
+function extractProviderFailure(output, providerName) {
+  const cliError = extractCliFailure(output, providerName);
+  if (!cliError) return null;
+
+  const classification = classifyProviderFailure(providerName, cliError.error);
+  const category = categoryForProviderFailure(cliError.error, classification);
+  return {
+    error: `Provider ${cliError.provider} failed (${category}; ${classification.kind})`,
+    provider: cliError.provider,
+    event: cliError.provider === 'codex' ? 'turn.failed' : 'terminal_error',
+    category,
+    classification,
+    diagnostic: cliError.diagnostic,
+  };
+}
+
+function redactTerminalFailureForControlPlane(state, providerName, content) {
+  const failure = extractProviderFailure(content, providerName);
+  if (!failure) return content;
+
+  state.providerFailure = failure;
+  let eventType = 'provider.failure';
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed?.type === 'string') eventType = parsed.type;
+  } catch {
+    // extractProviderFailure already proved a supported terminal envelope.
+  }
+  return JSON.stringify({
+    type: eventType,
+    ...(providerName === 'claude' ? { is_error: true } : {}),
+    ...(providerName === 'gemini' ? { status: 'error', severity: 'error' } : {}),
+    error: { message: failure.error },
+    zeroshot_failure: {
+      provider: failure.provider,
+      event: failure.event,
+      category: failure.category,
+      kind: failure.classification.kind,
+      retryable: failure.classification.retryable,
+      diagnostic: failure.diagnostic,
+    },
+  });
+}
+
+function decorateError(error, failure) {
+  if (!failure) return error;
+  error.provider = failure.provider || null;
+  error.providerEvent = failure.event || null;
+  error.providerCategory = failure.category || null;
+  error.classification = failure.classification || null;
+  error.providerDiagnostic = failure.diagnostic || null;
+  if (failure.classification?.retryable === false) error.permanent = true;
+  return error;
+}
+
+function receiptFields(error) {
+  if (!error?.provider) return {};
+  return {
+    provider: error.provider,
+    event: error.providerEvent,
+    category: error.providerCategory,
+    kind: error.classification?.kind,
+    retryable: error.classification?.retryable,
+    diagnostic: error.providerDiagnostic,
+  };
+}
+
+function workerFailure(error) {
+  const authenticationFailure =
+    error?.provider &&
+    error?.classification?.retryable === false &&
+    error?.providerCategory === 'authentication';
+  return authenticationFailure
+    ? { code: 'refusal', reason: 'authentication_required' }
+    : { code: 'crash', reason: 'declared_failure' };
+}
+
+function publishCriticalFailure({
+  agent,
+  error,
+  attempts,
+  worker,
+  unsupportedCapability,
+  structuredOutputInvalid,
+}) {
+  const specific =
+    error?.hookFailure ||
+    structuredOutputInvalid ||
+    unsupportedCapability ||
+    error?.vertexModelError ||
+    error?.terminationExhausted;
+  const critical =
+    agent.role === 'implementation' ||
+    agent.role === 'coordinator' ||
+    agent.id === 'consensus-coordinator';
+  if (!critical || specific) return worker;
+
+  agent._publish({
+    topic: 'CLUSTER_FAILED',
+    receiver: 'broadcast',
+    content: {
+      text: `Critical agent ${agent.id} exhausted its retry budget`,
+      data: {
+        reason: error?.provider ? 'provider_execution_failed' : 'critical_agent_exhausted',
+        agentId: agent.id,
+        role: agent.role,
+        attempts,
+        code: worker.code,
+        workerReason: worker.reason,
+        ...receiptFields(error),
+      },
+    },
+  });
+  return worker;
+}
+
+function buildFinalFailureInfo({
+  agent,
+  error,
+  attempts,
+  worker,
+  unsupportedCapability,
+  structuredOutputInvalid,
+}) {
+  return {
+    ...(error?.terminationExhausted ? agent.cluster.failureInfo : {}),
+    agentId: agent.id,
+    taskId: error?.taskId || agent.currentTaskId,
+    iteration: agent.iteration,
+    error: error.message,
+    attempts,
+    ...receiptFields(error),
+    ...(error?.provider ? { code: worker.code, workerReason: worker.reason } : {}),
+    ...(unsupportedCapability
+      ? {
+          code: error.code,
+          permanent: true,
+          provider: error.provider,
+          capability: error.capability,
+        }
+      : {}),
+    ...(structuredOutputInvalid ? { code: error.code, details: error.details ?? null } : {}),
+    timestamp: Date.now(),
+  };
+}
+
+module.exports = {
+  buildFinalFailureInfo,
+  decorateError,
+  extractProviderFailure,
+  publishCriticalFailure,
+  receiptFields,
+  redactTerminalFailureForControlPlane,
+  workerFailure,
+};

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -275,6 +275,7 @@ class Orchestrator {
     // Track if orchestrator is closed (prevents _saveClusters race conditions during cleanup)
     this.closed = false;
     this._conductorWatchdogs = new Set();
+    this._clusterRunBoundaries = new Map();
 
     // Track if clusters are loaded (for lazy loading pattern)
     this._clustersLoaded = options.skipLoad === true;
@@ -1575,15 +1576,17 @@ class Orchestrator {
   }
 
   _registerAgentErrorHandler(messageBus, clusterId) {
+    this._recordClusterRunBoundary(messageBus, clusterId);
     this._subscribeToClusterTopic(messageBus, clusterId, 'AGENT_ERROR', async (message) => {
       const agentRole = message.content?.data?.role;
       const attempts = message.content?.data?.attempts || 1;
       const hookFailure = message.content?.data?.hookFailure === true;
       const restartExhausted = message.content?.data?.restartExhausted === true;
-      const durableClusterFailure = messageBus.findLast({
-        cluster_id: clusterId,
-        topic: 'CLUSTER_FAILED',
-      });
+      const durableClusterFailure = this._findCurrentRunClusterFailure(
+        messageBus,
+        clusterId,
+        message.sequence
+      );
 
       await this._saveClusters();
 
@@ -1615,6 +1618,25 @@ class Orchestrator {
         });
       }
     });
+  }
+
+  _recordClusterRunBoundary(messageBus, clusterId) {
+    const latest = messageBus.findLast({ cluster_id: clusterId, orderBySequence: true });
+    this._clusterRunBoundaries.set(clusterId, latest?.sequence ?? null);
+  }
+
+  _findCurrentRunClusterFailure(messageBus, clusterId, throughId) {
+    const boundary = this._clusterRunBoundaries.get(clusterId);
+    return (
+      messageBus.query({
+        cluster_id: clusterId,
+        topic: 'CLUSTER_FAILED',
+        order: 'desc',
+        limit: 1,
+        ...(boundary === null ? {} : { afterId: boundary }),
+        ...(throughId === undefined ? {} : { throughId }),
+      })[0] || null
+    );
   }
 
   _registerPushBlockedHandler(messageBus, clusterId) {
@@ -2432,6 +2454,7 @@ class Orchestrator {
 
     // Now remove from memory after persisting
     this.clusters.delete(clusterId);
+    this._clusterRunBoundaries.delete(clusterId);
   }
 
   /**
@@ -2469,6 +2492,7 @@ class Orchestrator {
       watchdog.dispose();
     }
     this._conductorWatchdogs.clear();
+    this._clusterRunBoundaries.clear();
 
     for (const cluster of this.clusters.values()) {
       if (typeof cluster.snapshotter?.stop === 'function') {
@@ -2909,6 +2933,7 @@ class Orchestrator {
   }
 
   async _restartClusterAgents(cluster) {
+    this._recordClusterRunBoundary(cluster.messageBus, cluster.id);
     cluster.state = 'running';
     cluster.pid = process.pid;
     for (const agent of cluster.agents) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1580,6 +1580,10 @@ class Orchestrator {
       const attempts = message.content?.data?.attempts || 1;
       const hookFailure = message.content?.data?.hookFailure === true;
       const restartExhausted = message.content?.data?.restartExhausted === true;
+      const durableClusterFailure = messageBus.findLast({
+        cluster_id: clusterId,
+        topic: 'CLUSTER_FAILED',
+      });
 
       await this._saveClusters();
 
@@ -1587,7 +1591,10 @@ class Orchestrator {
         agentRole === 'implementation' ||
         agentRole === 'coordinator' ||
         message.sender === 'consensus-coordinator';
-      const shouldStop = shouldStopForRole && (hookFailure || restartExhausted || attempts >= 3);
+      const shouldStop =
+        !durableClusterFailure &&
+        shouldStopForRole &&
+        (hookFailure || restartExhausted || attempts >= 3);
 
       if (shouldStop) {
         this._log(`\n${'='.repeat(80)}`);

--- a/tests/cumulative-provider-output.test.js
+++ b/tests/cumulative-provider-output.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { createHash } = require('node:crypto');
 
 const {
   CONTROL_PLANE_OUTPUT_LIMITS,
@@ -155,6 +156,37 @@ describe('bounded cumulative provider output', function () {
       assert.ok(state.fullOutput.includes(terminal));
       assert.ok(published.some((message) => message.content.data.line.includes(terminal)));
     }
+  });
+});
+
+describe('isolated provider terminal redaction', function () {
+  it('redacts an isolated provider terminal failure before live publication', function () {
+    const rawError = 'insufficient_quota: Authorization: Bearer isolated-secret';
+    const state = createIsolatedLogState();
+    const published = [];
+    const agent = {
+      id: 'isolated-failure-worker',
+      iteration: 1,
+      cluster: { id: 'cluster-1' },
+      messageBus: { publish: (message) => published.push(message) },
+    };
+
+    broadcastIsolatedLine({
+      agent,
+      providerName: 'codex',
+      taskId: 'isolated-failure',
+      state,
+      line: JSON.stringify({ type: 'turn.failed', error: { message: rawError } }),
+    });
+    flushIsolatedOutput(agent, 'codex', 'isolated-failure', state);
+
+    const serialized = JSON.stringify(published);
+    assert.doesNotMatch(serialized, /isolated-secret|Authorization: Bearer|insufficient_quota/);
+    assert.match(serialized, /Provider codex failed \(quota; permanent-pattern\)/);
+    assert.deepStrictEqual(state.providerFailure.diagnostic, {
+      byteLength: Buffer.byteLength(rawError),
+      sha256: createHash('sha256').update(rawError).digest('hex'),
+    });
   });
 });
 

--- a/tests/e2e/codex-terminal-failure.test.js
+++ b/tests/e2e/codex-terminal-failure.test.js
@@ -1,0 +1,222 @@
+const { strict: assert } = require('node:assert');
+const { createHash } = require('node:crypto');
+const Database = require('better-sqlite3');
+
+const { setupE2ERepo, cleanupE2ERepo, runZeroshot } = require('./helpers/e2e-harness');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'codex-terminal-stress-config.json');
+const FAKE_CODEX_PATH = path.resolve(__dirname, '..', 'fixtures', 'fake-codex-terminal-stress.js');
+const STRESS_BYTES = 12 * 1024 * 1024;
+const TERMINAL_SECRET = 'sk-zs-secret-qualification';
+const TERMINAL_ERROR = `insufficient_quota: Authorization: Bearer ${TERMINAL_SECRET}`;
+const SAFE_ERROR = 'Provider codex failed (quota; permanent-pattern)';
+
+function diagnosticReceipt() {
+  return {
+    byteLength: Buffer.byteLength(TERMINAL_ERROR),
+    sha256: createHash('sha256').update(TERMINAL_ERROR).digest('hex'),
+  };
+}
+
+function readFailedTaskLog(homeDir) {
+  const storePath = path.join(homeDir, '.claude-zeroshot', 'store.db');
+  const database = new Database(storePath, { readonly: true, fileMustExist: true });
+  let tasks;
+  try {
+    tasks = database.prepare('SELECT status, error, log_file FROM tasks').all();
+  } catch (error) {
+    database.close();
+    throw error;
+  }
+  database.close();
+  assert.strictEqual(tasks.length, 1, 'permanent provider failure must run exactly once');
+  assert.strictEqual(tasks[0].status, 'failed', tasks[0].error || 'task did not fail');
+  assertRedacted(String(tasks[0].error || ''));
+  return fs.readFileSync(tasks[0].log_file, 'utf8');
+}
+
+function extractProviderOutput(rawLog) {
+  const normalized = rawLog
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map((line) => line.replace(/^\[\d{13}\]/, ''));
+  const start = normalized.findIndex((line) => line.includes('"type":"thread.started"'));
+  const end = normalized.findIndex(
+    (line, index) => index >= start && line.includes('"type":"turn.failed"')
+  );
+  assert.ok(start >= 0 && end >= start, 'raw task log must preserve the complete failed turn');
+  return `${normalized.slice(start, end + 1).join('\n')}\n`;
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pollCliStatus(env, clusterId, predicate, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  let lastResult;
+  while (Date.now() - startedAt < timeoutMs) {
+    lastResult = runZeroshot(env, ['status', clusterId, '--json']);
+    if (lastResult.status === 0) {
+      const status = JSON.parse(lastResult.stdout);
+      if (predicate(status)) return status;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(
+    `status predicate not met for ${clusterId}: ${lastResult?.stderr || lastResult?.stdout || ''}`
+  );
+}
+
+async function waitForPidExit(pid, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`daemon pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function startDetachedFailure(env, issueDir) {
+  const issuePath = path.join(issueDir, 'failing-task.md');
+  const expectedOutputPath = path.join(issueDir, 'expected-failed-provider-output.jsonl');
+  fs.writeFileSync(issuePath, '# Synthetic terminal failure stress\n');
+  const run = runZeroshot(
+    env,
+    [
+      'run',
+      issuePath,
+      '--detach',
+      '--provider',
+      'codex',
+      '--config',
+      CONFIG_PATH,
+      '--model',
+      'gpt-5.6-luna',
+      '--strict-schema',
+      '--sim',
+      'off',
+    ],
+    {
+      FAKE_CODEX_EXPECTED_OUTPUT: expectedOutputPath,
+      FAKE_CODEX_STRESS_BYTES: String(STRESS_BYTES),
+      FAKE_CODEX_TERMINAL_FAILURE: '1',
+      FAKE_CODEX_START_DELAY_MS: '2000',
+      timeout: 15000,
+    }
+  );
+  assert.strictEqual(run.status, 0, `STDOUT:\n${run.stdout}\nSTDERR:\n${run.stderr}`);
+  const match = /Started (\S+)/.exec(run.stdout);
+  assert.ok(match, `expected detached cluster id in:\n${run.stdout}`);
+  return { clusterId: match[1], expectedOutputPath };
+}
+
+function assertProviderEnvelope(value) {
+  assert.strictEqual(value.provider, 'codex');
+  assert.strictEqual(value.event, 'turn.failed');
+  assert.strictEqual(value.category, 'quota');
+  assert.strictEqual(value.kind, 'permanent-pattern');
+  assert.strictEqual(value.retryable, false);
+  assert.deepStrictEqual(value.diagnostic, diagnosticReceipt());
+}
+
+function assertRedacted(serialized) {
+  assert.doesNotMatch(serialized, new RegExp(TERMINAL_SECRET));
+  assert.doesNotMatch(serialized, /insufficient_quota|Authorization: Bearer/);
+}
+
+function exportCluster(env, clusterId) {
+  const outputPath = path.join(env.homeDir, `${clusterId}-export.json`);
+  const result = runZeroshot(env, [
+    'export',
+    clusterId,
+    '--output',
+    outputPath,
+    '--format',
+    'json',
+  ]);
+  assert.strictEqual(result.status, 0, result.stderr);
+  const text = fs.readFileSync(outputPath, 'utf8');
+  assertRedacted(text);
+  return JSON.parse(text);
+}
+
+function assertTerminalMessages(messages, status) {
+  const agentErrors = messages.filter((message) => message.topic === 'AGENT_ERROR');
+  assert.strictEqual(agentErrors.length, 1);
+  assert.strictEqual(agentErrors[0].content.data.error, SAFE_ERROR);
+  assert.strictEqual(agentErrors[0].content.data.stack, undefined);
+  assertProviderEnvelope(agentErrors[0].content.data);
+
+  const terminal = messages.filter((message) => message.topic === 'CLUSTER_FAILED');
+  assert.strictEqual(terminal.length, 1);
+  assert.strictEqual(terminal[0].content.data.reason, 'provider_execution_failed');
+  assert.strictEqual(terminal[0].content.data.code, 'crash');
+  assert.strictEqual(terminal[0].content.data.workerReason, 'declared_failure');
+  assertProviderEnvelope(terminal[0].content.data);
+  assert.strictEqual(messages.length, status.messageCount);
+}
+
+describe('e2e: detached Codex terminal failure', function () {
+  this.timeout(90000);
+
+  it('redacts the failed tail and exits with durable infrastructure terminal truth', async function () {
+    const env = setupE2ERepo();
+    const issueDir = fs.mkdtempSync(path.join(env.homeDir, 'terminal-failure-case-'));
+    try {
+      fs.symlinkSync(FAKE_CODEX_PATH, path.join(env.binDir, 'codex'));
+      const started = startDetachedFailure(env, issueDir);
+      const running = await pollCliStatus(
+        env,
+        started.clusterId,
+        (status) => Number.isInteger(status.pid) && status.pid > 1
+      );
+      await pollCliStatus(env, started.clusterId, (status) => status.state === 'stopped');
+      await waitForPidExit(running.pid);
+
+      const expectedOutput = fs.readFileSync(started.expectedOutputPath, 'utf8');
+      assert.ok(Buffer.byteLength(expectedOutput) > STRESS_BYTES);
+      assert.match(expectedOutput, /const Authorization = benignSource;/);
+      assert.match(expectedOutput, new RegExp(TERMINAL_SECRET));
+      assert.strictEqual(extractProviderOutput(readFailedTaskLog(env.homeDir)), expectedOutput);
+
+      const statusResult = runZeroshot(env, ['status', started.clusterId, '--json']);
+      assert.strictEqual(statusResult.status, 0, statusResult.stderr);
+      assertRedacted(statusResult.stdout);
+      const status = JSON.parse(statusResult.stdout);
+      assert.deepStrictEqual([status.state, status.pid, status.isZombie], ['stopped', null, false]);
+      assert.strictEqual(status.failureInfo.error, SAFE_ERROR);
+      assert.strictEqual(status.failureInfo.attempts, 1);
+      assert.strictEqual(status.failureInfo.code, 'crash');
+      assert.strictEqual(status.failureInfo.workerReason, 'declared_failure');
+      assertProviderEnvelope(status.failureInfo);
+
+      const exported = exportCluster(env, started.clusterId);
+      assertTerminalMessages(exported.messages, status);
+      assert.strictEqual(
+        exported.messages.some((message) =>
+          ['CLUSTER_COMPLETE', 'TASK_COMPLETE', 'VALIDATION_RESULT'].includes(message.topic)
+        ),
+        false,
+        'provider infrastructure failure must never reach scoreable/verifier completion'
+      );
+      assert.strictEqual(
+        exported.messages.some(
+          (message) =>
+            message.topic === 'AGENT_LIFECYCLE' && message.content?.data?.event === 'TASK_COMPLETED'
+        ),
+        false,
+        'failed provider turns must not publish a task-completed lifecycle event'
+      );
+    } finally {
+      cleanupE2ERepo(env);
+    }
+  });
+});

--- a/tests/e2e/fixtures/codex-terminal-stress-config.json
+++ b/tests/e2e/fixtures/codex-terminal-stress-config.json
@@ -6,6 +6,7 @@
       "role": "implementation",
       "modelLevel": "level1",
       "reasoningEffort": "max",
+      "maxRetries": 3,
       "timeout": 0,
       "triggers": [{ "topic": "ISSUE_OPENED", "action": "execute_task" }],
       "prompt": "Complete the synthetic terminal stress task.",

--- a/tests/fixtures/fake-codex-terminal-stress.js
+++ b/tests/fixtures/fake-codex-terminal-stress.js
@@ -24,6 +24,7 @@ function writeChunked(buffer) {
 
 function providerOutput() {
   const targetBytes = Number(process.env.FAKE_CODEX_STRESS_BYTES || 12 * 1024 * 1024);
+  const failAtTerminal = process.env.FAKE_CODEX_TERMINAL_FAILURE === '1';
   const recordPayload = 'medium-output-🌍'.repeat(2048);
   const lines = [JSON.stringify({ type: 'thread.started', thread_id: 'fake-stress-thread' })];
   let outputBytes = Buffer.byteLength(lines[0]) + 1;
@@ -61,20 +62,43 @@ function providerOutput() {
     JSON.stringify({
       type: 'item.completed',
       item: {
-        type: 'agent_message',
-        text: JSON.stringify({
-          summary: 'Synthetic terminal stress completed',
-          result: 'UTF-8 and final structured output survived 🌍',
-        }),
+        id: 'benign-auth-source',
+        type: 'command_execution',
+        command: 'inspect-source',
+        aggregated_output: 'const Authorization = benignSource;',
+        exit_code: 0,
       },
     })
   );
-  lines.push(
-    JSON.stringify({
-      type: 'turn.completed',
-      usage: { input_tokens: 0, output_tokens: 0 },
-    })
-  );
+  if (failAtTerminal) {
+    lines.push(
+      JSON.stringify({
+        type: 'turn.failed',
+        error: {
+          message: 'insufficient_quota: Authorization: Bearer sk-zs-secret-qualification',
+        },
+      })
+    );
+  } else {
+    lines.push(
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          type: 'agent_message',
+          text: JSON.stringify({
+            summary: 'Synthetic terminal stress completed',
+            result: 'UTF-8 and final structured output survived 🌍',
+          }),
+        },
+      })
+    );
+    lines.push(
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 0, output_tokens: 0 },
+      })
+    );
+  }
   return `${lines.join('\n')}\n`;
 }
 
@@ -91,11 +115,17 @@ async function main() {
     return;
   }
 
+  const startDelayMs = Number(process.env.FAKE_CODEX_START_DELAY_MS || 0);
+  if (startDelayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, startDelayMs));
+  }
+
   const output = providerOutput();
   const expectedPath = process.env.FAKE_CODEX_EXPECTED_OUTPUT;
   if (!expectedPath) throw new Error('FAKE_CODEX_EXPECTED_OUTPUT is required');
   fs.writeFileSync(expectedPath, output);
   await writeChunked(Buffer.from(output));
+  if (process.env.FAKE_CODEX_TERMINAL_FAILURE === '1') process.exitCode = 1;
 }
 
 main().catch((error) => {

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -7,9 +7,12 @@
  */
 
 const assert = require('assert');
+const { createHash } = require('node:crypto');
 const {
   extractJsonFromOutput,
   extractCliError,
+  extractCliFailure,
+  MAX_CLI_ERROR_BYTES,
   extractFromResultWrapper,
   extractFromTextEvents,
   extractFromMarkdown,
@@ -366,6 +369,52 @@ function defineCliErrorExtractionTests() {
         error: 'Something went wrong',
         provider: 'codex',
       });
+    });
+
+    it('uses the newest Codex terminal record and ignores benign source text', function () {
+      const output = [
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            type: 'command_execution',
+            aggregated_output: 'const Authorization = benignSource;',
+          },
+        }),
+        JSON.stringify({ type: 'turn.failed', error: { message: 'older failure' } }),
+        JSON.stringify({ type: 'turn.failed', error: { message: 'terminal provider failure' } }),
+      ].join('\n');
+
+      assert.deepStrictEqual(extractCliError(output, 'codex'), {
+        error: 'terminal provider failure',
+        provider: 'codex',
+      });
+    });
+
+    it('bounds Codex terminal messages by UTF-8 bytes and never returns object values', function () {
+      const huge = '🌍'.repeat(MAX_CLI_ERROR_BYTES);
+      const bounded = extractCliError(
+        JSON.stringify({ type: 'turn.failed', error: { message: huge } }),
+        'codex'
+      );
+      assert.ok(Buffer.byteLength(bounded.error) <= MAX_CLI_ERROR_BYTES);
+      assert.match(bounded.error, /\[truncated\]$/);
+      assert.deepStrictEqual(
+        extractCliFailure(
+          JSON.stringify({ type: 'turn.failed', error: { message: huge } }),
+          'codex'
+        ).diagnostic,
+        {
+          byteLength: Buffer.byteLength(huge),
+          sha256: createHash('sha256').update(huge).digest('hex'),
+        }
+      );
+      assert.deepStrictEqual(
+        extractCliError(
+          JSON.stringify({ type: 'turn.failed', error: { detail: { nested: true } } }),
+          'codex'
+        ),
+        { error: 'Turn failed', provider: 'codex' }
+      );
     });
 
     // Gemini errors

--- a/tests/provider-terminal-failure-lifecycle.test.js
+++ b/tests/provider-terminal-failure-lifecycle.test.js
@@ -76,6 +76,35 @@ describe('provider terminal failure lifecycle', function () {
     assert.strictEqual(agent.cluster.failureInfo.attempts, 1);
   });
 
+  it('installs failure info before a specific terminal event is published', async function () {
+    const messages = [];
+    const lifecycle = [];
+    const agent = retryableFailureAgent(messages, lifecycle);
+    let failureInfoAtPublish = null;
+    agent._spawnClaudeTask = () => {
+      const error = new Error('onComplete hook failed');
+      error.hookFailure = true;
+      error.hookRetries = 1;
+      return Promise.reject(error);
+    };
+    agent._publish = (message) => {
+      if (message.topic === 'CLUSTER_FAILED' && failureInfoAtPublish === null) {
+        failureInfoAtPublish = { ...agent.cluster.failureInfo };
+      }
+      messages.push(message);
+    };
+
+    await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'user' });
+
+    assert.strictEqual(failureInfoAtPublish.error, 'onComplete hook failed');
+    assert.strictEqual(failureInfoAtPublish.attempts, 1);
+    assert.strictEqual(failureInfoAtPublish.agentId, 'worker');
+  });
+});
+
+describe('isolated provider terminal failure lifecycle', function () {
+  this.timeout(10_000);
+
   it('redacts an isolated failure observed only during terminal catch-up', async function () {
     const rawError = 'insufficient_quota: Authorization: Bearer isolated-final-secret';
     const raw = `${JSON.stringify({

--- a/tests/provider-terminal-failure-lifecycle.test.js
+++ b/tests/provider-terminal-failure-lifecycle.test.js
@@ -1,0 +1,140 @@
+const assert = require('node:assert');
+const { createHash } = require('node:crypto');
+const EventEmitter = require('node:events');
+const { PassThrough } = require('node:stream');
+
+const { executeTask } = require('../src/agent/agent-lifecycle');
+const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
+
+const SAFE_RETRYABLE_ERROR = 'Provider codex failed (unknown; unknown-retryable)';
+
+function retryableFailureAgent(messages, lifecycle) {
+  return {
+    id: 'worker',
+    role: 'implementation',
+    running: true,
+    state: 'idle',
+    iteration: 0,
+    maxIterations: 5,
+    currentTaskId: null,
+    currentGuidanceSequence: null,
+    config: { maxRetries: 1, hooks: {}, cwd: process.cwd() },
+    cluster: { id: 'retryable-max-one', failureInfo: null },
+    messageBus: { query: () => [], publish: (message) => messages.push(message) },
+    _buildContext: () => 'synthetic context',
+    _spawnClaudeTask: () =>
+      Promise.resolve({
+        success: false,
+        error: SAFE_RETRYABLE_ERROR,
+        providerFailure: {
+          error: SAFE_RETRYABLE_ERROR,
+          provider: 'codex',
+          event: 'turn.failed',
+          category: 'unknown',
+          classification: { retryable: true, kind: 'unknown-retryable' },
+          diagnostic: { byteLength: 7, sha256: '0'.repeat(64) },
+        },
+      }),
+    _publish: (message) => messages.push(message),
+    _publishLifecycle: (event, data) => lifecycle.push({ event, data }),
+    _selectModel: () => 'synthetic',
+    _resolveProvider: () => 'codex',
+    _log() {},
+  };
+}
+
+function isolatedTailProcess() {
+  const processHandle = new EventEmitter();
+  processHandle.stdout = new PassThrough();
+  processHandle.stderr = new PassThrough();
+  processHandle.kill = () => {};
+  return processHandle;
+}
+
+describe('provider terminal failure lifecycle', function () {
+  this.timeout(10_000);
+
+  it('terminalizes a retryable provider failure when maxRetries is one', async function () {
+    const messages = [];
+    const lifecycle = [];
+    const agent = retryableFailureAgent(messages, lifecycle);
+
+    await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'user' });
+
+    const clusterFailures = messages.filter((message) => message.topic === 'CLUSTER_FAILED');
+    const agentErrors = messages.filter((message) => message.topic === 'AGENT_ERROR');
+    assert.strictEqual(clusterFailures.length, 1);
+    assert.strictEqual(agentErrors.length, 1);
+    assert.strictEqual(clusterFailures[0].content.data.attempts, 1);
+    assert.strictEqual(clusterFailures[0].content.data.retryable, true);
+    assert.strictEqual(agentErrors[0].content.data.attempts, 1);
+    assert.strictEqual(agentErrors[0].content.data.retryable, true);
+    assert.deepStrictEqual(
+      lifecycle.map((entry) => entry.event),
+      ['TASK_STARTED', 'TASK_FAILED']
+    );
+    assert.strictEqual(agent.cluster.failureInfo.attempts, 1);
+  });
+
+  it('redacts an isolated failure observed only during terminal catch-up', async function () {
+    const rawError = 'insufficient_quota: Authorization: Bearer isolated-final-secret';
+    const raw = `${JSON.stringify({
+      type: 'turn.failed',
+      error: { message: rawError },
+    })}\n`;
+    const published = [];
+    const manager = {
+      spawnInContainer: () => isolatedTailProcess(),
+      execInContainer(_clusterId, command) {
+        const rendered = command.join(' ');
+        if (rendered.includes('get-log-path')) {
+          return Promise.resolve({ code: 0, stdout: '/tmp/final.log\n', stderr: '' });
+        }
+        if (rendered.includes('zeroshot status')) {
+          return Promise.resolve({ code: 0, stdout: 'Status: failed\n', stderr: '' });
+        }
+        if (rendered.includes('wc -c')) {
+          return Promise.resolve({
+            code: 0,
+            stdout: `${Buffer.byteLength(raw)}\n`,
+            stderr: '',
+          });
+        }
+        if (rendered.includes('tail -c')) {
+          return Promise.resolve({ code: 0, stdout: raw, stderr: '' });
+        }
+        return Promise.reject(new Error(`Unexpected isolated command: ${rendered}`));
+      },
+    };
+    const agent = {
+      id: 'isolated-final-worker',
+      role: 'implementation',
+      iteration: 1,
+      running: true,
+      config: { outputFormat: 'text', cwd: process.cwd() },
+      cluster: { id: 'isolated-final' },
+      isolation: { manager, clusterId: 'isolated-final' },
+      messageBus: { publish: (message) => published.push(message) },
+      _resolveProvider: () => 'codex',
+      _log() {},
+      _stopLivenessCheck() {},
+    };
+
+    const result = await followClaudeTaskLogsIsolated(agent, 'task-final-only', {
+      skipStructuredResultCheck: true,
+    });
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'Provider codex failed (quota; permanent-pattern)');
+    assert.deepStrictEqual(result.providerFailure.diagnostic, {
+      byteLength: Buffer.byteLength(rawError),
+      sha256: createHash('sha256').update(rawError).digest('hex'),
+    });
+    assert.strictEqual(published.length, 1);
+    const serialized = JSON.stringify(published);
+    assert.doesNotMatch(
+      serialized,
+      /isolated-final-secret|Authorization: Bearer|insufficient_quota/
+    );
+  });
+});

--- a/tests/task-completion-classification.test.js
+++ b/tests/task-completion-classification.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { createHash } = require('node:crypto');
 
 const { buildCompletionResult, parseResultOutput } = require('../src/agent/agent-task-executor');
 
@@ -141,6 +142,45 @@ describe('buildCompletionResult', function () {
     assert.deepStrictEqual(parserOptions, { allowRecovery: false });
     assert.strictEqual(result.success, false);
     assert.match(result.error, /stale schema-invalid output/);
+  });
+  it('uses a concise classified Codex terminal tail after output beyond the inspection budget', async function () {
+    const sourceRecord = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        type: 'command_execution',
+        aggregated_output: `const Authorization = benignSource;${'x'.repeat(2 * 1024 * 1024)}`,
+      },
+    });
+    const terminalError = 'Synthetic provider failure after long output';
+    const output = `${sourceRecord}\n${JSON.stringify({
+      type: 'turn.failed',
+      error: { message: terminalError },
+    })}`;
+    assert.ok(Buffer.byteLength(output) > 2 * 1024 * 1024);
+
+    const result = await buildCompletionResult({
+      agent: createAgent({ outputFormat: 'text', jsonSchema: null }),
+      taskId: 'task-codex-tail',
+      providerName: 'codex',
+      state: createState(output),
+      stdout: 'Status: failed',
+      success: false,
+    });
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'Provider codex failed (unknown; unknown-retryable)');
+    assert.doesNotMatch(result.error, /Authorization|Task failed\. Output/);
+    assert.deepStrictEqual(result.providerFailure, {
+      error: 'Provider codex failed (unknown; unknown-retryable)',
+      provider: 'codex',
+      event: 'turn.failed',
+      category: 'unknown',
+      classification: { retryable: true, kind: 'unknown-retryable' },
+      diagnostic: {
+        byteLength: Buffer.byteLength(terminalError),
+        sha256: createHash('sha256').update(terminalError).digest('hex'),
+      },
+    });
   });
   it('propagates unannotated local authentication recovery failures without outer retry', async function () {
     const agent = createAgent({ role: 'planner' });

--- a/tests/unit/orchestrator-agent-error-stop.test.js
+++ b/tests/unit/orchestrator-agent-error-stop.test.js
@@ -9,6 +9,24 @@ const Ledger = require('../../src/ledger');
 const MessageBus = require('../../src/message-bus');
 const Orchestrator = require('../../src/orchestrator');
 
+function publishAgentError(messageBus, clusterId, sender, data) {
+  messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'AGENT_ERROR',
+    sender,
+    content: { data },
+  });
+}
+
+function publishClusterFailure(messageBus, clusterId) {
+  messageBus.publish({
+    cluster_id: clusterId,
+    topic: 'CLUSTER_FAILED',
+    sender: 'worker',
+    content: { data: { reason: 'provider_execution_failed' } },
+  });
+}
+
 describe('Orchestrator critical agent error handling', function () {
   this.timeout(10_000);
 
@@ -38,11 +56,10 @@ describe('Orchestrator critical agent error handling', function () {
     const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
     orchestrator._registerAgentErrorHandler(messageBus, 'c1');
 
-    messageBus.publish({
-      cluster_id: 'c1',
-      topic: 'AGENT_ERROR',
-      sender: 'consensus-coordinator',
-      content: { data: { role: 'coordinator', attempts: 3, error: 'boom' } },
+    publishAgentError(messageBus, 'c1', 'consensus-coordinator', {
+      role: 'coordinator',
+      attempts: 3,
+      error: 'boom',
     });
 
     await new Promise((r) => setTimeout(r, 10));
@@ -54,13 +71,11 @@ describe('Orchestrator critical agent error handling', function () {
     const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
     orchestrator._registerAgentErrorHandler(messageBus, 'c2');
 
-    messageBus.publish({
-      cluster_id: 'c2',
-      topic: 'AGENT_ERROR',
-      sender: 'consensus-coordinator',
-      content: {
-        data: { role: 'coordinator', attempts: 1, hookFailure: true, error: 'hook died' },
-      },
+    publishAgentError(messageBus, 'c2', 'consensus-coordinator', {
+      role: 'coordinator',
+      attempts: 1,
+      hookFailure: true,
+      error: 'hook died',
     });
 
     await new Promise((r) => setTimeout(r, 10));
@@ -72,14 +87,43 @@ describe('Orchestrator critical agent error handling', function () {
     const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
     orchestrator._registerAgentErrorHandler(messageBus, 'c3');
 
-    messageBus.publish({
-      cluster_id: 'c3',
-      topic: 'AGENT_ERROR',
-      sender: 'validator-1',
-      content: { data: { role: 'validator', attempts: 3, error: 'nope' } },
+    publishAgentError(messageBus, 'c3', 'validator-1', {
+      role: 'validator',
+      attempts: 3,
+      error: 'nope',
     });
 
     await new Promise((r) => setTimeout(r, 10));
     assert.equal(stopSpy.called, false);
+  });
+
+  it('does not terminalize a retryable critical-agent status observation', async () => {
+    const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
+    orchestrator._registerAgentErrorHandler(messageBus, 'c4');
+
+    publishAgentError(messageBus, 'c4', 'worker', {
+      role: 'implementation',
+      attempts: 1,
+      error: 'polling_timeout',
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(stopSpy.called, false);
+    assert.equal(messageBus.query({ cluster_id: 'c4', topic: 'CLUSTER_FAILED' }).length, 0);
+  });
+
+  it('does not stop twice after a durable cluster failure', async () => {
+    const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
+    orchestrator._registerClusterCompletionHandlers(messageBus, 'c5');
+    orchestrator._registerAgentErrorHandler(messageBus, 'c5');
+    publishClusterFailure(messageBus, 'c5');
+    publishAgentError(messageBus, 'c5', 'worker', {
+      role: 'implementation',
+      attempts: 3,
+      error: 'retry budget exhausted',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(stopSpy.callCount, 1);
   });
 });

--- a/tests/unit/orchestrator-agent-error-stop.test.js
+++ b/tests/unit/orchestrator-agent-error-stop.test.js
@@ -27,30 +27,36 @@ function publishClusterFailure(messageBus, clusterId) {
   });
 }
 
+function settleHandlers() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+let tempDir;
+let ledger;
+let messageBus;
+let orchestrator;
+
+function setupHarness() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-orchestrator-agent-error-'));
+  ledger = new Ledger(path.join(tempDir, 'test.db'));
+  messageBus = new MessageBus(ledger);
+  orchestrator = new Orchestrator({ quiet: true, skipLoad: true, storageDir: tempDir });
+  sinon.stub(orchestrator, '_saveClusters').resolves();
+}
+
+function cleanupHarness() {
+  sinon.restore();
+  if (ledger) ledger.close();
+  if (tempDir && fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe('Orchestrator critical agent error handling', function () {
   this.timeout(10_000);
 
-  let tempDir;
-  let ledger;
-  let messageBus;
-  let orchestrator;
-
-  beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-orchestrator-agent-error-'));
-    ledger = new Ledger(path.join(tempDir, 'test.db'));
-    messageBus = new MessageBus(ledger);
-
-    orchestrator = new Orchestrator({ quiet: true, skipLoad: true, storageDir: tempDir });
-    sinon.stub(orchestrator, '_saveClusters').resolves();
-  });
-
-  afterEach(() => {
-    sinon.restore();
-    if (ledger) ledger.close();
-    if (tempDir && fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+  beforeEach(setupHarness);
+  afterEach(cleanupHarness);
 
   it('stops cluster when coordinator fails after retries', async () => {
     const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
@@ -62,7 +68,7 @@ describe('Orchestrator critical agent error handling', function () {
       error: 'boom',
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await settleHandlers();
     assert.equal(stopSpy.calledOnce, true);
     assert.equal(stopSpy.firstCall.args[0], 'c1');
   });
@@ -78,7 +84,7 @@ describe('Orchestrator critical agent error handling', function () {
       error: 'hook died',
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await settleHandlers();
     assert.equal(stopSpy.calledOnce, true);
     assert.equal(stopSpy.firstCall.args[0], 'c2');
   });
@@ -93,7 +99,7 @@ describe('Orchestrator critical agent error handling', function () {
       error: 'nope',
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await settleHandlers();
     assert.equal(stopSpy.called, false);
   });
 
@@ -107,12 +113,17 @@ describe('Orchestrator critical agent error handling', function () {
       error: 'polling_timeout',
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await settleHandlers();
     assert.equal(stopSpy.called, false);
     assert.equal(messageBus.query({ cluster_id: 'c4', topic: 'CLUSTER_FAILED' }).length, 0);
   });
+});
 
-  it('does not stop twice after a durable cluster failure', async () => {
+describe('Orchestrator terminal stop deduplication', function () {
+  beforeEach(setupHarness);
+  afterEach(cleanupHarness);
+
+  it('deduplicates only a current-run durable cluster failure', async () => {
     const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
     orchestrator._registerClusterCompletionHandlers(messageBus, 'c5');
     orchestrator._registerAgentErrorHandler(messageBus, 'c5');
@@ -123,7 +134,20 @@ describe('Orchestrator critical agent error handling', function () {
       error: 'retry budget exhausted',
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settleHandlers();
     assert.equal(stopSpy.callCount, 1);
+
+    stopSpy.resetHistory();
+    publishClusterFailure(messageBus, 'c6');
+    orchestrator._registerAgentErrorHandler(messageBus, 'c6');
+    publishAgentError(messageBus, 'c6', 'worker', {
+      role: 'implementation',
+      attempts: 3,
+      error: 'failed again after resume',
+    });
+
+    await settleHandlers();
+    assert.equal(stopSpy.callCount, 1);
+    assert.equal(stopSpy.firstCall.args[0], 'c6');
   });
 });


### PR DESCRIPTION
## Summary

- extract typed provider terminal failures from the newest bounded Codex output instead of persisting an entire JSONL stream
- persist a closed provider failure envelope with category, retryability, diagnostic byte length, and SHA-256 while keeping raw provider text in the private task log
- durably terminalize exhausted work exactly once, including maxRetries=1, detached daemons, isolated execution, and legacy AGENT_ERROR fallback
- add local and detached zero-token stress regressions for 12 MiB output, terminal-only catch-up, retry exhaustion, process cleanup, export safety, and absence of false completion signals

## Root cause

The benchmark lifecycle exercises a different operational contract than foreground local use. Failed Codex tasks skipped structured result parsing, the fallback copied the bounded control-plane JSONL tail into failureInfo, and retry exhaustion could stop without one durable CLUSTER_FAILED event. A detached daemon could therefore exit while persisted state still looked running, and terminal provider diagnostics were both obscured and unsafe to retain in status or export.

Closes #968.

## Safety and compatibility

Raw provider terminal text is retained only in the task log. Status, task rows, AGENT_ERROR, CLUSTER_FAILED, and JSON export receive only the normalized envelope. Retryable failures still honor configured retry limits; permanent provider failures stop immediately. Existing legacy AGENT_ERROR-only terminalization remains supported, while paired durable terminal events no longer stop twice.

## Validation

- npm test: 2,761 passing, 18 pending
- npm run test:e2e: 27 passing
- npm run lint: 0 errors
- npm run typecheck
- npm run audit:production
- npm run prepublishOnly
- npm run release:preflight: patch after v6.34.2
- opcore check --changed
- npm run opcore:check
- Opcore Zero Verify and staged Sense: no introduced issues, cycles, duplicates, or interface findings
- 128 MiB heap stress and zero-token detached provider failure scenarios
