### PR TITLE
fix: preflight hosted provider runtime before apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,12 @@ and all second identities as conflicts, and leaves queue cancellation to capsule
 Its fixed `/workspace` starts empty and receives the exact installed checkout. Runtime settings and
 files are materialized under the private runtime home, executable wrappers and setup output use the
 private `.git/zeroshot-runtime` executable root, and the workspace is reverified clean before worker
-launch. The worker inherits no trusted service sockets. It receives the installed runtime
-environment and settings, then uses Zeroshot's existing provider runner to launch the configured
-executable with the subprocess and network behavior owned by that harness; Git delivery credentials
-are withheld from the provider invocation. A text-only response with no real workspace mutation
+launch. After bounded setup, the configured provider engine must pass the registry-owned runtime
+availability probe before apply can commit a run. The worker inherits no trusted service sockets. It
+receives the installed runtime environment and settings, then uses Zeroshot's existing provider
+runner to launch the configured executable with the subprocess and network behavior owned by that
+harness; Git delivery credentials are withheld from the provider invocation. A text-only response
+with no real workspace mutation
 cannot succeed. After provider success, trusted Git delivery verifies the mutation, history, remote,
 configuration, and that the retained revision remains an ancestor of the current target before
 pushing one deterministic-branch commit. Review delivery succeeds only with a verified open pull

