### PR TITLE
fix: bound hosted workspace readiness separately

### DIFF
--- a/zeroshot-rust/src/hosted_oecp/backend_runtime.rs
+++ b/zeroshot-rust/src/hosted_oecp/backend_runtime.rs
@@ -18,8 +18,9 @@ use super::backend_support::{
     accepted_plan, graph_invalid, idempotency_reuse, internal_error, precheck_generation,
     redact_request, rejected_plan, safe_application_error, same_apply_identity, second_apply_error,
     single_worker_diagnostics, status_from, step_timeout, terminal_failure_error, validate_apply,
-    validate_graph_input, validate_request, verify_trusted_service, worker_error_outcome,
-    worker_start_error,
+    validate_graph_input, validate_request, verify_trusted_service,
+    verify_trusted_service_with_deadline, worker_error_outcome, worker_start_error,
+    WORKSPACE_READINESS_DEADLINE,
 };
 use super::worker::{WorkerCommand, WorkerError, WorkerExecution, WorkerSpawnError};
 
@@ -29,10 +30,11 @@ fn shutdown_can_force(state: &HostedState) -> bool {
 
 impl HostedBackend {
     pub async fn verify_startup_readiness(&self) -> Result<(), BackendError> {
-        verify_trusted_service(
+        verify_trusted_service_with_deadline(
             self.worktree.verify_ready(),
             "WORKSPACE_NOT_READY",
             "Prepared workspace is not ready",
+            WORKSPACE_READINESS_DEADLINE,
         )
         .await?;
         verify_trusted_service(

--- a/zeroshot-rust/src/hosted_oecp/backend_support.rs
+++ b/zeroshot-rust/src/hosted_oecp/backend_support.rs
@@ -22,6 +22,8 @@ use super::worker::WorkerError;
 static NEXT_RUN: AtomicU64 = AtomicU64::new(1);
 pub(super) const MAX_WORKER_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 pub(super) const TRUSTED_SERVICE_DEADLINE: Duration = Duration::from_secs(5);
+// Workspace metadata scans include installed provider runtimes on capsule storage.
+pub(super) const WORKSPACE_READINESS_DEADLINE: Duration = Duration::from_secs(30);
 
 pub(super) async fn verify_trusted_service<F, T>(
     future: F,
@@ -31,7 +33,19 @@ pub(super) async fn verify_trusted_service<F, T>(
 where
     F: Future<Output = Result<T, TrustedServiceError>>,
 {
-    timeout(TRUSTED_SERVICE_DEADLINE, future)
+    verify_trusted_service_with_deadline(future, code, message, TRUSTED_SERVICE_DEADLINE).await
+}
+
+pub(super) async fn verify_trusted_service_with_deadline<F, T>(
+    future: F,
+    code: &'static str,
+    message: &'static str,
+    deadline: Duration,
+) -> Result<T, BackendError>
+where
+    F: Future<Output = Result<T, TrustedServiceError>>,
+{
+    timeout(deadline, future)
         .await
         .map_err(|_| safe_application_error(code, message))?
         .map_err(|_| safe_application_error(code, message))

--- a/zeroshot-rust/src/hosted_oecp/backend_tests.rs
+++ b/zeroshot-rust/src/hosted_oecp/backend_tests.rs
@@ -49,6 +49,16 @@ struct GatedWorktree {
     release: Notify,
 }
 
+struct SlowWorktree;
+
+#[async_trait]
+impl WorktreeReadinessPort for SlowWorktree {
+    async fn verify_ready(&self) -> Result<WorktreeReadinessReceipt, TrustedServiceError> {
+        sleep(Duration::from_secs(6)).await;
+        Ok(WorktreeReadinessReceipt::ready())
+    }
+}
+
 impl GatedWorktree {
     fn allow(&self) {
         self.released.store(true, Ordering::Release);
@@ -415,12 +425,15 @@ async fn timeout_reaps_before_failure_delivery() {
 
 #[tokio::test]
 async fn shutdown_without_a_run_still_cleans_the_proxy() {
-    let fixture = RuntimeFixture::new(10_000);
-    fixture
-        .backend
-        .verify_startup_readiness()
-        .await
-        .expect("startup readiness");
+    let mut fixture = RuntimeFixture::new(10_000);
+    fixture.backend.worktree = Arc::new(SlowWorktree);
+    timeout(
+        Duration::from_secs(10),
+        fixture.backend.verify_startup_readiness(),
+    )
+    .await
+    .expect("workspace readiness remains bounded")
+    .expect("large runtime workspace is ready");
     fixture
         .backend
         .shutdown()


### PR DESCRIPTION
Follow-up to #974 found by the zero-cloud issue 106 live OMP/OpenRouter ship gate.

Two fresh dev capsules completed runtime setup and provider preflight, then returned `WORKSPACE_NOT_READY` at generation 0 under the shared 5-second trusted-service deadline. This gives only the workspace metadata scan a bounded 30-second deadline; proxy and delivery readiness remain at 5 seconds.

Validation:
- `cargo test -p zeroshot-rust --lib hosted_oecp::backend::tests`
- `cargo clippy -p zeroshot-rust --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Opcore staged Verify clean; Sense no introduced findings (partial Rust interface coverage)