### PR TITLE
fix: terminalize exhausted provider roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -822,6 +822,11 @@ byte-length/SHA-256 receipt. Final critical-agent exhaustion installs `failureIn
 exactly one durable `CLUSTER_FAILED`; the legacy `AGENT_ERROR` stop fallback must not initiate a
 second stop after that terminal topic exists in the current run, while prior-run failures must not
 suppress terminalization after resume.
+Every named non-validator role is cluster-critical after final task retry exhaustion, including
+planning, conductor, custom, and orchestrator roles; validators alone use their rejection path.
+Keep that rule centralized in `src/agent/critical-agent-policy.js`. Terminal `AGENT_ERROR` records
+set `retryBudgetExhausted: true`; never infer task exhaustion from `attempts`, because status-poll
+observations use the same counter while the lifecycle still owns a retry.
 The SQLite ledger additionally keeps one cluster-wide newest tail of non-replayable
 `AGENT_OUTPUT` (8 MiB / 8192 exported messages) and a persisted deterministic omission receipt;
 live delivery is unchanged, while control and explicitly replayable messages are never compacted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,12 @@ Priority order for bare numbers:
 Agent A → publish() → SQLite Ledger → LogicEngine → trigger match → Agent B executes
 ```
 
+**Failure terminalization:** Every named non-validator role is cluster-critical after final task
+retry exhaustion; validators alone publish rejection and remain non-terminal. Keep the role rule in
+`src/agent/critical-agent-policy.js`. Final `AGENT_ERROR` records explicitly set
+`retryBudgetExhausted: true`; never infer task exhaustion from `attempts`, because status polling
+uses that counter before the lifecycle retry budget is exhausted.
+
 ### Core Primitives
 
 | Primitive    | Purpose                                                     |

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -892,7 +892,6 @@ ${'='.repeat(80)}`);
     unsupportedCapability,
     structuredOutputInvalid,
   });
-
   // Publish error to message bus for visibility in logs
   agent._publish({
     topic: 'AGENT_ERROR',
@@ -905,6 +904,7 @@ ${'='.repeat(80)}`);
         hookFailure: error?.hookFailure === true,
         restartExhausted: error?.restartExhausted === true,
         terminationExhausted: error?.terminationExhausted === true,
+        retryBudgetExhausted: true,
         hookRetries: error?.hookRetries ?? undefined,
         originalHookError: error?.originalHookError ?? undefined,
         agent: agent.id,

--- a/src/agent/critical-agent-policy.js
+++ b/src/agent/critical-agent-policy.js
@@ -1,0 +1,17 @@
+// @ts-nocheck
+
+// Validators publish a rejection when their task exhausts retries. Every other named role can
+// execute provider work, including user-defined and orchestrator roles, so exhaustion must
+// terminalize the cluster by default instead of requiring this policy to know each future role.
+const NON_TERMINAL_AGENT_ROLES = new Set(['validator']);
+
+function isCriticalAgent(agent) {
+  if (agent?.id === 'consensus-coordinator') return true;
+  return (
+    typeof agent?.role === 'string' &&
+    agent.role.length > 0 &&
+    !NON_TERMINAL_AGENT_ROLES.has(agent.role)
+  );
+}
+
+module.exports = { isCriticalAgent };

