### PR TITLE
fix: bound exact commit resolution

### DIFF
--- a/private/hosted-cli-candidate/credentials.js
+++ b/private/hosted-cli-candidate/credentials.js
@@ -177,7 +177,7 @@ async function resolveSubmissionBase(setup, token, fetchImpl = globalThis.fetch)
     targetBranch = setup.base.targetBranch;
     const commit = await githubMetadata(
       setup.repository,
-      `/commits/${setup.base.revision}`,
+      `/git/commits/${setup.base.revision}`,
       token,
       fetchImpl
     );

--- a/tests/private-hosted-cli/preflight-setup.test.js
+++ b/tests/private-hosted-cli/preflight-setup.test.js
@@ -130,7 +130,13 @@ it('stores references and resolves one provider-neutral runtime bundle per run',
       GH_TOKEN: 'github-test-token',
       LOCAL_AWS_ACCESS_KEY_ID: 'aws-local-secret',
     },
-    fetch: () => new globalThis.Response(JSON.stringify({ sha: BASE_REVISION }), { status: 200 }),
+    fetch: (url) => {
+      assert.equal(
+        url,
+        `https://api.github.com/repos/owner/repository/git/commits/${BASE_REVISION}`
+      );
+      return new globalThis.Response(JSON.stringify({ sha: BASE_REVISION }), { status: 200 });
+    },
   });
   assert.equal(bundle.githubToken, 'github-test-token');
   assert.equal(bundle.baseRevision, BASE_REVISION);


### PR DESCRIPTION
## Summary

- resolve exact hosted bases through GitHub’s compact Git commit endpoint
- assert the exact bounded endpoint in the hosted setup contract test

## Validation

- `node --test tests/private-hosted-cli/preflight-setup.test.js`
- `npx eslint private/hosted-cli-candidate/credentials.js tests/private-hosted-cli/preflight-setup.test.js`
- `opcore-zero check --repo . --staged --json`

Follow-up found by zero-cloud issue #106 full-stack validation.