### PR TITLE
fix: align hosted OMP preflight with execution

### DIFF
--- a/docker/zeroshot-oecp/.dockerignore
+++ b/docker/zeroshot-oecp/.dockerignore
@@ -38,6 +38,11 @@
 !scripts/omp/runtime-identities.js
 !scripts/omp/runtime-lock.js
 !scripts/omp/runtime-release.js
+!src/
+!src/command-cleanup-ownership.js
+!src/omp-config-overlay.js
+!src/worktree-claude-config.js
+!src/worktree-tooling-env.js
 !protocol/
 !protocol/openengine-cluster/
 !protocol/openengine-cluster/v1/

--- a/docker/zeroshot-oecp/Dockerfile
+++ b/docker/zeroshot-oecp/Dockerfile
@@ -54,6 +54,7 @@ COPY lib/cluster-worker/terminal-normalizer.js lib/cluster-worker/worker-interna
 COPY lib/cluster-worker/runtime-dependencies.js /opt/zeroshot/lib/cluster-worker/runtime-dependencies.js
 COPY lib/run-plan.js /opt/zeroshot/lib/run-plan.js
 COPY scripts/omp/runtime.js scripts/omp/runtime-identities.js scripts/omp/runtime-lock.js scripts/omp/runtime-release.js /opt/zeroshot/scripts/omp/
+COPY src/command-cleanup-ownership.js src/omp-config-overlay.js src/worktree-claude-config.js src/worktree-tooling-env.js /opt/zeroshot/src/
 COPY protocol/openengine-cluster/v1/worker.schema.json /opt/zeroshot/protocol/openengine-cluster/v1/worker.schema.json
 COPY zeroshot-rust/hosted-node /opt/zeroshot/zeroshot-rust/hosted-node
 

--- a/docker/zeroshot-oecp/Dockerfile.dockerignore
+++ b/docker/zeroshot-oecp/Dockerfile.dockerignore
@@ -38,6 +38,11 @@
 !scripts/omp/runtime-identities.js
 !scripts/omp/runtime-lock.js
 !scripts/omp/runtime-release.js
+!src/
+!src/command-cleanup-ownership.js
+!src/omp-config-overlay.js
+!src/worktree-claude-config.js
+!src/worktree-tooling-env.js
 !protocol/
 !protocol/openengine-cluster/
 !protocol/openengine-cluster/v1/

--- a/scripts/hosted-oecp-image-inspection.js
+++ b/scripts/hosted-oecp-image-inspection.js
@@ -3,6 +3,19 @@
 const { isDeepStrictEqual } = require('util');
 
 const EXPOSED_PORTS = Object.freeze(['8083/tcp', '8084/tcp', '8085/tcp']);