--- a/src/agent-cli-provider/single-agent-runtime.ts
+++ b/src/agent-cli-provider/single-agent-runtime.ts
@@ -921,11 +921,7 @@ function probeGatewayProvider(
   try {
     const settings = runtimeSettings ?? loadRuntimeSettings();
     const providerSettings = runtimeProviderSettings(settings, 'gateway', process.cwd());
-    resolveGatewayConfiguration(
-      providerSettings.gateway,
-      'settings.providerSettings.gateway',
-      process.cwd()
-    );
+    resolveRuntimeGatewayOptions('gateway', {}, providerSettings, providerSettings.gateway ?? {});
     return {
       available: true,
       helpText: 'Bundled gateway runner',

--- a/tests/cluster-worker/hosted-credentials.test.js
+++ b/tests/cluster-worker/hosted-credentials.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const { createTempDirectory, removeTempDirectory } = require('../helpers/temp-directory');
@@ -8,6 +9,17 @@ const {
   HostedConfigError,
   loadInstalledHostedWorkerConfiguration,
 } = require('../../zeroshot-rust/hosted-node/hosted-config');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CONFIGURATION_CHECK = path.join(ROOT, 'zeroshot-rust', 'hosted-node', 'config-check.js');
+
+function runConfigurationCheck(environment) {
+  return spawnSync(process.execPath, [CONFIGURATION_CHECK], {
+    cwd: ROOT,
+    env: environment,
+    encoding: 'utf8',
+  });
+}
 
 function fixture() {
   const directory = createTempDirectory('zeroshot-hosted-config-');
@@ -100,6 +112,62 @@ describe('hosted worker runtime boundary', () => {
           }
         );
       }
+    } finally {
+      removeTempDirectory(directory);
+    }
+  });
+});
+
+describe('hosted worker runtime preflight', () => {
+  it('uses the provider registry to preflight process and bundled runtimes', () => {
+    const { directory, environment } = fixture();
+    const settingsFile = environment.ZEROSHOT_SETTINGS_FILE;
+    const fakeOmp = path.join(directory, 'omp');
+    try {
+      fs.writeFileSync(
+        fakeOmp,
+        '#!/bin/sh\nif [ "$1" = "--help" ]; then echo "omp help"; exit 0; fi\nexit 1\n',
+        { mode: 0o700 }
+      );
+      fs.writeFileSync(
+        settingsFile,
+        JSON.stringify({ providerSettings: { omp: { transport: 'rpc' } } })
+      );
+      const ompEnvironment = {
+        ...environment,
+        PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+        ZEROSHOT_HOSTED_EXECUTABLE: 'omp',
+      };
+      const available = runConfigurationCheck(ompEnvironment);
+      assert.equal(available.status, 0, available.stderr);
+
+      fs.rmSync(fakeOmp);
+      const rejected = runConfigurationCheck({
+        ...ompEnvironment,
+        PATH: directory,
+      });
+      assert.equal(rejected.status, 1);
+      assert.doesNotMatch(`${rejected.stdout}\n${rejected.stderr}`, /canary/);
+
+      fs.writeFileSync(
+        settingsFile,
+        JSON.stringify({
+          providerSettings: {
+            gateway: {
+              baseUrl: 'https://models.example/v1',
+              apiKeyEnv: 'FUTURE_PROVIDER_TOKEN',
+              model: 'gateway/test-model',
+              toolPolicy: { roots: ['.'], commands: [] },
+            },
+          },
+        })
+      );
+      const gateway = runConfigurationCheck({
+        ...environment,
+        PATH: directory,
+        ZEROSHOT_HOSTED_EXECUTABLE: 'gateway',
+      });
+      assert.equal(gateway.status, 0, gateway.stderr);
     } finally {
       removeTempDirectory(directory);
     }

--- a/zeroshot-rust/hosted-node/config-check.js
+++ b/zeroshot-rust/hosted-node/config-check.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const { probeRuntimeProviderCli } = require('../../lib/agent-cli-provider');
 const { loadInstalledHostedWorkerConfiguration } = require('./hosted-config');
 
-loadInstalledHostedWorkerConfiguration();
+try {
+  const config = loadInstalledHostedWorkerConfiguration();
+  if (!probeRuntimeProviderCli(config.executable, undefined, config.settings).available) {
+    process.exitCode = 1;
+  }
+} catch {
+  process.exitCode = 1;
+}

--- a/zeroshot-rust/src/hosted_oecp/credential_runtime.rs
+++ b/zeroshot-rust/src/hosted_oecp/credential_runtime.rs
@@ -12,8 +12,11 @@ use super::credentials::{
     RUNTIME_MOUNT_ROOT, RUNTIME_ROOT, SETTINGS_FILE, SHARED_MOUNT_MODE, WORKER_GID, WORKER_UID,
 };
 use super::ports::WORKSPACE_ROOT;
+use super::worker::NODE_PROGRAM;
 
 const SETUP_COMMAND_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const CONFIGURATION_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+const CONFIGURATION_CHECK: &str = "/opt/zeroshot/zeroshot-rust/hosted-node/config-check.js";
 
 impl CredentialBundle {
     pub(super) async fn prepare_workspace(&self) -> Result<(), String> {
@@ -28,7 +31,22 @@ impl CredentialBundle {
             self.apply_setup_to(&mut command);
             run_bounded(&mut command, "runtime setup", SETUP_COMMAND_TIMEOUT).await?;
         }
+        self.verify_runtime_configuration().await?;
         verify_prepared_repository(self).await
+    }
+
+    async fn verify_runtime_configuration(&self) -> Result<(), String> {
+        let mut command = Command::new(NODE_PROGRAM);
+        command.arg(CONFIGURATION_CHECK);
+        apply_uncredentialed_worker_to(&mut command);
+        command.envs(self.worker_environment());
+        run_bounded(
+            &mut command,
+            "runtime configuration check",
+            CONFIGURATION_CHECK_TIMEOUT,
+        )
+        .await
+        .map(|_| ())
     }
 }
 


### PR DESCRIPTION
## Summary
- preflight the configured hosted provider engine after bounded setup and before apply commits
- delegate availability to the provider registry, so OMP RPC checks the configured CLI while bundled Gateway checks its real in-process configuration
- make Gateway preflight use the same fresh `apiKeyEnv` resolution path as execution

This is the narrow follow-up found by the zero-cloud #106 live gate: the hosted runtime accepted an unavailable execution lane and failed only after apply committed.

## Validation
- `npm run test:hosted` (71 private hosted CLI + 47 hosted-target tests)
- `npx mocha tests/cluster-worker/hosted-credentials.test.js tests/cluster-worker/hosted-runtime.test.js` (13 tests)
- `npm run typecheck:agent-cli-provider`
- `cargo test -p zeroshot-rust hosted_oecp::` (69 tests)
- `cargo clippy -p zeroshot-rust --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Opcore Zero staged Verify clean; Sense found no introduced cycles, duplicates, interface findings, or documentation requirements (global graph coverage remains partial for five pre-existing unsupported files)
