### PR TITLE
fix: order codex resume execution options

### DIFF
--- a/src/agent-cli-provider/adapters/codex.ts
+++ b/src/agent-cli-provider/adapters/codex.ts
@@ -222,6 +222,8 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
       : null;
   addWebSearchArgs(args, options);
   if (resumeSessionId) {
+    // Codex 0.147 parses --sandbox on `exec`, not on the `resume` subcommand.
+    addAutoApproveArgs(args, options);
     args.push('resume');
   }
 
@@ -229,8 +231,8 @@ function buildCommand(context: string, options: BuildProviderCommandOptions = {}
   addModelArgs(args, options);
   if (!resumeSessionId) {
     addCwdArgs(args, options);
+    addAutoApproveArgs(args, options);
   }
-  addAutoApproveArgs(args, options);
   addSkipGitArgs(args, options);
   const finalContext = applySchemaArgs(args, cleanup, context, options);
 

--- a/tests/agent-cli-provider/executable-contract-build.test.js
+++ b/tests/agent-cli-provider/executable-contract-build.test.js
@@ -174,7 +174,7 @@ test('build-command preserves Claude resume and continue options through JSON co
   assert.deepEqual(continued.envelope.result.commandSpec.args.slice(-2), ['--continue', 'ctx']);
 });
 
-test('build-command preserves Codex explicit session resume through JSON contract', () => {
+test('build-command places Codex 0.147 exec options before explicit session resume', () => {
   const resumed = runExecutable({
     schemaVersion: 1,
     command: 'build-command',
@@ -183,17 +183,31 @@ test('build-command preserves Codex explicit session resume through JSON contrac
     options: {
       resumeSessionId: 'thread-1',
       cwd: '/tmp/project',
+      autoApprove: true,
+      modelSpec: { model: 'gpt-5.4' },
       cliFeatures: {
         supportsResume: true,
         supportsCwd: true,
+        supportsAutoApprove: true,
       },
     },
   });
 
   assert.equal(resumed.exitCode, 0);
   assert.equal(resumed.envelope.ok, true);
-  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(0, 2), ['exec', 'resume']);
-  assert.deepEqual(resumed.envelope.result.commandSpec.args.slice(-2), ['thread-1', 'ctx']);
+  assert.deepEqual(resumed.envelope.result.commandSpec.args, [
+    'exec',
+    '--sandbox',
+    'workspace-write',
+    '--config',
+    'approval_policy="never"',
+    'resume',
+    '-m',
+    'gpt-5.4',
+    '--skip-git-repo-check',
+    'thread-1',
+    'ctx',
+  ]);
   assert.equal(resumed.envelope.result.commandSpec.args.includes('-C'), false);
   assert.equal(resumed.envelope.result.commandSpec.cwd, '/tmp/project');
 });


### PR DESCRIPTION
## What

Place Codex `exec`-level execution-policy options before the `resume` subcommand when reusing an existing Codex session. Keep fresh-task command ordering and same-session continuation semantics unchanged.

## Why

Codex CLI 0.147 parses `--sandbox` and the approval-policy `--config` on `codex exec`, not on `codex exec resume`. Zeroshot previously produced `codex exec resume ... --sandbox ...`, which failed before the resumed turn could run.

## Impact

Validator/worker continuation can resume the exact captured Codex thread as intended. This PR intentionally does not add validator isolation or change provider-session policy.

## Checks

- exact command-contract regression for the full resumed argv
- real zero-token Codex 0.147 parser proof: old argv exits 2 with `unexpected argument --sandbox`; fixed argv reaches local session lookup
- provider contract suite: 316/316
- full unit suite: 2,827 passed, 18 pending
- full E2E: 33/33
- `npm run check`
- package build / `npm pack --dry-run`
- `opcore check --changed`
- Opcore Zero staged verify + sense
- two independent reviewer approvals