### PR TITLE
feat(cli): add atomic foreground benchmark results

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -74,6 +74,11 @@ const {
 } = require('../lib/start-cluster');
 const { requirePreflight } = require('../src/preflight');
 const {
+  exitCodeForResult,
+  isForegroundStatusSettled,
+  writeForegroundResult,
+} = require('../src/foreground-benchmark-run');
+const {
   createUnsupportedProviderCapabilityError,
   serializeTaskStartupError,
 } = require('../src/task-startup-error');
@@ -249,6 +254,17 @@ async function runClusterPreflight({
 
 function shouldRunDetached(options) {
   return options.detach && !process.env.ZEROSHOT_DAEMON;
+}
+
+function requireForegroundResultMode(options) {
+  if (!options.resultFile) return;
+  if (shouldRunDetached(options) || process.env.ZEROSHOT_DAEMON) {
+    throw new Error('--result-file requires foreground execution without --detach');
+  }
+  if (options.pr || options.ship) {
+    throw new Error('--result-file is incompatible with --pr and --ship delivery');
+  }
+  process.env.ZEROSHOT_TASK_EXECUTION_CONTEXT = 'benchmark';
 }
 
 function printDetachedClusterStart(plan, clusterId, logPath) {
@@ -605,65 +621,83 @@ function createForegroundCleanup({
   return { stop, stopWithFlush };
 }
 
-function setupForegroundSigintHandler({ orchestrator, clusterId, cleanup, stopChecking }) {
-  const handler = async () => {
+function setupForegroundSignalHandler({ orchestrator, clusterId, cleanup, settle, handleSigterm }) {
+  let handling = false;
+  const handler = async (signal) => {
+    if (handling) return;
+    handling = true;
     cleanup.stop();
-    stopChecking();
-    console.log(chalk.dim('\n\n--- Interrupted ---'));
+    console.log(chalk.dim(`\n\n--- Interrupted (${signal}) ---`));
 
     try {
       console.log(chalk.dim(`Stopping cluster ${clusterId}...`));
       await orchestrator.stop(clusterId);
       console.log(chalk.dim(`Cluster ${clusterId} stopped.`));
+      settle({ cancelled: true });
     } catch (stopErr) {
-      console.error(chalk.red(`Failed to stop cluster: ${stopErr.message}`));
+      settle(null, stopErr);
     }
-
-    process.exit(0);
   };
 
-  process.on('SIGINT', handler);
+  const onSigint = () => handler('SIGINT');
+  const onSigterm = () => handler('SIGTERM');
+  process.on('SIGINT', onSigint);
+  if (handleSigterm) process.on('SIGTERM', onSigterm);
   return () => {
-    process.off('SIGINT', handler);
+    process.off('SIGINT', onSigint);
+    if (handleSigterm) process.off('SIGTERM', onSigterm);
   };
 }
 
-function waitForClusterCompletion(orchestrator, clusterId, cleanup) {
-  return new Promise((resolve) => {
+function waitForClusterCompletion(orchestrator, clusterId, cleanup, handleSigterm) {
+  return new Promise((resolve, reject) => {
     let checkInterval;
+    let settled = false;
+    let terminalObservedAt = null;
+    let removeSignals = () => {};
     const stopChecking = () => {
       if (checkInterval) {
         clearInterval(checkInterval);
       }
     };
-    const removeSigint = setupForegroundSigintHandler({
+    const settle = (result, error) => {
+      if (settled) return;
+      settled = true;
+      stopChecking();
+      removeSignals();
+      if (error) reject(error);
+      else resolve(result);
+    };
+    removeSignals = setupForegroundSignalHandler({
       orchestrator,
       clusterId,
       cleanup,
-      stopChecking,
+      settle,
+      handleSigterm,
     });
-
-    const finish = (finalizer) => {
-      stopChecking();
-      removeSigint();
-      finalizer();
-      resolve();
-    };
 
     checkInterval = setInterval(() => {
       try {
         const status = orchestrator.getStatus(clusterId);
-        if (status.state !== 'running') {
-          finish(cleanup.stopWithFlush);
+        if (isForegroundStatusSettled(status)) {
+          cleanup.stopWithFlush();
+          settle({ cancelled: false });
+        } else if (['stopped', 'killed'].includes(status.state)) {
+          terminalObservedAt ??= Date.now();
+          if (Date.now() - terminalObservedAt > 30_000) {
+            cleanup.stop();
+            settle(null, new Error('foreground agent processes did not settle after terminal'));
+          }
         }
-      } catch {
-        finish(cleanup.stop);
+      } catch (error) {
+        cleanup.stop();
+        settle(null, error);
       }
     }, 500);
   });
 }
 
-async function streamClusterInForeground(cluster, orchestrator, clusterId, plan) {
+async function streamClusterInForeground(cluster, orchestrator, clusterId, plan, handleSigterm) {
   const sendersWithOutput = new Set();
   const processedMessageIds = new Set();
 
@@ -696,8 +730,34 @@ async function streamClusterInForeground(cluster, orchestrator, clusterId, plan)
     sendersWithOutput,
   });
 
-  await waitForClusterCompletion(orchestrator, clusterId, cleanup);
-  console.log(chalk.dim(`\nCluster ${clusterId} completed.`));
+  const result = await waitForClusterCompletion(orchestrator, clusterId, cleanup, handleSigterm);
+  const label = result.cancelled ? 'cancelled' : 'finished';
+  console.log(chalk.dim(`\nCluster ${clusterId} ${label}.`));
+  return result;
+}
+
+async function finishForegroundRun({ cluster, orchestrator, clusterId, plan, resultPath }) {
+  try {
+    const foreground = await streamClusterInForeground(
+      cluster,
+      orchestrator,
+      clusterId,
+      plan,
+      Boolean(resultPath)
+    );
+    if (!resultPath) return;
+    const receipt = writeForegroundResult({
+      orchestrator,
+      cluster,
+      clusterId,
+      resultPath,
+      cancelled: foreground.cancelled,
+    });
+    process.exitCode = exitCodeForResult(receipt);
+    console.log(chalk.dim(`Result ${receipt.outcome} committed to ${resultPath}`));
+  } finally {
+    orchestrator.close();
+  }
 }
 
 function setupDaemonCleanup(orchestrator, clusterId) {
@@ -2662,6 +2722,10 @@ program
     'fast'
   )
   .option('-d, --detach', 'Run in background (default: attach to first agent)')
+  .option(
+    '--result-file <path>',
+    'Atomically write a closed foreground result receipt (incompatible with --detach)'
+  )
   .addHelpText(
     'after',
     `
@@ -2768,6 +2832,7 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps), -N (Line
       }
 
       const { generateName } = require('../src/name-generator');
+      requireForegroundResultMode(effectiveOptions);
       if (shouldRunDetached(effectiveOptions)) {
         const clusterId = generateName('cluster');
         await spawnDetachedCluster(effectiveOptions, effectiveRunPlan, clusterId, stdinText);
@@ -2811,8 +2876,13 @@ Force provider flags: -G (GitHub), -L (GitLab), -J (Jira), -D (DevOps), -N (Line
       }
 
       if (!process.env.ZEROSHOT_DAEMON) {
-        await streamClusterInForeground(cluster, orchestrator, clusterId, effectiveRunPlan);
-        orchestrator.close();
+        await finishForegroundRun({
+          cluster,
+          orchestrator,
+          clusterId,
+          plan: effectiveRunPlan,
+          resultPath: effectiveOptions.resultFile,
+        });
       }
       setupDaemonCleanup(orchestrator, clusterId);
     } catch (error) {

--- a/src/agent/agent-lifecycle.js
+++ b/src/agent/agent-lifecycle.js
@@ -17,7 +17,7 @@ const { executeHook } = require('./agent-hook-executor');
 const IsolationManager = require('../isolation-manager');
 const crypto = require('crypto');
 const { bufferMessage, scheduleDrain, drainBufferedMessages } = require('../message-buffer');
-const { isPlatformSupported } = require('./agent-stuck-detector');
+const { createLivenessPoll } = require('./agent-liveness-poll');
 const { normalizeProviderName, getDefaultProviderId } = require('../../lib/provider-names');
 const { loadSettings } = require('../../lib/settings');
 const { findPlatformMismatchReason } = require('./validation-platform');
@@ -223,7 +223,7 @@ async function stop(agent) {
   stopLivenessCheck(agent);
 
   const hasNestedExecutions = agent.nestedExecutions?.hasActive === true;
-  if (!agent.running && !agent.currentTask && !hasNestedExecutions) {
+  if (!agent.running && !agent.currentTask && !hasNestedExecutions && !agent._currentExecution) {
     return;
   }
 
@@ -242,26 +242,26 @@ async function stop(agent) {
       throw new Error(`Task shutdown could not confirm termination: ${termination.reason}`);
     }
   }
-
-  // Wait for in-flight execution to complete (up to 5 seconds)
-  // This prevents write-after-close race conditions
-  if (agent._currentExecution) {
+  const currentExecution = agent._currentExecution;
+  if (currentExecution) {
     let executionTimeout = null;
     try {
-      await Promise.race([
-        agent._currentExecution,
+      const outcome = await Promise.race([
+        Promise.resolve(currentExecution).then(
+          () => 'settled',
+          () => 'settled'
+        ),
         new Promise((resolve) => {
-          executionTimeout = setTimeout(resolve, 5000);
+          executionTimeout = setTimeout(() => resolve('timeout'), 5000);
         }),
       ]);
-    } catch {
-      // Ignore errors from cancelled execution
-    } finally {
-      if (executionTimeout) {
-        clearTimeout(executionTimeout);
+      if (outcome === 'timeout') {
+        throw new Error(`Agent ${agent.id} execution did not settle after task termination`);
       }
-      agent._currentExecution = null;
+    } finally {
+      if (executionTimeout) clearTimeout(executionTimeout);
     }
+    if (agent._currentExecution === currentExecution) agent._currentExecution = null;
   }
 
   agent._log(`Agent ${agent.id} stopped`);
@@ -1268,67 +1268,16 @@ function startLivenessCheck(agent) {
   agent.livenessTerminationAttempts = 0;
   agent.livenessTerminationRetryAt = 0;
 
-  agent.livenessCheckInterval = setInterval(() => {
-    const hasRecoverableTask =
-      Boolean(agent.currentTask) ||
-      Boolean(agent.isolation?.enabled && agent.currentTaskId) ||
-      agent.nestedExecutions?.hasActive === true;
-    if (!hasRecoverableTask || agent.livenessTerminationStarted) {
-      return;
-    }
-
-    const now = Date.now();
-    if (agent.livenessTerminationContext) {
-      if (now >= agent.livenessTerminationRetryAt) {
-        attemptLivenessTermination(agent, settings);
-      }
-      return;
-    }
-
-    const taskStartedAt = agent.taskStartedAt || agent.lastOutputTime || now;
-    const lastOutputTime = agent.lastOutputTime || taskStartedAt;
-    const taskRuntime = now - taskStartedAt;
-    const timeSinceLastOutput = now - lastOutputTime;
-
-    if (configuredTimeout && taskRuntime >= configuredTimeout) {
-      const reason = `Task timed out after ${configuredTimeout}ms`;
-      beginLivenessTermination(agent, settings, reason, 'AGENT_TASK_TIMEOUT', {
-        taskId: agent.currentTaskId,
-        taskRuntime,
-        timeout: configuredTimeout,
-      });
-      return;
-    }
-
-    if (timeSinceLastOutput < staleDuration) {
-      agent.consecutiveStaleWarnings = 0;
-      return;
-    }
-
-    agent.consecutiveStaleWarnings += 1;
-    agent._publishLifecycle('AGENT_STALE_WARNING', {
-      taskId: agent.currentTaskId,
-      timeSinceLastOutput,
-      staleDuration,
-      lastOutputTime,
-      consecutiveWarnings: agent.consecutiveStaleWarnings,
-      warningsBeforeKill,
-      processDiagnosticsAvailable: isPlatformSupported(),
-      analysis: `Provider produced no output for ${timeSinceLastOutput}ms`,
-    });
-
-    if (agent.consecutiveStaleWarnings < warningsBeforeKill) {
-      return;
-    }
-
-    const reason = `Provider produced no output for ${timeSinceLastOutput}ms`;
-    beginLivenessTermination(agent, settings, reason, 'PROVIDER_INACTIVITY_TIMEOUT', {
-      taskId: agent.currentTaskId,
-      timeSinceLastOutput,
-      staleDuration,
-      consecutiveWarnings: agent.consecutiveStaleWarnings,
-    });
-  }, checkIntervalMs);
+  const poll = createLivenessPoll({
+    agent,
+    settings,
+    configuredTimeout,
+    staleDuration,
+    warningsBeforeKill,
+    attemptTermination: attemptLivenessTermination,
+    beginTermination: beginLivenessTermination,
+  });
+  agent.livenessCheckInterval = setInterval(poll, checkIntervalMs);
 }
 
 const MAX_LIVENESS_TERMINATION_ATTEMPTS = 3;

--- a/src/agent/agent-liveness-poll.js
+++ b/src/agent/agent-liveness-poll.js
@@ -1,0 +1,93 @@
+const { isPlatformSupported } = require('./agent-stuck-detector');
+
+function hasRecoverableTask(agent) {
+  return (
+    Boolean(agent.currentTask) ||
+    Boolean(agent.isolation?.enabled && agent.currentTaskId) ||
+    agent.nestedExecutions?.hasActive === true
+  );
+}
+
+function handlePendingTermination(agent, settings, now, attemptTermination) {
+  if (!agent.livenessTerminationContext) return false;
+  if (now >= agent.livenessTerminationRetryAt) attemptTermination(agent, settings);
+  return true;
+}
+
+function taskTiming(agent, now) {
+  const taskStartedAt = agent.taskStartedAt || agent.lastOutputTime || now;
+  const lastOutputTime = agent.lastOutputTime || taskStartedAt;
+  return {
+    taskRuntime: now - taskStartedAt,
+    timeSinceLastOutput: now - lastOutputTime,
+    lastOutputTime,
+  };
+}
+
+function handleTaskTimeout(context, timing) {
+  const { agent, settings, configuredTimeout, beginTermination } = context;
+  if (!configuredTimeout || timing.taskRuntime < configuredTimeout) return false;
+  beginTermination(
+    agent,
+    settings,
+    `Task timed out after ${configuredTimeout}ms`,
+    'AGENT_TASK_TIMEOUT',
+    {
+      taskId: agent.currentTaskId,
+      taskRuntime: timing.taskRuntime,
+      timeout: configuredTimeout,
+    }
+  );
+  return true;
+}
+
+function publishStaleWarning(context, timing) {
+  const { agent, staleDuration, warningsBeforeKill } = context;
+  agent.consecutiveStaleWarnings += 1;
+  agent._publishLifecycle('AGENT_STALE_WARNING', {
+    taskId: agent.currentTaskId,
+    timeSinceLastOutput: timing.timeSinceLastOutput,
+    staleDuration,
+    lastOutputTime: timing.lastOutputTime,
+    consecutiveWarnings: agent.consecutiveStaleWarnings,
+    warningsBeforeKill,
+    processDiagnosticsAvailable: isPlatformSupported(),
+    analysis: `Provider produced no output for ${timing.timeSinceLastOutput}ms`,
+  });
+}
+
+function terminateForInactivity(context, timing) {
+  const { agent, settings, staleDuration, beginTermination } = context;
+  beginTermination(
+    agent,
+    settings,
+    `Provider produced no output for ${timing.timeSinceLastOutput}ms`,
+    'PROVIDER_INACTIVITY_TIMEOUT',
+    {
+      taskId: agent.currentTaskId,
+      timeSinceLastOutput: timing.timeSinceLastOutput,
+      staleDuration,
+      consecutiveWarnings: agent.consecutiveStaleWarnings,
+    }
+  );
+}
+
+function createLivenessPoll(context) {
+  const { agent, settings, staleDuration, warningsBeforeKill, attemptTermination } = context;
+  return () => {
+    if (!hasRecoverableTask(agent) || agent.livenessTerminationStarted) return;
+    const now = Date.now();
+    if (handlePendingTermination(agent, settings, now, attemptTermination)) return;
+    const timing = taskTiming(agent, now);
+    if (handleTaskTimeout(context, timing)) return;
+    if (timing.timeSinceLastOutput < staleDuration) {
+      agent.consecutiveStaleWarnings = 0;
+      return;
+    }
+    publishStaleWarning(context, timing);
+    if (agent.consecutiveStaleWarnings < warningsBeforeKill) return;
+    terminateForInactivity(context, timing);
+  };
+}
+
+module.exports = { createLivenessPoll };

--- a/src/agent/agent-task-executor.js
+++ b/src/agent/agent-task-executor.js
@@ -1866,6 +1866,19 @@ function finalizeLogFollow(agent, state) {
   }
 }
 
+function finishHostLogCapture(agent, state, pollLogFile, processNewContent, broadcastLine) {
+  // A task status can become terminal before the watcher has flushed its final
+  // filesystem write (observed on Modal). Stop the timers first, then take one
+  // authoritative catch-up read and finish any final UTF-8/non-newline record.
+  finalizeLogFollow(agent, state);
+  pollLogFile();
+  const decoderTail = state.logDecoder.end();
+  if (decoderTail) processNewContent(decoderTail);
+  if (state.lineBuffer.byteLength > 0) {
+    completeLogRecord(state.lineBuffer, broadcastLine, true);
+  }
+}
+
 function settleHostStatusFailure({ agent, providerName, state, resolve, text, data, error }) {
   if (state.resolved) return;
   state.resolved = true;
@@ -1986,6 +1999,7 @@ function handleStatusCompletion({
   state,
   stdout,
   pollLogFile,
+  finishLogCapture,
   resolve,
   reject,
 }) {
@@ -2012,7 +2026,7 @@ function handleStatusCompletion({
     if (state.resolved) return;
     state.resolved = true;
 
-    finalizeLogFollow(agent, state);
+    finishLogCapture();
     flushAgentOutput(agent, providerName, state);
 
     buildCompletionResult({
@@ -2066,14 +2080,12 @@ function createLogFollower({
     const state = createLogFollowState();
     state.skipStructuredResultCheck = skipStructuredResultCheck;
     state.nested = nested;
-
     state.logFilePath = lookupLogFilePath(ctPath, taskId);
     if (state.logFilePath) {
       agent._log(`📋 Agent ${agent.id}: Following ct logs for ${taskId}`);
     } else {
       agent._log(`⏳ Agent ${agent.id}: Waiting for log file...`);
     }
-
     const broadcastLine = (line) => broadcastAgentLine({ agent, providerName, state, line });
     const processNewContent = (content) => appendContentToBuffer(state, content, broadcastLine);
     const pollLogFile = () =>
@@ -2085,6 +2097,8 @@ function createLogFollower({
         state,
         onNewContent: processNewContent,
       });
+    const finishLogCapture = () =>
+      finishHostLogCapture(agent, state, pollLogFile, processNewContent, broadcastLine);
 
     state.pollInterval = setInterval(pollLogFile, 300);
 
@@ -2120,6 +2134,7 @@ function createLogFollower({
             state,
             stdout,
             pollLogFile,
+            finishLogCapture,
             resolve,
             reject,
           });
@@ -3546,6 +3561,7 @@ module.exports = {
   consumeIsolatedTailChunk,
   flushAgentOutput,
   flushIsolatedOutput,
+  finishHostLogCapture,
   CONTROL_PLANE_OUTPUT_LIMITS: Object.freeze({
     maxBytes: MAX_CONTROL_PLANE_OUTPUT_BYTES,
     maxRecords: MAX_CONTROL_PLANE_OUTPUT_RECORDS,

--- a/src/foreground-benchmark-files.js
+++ b/src/foreground-benchmark-files.js
@@ -1,0 +1,81 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { buildTelemetry } = require('./foreground-benchmark-result');
+
+function serialized(value) {
+  return Buffer.from(`${JSON.stringify(value)}\n`, 'utf8');
+}
+
+function atomicWriteNew(targetPath, content) {
+  const directory = path.dirname(targetPath);
+  const temporary = path.join(
+    directory,
+    `.${path.basename(targetPath)}.${process.pid}.${crypto.randomBytes(8).toString('hex')}.tmp`
+  );
+  let descriptor;
+  let published = false;
+  try {
+    descriptor = fs.openSync(temporary, 'wx', 0o600);
+    fs.writeFileSync(descriptor, content);
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.linkSync(temporary, targetPath);
+    published = true;
+    fs.unlinkSync(temporary);
+    const directoryDescriptor = fs.openSync(directory, fs.constants.O_RDONLY);
+    try {
+      fs.fsyncSync(directoryDescriptor);
+    } finally {
+      fs.closeSync(directoryDescriptor);
+    }
+  } catch (error) {
+    error.atomicTargetPublished = published;
+    throw error;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    try {
+      fs.unlinkSync(temporary);
+    } catch {
+      // Preserve the primary write error; a leftover randomized temp is non-authoritative.
+    }
+  }
+}
+
+function removeOrphanTelemetry(telemetryPath, primaryError) {
+  try {
+    fs.unlinkSync(telemetryPath);
+  } catch (cleanupError) {
+    if (cleanupError.code !== 'ENOENT') primaryError.cleanupError = cleanupError;
+  }
+}
+
+function writeBenchmarkResultBundle(resultPath, result, snapshot) {
+  if (typeof resultPath !== 'string' || resultPath.length === 0) {
+    throw new Error('result path must be non-empty text');
+  }
+  const resolvedResult = path.resolve(resultPath);
+  const telemetryPath = `${resolvedResult}.telemetry.json`;
+  const telemetry = buildTelemetry(result.runId, snapshot);
+  const telemetryBytes = serialized(telemetry);
+  atomicWriteNew(telemetryPath, telemetryBytes);
+  const receipt = {
+    ...result,
+    telemetry: {
+      artifact: path.basename(telemetryPath),
+      byteLength: telemetryBytes.length,
+      sha256: crypto.createHash('sha256').update(telemetryBytes).digest('hex'),
+    },
+  };
+  try {
+    atomicWriteNew(resolvedResult, serialized(receipt));
+  } catch (error) {
+    if (!error.atomicTargetPublished) removeOrphanTelemetry(telemetryPath, error);
+    throw error;
+  }
+  return receipt;
+}
+
+module.exports = { writeBenchmarkResultBundle };

--- a/src/foreground-benchmark-result.js
+++ b/src/foreground-benchmark-result.js
@@ -1,0 +1,233 @@
+const crypto = require('node:crypto');
+const { VALID_PROVIDERS } = require('../lib/provider-names');
+
+const RESULT_SCHEMA = 'zeroshot-benchmark-result/v1';
+const TELEMETRY_SCHEMA = 'zeroshot-benchmark-telemetry/v1';
+const EMPTY_DIAGNOSTIC = Object.freeze({
+  byteLength: 0,
+  sha256: crypto.createHash('sha256').update('').digest('hex'),
+});
+const TASK_FAILURE_REASONS = new Set(['max_iterations', 'structured_output_invalid']);
+const PROVIDER_CODES = new Set(['crash', 'refusal']);
+const PROVIDERS = new Set(VALID_PROVIDERS);
+const PROVIDER_EVENTS = new Set(['terminal_error', 'turn.failed']);
+const PROVIDER_CATEGORIES = new Set([
+  'authentication',
+  'permanent',
+  'quota',
+  'transient',
+  'unknown',
+]);
+const PROVIDER_KINDS = new Set([
+  'permanent-pattern',
+  'rate-limit',
+  'retryable-pattern',
+  'status-permanent',
+  'status-retryable',
+  'code-retryable',
+  'unknown-retryable',
+]);
+const TOKEN_FIELDS = [
+  'inputTokens',
+  'outputTokens',
+  'cacheReadInputTokens',
+  'cacheCreationInputTokens',
+  'totalCostUsd',
+  'count',
+];
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireClosedText(value, allowed, label) {
+  if (typeof value !== 'string' || !allowed.has(value)) {
+    throw new Error(`${label} is outside the closed result contract`);
+  }
+  return value;
+}
+
+function requireDiagnostic(value) {
+  if (
+    value &&
+    Number.isSafeInteger(value.byteLength) &&
+    value.byteLength >= 0 &&
+    typeof value.sha256 === 'string' &&
+    /^[a-f0-9]{64}$/.test(value.sha256)
+  ) {
+    return { byteLength: value.byteLength, sha256: value.sha256 };
+  }
+  throw new Error('provider diagnostic is outside the closed result contract');
+}
+
+function terminalData(message) {
+  return requireObject(requireObject(message.content, 'terminal content').data, 'terminal data');
+}
+
+function isExplicitTaskFailure(message, data) {
+  if (message.sender === 'orchestrator' || !TASK_FAILURE_REASONS.has(data.reason)) return false;
+  if (data.reason === 'max_iterations') return message.receiver === 'system';
+  return message.receiver === 'broadcast' && data.code === 'STRUCTURED_OUTPUT_INVALID';
+}
+
+function classifyTerminal(message) {
+  if (message.topic === 'CLUSTER_COMPLETE') {
+    return {
+      outcome: 'completed',
+      terminalOwner: 'task',
+      code: 'ok',
+      kind: 'workflow_complete',
+      retryable: false,
+      diagnostic: { ...EMPTY_DIAGNOSTIC },
+      provider: null,
+      event: null,
+      category: null,
+    };
+  }
+
+  if (message.topic !== 'CLUSTER_FAILED') {
+    throw new Error(`unsupported terminal topic: ${message.topic}`);
+  }
+  const data = terminalData(message);
+  if (isExplicitTaskFailure(message, data)) {
+    return {
+      outcome: 'task_failure',
+      terminalOwner: 'task',
+      code: data.reason,
+      kind: 'declared_failure',
+      retryable: false,
+      diagnostic: { ...EMPTY_DIAGNOSTIC },
+      provider: null,
+      event: null,
+      category: null,
+    };
+  }
+  if (data.reason === 'provider_execution_failed') {
+    if (typeof data.retryable !== 'boolean') {
+      throw new Error('provider retryable must be boolean');
+    }
+    return {
+      outcome: 'provider_failure',
+      terminalOwner: 'provider',
+      code: requireClosedText(data.code, PROVIDER_CODES, 'provider code'),
+      kind: requireClosedText(data.kind, PROVIDER_KINDS, 'provider kind'),
+      retryable: data.retryable,
+      diagnostic: requireDiagnostic(data.diagnostic),
+      provider: requireClosedText(data.provider, PROVIDERS, 'provider'),
+      event: requireClosedText(data.event, PROVIDER_EVENTS, 'provider event'),
+      category: requireClosedText(data.category, PROVIDER_CATEGORIES, 'provider category'),
+    };
+  }
+  return {
+    outcome: 'engine_failure',
+    terminalOwner: 'engine',
+    code: 'engine_failed',
+    kind: 'declared_failure',
+    retryable: false,
+    diagnostic: { ...EMPTY_DIAGNOSTIC },
+    provider: null,
+    event: null,
+    category: null,
+  };
+}
+
+function validateStoppedAgents(agents) {
+  if (!Array.isArray(agents)) throw new Error('agents must be an array');
+  for (const agent of agents) {
+    const state = requireObject(agent, 'agent state');
+    if (state.pid !== null && state.pid !== undefined) {
+      throw new Error(`agent ${String(state.id)} still has a live process identity`);
+    }
+  }
+}
+
+function validateRunId(runId) {
+  const parts = typeof runId === 'string' ? runId.split('-') : [];
+  const valid =
+    parts.length >= 2 &&
+    parts.every(
+      (part) => part.length > 0 && [...part].every((character) => /[a-z0-9]/.test(character))
+    );
+  if (!valid) {
+    throw new Error('runId must be a canonical cluster id');
+  }
+}
+
+function buildBenchmarkResult({ runId, terminalMessages, agents }) {
+  validateRunId(runId);
+  if (!Array.isArray(terminalMessages) || terminalMessages.length !== 1) {
+    throw new Error('foreground run must have exactly one terminal event');
+  }
+  validateStoppedAgents(agents);
+  return {
+    schema: RESULT_SCHEMA,
+    runId,
+    ...classifyTerminal(terminalMessages[0]),
+  };
+}
+
+function buildCancelledResult({ runId, agents }) {
+  validateRunId(runId);
+  validateStoppedAgents(agents);
+  return {
+    schema: RESULT_SCHEMA,
+    runId,
+    outcome: 'cancelled',
+    terminalOwner: 'controller',
+    code: 'cancelled',
+    kind: 'controlled_cancellation',
+    retryable: false,
+    diagnostic: { ...EMPTY_DIAGNOSTIC },
+    provider: null,
+    event: null,
+    category: null,
+  };
+}
+
+function normalizeTokenEntry(value, label) {
+  const source = requireObject(value, label);
+  const entry = {};
+  for (const field of TOKEN_FIELDS) {
+    const amount = source[field] ?? 0;
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount < 0) {
+      throw new Error(`${label}.${field} must be a finite non-negative number`);
+    }
+    entry[field] = amount;
+  }
+  return entry;
+}
+
+function buildTelemetry(runId, snapshot) {
+  validateRunId(runId);
+  const source = requireObject(snapshot, 'telemetry snapshot');
+  if (!Number.isSafeInteger(source.messageCount) || source.messageCount < 0) {
+    throw new Error('telemetry messageCount must be a non-negative safe integer');
+  }
+  const roles = requireObject(source.tokensByRole, 'tokensByRole');
+  const names = Object.keys(roles).sort();
+  if (names.length > 64) throw new Error('telemetry role count exceeds 64');
+  const tokensByRole = {};
+  for (const name of names) {
+    const validRoleName =
+      name === '_total' ||
+      (name.length <= 128 &&
+        /^[a-zA-Z0-9]$/.test(name[0] || '') &&
+        [...name].every((character) => /[a-zA-Z0-9_.-]/.test(character)));
+    if (!validRoleName) {
+      throw new Error('telemetry role name is invalid');
+    }
+    tokensByRole[name] = normalizeTokenEntry(roles[name], `tokensByRole.${name}`);
+  }
+  return { schema: TELEMETRY_SCHEMA, runId, messageCount: source.messageCount, tokensByRole };
+}
+
+module.exports = {
+  RESULT_SCHEMA,
+  TELEMETRY_SCHEMA,
+  buildBenchmarkResult,
+  buildCancelledResult,
+  buildTelemetry,
+};

--- a/src/foreground-benchmark-run.js
+++ b/src/foreground-benchmark-run.js
@@ -1,0 +1,72 @@
+const { buildBenchmarkResult, buildCancelledResult } = require('./foreground-benchmark-result');
+const { writeBenchmarkResultBundle } = require('./foreground-benchmark-files');
+
+const TERMINAL_TOPICS = ['CLUSTER_COMPLETE', 'CLUSTER_FAILED'];
+const VERIFIER_ELIGIBLE = new Set(['completed', 'task_failure']);
+const EXIT_CODES = Object.freeze({
+  provider_failure: 20,
+  engine_failure: 21,
+  cancelled: 22,
+});
+
+function isForegroundStatusSettled(status) {
+  return (
+    status &&
+    ['stopped', 'killed'].includes(status.state) &&
+    status.isZombie === false &&
+    Array.isArray(status.agents) &&
+    status.agents.every((agent) => agent && (agent.pid === null || agent.pid === undefined))
+  );
+}
+
+function terminalMessages(cluster, clusterId) {
+  const messages = TERMINAL_TOPICS.flatMap((topic) =>
+    cluster.messageBus.query({ cluster_id: clusterId, topic })
+  );
+  return messages.sort((left, right) => {
+    const a = BigInt(left.sequence);
+    const b = BigInt(right.sequence);
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  });
+}
+
+function requireSettledStatus(orchestrator, clusterId) {
+  const status = orchestrator.getStatus(clusterId);
+  if (!isForegroundStatusSettled(status)) {
+    throw new Error(`foreground cluster is not settled: ${String(status?.state || 'unavailable')}`);
+  }
+  return status;
+}
+
+function writeForegroundResult({ orchestrator, cluster, clusterId, resultPath, cancelled }) {
+  const status = requireSettledStatus(orchestrator, clusterId);
+  const terminals = terminalMessages(cluster, clusterId);
+  let result;
+  if (cancelled && terminals.length === 0) {
+    result = buildCancelledResult({ runId: clusterId, agents: status.agents });
+  } else {
+    result = buildBenchmarkResult({
+      runId: clusterId,
+      terminalMessages: terminals,
+      agents: status.agents,
+    });
+  }
+  const snapshot = cluster.messageBus.readSnapshot(clusterId);
+  return writeBenchmarkResultBundle(resultPath, result, snapshot);
+}
+
+function exitCodeForResult(result) {
+  if (VERIFIER_ELIGIBLE.has(result.outcome)) return 0;
+  const exitCode = EXIT_CODES[result.outcome];
+  if (exitCode === undefined) throw new Error(`unsupported result outcome: ${result.outcome}`);
+  return exitCode;
+}
+
+module.exports = {
+  exitCodeForResult,
+  isForegroundStatusSettled,
+  terminalMessages,
+  writeForegroundResult,
+};

--- a/task-lib/runner.js
+++ b/task-lib/runner.js
@@ -625,6 +625,13 @@ export function shouldUseAttachableWatcher(options, providerName) {
     return false;
   }
 
+  // Benchmark runs are non-interactive and keep the cluster process in the foreground. Use the
+  // pipe watcher so task completion is observed only after stdout/stderr close; a PTY exit can
+  // race its final buffered output on remote runtimes and lose the terminal structured result.
+  if (resolveTaskExecutionContext() === 'benchmark') {
+    return false;
+  }
+
   // The rpc-stdio lane owns bidirectional correlated RPC over stdio itself (see
   // omp-rpc-driver.ts) and always uses rpc-watcher.js instead of the attachable PTY watcher.
   if (getProviderRegistryEntry(providerName).invoke.lane === 'rpc-stdio') {

--- a/tests/e2e/codex-terminal-stress.test.js
+++ b/tests/e2e/codex-terminal-stress.test.js
@@ -55,9 +55,10 @@ function readTaskLog(homeDir) {
   const storePath = path.join(homeDir, '.claude-zeroshot', 'store.db');
   const database = new Database(storePath, { readonly: true, fileMustExist: true });
   try {
-    const tasks = database.prepare('SELECT status, error, log_file FROM tasks').all();
+    const tasks = database.prepare('SELECT status, error, log_file, attachable FROM tasks').all();
     assert.strictEqual(tasks.length, 1, `expected one real provider task, got ${tasks.length}`);
     assert.strictEqual(tasks[0].status, 'completed', tasks[0].error || 'task did not complete');
+    assert.strictEqual(tasks[0].attachable, 0, 'benchmark tasks must use the pipe watcher');
     return fs.readFileSync(tasks[0].log_file, 'utf8');
   } finally {
     database.close();
@@ -117,6 +118,7 @@ describe('e2e: Codex compressed terminal stress', function () {
       ],
       {
         ZEROSHOT_CLUSTER_ID: clusterId,
+        ZEROSHOT_TASK_EXECUTION_CONTEXT: 'benchmark',
         FAKE_CODEX_EXPECTED_OUTPUT: expectedOutputPath,
         FAKE_CODEX_STRESS_BYTES: String(STRESS_BYTES),
       }

--- a/tests/e2e/foreground-benchmark-result.test.js
+++ b/tests/e2e/foreground-benchmark-result.test.js
@@ -1,0 +1,215 @@
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const Database = require('better-sqlite3');
+
+const {
+  cleanupE2ERepo,
+  buildEnv,
+  CLI_ENTRY,
+  runZeroshot,
+  scenarioPath,
+  setupE2ERepo,
+} = require('./helpers/e2e-harness');
+
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'single-worker-config.json');
+
+function runUntilSignal(env, args, envOverrides, marker) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      cwd: env.repoDir,
+      env: buildEnv(env, envOverrides),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let signalled = false;
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`foreground cancellation timed out\n${stdout}\n${stderr}`));
+    }, 30_000);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+      if (!signalled && stdout.includes(marker)) {
+        signalled = true;
+        child.kill('SIGTERM');
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (status, signal) => {
+      clearTimeout(timeout);
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
+
+function readBundle(resultPath) {
+  const receiptBytes = fs.readFileSync(resultPath);
+  const receipt = JSON.parse(receiptBytes);
+  const telemetryPath = path.join(path.dirname(resultPath), receipt.telemetry.artifact);
+  const telemetryBytes = fs.readFileSync(telemetryPath);
+  const observedIdentity = [
+    telemetryBytes.length,
+    crypto.createHash('sha256').update(telemetryBytes).digest('hex'),
+  ];
+  assert.deepStrictEqual(
+    [receipt.telemetry.byteLength, receipt.telemetry.sha256],
+    observedIdentity
+  );
+  return { receipt, telemetry: JSON.parse(telemetryBytes) };
+}
+
+function describeWithE2ERepo(name, defineTests) {
+  describe(name, function () {
+    this.timeout(60_000);
+    let env;
+    beforeEach(() => {
+      env = setupE2ERepo();
+    });
+    afterEach(() => {
+      cleanupE2ERepo(env);
+    });
+    defineTests(() => env);
+  });
+}
+
+describeWithE2ERepo('e2e: foreground benchmark outcomes', (environment) => {
+  it('runs the real workflow and commits a verifier-eligible result', function () {
+    const env = environment();
+    const resultPath = path.join(env.homeDir, 'success-result.json');
+    const execution = runZeroshot(
+      env,
+      [
+        'run',
+        'Implement the fixture task',
+        '--no-isolation',
+        '--config',
+        CONFIG_PATH,
+        '--sim',
+        'off',
+        '--result-file',
+        resultPath,
+      ],
+      { FAKE_AGENT_SCENARIO: scenarioPath('single-worker-success'), timeout: 30_000 }
+    );
+
+    assert.strictEqual(execution.status, 0, `${execution.stdout}\n${execution.stderr}`);
+    const { receipt, telemetry } = readBundle(resultPath);
+    assert.strictEqual(receipt.schema, 'zeroshot-benchmark-result/v1');
+    assert.strictEqual(receipt.outcome, 'completed');
+    assert.strictEqual(receipt.terminalOwner, 'task');
+    assert.strictEqual(telemetry.runId, receipt.runId);
+    assert.ok(telemetry.messageCount > 0);
+    assert.ok(telemetry.tokensByRole._total.count > 0);
+    assert.match(execution.stdout, /Result completed committed/);
+    const taskStore = new Database(path.join(env.homeDir, '.claude-zeroshot', 'store.db'), {
+      readonly: true,
+      fileMustExist: true,
+    });
+    const tasks = taskStore.prepare('SELECT attachable FROM tasks').all();
+    taskStore.close();
+    assert.deepStrictEqual(tasks, [{ attachable: 0 }], 'result mode must select the pipe watcher');
+  });
+
+  it('commits a provider failure and returns its closed transport exit code', function () {
+    const env = environment();
+    const resultPath = path.join(env.homeDir, 'failure-result.json');
+    const execution = runZeroshot(
+      env,
+      [
+        'run',
+        'Exercise failure handling',
+        '--no-isolation',
+        '--config',
+        CONFIG_PATH,
+        '--sim',
+        'off',
+        '--result-file',
+        resultPath,
+      ],
+      { FAKE_AGENT_SCENARIO: scenarioPath('failing-agent'), timeout: 30_000 }
+    );
+
+    assert.strictEqual(execution.status, 20, `${execution.stdout}\n${execution.stderr}`);
+    const { receipt } = readBundle(resultPath);
+    assert.strictEqual(receipt.outcome, 'provider_failure');
+    assert.strictEqual(receipt.terminalOwner, 'provider');
+    assert.strictEqual(receipt.provider, 'claude');
+    assert.strictEqual(receipt.kind, 'unknown-retryable');
+    assert.ok(!JSON.stringify(receipt).includes('simulated fatal error'));
+  });
+});
+
+describeWithE2ERepo('e2e: foreground benchmark guards', (environment) => {
+  it('rejects a result path in detached mode before starting a cluster', function () {
+    const env = environment();
+    const resultPath = path.join(env.homeDir, 'detached-result.json');
+    const execution = runZeroshot(env, [
+      'run',
+      'Do not launch',
+      '--detach',
+      '--no-isolation',
+      '--sim',
+      'off',
+      '--result-file',
+      resultPath,
+    ]);
+
+    assert.strictEqual(execution.status, 1);
+    assert.match(execution.stderr, /result-file requires foreground execution/);
+    assert.strictEqual(fs.existsSync(resultPath), false);
+  });
+
+  it('settles SIGTERM through Harbor-compatible cancellation before writing a receipt', async function () {
+    const env = environment();
+    const resultPath = path.join(env.homeDir, 'cancelled-result.json');
+    const execution = await runUntilSignal(
+      env,
+      [
+        'run',
+        'Exercise cancellation',
+        '--no-isolation',
+        '--config',
+        CONFIG_PATH,
+        '--sim',
+        'off',
+        '--result-file',
+        resultPath,
+      ],
+      { FAKE_AGENT_SCENARIO: scenarioPath('single-worker-success-delayed') },
+      'TASK_ID_ASSIGNED'
+    );
+
+    assert.strictEqual(execution.signal, null, execution.stderr);
+    assert.strictEqual(execution.status, 22, `${execution.stdout}\n${execution.stderr}`);
+    const { receipt } = readBundle(resultPath);
+    assert.strictEqual(receipt.outcome, 'cancelled');
+    assert.strictEqual(receipt.terminalOwner, 'controller');
+  });
+
+  it('preserves legacy SIGTERM behavior without a result contract', async function () {
+    const env = environment();
+    const execution = await runUntilSignal(
+      env,
+      [
+        'run',
+        'Exercise legacy foreground termination',
+        '--no-isolation',
+        '--config',
+        CONFIG_PATH,
+        '--sim',
+        'off',
+      ],
+      { FAKE_AGENT_SCENARIO: scenarioPath('single-worker-success-delayed') },
+      'TASK_ID_ASSIGNED'
+    );
+
+    assert.strictEqual(execution.status, null, execution.stderr);
+    assert.strictEqual(execution.signal, 'SIGTERM');
+  });
+});

--- a/tests/fixtures/foreground-atomic-kill.js
+++ b/tests/fixtures/foreground-atomic-kill.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+
+const [resultPath, markerPath, phase] = process.argv.slice(2);
+const originalLink = fs.linkSync;
+let links = 0;
+fs.linkSync = (source, target) => {
+  links += 1;
+  if (links !== 2) return originalLink(source, target);
+  if (phase === 'after') originalLink(source, target);
+  fs.writeFileSync(markerPath, `${phase}\n`, { flag: 'wx', mode: 0o600 });
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+};
+
+const { writeBenchmarkResultBundle } = require('../../src/foreground-benchmark-files');
+writeBenchmarkResultBundle(
+  resultPath,
+  {
+    schema: 'zeroshot-benchmark-result/v1',
+    runId: 'atomic-kill-test',
+    outcome: 'completed',
+    terminalOwner: 'task',
+    code: 'ok',
+    kind: 'workflow_complete',
+    retryable: false,
+    diagnostic: {
+      byteLength: 0,
+      sha256: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    },
+    provider: null,
+    event: null,
+    category: null,
+  },
+  {
+    messageCount: 0,
+    tokensByRole: {
+      _total: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheCreationInputTokens: 0,
+        totalCostUsd: 0,
+        count: 0,
+      },
+    },
+  }
+);

--- a/tests/foreground-benchmark-files.test.js
+++ b/tests/foreground-benchmark-files.test.js
@@ -1,0 +1,175 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+const crypto = require('node:crypto');
+const path = require('node:path');
+
+const { writeBenchmarkResultBundle } = require('../src/foreground-benchmark-files');
+const {
+  RESULT_SCHEMA,
+  buildBenchmarkResult,
+  buildCancelledResult,
+} = require('../src/foreground-benchmark-result');
+const { writeForegroundResult } = require('../src/foreground-benchmark-run');
+const { createTempDirectory, removeTempDirectory } = require('./helpers/temp-directory');
+
+const RUN_ID = 'benchmark-result-test';
+const STOPPED_AGENTS = [{ id: 'planner', pid: null }];
+const ATOMIC_KILL_FIXTURE = path.join(__dirname, 'fixtures', 'foreground-atomic-kill.js');
+
+function terminal(topic) {
+  return { topic, sender: 'planner', receiver: 'system', content: { data: {} } };
+}
+
+function snapshot() {
+  return {
+    messageCount: 17,
+    tokensByRole: {
+      _total: { inputTokens: 10, outputTokens: 5, count: 2 },
+    },
+  };
+}
+
+function completedResult() {
+  return buildBenchmarkResult({
+    runId: RUN_ID,
+    terminalMessages: [terminal('CLUSTER_COMPLETE')],
+    agents: STOPPED_AGENTS,
+  });
+}
+
+describe('foreground benchmark atomic bundle', function () {
+  let directory;
+  beforeEach(() => {
+    directory = createTempDirectory('zeroshot-foreground-result-');
+  });
+
+  afterEach(() => {
+    removeTempDirectory(directory);
+  });
+
+  it('writes telemetry before one non-overwriting receipt with matching digest', function () {
+    const resultPath = path.join(directory, 'result.json');
+    const receipt = writeBenchmarkResultBundle(resultPath, completedResult(), snapshot());
+    const persisted = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+    const telemetryPath = path.join(directory, persisted.telemetry.artifact);
+    const telemetry = fs.readFileSync(telemetryPath);
+
+    assert.deepStrictEqual(persisted, receipt);
+    assert.strictEqual(persisted.telemetry.byteLength, telemetry.length);
+    assert.strictEqual(
+      persisted.telemetry.sha256,
+      crypto.createHash('sha256').update(telemetry).digest('hex')
+    );
+    assert.strictEqual(fs.statSync(resultPath).mode & 0o777, 0o600);
+    assert.strictEqual(fs.statSync(telemetryPath).mode & 0o777, 0o600);
+    assert.deepStrictEqual(fs.readdirSync(directory).sort(), [
+      'result.json',
+      'result.json.telemetry.json',
+    ]);
+  });
+
+  it('refuses to replace an existing result and removes its orphan telemetry', function () {
+    const resultPath = path.join(directory, 'result.json');
+    fs.writeFileSync(resultPath, 'existing\n', { mode: 0o600 });
+    const result = buildCancelledResult({ runId: RUN_ID, agents: STOPPED_AGENTS });
+
+    assert.throws(() => writeBenchmarkResultBundle(resultPath, result, snapshot()), /EEXIST/);
+    assert.strictEqual(fs.readFileSync(resultPath, 'utf8'), 'existing\n');
+    assert.deepStrictEqual(fs.readdirSync(directory), ['result.json']);
+  });
+
+  it('retains a complete published bundle when the final durability sync fails', function () {
+    const resultPath = path.join(directory, 'result.json');
+    const originalFsync = fs.fsyncSync;
+    let calls = 0;
+    fs.fsyncSync = (descriptor) => {
+      calls += 1;
+      if (calls === 4)
+        throw Object.assign(new Error('simulated directory fsync failure'), { code: 'EIO' });
+      return originalFsync(descriptor);
+    };
+    try {
+      assert.throws(
+        () => writeBenchmarkResultBundle(resultPath, completedResult(), snapshot()),
+        /simulated directory fsync failure/
+      );
+    } finally {
+      fs.fsyncSync = originalFsync;
+    }
+
+    const receipt = JSON.parse(fs.readFileSync(resultPath));
+    const telemetryPath = path.join(directory, receipt.telemetry.artifact);
+    assert.strictEqual(fs.existsSync(telemetryPath), true);
+    const telemetry = fs.readFileSync(telemetryPath);
+    assert.strictEqual(receipt.telemetry.byteLength, telemetry.length);
+    assert.strictEqual(
+      receipt.telemetry.sha256,
+      crypto.createHash('sha256').update(telemetry).digest('hex')
+    );
+  });
+});
+
+describe('foreground benchmark terminal and crash races', function () {
+  let directory;
+  beforeEach(() => {
+    directory = createTempDirectory('zeroshot-foreground-race-');
+  });
+  afterEach(() => {
+    removeTempDirectory(directory);
+  });
+
+  it('lets an authoritative terminal win a cancellation race', function () {
+    const resultPath = path.join(directory, 'raced-result.json');
+    const completed = { ...terminal('CLUSTER_COMPLETE'), sequence: '9' };
+    const cluster = {
+      messageBus: {
+        query: ({ topic }) => (topic === 'CLUSTER_COMPLETE' ? [completed] : []),
+        readSnapshot: snapshot,
+      },
+    };
+    const orchestrator = {
+      getStatus: () => ({ state: 'stopped', isZombie: false, agents: STOPPED_AGENTS }),
+    };
+    const receipt = writeForegroundResult({
+      orchestrator,
+      cluster,
+      clusterId: RUN_ID,
+      resultPath,
+      cancelled: true,
+    });
+
+    assert.strictEqual(receipt.outcome, 'completed');
+    assert.strictEqual(receipt.terminalOwner, 'task');
+  });
+
+  for (const phase of ['before', 'after']) {
+    it(`survives SIGKILL ${phase} the authoritative receipt link`, async function () {
+      const resultPath = path.join(directory, `${phase}-kill-result.json`);
+      const markerPath = path.join(directory, `${phase}-kill.marker`);
+      const child = spawn(process.execPath, [ATOMIC_KILL_FIXTURE, resultPath, markerPath, phase], {
+        stdio: 'ignore',
+      });
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(markerPath) && child.exitCode === null && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      assert.strictEqual(fs.existsSync(markerPath), true, 'child did not reach atomic boundary');
+      child.kill('SIGKILL');
+      await new Promise((resolve) => child.once('close', resolve));
+
+      assert.strictEqual(fs.existsSync(resultPath), phase === 'after');
+      if (phase === 'after') {
+        const { schema, outcome, telemetry } = JSON.parse(fs.readFileSync(resultPath));
+        assert.strictEqual(schema, RESULT_SCHEMA);
+        assert.strictEqual(outcome, 'completed');
+        const telemetryBytes = fs.readFileSync(path.join(directory, telemetry.artifact));
+        assert.strictEqual(telemetry.byteLength, telemetryBytes.length);
+        assert.strictEqual(
+          telemetry.sha256,
+          crypto.createHash('sha256').update(telemetryBytes).digest('hex')
+        );
+      }
+    });
+  }
+});

--- a/tests/foreground-benchmark-result.test.js
+++ b/tests/foreground-benchmark-result.test.js
@@ -1,0 +1,193 @@
+const assert = require('node:assert');
+const crypto = require('node:crypto');
+const {
+  RESULT_SCHEMA,
+  TELEMETRY_SCHEMA,
+  buildBenchmarkResult,
+  buildCancelledResult,
+  buildTelemetry,
+} = require('../src/foreground-benchmark-result');
+const { isForegroundStatusSettled } = require('../src/foreground-benchmark-run');
+
+const RUN_ID = 'benchmark-result-test';
+const STOPPED_AGENTS = [{ id: 'planner', pid: null }];
+const EMPTY_SHA256 = crypto.createHash('sha256').update('').digest('hex');
+
+function terminal(topic, data = {}, sender = 'planner', receiver = 'system') {
+  return { topic, sender, receiver, content: { data } };
+}
+
+function snapshot() {
+  return {
+    messageCount: 17,
+    tokensByRole: {
+      _total: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadInputTokens: 2,
+        cacheCreationInputTokens: 1,
+        totalCostUsd: 0.01,
+        count: 2,
+      },
+      planning: { inputTokens: 10, outputTokens: 5, count: 2 },
+    },
+  };
+}
+
+describe('foreground benchmark result contract', function () {
+  it('maps successful and explicit task-failure terminals to verifier-eligible outcomes', function () {
+    const success = buildBenchmarkResult({
+      runId: RUN_ID,
+      terminalMessages: [terminal('CLUSTER_COMPLETE')],
+      agents: STOPPED_AGENTS,
+    });
+    assert.deepStrictEqual(success, {
+      schema: RESULT_SCHEMA,
+      runId: RUN_ID,
+      outcome: 'completed',
+      terminalOwner: 'task',
+      code: 'ok',
+      kind: 'workflow_complete',
+      retryable: false,
+      diagnostic: { byteLength: 0, sha256: EMPTY_SHA256 },
+      provider: null,
+      event: null,
+      category: null,
+    });
+
+    const taskFailure = buildBenchmarkResult({
+      runId: RUN_ID,
+      terminalMessages: [terminal('CLUSTER_FAILED', { reason: 'max_iterations' })],
+      agents: STOPPED_AGENTS,
+    });
+    assert.strictEqual(taskFailure.outcome, 'task_failure');
+    assert.strictEqual(taskFailure.terminalOwner, 'task');
+    assert.strictEqual(taskFailure.code, 'max_iterations');
+
+    const structuredFailure = buildBenchmarkResult({
+      runId: RUN_ID,
+      terminalMessages: [
+        terminal(
+          'CLUSTER_FAILED',
+          { reason: 'structured_output_invalid', code: 'STRUCTURED_OUTPUT_INVALID' },
+          'worker',
+          'broadcast'
+        ),
+      ],
+      agents: STOPPED_AGENTS,
+    });
+    assert.strictEqual(structuredFailure.outcome, 'task_failure');
+    assert.strictEqual(structuredFailure.code, 'structured_output_invalid');
+  });
+
+  it('retains only a closed provider failure envelope', function () {
+    const rawSecret = 'Authorization: Bearer should-never-survive';
+    const result = buildBenchmarkResult({
+      runId: RUN_ID,
+      terminalMessages: [
+        terminal(
+          'CLUSTER_FAILED',
+          {
+            reason: 'provider_execution_failed',
+            provider: 'codex',
+            event: 'turn.failed',
+            category: 'quota',
+            code: 'crash',
+            kind: 'permanent-pattern',
+            retryable: false,
+            diagnostic: { byteLength: 44, sha256: 'a'.repeat(64) },
+            rawSecret,
+          },
+          'planner',
+          'broadcast'
+        ),
+      ],
+      agents: STOPPED_AGENTS,
+    });
+    assert.strictEqual(result.outcome, 'provider_failure');
+    assert.strictEqual(result.terminalOwner, 'provider');
+    assert.strictEqual(result.provider, 'codex');
+    assert.strictEqual(result.event, 'turn.failed');
+    assert.strictEqual(result.category, 'quota');
+    assert.deepStrictEqual(result.diagnostic, { byteLength: 44, sha256: 'a'.repeat(64) });
+    assert.ok(!JSON.stringify(result).includes(rawSecret));
+  });
+});
+
+describe('foreground benchmark result rejection and telemetry', function () {
+  it('requires terminal state and every agent process identity to settle', function () {
+    const status = { state: 'stopped', isZombie: false, agents: STOPPED_AGENTS };
+    assert.strictEqual(isForegroundStatusSettled(status), true);
+    assert.strictEqual(
+      isForegroundStatusSettled({ ...status, agents: [{ id: 'worker', pid: 123 }] }),
+      false
+    );
+    assert.strictEqual(isForegroundStatusSettled({ ...status, isZombie: true }), false);
+  });
+
+  it('rejects a malformed provider envelope instead of inventing defaults', function () {
+    assert.throws(
+      () =>
+        buildBenchmarkResult({
+          runId: RUN_ID,
+          terminalMessages: [
+            terminal('CLUSTER_FAILED', {
+              reason: 'provider_execution_failed',
+              provider: 'unregistered-provider',
+              event: 'turn.failed',
+              category: 'unknown',
+              code: 'crash',
+              kind: 'unknown-retryable',
+              retryable: true,
+              diagnostic: { byteLength: 1, sha256: 'b'.repeat(64) },
+            }),
+          ],
+          agents: STOPPED_AGENTS,
+        }),
+      /provider is outside the closed result contract/
+    );
+  });
+
+  it('rejects missing, duplicate, and not-yet-stopped terminal state', function () {
+    assert.throws(
+      () => buildBenchmarkResult({ runId: RUN_ID, terminalMessages: [], agents: STOPPED_AGENTS }),
+      /exactly one terminal/
+    );
+    assert.throws(
+      () =>
+        buildBenchmarkResult({
+          runId: RUN_ID,
+          terminalMessages: [terminal('CLUSTER_COMPLETE'), terminal('CLUSTER_FAILED')],
+          agents: STOPPED_AGENTS,
+        }),
+      /exactly one terminal/
+    );
+    assert.throws(
+      () =>
+        buildBenchmarkResult({
+          runId: RUN_ID,
+          terminalMessages: [terminal('CLUSTER_COMPLETE')],
+          agents: [{ id: 'planner', pid: 123 }],
+        }),
+      /live process identity/
+    );
+  });
+
+  it('builds a closed controlled-cancellation result', function () {
+    const result = buildCancelledResult({ runId: RUN_ID, agents: STOPPED_AGENTS });
+    assert.strictEqual(result.outcome, 'cancelled');
+    assert.strictEqual(result.terminalOwner, 'controller');
+    assert.strictEqual(result.code, 'cancelled');
+  });
+
+  it('normalizes bounded telemetry and rejects invalid numeric data', function () {
+    const telemetry = buildTelemetry(RUN_ID, snapshot());
+    assert.strictEqual(telemetry.schema, TELEMETRY_SCHEMA);
+    assert.strictEqual(telemetry.messageCount, 17);
+    assert.strictEqual(telemetry.tokensByRole.planning.cacheReadInputTokens, 0);
+    assert.throws(
+      () => buildTelemetry(RUN_ID, { ...snapshot(), messageCount: -1 }),
+      /messageCount/
+    );
+  });
+});

--- a/tests/host-terminal-tail-catchup.test.js
+++ b/tests/host-terminal-tail-catchup.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert');
+
+const {
+  appendContentToBuffer,
+  broadcastAgentLine,
+  createLogFollowState,
+  finishHostLogCapture,
+} = require('../src/agent/agent-task-executor');
+
+describe('host terminal log catch-up', function () {
+  it('reads and parses the final UTF-8 record after terminal status', function () {
+    const published = [];
+    const agent = {
+      id: 'tail-worker',
+      role: 'implementation',
+      iteration: 1,
+      currentTask: {},
+      lastOutputTime: null,
+      messageBus: { publish: (message) => published.push(message) },
+      _publish: (message) => published.push(message),
+    };
+    const state = createLogFollowState();
+    const broadcast = (line) => broadcastAgentLine({ agent, providerName: 'codex', state, line });
+    const consume = (content) => appendContentToBuffer(state, content, broadcast);
+    const final = JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '{"summary":"café 🌍","result":"ok"}' },
+    });
+    let polls = 0;
+
+    finishHostLogCapture(
+      agent,
+      state,
+      () => {
+        polls += 1;
+        consume(`[1700000000000]${final}`);
+      },
+      consume,
+      broadcast
+    );
+
+    assert.strictEqual(polls, 1);
+    assert.match(state.output, /café 🌍/);
+    assert.strictEqual(state.lineBuffer.byteLength, 0);
+    assert.strictEqual(agent.currentTask, null);
+    assert.strictEqual(published.length, 1);
+  });
+});

--- a/tests/task-execution-context.test.js
+++ b/tests/task-execution-context.test.js
@@ -34,6 +34,21 @@ describe('Detached task execution context', function () {
     }
   });
 
+  it('uses the close-delimited pipe watcher for non-interactive benchmark tasks', async function () {
+    const previous = process.env[EXECUTION_CONTEXT_ENV];
+    process.env[EXECUTION_CONTEXT_ENV] = 'benchmark';
+    try {
+      const { shouldUseAttachableWatcher } = await import('../task-lib/runner.js');
+      assert.equal(
+        shouldUseAttachableWatcher({ attachable: true, jsonSchema: { type: 'object' } }, 'codex'),
+        false
+      );
+    } finally {
+      if (previous === undefined) delete process.env[EXECUTION_CONTEXT_ENV];
+      else process.env[EXECUTION_CONTEXT_ENV] = previous;
+    }
+  });
+
   it('rejects an invalid outer boundary before provider command preparation', async function () {
     const previous = process.env[EXECUTION_CONTEXT_ENV];
     process.env[EXECUTION_CONTEXT_ENV] = 'modal';

--- a/tests/unit/agent-lifecycle-stop.test.js
+++ b/tests/unit/agent-lifecycle-stop.test.js
@@ -46,4 +46,33 @@ describe('Agent lifecycle stop', function () {
       global.clearTimeout = originalClearTimeout;
     }
   });
+
+  it('fails closed instead of abandoning an in-flight execution after the wait bound', async function () {
+    const originalSetTimeout = global.setTimeout;
+    const originalClearTimeout = global.clearTimeout;
+    const execution = new Promise(() => {});
+    const timeoutHandle = {};
+    global.setTimeout = (callback, delay) => {
+      assert.strictEqual(delay, 5000);
+      setImmediate(callback);
+      return timeoutHandle;
+    };
+    global.clearTimeout = () => {};
+
+    const agent = {
+      id: 'slow-agent',
+      running: true,
+      currentTask: null,
+      _currentExecution: execution,
+      unsubscribe: null,
+      _log() {},
+    };
+    try {
+      await assert.rejects(stop(agent), /execution did not settle after task termination/);
+      assert.strictEqual(agent._currentExecution, execution);
+    } finally {
+      global.setTimeout = originalSetTimeout;
+      global.clearTimeout = originalClearTimeout;
+    }
+  });
 });

--- a/tests/unit/cli-help.test.js
+++ b/tests/unit/cli-help.test.js
@@ -241,6 +241,7 @@ describe('CLI completion snapshots', function () {
       '--sim',
       '-d',
       '--detach',
+      '--result-file',
       '-h',
       '--help',
     ]);


### PR DESCRIPTION
## Summary
- add a foreground-only `--result-file` contract with atomic result and telemetry receipts
- make terminal settlement, cancellation, and exit classification explicit and fail closed
- use the pipe watcher for benchmark execution so remote PTY tail races cannot drop structured terminal output
- add deterministic crash, signal, large-output, liveness, and terminal-tail regressions

## Why
Benchmarks needs one authoritative, bounded, programmatic result boundary instead of reconstructing terminal truth from detached process state, status polling, and full ledger exports. This also fixes the Modal-only PTY tail-loss race reproduced by the zero-token qualification gate.

## Validation
- 2788 unit tests passed; 18 pending
- 33 E2E tests passed
- 12 MiB terminal-output stress passed
- zero-token Modal foreground Harbor gate passed with reward 1.0
- zero-token Docker success and provider-failure gates passed
- lint/typecheck/package/release preflight passed
- `npm run opcore:check`, direct Opcore changed, and Opcore Zero passed

Tracks the-open-engine/benchmarks#283 and the-open-engine/benchmarks#286.