--- a/src/agent/provider-terminal-failure.js
+++ b/src/agent/provider-terminal-failure.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 const { getProvider } = require('../providers');
+const { isCriticalAgent } = require('./critical-agent-policy');
 const { extractCliFailure } = require('./output-extraction');
 
 function categoryForProviderFailure(error, classification) {
@@ -120,10 +121,7 @@ function publishCriticalFailure({
     unsupportedCapability ||
     error?.vertexModelError ||
     error?.terminationExhausted;
-  const critical =
-    agent.role === 'implementation' ||
-    agent.role === 'coordinator' ||
-    agent.id === 'consensus-coordinator';
+  const critical = isCriticalAgent(agent);
   if (!critical || specific) return worker;
 
   agent._publish({

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -60,6 +60,7 @@ const {
   normalizeProviderSession,
   restoreAgentProviderSession,
 } = require('./agent/provider-session');
+const { isCriticalAgent } = require('./agent/critical-agent-policy');
 const {
   commandProofsToQualityGates,
   mergeCommandProofs,
@@ -1582,6 +1583,7 @@ class Orchestrator {
       const attempts = message.content?.data?.attempts || 1;
       const hookFailure = message.content?.data?.hookFailure === true;
       const restartExhausted = message.content?.data?.restartExhausted === true;
+      const retryBudgetExhausted = message.content?.data?.retryBudgetExhausted === true;
       const durableClusterFailure = this._findCurrentRunClusterFailure(
         messageBus,
         clusterId,
@@ -1590,14 +1592,14 @@ class Orchestrator {
 
       await this._saveClusters();
 
-      const shouldStopForRole =
-        agentRole === 'implementation' ||
-        agentRole === 'coordinator' ||
-        message.sender === 'consensus-coordinator';
+      const shouldStopForRole = isCriticalAgent({
+        id: message.sender,
+        role: agentRole,
+      });
       const shouldStop =
         !durableClusterFailure &&
         shouldStopForRole &&
-        (hookFailure || restartExhausted || attempts >= 3);
+        (hookFailure || restartExhausted || retryBudgetExhausted);
 
       if (shouldStop) {
         this._log(`\n${'='.repeat(80)}`);
@@ -1607,6 +1609,7 @@ class Orchestrator {
           `${message.sender} (${agentRole || 'unknown role'}) failed` +
             (hookFailure ? ` (hookFailure=true)` : ``) +
             (restartExhausted ? ` (restartExhausted=true)` : ``) +
+            (retryBudgetExhausted ? ` (retryBudgetExhausted=true)` : ``) +
             ` after ${attempts} attempts`
         );
         this._log(`Error: ${message.content?.data?.error || 'unknown'}`);

--- a/tests/e2e/codex-planner-retry-terminalization.test.js
+++ b/tests/e2e/codex-planner-retry-terminalization.test.js
@@ -264,7 +264,7 @@ function assertPersistedControlPlane(env, clusterId, exportPath, status) {
 }
 
 describe('e2e: detached Codex planning retry exhaustion', function () {
-  this.timeout(30_000);
+  this.timeout(60_000);
 
   it('stops cleanly after three retryable turn.failed attempts without leaking diagnostics', async function () {
     const env = setupE2ERepo();
@@ -280,13 +280,13 @@ describe('e2e: detached Codex planning retry exhaustion', function () {
         (status) => Number.isInteger(status.pid) && status.pid > 1
       );
       daemonPid = running.pid;
-      await waitForPidExit(daemonPid);
       const status = await pollCliStatus(
         env,
         clusterId,
         (value) => value.state === 'stopped',
-        5_000
+        30_000
       );
+      await waitForPidExit(daemonPid);
       assertStoppedStatus(env, clusterId, status, daemonPid);
       assert.strictEqual(fs.readFileSync(fixture.countFile, 'utf8').trim(), '3');
       assertFailedTasks(env.homeDir, status.failureInfo.taskId);

--- a/tests/e2e/codex-planner-retry-terminalization.test.js
+++ b/tests/e2e/codex-planner-retry-terminalization.test.js
@@ -1,0 +1,299 @@
+const { strict: assert } = require('node:assert');
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const Database = require('better-sqlite3');
+
+const { setupE2ERepo, cleanupE2ERepo, runZeroshot } = require('./helpers/e2e-harness');
+const {
+  pidExists,
+  pollCliStatus,
+  waitForPidExit,
+  terminateDetachedDaemon,
+} = require('./helpers/detached-process');
+
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'codex-retryable-planner-config.json');
+const FAKE_CODEX_PATH = path.resolve(__dirname, '..', 'fixtures', 'fake-codex-terminal-stress.js');
+const RAW_SECRET = 'sk-zs-retryable-secret';
+const RAW_FAILURE =
+  `service_unavailable: synthetic retryable provider outage; ` +
+  `Authorization: Bearer ${RAW_SECRET}`;
+const SAFE_ERROR = 'Provider codex failed (transient; retryable-pattern)';
+const DIAGNOSTIC_RECEIPT = {
+  byteLength: Buffer.byteLength(RAW_FAILURE),
+  sha256: createHash('sha256').update(RAW_FAILURE).digest('hex'),
+};
+
+function assertRedacted(serialized) {
+  assert.doesNotMatch(serialized, new RegExp(RAW_SECRET));
+  assert.doesNotMatch(
+    serialized,
+    /service_unavailable|synthetic retryable provider outage|Authorization: Bearer/
+  );
+}
+
+function assertProviderReceipt(value) {
+  assert.strictEqual(value.provider, 'codex');
+  assert.strictEqual(value.event, 'turn.failed');
+  assert.strictEqual(value.category, 'transient');
+  assert.strictEqual(value.kind, 'retryable-pattern');
+  assert.strictEqual(value.retryable, true);
+  assert.deepStrictEqual(value.diagnostic, DIAGNOSTIC_RECEIPT);
+}
+
+function expectedAgentOutputEnvelope() {
+  return {
+    type: 'turn.failed',
+    error: { message: SAFE_ERROR },
+    zeroshot_failure: {
+      provider: 'codex',
+      event: 'turn.failed',
+      category: 'transient',
+      kind: 'retryable-pattern',
+      retryable: true,
+      diagnostic: DIAGNOSTIC_RECEIPT,
+    },
+  };
+}
+
+function readTaskRows(homeDir) {
+  const storePath = path.join(homeDir, '.claude-zeroshot', 'store.db');
+  const database = new Database(storePath, { readonly: true, fileMustExist: true });
+  try {
+    return database
+      .prepare(
+        `SELECT id, status, error, log_file, pid, process_group_id, exit_code
+         FROM tasks ORDER BY created_at, id`
+      )
+      .all();
+  } finally {
+    database.close();
+  }
+}
+
+function exportCluster(env, clusterId, outputPath) {
+  const result = runZeroshot(env, [
+    'export',
+    clusterId,
+    '--output',
+    outputPath,
+    '--format',
+    'json',
+  ]);
+  assert.strictEqual(result.status, 0, result.stderr);
+  const serialized = fs.readFileSync(outputPath, 'utf8');
+  assertRedacted(serialized);
+  return JSON.parse(serialized);
+}
+
+function lifecycleEvents(messages, event) {
+  return messages.filter(
+    (message) => message.topic === 'AGENT_LIFECYCLE' && message.content?.data?.event === event
+  );
+}
+
+function assertTerminalMessages(messages, status) {
+  const taskStarted = lifecycleEvents(messages, 'TASK_STARTED');
+  const taskFailed = lifecycleEvents(messages, 'TASK_FAILED');
+  const retryScheduled = lifecycleEvents(messages, 'RETRY_SCHEDULED');
+  assert.strictEqual(taskStarted.length, 3);
+  assert.strictEqual(taskFailed.length, 3);
+  assert.strictEqual(retryScheduled.length, 2);
+  assert.deepStrictEqual(
+    taskFailed.map((message) => message.content.data.attempt),
+    [1, 2, 3]
+  );
+  assert.deepStrictEqual(
+    retryScheduled.map((message) => message.content.data.attempt),
+    [1, 2]
+  );
+
+  const terminalAgentOutput = messages
+    .filter((message) => message.topic === 'AGENT_OUTPUT')
+    .map((message) => message.content?.data?.line)
+    .filter((line) => typeof line === 'string' && line.trim().startsWith('{'))
+    .map((line) => JSON.parse(line))
+    .filter((value) => value.type === 'turn.failed');
+  assert.strictEqual(terminalAgentOutput.length, 3);
+  for (const envelope of terminalAgentOutput) {
+    assert.deepStrictEqual(envelope, expectedAgentOutputEnvelope());
+  }
+
+  const clusterFailures = messages.filter((message) => message.topic === 'CLUSTER_FAILED');
+  assert.strictEqual(clusterFailures.length, 1);
+  const clusterFailure = clusterFailures[0];
+  assert.strictEqual(clusterFailure.sender, 'planner');
+  assert.strictEqual(clusterFailure.content.data.reason, 'provider_execution_failed');
+  assert.strictEqual(clusterFailure.content.data.agentId, 'planner');
+  assert.strictEqual(clusterFailure.content.data.role, 'planning');
+  assert.strictEqual(clusterFailure.content.data.attempts, 3);
+  assert.strictEqual(clusterFailure.content.data.code, 'crash');
+  assert.strictEqual(clusterFailure.content.data.workerReason, 'declared_failure');
+  assertProviderReceipt(clusterFailure.content.data);
+
+  const agentErrors = messages.filter((message) => message.topic === 'AGENT_ERROR');
+  assert.strictEqual(agentErrors.length, 1);
+  const agentError = agentErrors[0];
+  assert.strictEqual(agentError.content.data.error, SAFE_ERROR);
+  assert.strictEqual(agentError.content.data.stack, undefined);
+  assert.strictEqual(agentError.content.data.agent, 'planner');
+  assert.strictEqual(agentError.content.data.role, 'planning');
+  assert.strictEqual(agentError.content.data.attempts, 3);
+  assert.strictEqual(agentError.content.data.retryBudgetExhausted, true);
+  assert.strictEqual(agentError.content.data.workerCode, 'crash');
+  assert.strictEqual(agentError.content.data.workerReason, 'declared_failure');
+  assertProviderReceipt(agentError.content.data);
+
+  assert.ok(BigInt(String(taskFailed.at(-1).sequence)) < BigInt(String(clusterFailure.sequence)));
+  assert.ok(BigInt(String(clusterFailure.sequence)) < BigInt(String(agentError.sequence)));
+  assert.strictEqual(messages.length, status.messageCount);
+
+  assert.strictEqual(
+    messages.some((message) =>
+      ['CLUSTER_COMPLETE', 'TASK_COMPLETE', 'PLAN_READY', 'VALIDATION_RESULT'].includes(
+        message.topic
+      )
+    ),
+    false,
+    'provider infrastructure failure must never reach scoreable/verifier completion'
+  );
+  assert.strictEqual(lifecycleEvents(messages, 'TASK_COMPLETED').length, 0);
+}
+
+function prepareFixture(env, issueDir) {
+  const issuePath = path.join(issueDir, 'task.md');
+  const countFile = path.join(issueDir, 'attempt-count');
+  const exportPath = path.join(issueDir, 'cluster-export.json');
+  fs.writeFileSync(issuePath, '# Synthetic retryable planning failure\n');
+  fs.writeFileSync(
+    path.join(env.homeDir, '.zeroshot', 'settings.json'),
+    `${JSON.stringify({
+      autoCheckUpdates: false,
+      backoffBaseMs: 0,
+      backoffMaxMs: 0,
+      jitterFactor: 0,
+    })}\n`
+  );
+  fs.symlinkSync(FAKE_CODEX_PATH, path.join(env.binDir, 'codex'));
+  return { issuePath, countFile, exportPath };
+}
+
+function startDetachedPlanner(env, issuePath, countFile) {
+  const run = runZeroshot(
+    env,
+    [
+      'run',
+      issuePath,
+      '--detach',
+      '--provider',
+      'codex',
+      '--config',
+      CONFIG_PATH,
+      '--model',
+      'gpt-5.6-luna',
+      '--strict-schema',
+      '--sim',
+      'off',
+    ],
+    {
+      OPENAI_API_KEY: '',
+      CODEX_API_KEY: '',
+      OPENROUTER_API_KEY: '',
+      ANTHROPIC_API_KEY: '',
+      FAKE_CODEX_COUNT_FILE: countFile,
+      FAKE_CODEX_DELAY_MS: '250',
+      FAKE_CODEX_RETRYABLE_TERMINAL: '1',
+      timeout: 15_000,
+    }
+  );
+  assert.strictEqual(run.status, 0, `STDOUT:\n${run.stdout}\nSTDERR:\n${run.stderr}`);
+  const clusterMatch = /Started (\S+)/.exec(run.stdout);
+  assert.ok(clusterMatch, `expected detached cluster id in:\n${run.stdout}`);
+  return clusterMatch[1];
+}
+
+function assertStoppedStatus(env, clusterId, status, daemonPid) {
+  const statusResult = runZeroshot(env, ['status', clusterId, '--json']);
+  assert.strictEqual(statusResult.status, 0, statusResult.stderr);
+  assertRedacted(statusResult.stdout);
+  assert.deepStrictEqual([status.state, status.pid, status.isZombie], ['stopped', null, false]);
+  assert.strictEqual(status.failureInfo.error, SAFE_ERROR);
+  assert.strictEqual(status.failureInfo.agentId, 'planner');
+  assert.strictEqual(status.failureInfo.attempts, 3);
+  assert.strictEqual(status.failureInfo.iteration, 3);
+  assert.strictEqual(status.failureInfo.code, 'crash');
+  assert.strictEqual(status.failureInfo.workerReason, 'declared_failure');
+  assertProviderReceipt(status.failureInfo);
+
+  const planner = status.agents.find((agent) => agent.id === 'planner');
+  assert.ok(planner, 'planner state must remain inspectable after failure');
+  assert.deepStrictEqual(
+    {
+      iteration: planner.iteration,
+      currentTask: planner.currentTask,
+      currentTaskId: planner.currentTaskId,
+      pid: planner.pid,
+    },
+    { iteration: 3, currentTask: false, currentTaskId: null, pid: null }
+  );
+  assert.strictEqual(pidExists(daemonPid), false);
+}
+
+function assertFailedTasks(homeDir, failureTaskId) {
+  const tasks = readTaskRows(homeDir);
+  assert.strictEqual(tasks.length, 3);
+  assertRedacted(JSON.stringify(tasks));
+  for (const task of tasks) {
+    assert.strictEqual(task.status, 'failed');
+    assert.strictEqual(task.pid, null);
+    assert.strictEqual(task.process_group_id, null);
+    assert.strictEqual(task.exit_code, 1);
+    const rawLog = fs.readFileSync(task.log_file, 'utf8');
+    assert.match(rawLog, new RegExp(RAW_SECRET));
+    assert.match(rawLog, /service_unavailable|Authorization: Bearer/);
+  }
+  assert.ok(tasks.some((task) => task.id === failureTaskId));
+}
+
+function assertPersistedControlPlane(env, clusterId, exportPath, status) {
+  const registry = fs.readFileSync(path.join(env.homeDir, '.zeroshot', 'clusters.json'), 'utf8');
+  assertRedacted(registry);
+  const exported = exportCluster(env, clusterId, exportPath);
+  assertTerminalMessages(exported.messages, status);
+}
+
+describe('e2e: detached Codex planning retry exhaustion', function () {
+  this.timeout(30_000);
+
+  it('stops cleanly after three retryable turn.failed attempts without leaking diagnostics', async function () {
+    const env = setupE2ERepo();
+    const issueDir = fs.mkdtempSync(path.join(env.homeDir, 'planner-retry-failure-'));
+    let daemonPid = null;
+    try {
+      const fixture = prepareFixture(env, issueDir);
+      const clusterId = startDetachedPlanner(env, fixture.issuePath, fixture.countFile);
+
+      const running = await pollCliStatus(
+        env,
+        clusterId,
+        (status) => Number.isInteger(status.pid) && status.pid > 1
+      );
+      daemonPid = running.pid;
+      await waitForPidExit(daemonPid);
+      const status = await pollCliStatus(
+        env,
+        clusterId,
+        (value) => value.state === 'stopped',
+        5_000
+      );
+      assertStoppedStatus(env, clusterId, status, daemonPid);
+      assert.strictEqual(fs.readFileSync(fixture.countFile, 'utf8').trim(), '3');
+      assertFailedTasks(env.homeDir, status.failureInfo.taskId);
+      assertPersistedControlPlane(env, clusterId, fixture.exportPath, status);
+    } finally {
+      await terminateDetachedDaemon(daemonPid);
+      cleanupE2ERepo(env);
+    }
+  });
+});

--- a/tests/e2e/fixtures/codex-retryable-planner-config.json
+++ b/tests/e2e/fixtures/codex-retryable-planner-config.json
@@ -1,0 +1,37 @@
+{
+  "defaultProvider": "codex",
+  "agents": [
+    {
+      "id": "planner",
+      "role": "planning",
+      "provider": "codex",
+      "modelLevel": "level1",
+      "reasoningEffort": "max",
+      "maxRetries": 3,
+      "timeout": 0,
+      "outputFormat": "json",
+      "jsonSchema": {
+        "type": "object",
+        "properties": {
+          "plan": { "type": "string" },
+          "summary": { "type": "string" }
+        },
+        "required": ["plan", "summary"]
+      },
+      "triggers": [{ "topic": "ISSUE_OPENED", "action": "execute_task" }],
+      "prompt": "Produce a plan for the synthetic qualification task.",
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": { "topic": "PLAN_READY", "content": { "text": "Done" } }
+        }
+      }
+    },
+    {
+      "id": "completion-detector",
+      "role": "orchestrator",
+      "timeout": 0,
+      "triggers": [{ "topic": "PLAN_READY", "action": "stop_cluster" }]
+    }
+  ]
+}

--- a/tests/e2e/helpers/detached-process.js
+++ b/tests/e2e/helpers/detached-process.js
@@ -1,0 +1,69 @@
+const { runZeroshot } = require('./e2e-harness');
+
+function pidExists(pid) {
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+async function waitUntil(description, probe, timeoutMs, intervalMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = probe();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`${description} was not observed within ${timeoutMs}ms`);
+}
+
+async function pollCliStatus(env, clusterId, predicate, timeoutMs = 10_000) {
+  let diagnostic = '';
+  try {
+    return await waitUntil(
+      `status predicate for ${clusterId}`,
+      () => {
+        const result = runZeroshot(env, ['status', clusterId, '--json']);
+        diagnostic = result.stderr || result.stdout;
+        if (result.status !== 0) return null;
+        const status = JSON.parse(result.stdout);
+        return predicate(status) ? status : null;
+      },
+      timeoutMs,
+      75
+    );
+  } catch (error) {
+    throw new Error(`${error.message}: ${diagnostic}`);
+  }
+}
+
+function waitForPidExit(pid, timeoutMs = 10_000) {
+  return waitUntil(`daemon pid ${pid} exit`, () => !pidExists(pid), timeoutMs, 50);
+}
+
+async function terminateDetachedDaemon(pid) {
+  if (!pidExists(pid)) return;
+  const target = process.platform === 'win32' ? pid : -pid;
+  for (const signal of ['SIGTERM', 'SIGKILL']) {
+    try {
+      process.kill(target, signal);
+    } catch {
+      try {
+        process.kill(pid, signal);
+      } catch {
+        return;
+      }
+    }
+    try {
+      await waitForPidExit(pid, 2_000);
+      return;
+    } catch {
+      // Escalate once from a graceful stop to a forced stop.
+    }
+  }
+}
+
+module.exports = { pidExists, pollCliStatus, waitForPidExit, terminateDetachedDaemon };

--- a/tests/fixtures/fake-codex-terminal-stress.js
+++ b/tests/fixtures/fake-codex-terminal-stress.js
@@ -2,6 +2,10 @@
 
 const fs = require('node:fs');
 
+const RETRYABLE_FAILURE =
+  'service_unavailable: synthetic retryable provider outage; ' +
+  'Authorization: Bearer sk-zs-retryable-secret';
+
 function writeChunked(buffer) {
   return new Promise((resolve, reject) => {
     let offset = 0;
@@ -102,6 +106,23 @@ function providerOutput() {
   return `${lines.join('\n')}\n`;
 }
 
+async function retryableProviderOutput() {
+  const countFile = process.env.FAKE_CODEX_COUNT_FILE;
+  if (!countFile) throw new Error('FAKE_CODEX_COUNT_FILE is required');
+  const previous = fs.existsSync(countFile)
+    ? Number.parseInt(fs.readFileSync(countFile, 'utf8').trim(), 10) || 0
+    : 0;
+  const attempt = previous + 1;
+  fs.writeFileSync(countFile, `${attempt}\n`);
+  const delayMs = Number(process.env.FAKE_CODEX_DELAY_MS || 0);
+  if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+  process.stdout.write(
+    `${JSON.stringify({ type: 'thread.started', thread_id: `fake-retry-${attempt}` })}\n` +
+      `${JSON.stringify({ type: 'turn.failed', error: { message: RETRYABLE_FAILURE } })}\n`
+  );
+  process.exitCode = 1;
+}
+
 async function main() {
   if (process.argv.includes('--version')) {
     process.stdout.write('codex-cli 0.147.0\n');
@@ -112,6 +133,11 @@ async function main() {
       'codex exec --json --output-schema -m -C --config --skip-git-repo-check ' +
         '--sandbox --ephemeral --ignore-user-config --ignore-rules --strict-config resume\n'
     );
+    return;
+  }
+
+  if (process.env.FAKE_CODEX_RETRYABLE_TERMINAL === '1') {
+    await retryableProviderOutput();
     return;
   }
 

--- a/tests/provider-terminal-failure-lifecycle.test.js
+++ b/tests/provider-terminal-failure-lifecycle.test.js
@@ -4,6 +4,7 @@ const EventEmitter = require('node:events');
 const { PassThrough } = require('node:stream');
 
 const { executeTask } = require('../src/agent/agent-lifecycle');
+const { isCriticalAgent } = require('../src/agent/critical-agent-policy');
 const { followClaudeTaskLogsIsolated } = require('../src/agent/agent-task-executor');
 
 const SAFE_RETRYABLE_ERROR = 'Provider codex failed (unknown; unknown-retryable)';
@@ -99,6 +100,61 @@ describe('provider terminal failure lifecycle', function () {
     assert.strictEqual(failureInfoAtPublish.error, 'onComplete hook failed');
     assert.strictEqual(failureInfoAtPublish.attempts, 1);
     assert.strictEqual(failureInfoAtPublish.agentId, 'worker');
+  });
+});
+
+describe('critical workflow role terminalization', function () {
+  it('uses one terminal policy for executable workflow roles', function () {
+    for (const role of [
+      'planning',
+      'implementation',
+      'conductor',
+      'coordinator',
+      'completion',
+      'orchestrator',
+    ]) {
+      assert.strictEqual(isCriticalAgent({ id: role, role }), true);
+    }
+    assert.strictEqual(isCriticalAgent({ id: 'consensus-coordinator', role: 'custom' }), true);
+    assert.strictEqual(isCriticalAgent({ id: 'validator-1', role: 'validator' }), false);
+    assert.strictEqual(isCriticalAgent({ id: 'missing-role' }), false);
+  });
+
+  it('terminalizes retryable provider failure for planner, conductor, and orchestrator roles', async function () {
+    for (const [id, role] of [
+      ['planner', 'planning'],
+      ['junior-conductor', 'conductor'],
+      ['completion-detector', 'orchestrator'],
+    ]) {
+      const messages = [];
+      const lifecycle = [];
+      const agent = retryableFailureAgent(messages, lifecycle);
+      agent.id = id;
+      agent.role = role;
+
+      await executeTask(agent, { topic: 'ISSUE_OPENED', sender: 'user' });
+
+      const clusterFailures = messages.filter((message) => message.topic === 'CLUSTER_FAILED');
+      const agentErrors = messages.filter((message) => message.topic === 'AGENT_ERROR');
+      assert.strictEqual(clusterFailures.length, 1);
+      assert.strictEqual(clusterFailures[0].content.data.reason, 'provider_execution_failed');
+      assert.strictEqual(clusterFailures[0].content.data.role, role);
+      assert.strictEqual(agentErrors.length, 1);
+    }
+  });
+
+  it('keeps validator provider exhaustion nonterminal', async function () {
+    const messages = [];
+    const lifecycle = [];
+    const agent = retryableFailureAgent(messages, lifecycle);
+    agent.id = 'validator-requirements';
+    agent.role = 'validator';
+    agent.testMode = true;
+
+    await executeTask(agent, { topic: 'IMPLEMENTATION_READY', sender: 'worker' });
+
+    assert.strictEqual(messages.filter((message) => message.topic === 'CLUSTER_FAILED').length, 0);
+    assert.strictEqual(messages.filter((message) => message.topic === 'AGENT_ERROR').length, 1);
   });
 });
 

--- a/tests/unit/orchestrator-agent-error-stop.test.js
+++ b/tests/unit/orchestrator-agent-error-stop.test.js
@@ -65,6 +65,7 @@ describe('Orchestrator critical agent error handling', function () {
     publishAgentError(messageBus, 'c1', 'consensus-coordinator', {
       role: 'coordinator',
       attempts: 3,
+      retryBudgetExhausted: true,
       error: 'boom',
     });
 
@@ -98,7 +99,6 @@ describe('Orchestrator critical agent error handling', function () {
       attempts: 3,
       error: 'nope',
     });
-
     await settleHandlers();
     assert.equal(stopSpy.called, false);
   });
@@ -109,13 +109,42 @@ describe('Orchestrator critical agent error handling', function () {
 
     publishAgentError(messageBus, 'c4', 'worker', {
       role: 'implementation',
-      attempts: 1,
+      attempts: 30,
       error: 'polling_timeout',
     });
 
     await settleHandlers();
     assert.equal(stopSpy.called, false);
     assert.equal(messageBus.query({ cluster_id: 'c4', topic: 'CLUSTER_FAILED' }).length, 0);
+  });
+});
+
+describe('Orchestrator workflow role terminalization', function () {
+  beforeEach(setupHarness);
+  afterEach(cleanupHarness);
+
+  it('stops cluster when planner, conductor, and orchestrator roles exhaust retries', async () => {
+    const stopSpy = sinon.stub(orchestrator, 'stop').resolves();
+    for (const [clusterId, sender, role] of [
+      ['planning-cluster', 'planner', 'planning'],
+      ['conductor-cluster', 'junior-conductor', 'conductor'],
+      ['orchestrator-cluster', 'completion-detector', 'orchestrator'],
+    ]) {
+      orchestrator._registerAgentErrorHandler(messageBus, clusterId);
+      publishAgentError(messageBus, clusterId, sender, {
+        role,
+        attempts: 3,
+        retryBudgetExhausted: true,
+        error: 'retry budget exhausted',
+      });
+    }
+
+    await settleHandlers();
+    assert.deepStrictEqual(stopSpy.args.map(([clusterId]) => clusterId).sort(), [
+      'conductor-cluster',
+      'orchestrator-cluster',
+      'planning-cluster',
+    ]);
   });
 });
 
@@ -131,6 +160,7 @@ describe('Orchestrator terminal stop deduplication', function () {
     publishAgentError(messageBus, 'c5', 'worker', {
       role: 'implementation',
       attempts: 3,
+      retryBudgetExhausted: true,
       error: 'retry budget exhausted',
     });
 
@@ -143,6 +173,7 @@ describe('Orchestrator terminal stop deduplication', function () {
     publishAgentError(messageBus, 'c6', 'worker', {
       role: 'implementation',
       attempts: 3,
+      retryBudgetExhausted: true,
       error: 'failed again after resume',
     });
 


### PR DESCRIPTION
## Summary

- centralize critical-agent terminalization for every named non-validator role
- publish one durable cluster failure when planner, conductor, custom, or orchestrator provider retries exhaust
- distinguish final retry exhaustion from transient status-poll observations with an explicit marker
- add a detached zero-token Codex planner regression covering retries, terminal ordering, cleanup, zombie prevention, and redaction

## Validation

- 2,771 core tests passed; 18 pending
- 28 end-to-end tests passed
- exact detached planner regression: 3 attempts, 1 CLUSTER_FAILED, stopped/non-zombie
- typecheck and lint passed (existing warnings only)
- npm production audit, release preflight, and package dry-run passed
- Opcore introduced-change and Opcore Zero staged gates passed
- Benchmarks actual-checkout gate passed in 20.8s; full zero-token Harbor Job/Trial gate passed in 111.1s

No paid provider calls were used for validation.