+const REQUIRED_RUNTIME_MODULES = Object.freeze([
+  'commandCleanupOwnership',
+  'deliveryContract',
+  'engineStart',
+  'ompConfigOverlay',
+  'ompRuntime',
+  'ompRuntimeIdentities',
+  'ompRuntimeLock',
+  'ompRuntimeRelease',
+  'runtimeDependencies',
+  'worktreeClaudeConfig',
+  'worktreeToolingEnv',
+]);
 const EXPECTED_PACKAGE_MANAGER_PATHS = Object.freeze({
   '/usr/local/bin/npm': false,
   '/usr/local/bin/npx': false,
@@ -68,13 +81,17 @@ process.stdout.write(JSON.stringify({
     '/opt/yarn-v1.22.22': present('/opt/yarn-v1.22.22'),
   },
   runtimeModules: {
+    commandCleanupOwnership: loadable('/opt/zeroshot/src/command-cleanup-ownership.js'),
     deliveryContract: loadable('/opt/zeroshot/lib/delivery-contract.js'),
     engineStart: fs.existsSync('/opt/zeroshot/lib/cluster-worker/engine-start.js'),
+    ompConfigOverlay: loadable('/opt/zeroshot/src/omp-config-overlay.js'),
     runtimeDependencies: fs.existsSync('/opt/zeroshot/lib/cluster-worker/runtime-dependencies.js'),
     ompRuntime: loadable('/opt/zeroshot/scripts/omp/runtime.js'),
     ompRuntimeIdentities: loadable('/opt/zeroshot/scripts/omp/runtime-identities.js'),
     ompRuntimeLock: loadable('/opt/zeroshot/scripts/omp/runtime-lock.js'),
     ompRuntimeRelease: loadable('/opt/zeroshot/scripts/omp/runtime-release.js'),
+    worktreeClaudeConfig: loadable('/opt/zeroshot/src/worktree-claude-config.js'),
+    worktreeToolingEnv: loadable('/opt/zeroshot/src/worktree-tooling-env.js'),
   },
   serverExecutable: executable('/usr/local/bin/zeroshot-oecp-server'),
   tiniExecutable: executable('/usr/bin/tini'),
@@ -138,15 +155,7 @@ function validateRuntimePermissions(runtime) {
 }
 
 function validateRequiredRuntimeModules(runtimeModules) {
-  if (
-    runtimeModules?.deliveryContract !== true ||
-    runtimeModules?.engineStart !== true ||
-    runtimeModules?.runtimeDependencies !== true ||
-    runtimeModules?.ompRuntime !== true ||
-    runtimeModules?.ompRuntimeIdentities !== true ||
-    runtimeModules?.ompRuntimeLock !== true ||
-    runtimeModules?.ompRuntimeRelease !== true
-  ) {
+  if (!REQUIRED_RUNTIME_MODULES.every((name) => runtimeModules?.[name] === true)) {
     throw new Error('Hosted image is missing a required runtime module');
   }
 }

--- a/src/agent-cli-provider/adapters/omp.ts
+++ b/src/agent-cli-provider/adapters/omp.ts
@@ -81,7 +81,7 @@ function detectCliFeatures(helpText?: string | null, versionText?: string | null
   return {
     provider: 'omp',
     versionMatches: VERSION_TOKEN_PATTERN.test(version),
-    supportsRpcMode: /(^|\s)rpc(\s|$)/m.test(help),
+    supportsRpcMode: /(?<![A-Za-z0-9_-])rpc(?![A-Za-z0-9_-])/.test(help),
     supportsConfig: /--config\b/.test(help),
     supportsModel: /--model\b/.test(help),
     supportsThinking: /--thinking\b/.test(help),

--- a/tests/agent-cli-provider/omp-adapter.test.js
+++ b/tests/agent-cli-provider/omp-adapter.test.js
@@ -354,7 +354,7 @@ test('omp detectCliFeatures parses help evidence for every required and probed f
   const adapter = helper.getProviderAdapter('omp');
   const help = [
     'Usage: omp [options] [command]',
-    '  rpc',
+    '  --mode=<value>  Output mode: text (default), json, rpc, or rpc-ui',
     '  --config <path>',
     '  --model <selector>',
     '  --thinking <level>',
@@ -375,6 +375,7 @@ test('omp detectCliFeatures parses help evidence for every required and probed f
   assert.equal(features.supportsNoSession, true);
   assert.equal(features.supportsSessionDir, true);
   assert.equal(features.supportsResume, true);
+  assert.equal(adapter.detectCliFeatures('  --mode=<value>  rpc-ui', '').supportsRpcMode, false);
 });
 
 test('omp parseEvent is a validating passthrough over already-normalized OutputEvent JSON', () => {

--- a/tests/cluster-worker/hosted-credentials.test.js
+++ b/tests/cluster-worker/hosted-credentials.test.js
@@ -136,8 +136,27 @@ describe('hosted worker runtime preflight', () => {
       const ompEnvironment = {
         ...environment,
         PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+        TMPDIR: directory,
         ZEROSHOT_HOSTED_EXECUTABLE: 'omp',
       };
+      const missingContract = runConfigurationCheck(ompEnvironment);
+      assert.equal(missingContract.status, 1);
+
+      fs.writeFileSync(
+        fakeOmp,
+        [
+          '#!/bin/sh',
+          'if [ "$1" = "--help" ]; then',
+          '  echo "--mode=<value> text, json, rpc, or rpc-ui"',
+          '  echo "--config --model --approval-mode --no-title --no-session"',
+          '  exit 0',
+          'fi',
+          'if [ "$1" = "--version" ]; then echo "omp/17.2.1"; exit 0; fi',
+          'exit 1',
+          '',
+        ].join('\n'),
+        { mode: 0o700 }
+      );
       const available = runConfigurationCheck(ompEnvironment);
       assert.equal(available.status, 0, available.stderr);
 
@@ -166,6 +185,7 @@ describe('hosted worker runtime preflight', () => {
         ...environment,
         PATH: directory,
         ZEROSHOT_HOSTED_EXECUTABLE: 'gateway',
+        ZEROSHOT_HOSTED_MODEL: 'gateway/test-model',
       });
       assert.equal(gateway.status, 0, gateway.stderr);
     } finally {

--- a/tests/unit/hosted-oecp-image.test.js
+++ b/tests/unit/hosted-oecp-image.test.js
@@ -53,13 +53,17 @@ function runtimeInspection() {
     forbiddenPresent: [],
     packageManagerPaths: absentPackageManagerPaths(),
     runtimeModules: {
+      commandCleanupOwnership: true,
       deliveryContract: true,
       engineStart: true,
+      ompConfigOverlay: true,
       runtimeDependencies: true,
       ompRuntime: true,
       ompRuntimeIdentities: true,
       ompRuntimeLock: true,
       ompRuntimeRelease: true,
+      worktreeClaudeConfig: true,
+      worktreeToolingEnv: true,
     },
     serverExecutable: true,
     tiniExecutable: true,
@@ -142,6 +146,13 @@ function registerRuntimeInspectionTests() {
     const missingOmpRuntime = runtimeInspection();
     missingOmpRuntime.runtimeModules.ompRuntimeRelease = false;
     assert.throws(() => validateRuntimeInspection(missingOmpRuntime), /required runtime module/);
+
+    const missingProviderDependency = runtimeInspection();
+    missingProviderDependency.runtimeModules.commandCleanupOwnership = false;
+    assert.throws(
+      () => validateRuntimeInspection(missingProviderDependency),
+      /required runtime module/
+    );
 
     const vulnerableUndici = runtimeInspection();
     vulnerableUndici.undiciVersion = '8.5.0';

--- a/zeroshot-rust/hosted-node/config-check.js
+++ b/zeroshot-rust/hosted-node/config-check.js
@@ -1,12 +1,35 @@
 'use strict';
 
-const { probeRuntimeProviderCli } = require('../../lib/agent-cli-provider');
+const {
+  prepareSingleAgentProviderCommand,
+  probeRuntimeProviderCli,
+} = require('../../lib/agent-cli-provider');
+const { createCommandSpecCleanup } = require('../../src/command-cleanup-ownership');
 const { loadInstalledHostedWorkerConfiguration } = require('./hosted-config');
 
 try {
   const config = loadInstalledHostedWorkerConfiguration();
   if (!probeRuntimeProviderCli(config.executable, undefined, config.settings).available) {
-    process.exitCode = 1;
+    throw new Error('hosted executable is unavailable');
+  }
+  const prepared = prepareSingleAgentProviderCommand(
+    {
+      context: 'Validate the installed hosted provider runtime.',
+      provider: config.executable,
+      options: {
+        ...(config.executable === 'omp' ? {} : { authEnv: config.runtimeEnvironment }),
+        autoApprove: true,
+        cwd: process.cwd(),
+        executionContext: 'docker',
+        ...(config.model === undefined ? {} : { modelSpec: { model: config.model } }),
+      },
+    },
+    config.settings
+  );
+  const ownsCleanup =
+    Array.isArray(prepared.commandSpec.cleanup) && prepared.commandSpec.cleanup.length > 0;
+  if (ownsCleanup && !createCommandSpecCleanup(prepared.commandSpec, () => {}).runSync()) {
+    throw new Error('hosted provider preflight cleanup failed');
   }
 } catch {
   process.exitCode = 1;


### PR DESCRIPTION
Closes the remaining live OMP boundary for the-open-engine/zero-cloud#106.

- recognize the punctuation-delimited rpc token emitted by OMP 17.2.1 help while rejecting rpc-ui alone
- make hosted preflight prepare the same provider command contract used by execution
- ship and inspect the exact source-module closure required by the provider helper in the OECP image

Verified with focused and full provider suites, hosted target tests, hosted Rust tests/clippy/fmt, OECP image build/inspection/smoke, and an isolated real OMP/OpenRouter one-file edit.