### PR TITLE
feat: add native admission and restart path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Graph verifier facade                 | `crates/openengine-cluster-server/src/graph_verifier.rs`                                                                         |
 | Graph verifier analysis               | `crates/openengine-cluster-server/src/graph_verifier/`                                                                           |
 | Native product construction           | `zeroshot-rust/`                                                                                                                 |
+| Native admission composition          | `zeroshot-rust/src/native_admission.rs`, `zeroshot-rust/src/main.rs`                                                             |
 | Native release targets                | `distribution/zeroshot-rust-targets.json`                                                                                        |
 | Native npm binary shim                | `npm/zeroshot-rust/`                                                                                                             |
 | Native distribution tooling           | `scripts/rust-distribution.js`                                                                                                   |
@@ -117,8 +118,8 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Native observability                  | `zeroshot-rust/src/observability.rs`                                                                                             |
 | Native daemon discovery               | `zeroshot-rust/src/daemon_discovery.rs`                                                                                          |
 | Native daemon authorization           | `zeroshot-rust/src/daemon_auth.rs`                                                                                               |
-| Native loopback listener              | `zeroshot-rust/src/daemon_listener.rs`                                                                                           |
-| Admission coordinator                 | `crates/openengine-cluster-server/src/admission.rs`                                                                              |
+| Native loopback listener              | `zeroshot-rust/src/daemon_listener.rs`, `zeroshot-rust/src/daemon_listener/`                                                     |
+| Admission coordinator                 | `crates/openengine-cluster-server/src/admission.rs`, `crates/openengine-cluster-server/src/admission/core.rs`                    |
 | Admission durable ports               | `crates/openengine-cluster-server/src/admission/ports.rs`                                                                        |
 | Admission snapshot folding            | `crates/openengine-cluster-server/src/admission/snapshot.rs`                                                                     |
 | Lifecycle state machine               | `crates/openengine-cluster-server/src/lifecycle.rs`                                                                              |
@@ -254,6 +255,10 @@ authorization, and loopback-listener lifecycle. Artifact stages, bytes, roots, f
 locks, and manifests remain product-private; only verified protocol `ArtifactRef` receipts cross
 the engine boundary. `LocalCasArtifactStore` takes an explicit root, is a single-writer local
 filesystem store, and must preserve ref-first release plus synchronized blob-then-ref publication.
+The narrow native stdio admission entrypoint composes one capability-negative verifier registry,
+one SQLite ledger resource, and only initialize/plan/apply/get. It advertises no graph profile,
+renews one process-owned fence while serving, and on graceful EOF stops renewal before exact
+conditional fence release; it must not acquire provider, watch, lifecycle, or execution authority.
 Issue and source registries and identifiers remain independent; neither is a worker/model provider.
 Mutating source calls carry an exclusively borrowed, non-serializable verified-workspace capability;
 their serializable intent and closed operation-specific receipts contain only canonical workspace,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "getrandom 0.3.4",
  "httparse",
  "libc",
+ "openengine-cluster-client",
  "openengine-cluster-protocol",
  "openengine-cluster-server",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,6 @@ windows-sys = "0.61.2"
 
 openengine-cluster-protocol = { path = "crates/openengine-cluster-protocol" }
 openengine-cluster-server = { path = "crates/openengine-cluster-server" }
+openengine_cluster_client = { package = "openengine-cluster-client", path = "crates/openengine-cluster-client" }
 openengine-cluster-client = { path = "crates/openengine-cluster-client" }
 openengine-cluster-testkit = { path = "crates/openengine-cluster-testkit" }

--- a/crates/openengine-cluster-server/src/admission.rs
+++ b/crates/openengine-cluster-server/src/admission.rs
@@ -3,6 +3,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+mod core;
 mod errors;
 mod ports;
 mod snapshot;
@@ -99,125 +100,6 @@ impl<V, S> AdmissionCoordinator<V, S> {
     }
 }
 
-impl<V, S> AdmissionCoordinator<V, S>
-where
-    V: GraphVerifier,
-    S: AdmissionStore,
-{
-    async fn read_valid_snapshot(
-        &self,
-    ) -> Result<(AdmissionSnapshot, LifecycleSnapshot), BackendError> {
-        let (snapshot, lifecycle) = self
-            .store
-            .read_aggregate()
-            .await
-            .map_err(store_error_to_backend)?;
-        validate_snapshot(&snapshot, &lifecycle)?;
-        Ok((snapshot, lifecycle))
-    }
-
-    async fn verify_for_apply(&self, graph: &GraphSpec) -> Result<VerifiedGraph, BackendError> {
-        match self.verifier.verify(graph).await {
-            Ok(verified) => {
-                diff_compiled_graphs(None, &verified.compiled_ir).map_err(|error| {
-                    BackendError::application(
-                        GRAPH_INVALID,
-                        "Graph verifier returned invalid compiled IR",
-                        Some(json!({ "reason": error.to_string() })),
-                    )
-                })?;
-                Ok(verified)
-            }
-            Err(VerificationError::Rejected { diagnostics }) => Err(BackendError::application(
-                GRAPH_INVALID,
-                "Graph verification failed",
-                Some(json!({ "diagnostics": diagnostics })),
-            )),
-            Err(VerificationError::Internal(message)) => {
-                Err(BackendError::new(INTERNAL_ERROR_CODE, message))
-            }
-        }
-    }
-
-    async fn replay_if_known(
-        &self,
-        key: &IdempotencyKey,
-        fingerprint: &RequestFingerprint,
-    ) -> Result<Option<ApplyResult>, BackendError> {
-        let record = self
-            .store
-            .lookup_idempotency(key)
-            .await
-            .map_err(store_error_to_backend)?;
-        match record {
-            Some(record) if record.fingerprint == *fingerprint => {
-                let MutationReceipt::Apply(mut receipt) = record.receipt else {
-                    return Err(BackendError::application(
-                        IDEMPOTENCY_REUSE,
-                        "Idempotency key was reused by a different method",
-                        None,
-                    ));
-                };
-                receipt.deduped = true;
-                Ok(Some(receipt))
-            }
-            Some(_) => Err(BackendError::application(
-                IDEMPOTENCY_REUSE,
-                "Idempotency key was reused with different parameters",
-                None,
-            )),
-            None => Ok(None),
-        }
-    }
-
-    async fn replay_apply(
-        &self,
-        params: &ApplyParams,
-        fingerprint: &RequestFingerprint,
-    ) -> Result<Option<ApplyResult>, BackendError> {
-        match &params.idempotency_key {
-            Some(key) => self.replay_if_known(key, fingerprint).await,
-            None => Ok(None),
-        }
-    }
-
-    async fn commit_verified(
-        &self,
-        context: &ConnectionContext,
-        prepared: PreparedCommit,
-    ) -> Result<ApplyResult, BackendError> {
-        let PreparedCommit {
-            params,
-            fingerprint,
-            verified,
-            snapshot,
-        } = prepared;
-        precheck_input(
-            snapshot.control.compiled_ir.as_ref(),
-            &verified.compiled_ir,
-            &params.graph,
-            params.input.as_ref(),
-        )?;
-        if context.cancellation.is_cancelled() {
-            return Err(cancelled_error());
-        }
-        let proposal = CommitProposal {
-            graph: params.graph,
-            compiled_ir: verified.compiled_ir,
-            input: params.input,
-            if_generation: params.if_generation,
-            idempotency_key: params
-                .idempotency_key
-                .expect("committed apply mode requires an idempotency key"),
-            fingerprint,
-        };
-        self.store
-            .commit(proposal, &context.cancellation)
-            .await
-            .map_err(store_error_to_backend)
-    }
-}
-
 #[async_trait]
 impl<V, S> ClusterBackend for AdmissionCoordinator<V, S>
 where
@@ -226,48 +108,18 @@ where
 {
     async fn initialize(
         &self,
-        _context: &ConnectionContext,
-        _params: InitializeParams,
+        context: &ConnectionContext,
+        params: InitializeParams,
     ) -> Result<InitializeResult, BackendError> {
-        let (snapshot, lifecycle) = self.read_valid_snapshot().await?;
-        Ok(InitializeResult::new(
-            ServerCapabilities {
-                logs: self.log_store.is_some(),
-                ..ServerCapabilities::default()
-            },
-            snapshot.control.status_with_lifecycle(&lifecycle),
-        ))
+        self.initialize_admission(context, params).await
     }
 
     async fn plan(
         &self,
-        _context: &ConnectionContext,
+        context: &ConnectionContext,
         params: PlanParams,
     ) -> Result<PlanResult, BackendError> {
-        match self.verifier.verify(&params.graph).await {
-            Ok(verified) => {
-                diff_compiled_graphs(None, &verified.compiled_ir).map_err(|error| {
-                    BackendError::application(
-                        GRAPH_INVALID,
-                        "Graph verifier returned invalid compiled IR",
-                        Some(json!({ "reason": error.to_string() })),
-                    )
-                })?;
-                Ok(PlanResult {
-                    ok: true,
-                    diagnostics: verified.diagnostics,
-                    bounds: Some(verified.compiled_ir.bounds),
-                })
-            }
-            Err(VerificationError::Rejected { diagnostics }) => Ok(PlanResult {
-                ok: false,
-                diagnostics,
-                bounds: None,
-            }),
-            Err(VerificationError::Internal(message)) => {
-                Err(BackendError::new(INTERNAL_ERROR_CODE, message))
-            }
-        }
+        self.plan_admission(context, params).await
     }
 
     async fn apply(
@@ -275,74 +127,15 @@ where
         context: &ConnectionContext,
         params: ApplyParams,
     ) -> Result<ApplyResult, BackendError> {
-        validate_apply_mode(&params)?;
-        let fingerprint = method_fingerprint("apply", &params)?;
-
-        if let Some(receipt) = self.replay_apply(&params, &fingerprint).await? {
-            return Ok(receipt);
-        }
-
-        let verified = self.verify_for_apply(&params.graph).await?;
-        let (snapshot, _) = self.read_valid_snapshot().await?;
-        precheck_generation(params.if_generation, snapshot.control.generation)?;
-
-        let diff =
-            diff_compiled_graphs(snapshot.control.compiled_ir.as_ref(), &verified.compiled_ir)
-                .map_err(|error| {
-                    BackendError::application(
-                        GRAPH_INVALID,
-                        "Graph verifier returned invalid compiled IR",
-                        Some(json!({ "reason": error.to_string() })),
-                    )
-                })?;
-
-        if params.dry_run {
-            return Ok(ApplyResult {
-                generation: snapshot.control.generation,
-                run_id: snapshot.control.run_id,
-                phase: snapshot.control.phase,
-                deduped: false,
-                diff: Some(diff),
-            });
-        }
-
-        self.commit_verified(
-            context,
-            PreparedCommit {
-                params,
-                fingerprint,
-                verified,
-                snapshot,
-            },
-        )
-        .await
+        self.apply_admission(context, params).await
     }
 
     async fn get(
         &self,
-        _context: &ConnectionContext,
+        context: &ConnectionContext,
         params: GetParams,
     ) -> Result<GetResult, BackendError> {
-        let (snapshot, lifecycle) = self.read_valid_snapshot().await?;
-        if let Some(requested) = params.at_cursor {
-            let current_cursor = lifecycle
-                .latest_cursor
-                .as_ref()
-                .or(snapshot.control.cursor.as_ref());
-            if current_cursor != Some(&requested) {
-                return Err(BackendError::application(
-                    INVALID_PHASE,
-                    "Requested cursor is not available",
-                    Some(json!({ "currentCursor": current_cursor })),
-                ));
-            }
-        }
-        let status = snapshot.control.status_with_lifecycle(&lifecycle);
-        Ok(GetResult {
-            spec: snapshot.control.spec,
-            status,
-            at_cursor: lifecycle.latest_cursor.or(snapshot.control.cursor),
-        })
+        self.get_admission(context, params).await
     }
 
     async fn update(

--- a/crates/openengine-cluster-server/src/admission/core.rs
+++ b/crates/openengine-cluster-server/src/admission/core.rs
@@ -1,0 +1,268 @@
+use super::*;
+
+fn checked_graph_diff(
+    previous: Option<&openengine_cluster_protocol::CompiledGraphIr>,
+    next: &openengine_cluster_protocol::CompiledGraphIr,
+) -> Result<openengine_cluster_protocol::GraphDiff, BackendError> {
+    diff_compiled_graphs(previous, next).map_err(|error| {
+        BackendError::application(
+            GRAPH_INVALID,
+            "Graph verifier returned invalid compiled IR",
+            Some(json!({ "reason": error.to_string() })),
+        )
+    })
+}
+
+impl<V, S> AdmissionCoordinator<V, S>
+where
+    V: GraphVerifier,
+    S: AdmissionStore,
+{
+    async fn read_valid_snapshot(
+        &self,
+    ) -> Result<(AdmissionSnapshot, LifecycleSnapshot), BackendError> {
+        let (snapshot, lifecycle) = self
+            .store
+            .read_aggregate()
+            .await
+            .map_err(store_error_to_backend)?;
+        validate_snapshot(&snapshot, &lifecycle)?;
+        Ok((snapshot, lifecycle))
+    }
+
+    async fn verify_for_apply(&self, graph: &GraphSpec) -> Result<VerifiedGraph, BackendError> {
+        match self.verifier.verify(graph).await {
+            Ok(verified) => {
+                checked_graph_diff(None, &verified.compiled_ir)?;
+                Ok(verified)
+            }
+            Err(VerificationError::Rejected { diagnostics }) => Err(BackendError::application(
+                GRAPH_INVALID,
+                "Graph verification failed",
+                Some(json!({ "diagnostics": diagnostics })),
+            )),
+            Err(VerificationError::Internal(message)) => {
+                Err(BackendError::new(INTERNAL_ERROR_CODE, message))
+            }
+        }
+    }
+
+    async fn replay_if_known(
+        &self,
+        key: &IdempotencyKey,
+        fingerprint: &RequestFingerprint,
+    ) -> Result<Option<ApplyResult>, BackendError> {
+        let record = self
+            .store
+            .lookup_idempotency(key)
+            .await
+            .map_err(store_error_to_backend)?;
+        match record {
+            Some(record) if record.fingerprint == *fingerprint => {
+                let MutationReceipt::Apply(mut receipt) = record.receipt else {
+                    return Err(BackendError::application(
+                        IDEMPOTENCY_REUSE,
+                        "Idempotency key was reused by a different method",
+                        None,
+                    ));
+                };
+                receipt.deduped = true;
+                Ok(Some(receipt))
+            }
+            Some(_) => Err(BackendError::application(
+                IDEMPOTENCY_REUSE,
+                "Idempotency key was reused with different parameters",
+                None,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn replay_apply(
+        &self,
+        params: &ApplyParams,
+        fingerprint: &RequestFingerprint,
+    ) -> Result<Option<ApplyResult>, BackendError> {
+        match &params.idempotency_key {
+            Some(key) => self.replay_if_known(key, fingerprint).await,
+            None => Ok(None),
+        }
+    }
+
+    async fn commit_verified(
+        &self,
+        context: &ConnectionContext,
+        prepared: PreparedCommit,
+    ) -> Result<ApplyResult, BackendError> {
+        let PreparedCommit {
+            params,
+            fingerprint,
+            verified,
+            snapshot,
+        } = prepared;
+        precheck_input(
+            snapshot.control.compiled_ir.as_ref(),
+            &verified.compiled_ir,
+            &params.graph,
+            params.input.as_ref(),
+        )?;
+        if context.cancellation.is_cancelled() {
+            return Err(cancelled_error());
+        }
+        let proposal = CommitProposal {
+            graph: params.graph,
+            compiled_ir: verified.compiled_ir,
+            input: params.input,
+            if_generation: params.if_generation,
+            idempotency_key: params
+                .idempotency_key
+                .expect("committed apply mode requires an idempotency key"),
+            fingerprint,
+        };
+        self.store
+            .commit(proposal, &context.cancellation)
+            .await
+            .map_err(store_error_to_backend)
+    }
+
+    async fn finish_apply(
+        &self,
+        context: &ConnectionContext,
+        prepared: PreparedCommit,
+        diff: openengine_cluster_protocol::GraphDiff,
+    ) -> Result<ApplyResult, BackendError> {
+        if prepared.params.dry_run {
+            return Ok(ApplyResult {
+                generation: prepared.snapshot.control.generation,
+                run_id: prepared.snapshot.control.run_id,
+                phase: prepared.snapshot.control.phase,
+                deduped: false,
+                diff: Some(diff),
+            });
+        }
+        self.commit_verified(context, prepared).await
+    }
+
+    async fn precheck_generation_or_replay(
+        &self,
+        params: &ApplyParams,
+        fingerprint: &RequestFingerprint,
+        current: Option<openengine_cluster_protocol::Generation>,
+    ) -> Result<Option<ApplyResult>, BackendError> {
+        let Err(generation_error) = precheck_generation(params.if_generation, current) else {
+            return Ok(None);
+        };
+        // The receipt and snapshot are one atomic store commit. If a concurrent request won
+        // between the first receipt lookup and this snapshot read, replay (or conflicting reuse)
+        // retains precedence over its resulting generation change.
+        if let Some(receipt) = self.replay_apply(params, fingerprint).await? {
+            return Ok(Some(receipt));
+        }
+        Err(generation_error)
+    }
+
+    /// Initializes the admission-only surface without requiring an observation/watch port.
+    pub async fn initialize_admission(
+        &self,
+        _context: &ConnectionContext,
+        _params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        let (snapshot, lifecycle) = self.read_valid_snapshot().await?;
+        Ok(InitializeResult::new(
+            ServerCapabilities {
+                logs: self.log_store.is_some(),
+                ..ServerCapabilities::default()
+            },
+            snapshot.control.status_with_lifecycle(&lifecycle),
+        ))
+    }
+
+    /// Plans one graph without requiring an observation/watch port.
+    pub async fn plan_admission(
+        &self,
+        _context: &ConnectionContext,
+        params: PlanParams,
+    ) -> Result<PlanResult, BackendError> {
+        match self.verifier.verify(&params.graph).await {
+            Ok(verified) => {
+                checked_graph_diff(None, &verified.compiled_ir)?;
+                Ok(PlanResult {
+                    ok: true,
+                    diagnostics: verified.diagnostics,
+                    bounds: Some(verified.compiled_ir.bounds),
+                })
+            }
+            Err(VerificationError::Rejected { diagnostics }) => Ok(PlanResult {
+                ok: false,
+                diagnostics,
+                bounds: None,
+            }),
+            Err(VerificationError::Internal(message)) => {
+                Err(BackendError::new(INTERNAL_ERROR_CODE, message))
+            }
+        }
+    }
+
+    /// Applies one verified graph without requiring an observation/watch port.
+    pub async fn apply_admission(
+        &self,
+        context: &ConnectionContext,
+        params: ApplyParams,
+    ) -> Result<ApplyResult, BackendError> {
+        validate_apply_mode(&params)?;
+        let fingerprint = method_fingerprint("apply", &params)?;
+        if let Some(receipt) = self.replay_apply(&params, &fingerprint).await? {
+            return Ok(receipt);
+        }
+
+        let verified = self.verify_for_apply(&params.graph).await?;
+        let (snapshot, _) = self.read_valid_snapshot().await?;
+        if let Some(receipt) = self
+            .precheck_generation_or_replay(&params, &fingerprint, snapshot.control.generation)
+            .await?
+        {
+            return Ok(receipt);
+        }
+        let diff =
+            checked_graph_diff(snapshot.control.compiled_ir.as_ref(), &verified.compiled_ir)?;
+        self.finish_apply(
+            context,
+            PreparedCommit {
+                params,
+                fingerprint,
+                verified,
+                snapshot,
+            },
+            diff,
+        )
+        .await
+    }
+
+    /// Reads authoritative admission state without requiring an observation/watch port.
+    pub async fn get_admission(
+        &self,
+        _context: &ConnectionContext,
+        params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        let (snapshot, lifecycle) = self.read_valid_snapshot().await?;
+        if let Some(requested) = params.at_cursor {
+            let current_cursor = lifecycle
+                .latest_cursor
+                .as_ref()
+                .or(snapshot.control.cursor.as_ref());
+            if current_cursor != Some(&requested) {
+                return Err(BackendError::application(
+                    INVALID_PHASE,
+                    "Requested cursor is not available",
+                    Some(json!({ "currentCursor": current_cursor })),
+                ));
+            }
+        }
+        let status = snapshot.control.status_with_lifecycle(&lifecycle);
+        Ok(GetResult {
+            spec: snapshot.control.spec,
+            status,
+            at_cursor: lifecycle.latest_cursor.or(snapshot.control.cursor),
+        })
+    }
+}

--- a/crates/openengine-cluster-server/src/graph_verifier/analyzer_index.rs
+++ b/crates/openengine-cluster-server/src/graph_verifier/analyzer_index.rs
@@ -71,15 +71,6 @@ impl<'a> Analyzer<'a> {
                 Vec::new(),
             );
         }
-        if self.attempts.is_empty() {
-            emit_diagnostic!(
-                self,
-                GraphDiagnosticCode::InvalidGraphShape,
-                "full-v1 graph must contain at least one step or verifier",
-                vec![field_segment("root")],
-                Vec::new(),
-            );
-        }
         if self.guard_nodes > FULL_V1_MAX_GUARD_NODES {
             emit_diagnostic!(
                 self,
@@ -96,8 +87,8 @@ impl<'a> Analyzer<'a> {
         fold: Fold,
         order: Vec<NodeName>,
     ) -> Option<StructuralBounds> {
-        let max_node_executions = PositiveInteger::new(fold.executions).ok()?;
-        let peak_concurrency = PositiveInteger::new(fold.concurrency).ok()?;
+        let max_node_executions = PositiveInteger::new(fold.executions.max(1)).ok()?;
+        let peak_concurrency = PositiveInteger::new(fold.concurrency.max(1)).ok()?;
         let termination = if self.loops.is_empty() {
             TerminationWitness::Acyclic {
                 order: NonEmptyVec::new(order).ok()?,

--- a/crates/openengine-cluster-server/tests/graph_verifier.rs
+++ b/crates/openengine-cluster-server/tests/graph_verifier.rs
@@ -259,6 +259,33 @@ async fn structural_rejection_precedes_registry_resolution_and_is_stably_sorted(
 }
 
 #[tokio::test]
+async fn terminal_only_full_graph_is_bounded_without_registry_resolution() {
+    let graph: GraphSpec = serde_json::from_value(json!({
+        "profile": "openengine.graph.full/v1",
+        "initialInput": {"kind": "null"},
+        "policy": {"policy": "policy.default@1", "default": "deny"},
+        "root": {
+            "kind": "succeed",
+            "name": "done",
+            "output": {"kind": "null"},
+            "bindings": []
+        }
+    }))
+    .unwrap();
+    let registry = registry();
+    let resolutions = Arc::clone(&registry.resolutions);
+    let verified = ProductionGraphVerifier::new(registry)
+        .verify(&graph)
+        .await
+        .unwrap();
+
+    assert_eq!(resolutions.load(Ordering::Relaxed), 0);
+    assert_eq!(verified.compiled_ir.bounds.max_node_executions.get(), 1);
+    assert_eq!(verified.compiled_ir.bounds.peak_concurrency.get(), 1);
+    assert!(verified.compiled_ir.bounds.attempts_per_node.is_empty());
+}
+
+#[tokio::test]
 async fn single_worker_profile_and_missing_worker_are_rejections() {
     let mut single = valid_graph();
     single["profile"] = json!("openengine.graph.single-worker/v1");

--- a/tests/unit/rust-npm-shim.test.js
+++ b/tests/unit/rust-npm-shim.test.js
@@ -85,16 +85,28 @@ function registerNativeMetadataTest() {
       'hosted-node/workspace-ship.js',
       'hosted-node/workspace-tools.js',
     ]);
-    for (const file of relativeFiles(rustRoot)) {
+    const rustFiles = relativeFiles(rustRoot);
+    for (const file of rustFiles) {
       assert(
         file === 'Cargo.toml' || file.endsWith('.rs') || privateHostedAdapterFiles.has(file),
         `unexpected product file outside the private hosted adapter: ${file}`
       );
     }
-    assert.strictEqual(
-      fs.readFileSync(path.join(rustRoot, 'src', 'main.rs'), 'utf8'),
-      'fn main() {}\n'
-    );
+    const nativeRustSource = rustFiles
+      .filter((file) => file.endsWith('.rs'))
+      .map((file) => fs.readFileSync(path.join(rustRoot, file), 'utf8'))
+      .join('\n');
+    for (const forbiddenMetadataToken of [
+      'SHA256SUMS',
+      'npm/zeroshot-rust',
+      'rust-distribution.js',
+      'RELEASE_BASE_URL',
+    ]) {
+      assert(
+        !nativeRustSource.includes(forbiddenMetadataToken),
+        `native product must not own release metadata: ${forbiddenMetadataToken}`
+      );
+    }
 
     const rootPackage = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'));
     assert.deepStrictEqual(rootPackage.files, [

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -49,3 +49,4 @@ windows-sys = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+openengine_cluster_client.workspace = true

--- a/zeroshot-rust/src/cluster_ledger.rs
+++ b/zeroshot-rust/src/cluster_ledger.rs
@@ -240,6 +240,20 @@ impl ClusterLedger {
         Ok(renewed)
     }
 
+    pub async fn release_fence(&self) -> Result<(), LedgerError> {
+        self.store
+            .release_fence(&self.fence())
+            .await
+            .map_err(|error| self.store_error(FaultContext::Cleanup, error))
+    }
+
+    pub async fn check_fence(&self) -> Result<(), LedgerError> {
+        self.store
+            .check_fence(&self.fence())
+            .await
+            .map_err(|error| self.store_error(FaultContext::Recovery, error))
+    }
+
     pub async fn state(&self) -> Result<ReplayState, LedgerError> {
         self.read_state(FaultContext::Recovery).await
     }
@@ -302,6 +316,7 @@ impl ClusterLedger {
     pub(crate) fn domain_error(&self, context: FaultContext, kind: LedgerErrorKind) -> LedgerError {
         let evidence = match kind {
             LedgerErrorKind::BoundViolation => EvidenceClass::ResourceExhausted,
+            LedgerErrorKind::PositionConflict => EvidenceClass::Unavailable,
             LedgerErrorKind::IdempotencyConflict
             | LedgerErrorKind::InvalidLifecycle
             | LedgerErrorKind::InvalidSettlement

--- a/zeroshot-rust/src/cluster_ledger/adapters.rs
+++ b/zeroshot-rust/src/cluster_ledger/adapters.rs
@@ -1,5 +1,8 @@
 //! Protocol store adapters backed by one coherent ordered-prefix fold.
 
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
 mod apply;
 mod protocol;
 mod state;
@@ -22,8 +25,12 @@ use apply::{
     ensure_change_is_safe, prepare_apply_plan, prepare_changed_apply, prepare_unchanged_apply,
     ApplyPlan, ChangedApply,
 };
-use super::store::IdempotencyId;
-use super::{ClusterLedger, CommitRequest, MutationIdentity, ReceiptExpectation};
+use super::record::CanonicalDigest;
+use super::store::{IdempotencyId, LedgerClock};
+use super::{
+    ClusterLedger, CommitRequest, CommitResult, LedgerError, LedgerErrorKind, MutationIdentity,
+    ReceiptExpectation,
+};
 use protocol::{
     cancellation_guard, fingerprint_bytes, protocol_cursor, protocol_error,
     protocol_idempotency_record, protocol_run_id,
@@ -33,12 +40,61 @@ use state::FoldedProtocolState;
 #[derive(Clone)]
 pub struct ClusterLedgerAdapters {
     ledger: ClusterLedger,
+    admission: AdmissionRecordContext,
+}
+
+#[derive(Clone)]
+pub struct AdmissionRecordContext {
+    catalog_digest: CanonicalDigest,
+    profile_digest: CanonicalDigest,
+    clock: Arc<dyn LedgerClock>,
+    run_timeout_ms: NonZeroU64,
+}
+
+enum ApplyRacePlan {
+    Existing(ApplyResult),
+    Retry(ChangedApply),
+}
+
+impl AdmissionRecordContext {
+    #[must_use]
+    pub fn new(
+        catalog_digest: CanonicalDigest,
+        profile_digest: CanonicalDigest,
+        clock: Arc<dyn LedgerClock>,
+        run_timeout_ms: NonZeroU64,
+    ) -> Self {
+        Self {
+            catalog_digest,
+            profile_digest,
+            clock,
+            run_timeout_ms,
+        }
+    }
+
+    #[must_use]
+    pub fn catalog_digest(&self) -> &CanonicalDigest {
+        &self.catalog_digest
+    }
+
+    #[must_use]
+    pub fn profile_digest(&self) -> &CanonicalDigest {
+        &self.profile_digest
+    }
+
+    fn absolute_deadline_ms(&self) -> Result<u64, ProtocolStoreError> {
+        self.clock
+            .now_ms()
+            .checked_add(self.run_timeout_ms.get())
+            .filter(|deadline| *deadline <= i64::MAX as u64)
+            .ok_or_else(|| ProtocolStoreError::Internal("admission deadline overflow".into()))
+    }
 }
 
 impl ClusterLedgerAdapters {
     #[must_use]
-    pub const fn new(ledger: ClusterLedger) -> Self {
-        Self { ledger }
+    pub fn new(ledger: ClusterLedger, admission: AdmissionRecordContext) -> Self {
+        Self { ledger, admission }
     }
 
     #[must_use]
@@ -47,7 +103,11 @@ impl ClusterLedgerAdapters {
     }
 
     async fn folded(&self) -> Result<FoldedProtocolState, ProtocolStoreError> {
-        let state = self.ledger.state().await.map_err(protocol_error)?;
+        let state = self
+            .ledger
+            .validated_state(crate::fault::FaultContext::Recovery)
+            .await
+            .map_err(protocol_error)?;
         FoldedProtocolState::from_replay(&state)
     }
 
@@ -83,53 +143,140 @@ impl ClusterLedgerAdapters {
         plan: ApplyPlan,
         commit: ApplyCommit<'_>,
     ) -> Result<ApplyResult, ProtocolStoreError> {
-        let changed = match plan {
+        let changed = self.prepare_changed_apply(state, plan)?;
+        if commit.cancellation.is_cancelled() {
+            return Err(ProtocolStoreError::Cancelled);
+        }
+        self.commit_protocol_apply(state, changed, &commit).await
+    }
+
+    fn prepare_changed_apply(
+        &self,
+        state: &mut super::ReplayState,
+        plan: ApplyPlan,
+    ) -> Result<ChangedApply, ProtocolStoreError> {
+        match plan {
             ApplyPlan::Unchanged {
                 proposal,
                 generation,
-            } => prepare_unchanged_apply(state, proposal, generation)?,
+            } => prepare_unchanged_apply(state, proposal, generation),
             ApplyPlan::Changed {
                 proposal,
                 canonical_compiled_ir,
             } => {
                 ensure_change_is_safe(state)?;
-                prepare_changed_apply(state, proposal, canonical_compiled_ir)?
+                prepare_changed_apply(state, proposal, canonical_compiled_ir, &self.admission)
             }
-        };
-        if commit.cancellation.is_cancelled() {
-            return Err(ProtocolStoreError::Cancelled);
         }
-        self.commit_protocol_apply(state, changed, commit).await
     }
 
-    async fn commit_protocol_apply(
+    async fn commit_once(
         &self,
         state: &super::ReplayState,
         changed: ChangedApply,
-        commit: ApplyCommit<'_>,
-    ) -> Result<ApplyResult, ProtocolStoreError> {
+        commit: &ApplyCommit<'_>,
+    ) -> Result<CommitResult<ApplyResult>, LedgerError> {
         let ChangedApply { result, payloads } = changed;
-        let committed = self
-            .ledger
+        self.ledger
             .commit(
                 CommitRequest::new(
                     crate::fault::FaultContext::Admission,
                     state,
-                    MutationIdentity::new(commit.key, "protocol_apply", commit.fingerprint),
+                    MutationIdentity::new(commit.key.clone(), "protocol_apply", commit.fingerprint),
                     &result,
                 )
                 .with_payloads(payloads)
                 .guarded(cancellation_guard(commit.cancellation)),
             )
             .await
-            .map_err(protocol_error)?;
+    }
+
+    fn protocol_commit_result(committed: CommitResult<ApplyResult>) -> ApplyResult {
         let mut value = committed.value;
         value.deduped = committed.replayed;
-        Ok(value)
+        value
+    }
+
+    async fn commit_protocol_apply(
+        &self,
+        state: &super::ReplayState,
+        changed: ChangedApply,
+        commit: &ApplyCommit<'_>,
+    ) -> Result<ApplyResult, ProtocolStoreError> {
+        match self.commit_once(state, changed, commit).await {
+            Ok(committed) => Ok(Self::protocol_commit_result(committed)),
+            Err(error) if error.kind() == &LedgerErrorKind::PositionConflict => {
+                self.reconcile_protocol_apply_race(commit).await
+            }
+            Err(error) => Err(protocol_error(error)),
+        }
+    }
+
+    async fn repeated_position_conflict(
+        &self,
+        commit: &ApplyCommit<'_>,
+    ) -> Result<ApplyResult, ProtocolStoreError> {
+        let latest = self
+            .ledger
+            .validated_state(crate::fault::FaultContext::Admission)
+            .await
+            .map_err(protocol_error)?;
+        if let Some(existing) =
+            self.existing_protocol_apply(&latest, &commit.key, commit.fingerprint)?
+        {
+            return Ok(existing);
+        }
+        // Preserve explicit generation semantics if another distinct mutation won the bounded
+        // retry. Omitted generation remains an upsert, but repeated contention fails closed.
+        prepare_apply_plan(&latest, commit.proposal.clone())?;
+        Err(ProtocolStoreError::Internal(
+            "native admission position changed during bounded reconciliation".into(),
+        ))
+    }
+
+    fn prepare_race_retry(
+        &self,
+        current: &mut super::ReplayState,
+        commit: &ApplyCommit<'_>,
+    ) -> Result<ApplyRacePlan, ProtocolStoreError> {
+        if let Some(existing) =
+            self.existing_protocol_apply(current, &commit.key, commit.fingerprint)?
+        {
+            return Ok(ApplyRacePlan::Existing(existing));
+        }
+        let retry_plan = prepare_apply_plan(current, commit.proposal.clone())?;
+        let retry = self.prepare_changed_apply(current, retry_plan)?;
+        if commit.cancellation.is_cancelled() {
+            return Err(ProtocolStoreError::Cancelled);
+        }
+        Ok(ApplyRacePlan::Retry(retry))
+    }
+
+    async fn reconcile_protocol_apply_race(
+        &self,
+        commit: &ApplyCommit<'_>,
+    ) -> Result<ApplyResult, ProtocolStoreError> {
+        let mut current = self
+            .ledger
+            .validated_state(crate::fault::FaultContext::Admission)
+            .await
+            .map_err(protocol_error)?;
+        let retry = match self.prepare_race_retry(&mut current, commit)? {
+            ApplyRacePlan::Existing(existing) => return Ok(existing),
+            ApplyRacePlan::Retry(retry) => retry,
+        };
+        match self.commit_once(&current, retry, commit).await {
+            Ok(retried) => Ok(Self::protocol_commit_result(retried)),
+            Err(error) if error.kind() == &LedgerErrorKind::PositionConflict => {
+                self.repeated_position_conflict(commit).await
+            }
+            Err(error) => Err(protocol_error(error)),
+        }
     }
 }
 
 struct ApplyCommit<'a> {
+    proposal: CommitProposal,
     key: IdempotencyId,
     fingerprint: [u8; 32],
     cancellation: &'a CancellationSignal,
@@ -199,11 +346,12 @@ impl AdmissionStore for ClusterLedgerAdapters {
         if let Some(existing) = self.existing_protocol_apply(&state, &key, fingerprint)? {
             return Ok(existing);
         }
-        let plan = prepare_apply_plan(&state, proposal)?;
+        let plan = prepare_apply_plan(&state, proposal.clone())?;
         self.commit_plan(
             &mut state,
             plan,
             ApplyCommit {
+                proposal,
                 key,
                 fingerprint,
                 cancellation,

--- a/zeroshot-rust/src/cluster_ledger/adapters/apply.rs
+++ b/zeroshot-rust/src/cluster_ledger/adapters/apply.rs
@@ -3,10 +3,12 @@
 
 use openengine_cluster_protocol::{canonical_value_bytes, ApplyResult, Generation, Phase};
 use openengine_cluster_server::admission::{CommitProposal, StoreError as ProtocolStoreError};
+use serde::Serialize;
 
 use super::super::record::{CanonicalDigest, RecordPayload};
 use super::super::ReplayState;
 use super::protocol::protocol_run_id;
+use super::AdmissionRecordContext;
 
 pub(super) enum ApplyPlan {
     Unchanged {
@@ -64,10 +66,29 @@ pub(super) fn ensure_change_is_safe(state: &ReplayState) -> Result<(), ProtocolS
     Ok(())
 }
 
+fn canonical_internal<T: Serialize>(
+    value: &T,
+    encoding_error: &'static str,
+    canonical_error: &'static str,
+) -> Result<Vec<u8>, ProtocolStoreError> {
+    let value = serde_json::to_value(value)
+        .map_err(|_| ProtocolStoreError::Internal(encoding_error.into()))?;
+    canonical_value_bytes(&value).map_err(|_| ProtocolStoreError::Internal(canonical_error.into()))
+}
+
+fn canonical_input(proposal: &CommitProposal) -> Result<Vec<u8>, ProtocolStoreError> {
+    let input = proposal.input.as_ref().ok_or_else(|| {
+        ProtocolStoreError::SchemaViolation("changed admission requires verified input".into())
+    })?;
+    canonical_value_bytes(input)
+        .map_err(|_| ProtocolStoreError::SchemaViolation("input is not canonical".into()))
+}
+
 pub(super) fn prepare_changed_apply(
     state: &mut ReplayState,
     proposal: CommitProposal,
     canonical_compiled_ir: Vec<u8>,
+    admission: &AdmissionRecordContext,
 ) -> Result<ChangedApply, ProtocolStoreError> {
     let generation = state
         .identities
@@ -77,24 +98,30 @@ pub(super) fn prepare_changed_apply(
         .identities
         .allocate_run()
         .map_err(|_| ProtocolStoreError::Internal("run allocation failed".into()))?;
-    let canonical_graph = serde_json::to_vec(&proposal.graph)
-        .map_err(|_| ProtocolStoreError::Internal("graph encoding failed".into()))?;
-    let canonical_input = canonical_value_bytes(proposal.input.as_ref().ok_or_else(|| {
-        ProtocolStoreError::SchemaViolation("changed admission requires verified input".into())
-    })?)
-    .map_err(|_| ProtocolStoreError::SchemaViolation("input is not canonical".into()))?;
+    let canonical_graph = canonical_internal(
+        &proposal.graph,
+        "graph encoding failed",
+        "graph canonicalization failed",
+    )?;
+    let canonical_policy = canonical_internal(
+        &proposal.graph.policy,
+        "graph policy encoding failed",
+        "graph policy is not canonical",
+    )?;
+    let canonical_input = canonical_input(&proposal)?;
     let input_digest = CanonicalDigest::of(&canonical_input);
-    let payloads = changed_apply_payloads(
-        &proposal,
-        ChangedPayloads {
-            generation,
-            run,
-            canonical_graph,
-            canonical_input,
-            input_digest,
-            canonical_compiled_ir,
-        },
-    );
+    let payloads = changed_apply_payloads(ChangedPayloads {
+        generation,
+        run,
+        canonical_graph,
+        canonical_input,
+        input_digest,
+        canonical_compiled_ir,
+        policy_digest: CanonicalDigest::of(&canonical_policy),
+        catalog_digest: *admission.catalog_digest(),
+        profile_digest: *admission.profile_digest(),
+        absolute_deadline_ms: admission.absolute_deadline_ms()?,
+    });
     Ok(ChangedApply {
         result: ApplyResult {
             generation: Some(Generation::new(generation.get()).map_err(|_| {
@@ -116,12 +143,13 @@ struct ChangedPayloads {
     canonical_input: Vec<u8>,
     input_digest: CanonicalDigest,
     canonical_compiled_ir: Vec<u8>,
+    policy_digest: CanonicalDigest,
+    catalog_digest: CanonicalDigest,
+    profile_digest: CanonicalDigest,
+    absolute_deadline_ms: u64,
 }
 
-fn changed_apply_payloads(
-    proposal: &CommitProposal,
-    changed: ChangedPayloads,
-) -> Vec<RecordPayload> {
+fn changed_apply_payloads(changed: ChangedPayloads) -> Vec<RecordPayload> {
     let ChangedPayloads {
         generation,
         run,
@@ -129,6 +157,10 @@ fn changed_apply_payloads(
         canonical_input,
         input_digest,
         canonical_compiled_ir,
+        policy_digest,
+        catalog_digest,
+        profile_digest,
+        absolute_deadline_ms,
     } = changed;
     vec![
         RecordPayload::Admission {
@@ -136,10 +168,10 @@ fn changed_apply_payloads(
             run,
             graph_digest: CanonicalDigest::of(&canonical_graph),
             input_digest,
-            policy_digest: CanonicalDigest::of(&canonical_compiled_ir),
-            catalog_digest: CanonicalDigest::of(b"worker-catalog/v1"),
-            profile_digest: CanonicalDigest::of(proposal.compiled_ir.profile.as_str().as_bytes()),
-            absolute_deadline_ms: u64::MAX,
+            policy_digest,
+            catalog_digest,
+            profile_digest,
+            absolute_deadline_ms,
             canonical_graph,
             canonical_compiled_ir,
         },
@@ -151,7 +183,7 @@ fn changed_apply_payloads(
     ]
 }
 
-fn current_protocol_generation(
+pub(super) fn current_protocol_generation(
     state: &ReplayState,
 ) -> Result<Option<Generation>, ProtocolStoreError> {
     state

--- a/zeroshot-rust/src/cluster_ledger/adapters/state.rs
+++ b/zeroshot-rust/src/cluster_ledger/adapters/state.rs
@@ -41,7 +41,7 @@ impl FoldedProtocolState {
         Ok(Self {
             admission: AdmissionSnapshot {
                 control,
-                seed: verified_seed(state, admission.run, run_id)?,
+                seed: verified_seed(state, admission.run, run_id, cursor.clone())?,
             },
             lifecycle: lifecycle_snapshot(state, cursor)?,
         })
@@ -70,6 +70,7 @@ fn verified_seed(
     state: &super::super::ReplayState,
     run: super::super::RunSequence,
     run_id: RunId,
+    cursor: Cursor,
 ) -> Result<Option<VerifiedSeed>, ProtocolStoreError> {
     state
         .verified_inputs
@@ -82,7 +83,7 @@ fn verified_seed(
                         "durable verified input encoding is invalid".into(),
                     )
                 })?,
-                cursor: protocol_cursor(verified.position),
+                cursor: cursor.clone(),
             })
         })
         .transpose()

--- a/zeroshot-rust/src/cluster_ledger/commit.rs
+++ b/zeroshot-rust/src/cluster_ledger/commit.rs
@@ -218,7 +218,12 @@ impl ClusterLedger {
                 Err(self.domain_error(context, LedgerErrorKind::IdempotencyConflict))
             }
             Err(StoreError::PositionConflict { .. }) => {
-                Err(self.domain_error(context, LedgerErrorKind::InvalidLifecycle))
+                let kind = if context == FaultContext::Admission {
+                    LedgerErrorKind::PositionConflict
+                } else {
+                    LedgerErrorKind::InvalidLifecycle
+                };
+                Err(self.domain_error(context, kind))
             }
             Err(error) => Err(self.store_error(context, error)),
         }

--- a/zeroshot-rust/src/cluster_ledger/error.rs
+++ b/zeroshot-rust/src/cluster_ledger/error.rs
@@ -15,6 +15,7 @@ pub enum LedgerErrorKind {
     Replay(ReplayError),
     BoundViolation,
     IdempotencyConflict,
+    PositionConflict,
     InvalidLifecycle,
     InvalidSettlement,
     TerminalRequired,

--- a/zeroshot-rust/src/cluster_ledger/store.rs
+++ b/zeroshot-rust/src/cluster_ledger/store.rs
@@ -414,6 +414,15 @@ pub trait LedgerClock: Send + Sync {
     fn now_ms(&self) -> u64;
 }
 
+impl<T> LedgerClock for Arc<T>
+where
+    T: LedgerClock + ?Sized,
+{
+    fn now_ms(&self) -> u64 {
+        (**self).now_ms()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SystemLedgerClock;
 

--- a/zeroshot-rust/src/cluster_ledger/store/contract.rs
+++ b/zeroshot-rust/src/cluster_ledger/store/contract.rs
@@ -27,6 +27,7 @@ pub trait LedgerStore: Send + Sync + 'static {
         ttl_ms: u64,
     ) -> Result<Fence, StoreError>;
     async fn renew_fence(&self, fence: &Fence, ttl_ms: u64) -> Result<Fence, StoreError>;
+    async fn release_fence(&self, fence: &Fence) -> Result<(), StoreError>;
     async fn check_fence(&self, fence: &Fence) -> Result<(), StoreError>;
     async fn read_prefix(
         &self,

--- a/zeroshot-rust/src/cluster_ledger/store/fake.rs
+++ b/zeroshot-rust/src/cluster_ledger/store/fake.rs
@@ -8,7 +8,10 @@ mod lifecycle;
 use async_trait::async_trait;
 use tokio::sync::Notify;
 
-use append::{apply_append, existing_outcome, take_failpoint, validate_append, validate_fence};
+use append::{
+    apply_append, existing_outcome, release_exact_fence, take_failpoint, validate_append,
+    validate_exact_fence, validate_fence_identity,
+};
 pub use clock::ManualLedgerClock;
 use super::{
     completed_wait_position, fence_expiry, AppendRequest, FailPoint, LedgerClock, WaitProbe,
@@ -110,7 +113,7 @@ impl FakeLedgerStore {
             .resources
             .get_mut(resource)
             .ok_or(StoreError::ResourceNotFound)?;
-        validate_fence(self.clock.as_ref(), data, fence)?;
+        validate_fence_identity(self.clock.as_ref(), data, fence)?;
         if let Some(outcome) = existing_outcome(data, &batch)? {
             return Ok(outcome);
         }
@@ -285,13 +288,25 @@ impl LedgerStore for FakeLedgerStore {
             .resources
             .get_mut(&fence.resource)
             .ok_or(StoreError::ResourceNotFound)?;
-        validate_fence(self.clock.as_ref(), data, fence)?;
+        validate_exact_fence(self.clock.as_ref(), data, fence)?;
         let renewed = Fence {
             expires_at_ms,
             ..fence.clone()
         };
         data.fence = Some(renewed.clone());
         Ok(renewed)
+    }
+
+    async fn release_fence(&self, fence: &Fence) -> Result<(), StoreError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake ledger mutex must not be poisoned");
+        let data = state
+            .resources
+            .get_mut(&fence.resource)
+            .ok_or(StoreError::ResourceNotFound)?;
+        release_exact_fence(self.clock.as_ref(), data, fence)
     }
 
     async fn check_fence(&self, fence: &Fence) -> Result<(), StoreError> {
@@ -303,7 +318,7 @@ impl LedgerStore for FakeLedgerStore {
             .resources
             .get(&fence.resource)
             .ok_or(StoreError::ResourceNotFound)?;
-        validate_fence(self.clock.as_ref(), data, fence)
+        validate_fence_identity(self.clock.as_ref(), data, fence)
     }
 
     async fn read_prefix(
@@ -465,7 +480,7 @@ impl LedgerStore for FakeLedgerStore {
             .resources
             .get(resource)
             .ok_or(StoreError::ResourceNotFound)?;
-        validate_fence(self.clock.as_ref(), data, fence)?;
+        validate_fence_identity(self.clock.as_ref(), data, fence)?;
         let actual = Position::new(
             u64::try_from(data.records.len()).map_err(|_| StoreError::PositionOverflow)?,
         )?;

--- a/zeroshot-rust/src/cluster_ledger/store/fake/append.rs
+++ b/zeroshot-rust/src/cluster_ledger/store/fake/append.rs
@@ -13,18 +13,46 @@ pub(super) fn take_failpoint(state: &mut FakeState, point: FailPoint) -> bool {
     }
 }
 
-pub(super) fn validate_fence(
+pub(super) fn validate_fence_identity(
     clock: &dyn LedgerClock,
     data: &ResourceData,
     fence: &Fence,
 ) -> Result<(), StoreError> {
     let current = data.fence.as_ref().ok_or(StoreError::StaleFence)?;
-    if current != fence {
+    if current.resource != fence.resource
+        || current.owner != fence.owner
+        || current.epoch != fence.epoch
+    {
         return Err(StoreError::StaleFence);
     }
     if current.expires_at_ms <= clock.now_ms() {
         return Err(StoreError::FenceExpired);
     }
+    Ok(())
+}
+
+pub(super) fn validate_exact_fence(
+    clock: &dyn LedgerClock,
+    data: &ResourceData,
+    fence: &Fence,
+) -> Result<(), StoreError> {
+    validate_fence_identity(clock, data, fence)?;
+    if data.fence.as_ref() != Some(fence) {
+        return Err(StoreError::StaleFence);
+    }
+    Ok(())
+}
+
+pub(super) fn release_exact_fence(
+    clock: &dyn LedgerClock,
+    data: &mut ResourceData,
+    fence: &Fence,
+) -> Result<(), StoreError> {
+    validate_exact_fence(clock, data, fence)?;
+    data.fence = Some(Fence {
+        expires_at_ms: clock.now_ms(),
+        ..fence.clone()
+    });
     Ok(())
 }
 

--- a/zeroshot-rust/src/cluster_ledger/store/sqlite.rs
+++ b/zeroshot-rust/src/cluster_ledger/store/sqlite.rs
@@ -28,12 +28,15 @@ mod transactions;
 pub use operations::database_path;
 pub use schema::{APPLICATION_ID, SCHEMA_VERSION};
 pub use settings::SqliteSettings;
-use queries::{query_fence, query_receipt, query_receipts, query_records, to_sql_i64};
+use queries::{query_receipt, query_receipts, query_records, to_sql_i64};
 use discovery::{
     configure_connection, discover_database, lock_resource_file, remove_database_files,
     validate_schema,
 };
-use transactions::{acquire_fence_transaction, write_removal_tombstone, FenceAcquisition};
+use transactions::{
+    acquire_fence_transaction, check_exact_fence_transaction, check_fence_transaction,
+    write_removal_tombstone, FenceAcquisition,
+};
 
 #[derive(Clone)]
 pub struct SqliteLedgerStore {
@@ -108,21 +111,6 @@ impl SqliteLedgerStore {
             .and_then(Position::new)
     }
 
-    fn check_fence_tx(
-        &self,
-        transaction: &Transaction<'_>,
-        fence: &Fence,
-    ) -> Result<(), StoreError> {
-        let current = query_fence(transaction)?.ok_or(StoreError::StaleFence)?;
-        if current != *fence {
-            return Err(StoreError::StaleFence);
-        }
-        if current.expires_at_ms <= self.clock.now_ms() {
-            return Err(StoreError::FenceExpired);
-        }
-        Ok(())
-    }
-
     fn append(&self, request: AppendRequest<'_>) -> Result<AppendOutcome, StoreError> {
         request.batch.validate()?;
         if self.take_failpoint(FailPoint::BeforeCommit) {
@@ -155,7 +143,7 @@ impl SqliteLedgerStore {
         transaction: &Transaction<'_>,
         request: AppendRequest<'_>,
     ) -> Result<AppendDecision, StoreError> {
-        self.check_fence_tx(transaction, request.fence)?;
+        check_fence_transaction(transaction, request.fence, self.clock.now_ms())?;
         if let Some(outcome) = operations::existing_receipt_outcome(transaction, &request.batch)? {
             return Ok(AppendDecision {
                 outcome,
@@ -185,7 +173,7 @@ impl SqliteLedgerStore {
         let transaction = connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|_| StoreError::Storage)?;
-        self.check_fence_tx(&transaction, request.fence)?;
+        check_fence_transaction(&transaction, request.fence, self.clock.now_ms())?;
         let actual = Self::position(&transaction)?;
         if actual != request.expected {
             return Err(StoreError::PositionConflict {
@@ -309,7 +297,7 @@ impl LedgerStore for SqliteLedgerStore {
         let transaction = connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|_| StoreError::Storage)?;
-        self.check_fence_tx(&transaction, fence)?;
+        check_exact_fence_transaction(&transaction, fence, self.clock.now_ms())?;
         transaction
             .execute(
                 "UPDATE fence SET expires_at_ms = ?1 WHERE singleton = 1",
@@ -323,10 +311,39 @@ impl LedgerStore for SqliteLedgerStore {
         })
     }
 
+    async fn release_fence(&self, fence: &Fence) -> Result<(), StoreError> {
+        let _writer = self
+            .writer
+            .lock()
+            .expect("SQLite writer mutex must not be poisoned");
+        let released_at_ms = self.clock.now_ms();
+        let mut connection = self.connect_existing(&fence.resource)?;
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|_| StoreError::Storage)?;
+        check_exact_fence_transaction(&transaction, fence, self.clock.now_ms())?;
+        let changed = transaction
+            .execute(
+                "UPDATE fence SET expires_at_ms = ?1
+                 WHERE singleton = 1 AND owner_id = ?2 AND epoch = ?3 AND expires_at_ms = ?4",
+                rusqlite::params![
+                    to_sql_i64(released_at_ms)?,
+                    fence.owner.as_str(),
+                    to_sql_i64(fence.epoch)?,
+                    to_sql_i64(fence.expires_at_ms)?
+                ],
+            )
+            .map_err(|_| StoreError::Storage)?;
+        if changed != 1 {
+            return Err(StoreError::StaleFence);
+        }
+        transaction.commit().map_err(|_| StoreError::Storage)
+    }
+
     async fn check_fence(&self, fence: &Fence) -> Result<(), StoreError> {
         let mut connection = self.connect_existing(&fence.resource)?;
         let transaction = connection.transaction().map_err(|_| StoreError::Storage)?;
-        self.check_fence_tx(&transaction, fence)?;
+        check_fence_transaction(&transaction, fence, self.clock.now_ms())?;
         transaction.commit().map_err(|_| StoreError::Storage)
     }
 

--- a/zeroshot-rust/src/cluster_ledger/store/sqlite/transactions.rs
+++ b/zeroshot-rust/src/cluster_ledger/store/sqlite/transactions.rs
@@ -10,6 +10,36 @@ pub(super) struct FenceAcquisition<'a> {
     pub expires_at_ms: u64,
 }
 
+pub(super) fn check_fence_transaction(
+    transaction: &Transaction<'_>,
+    fence: &Fence,
+    now_ms: u64,
+) -> Result<(), StoreError> {
+    let current = query_fence(transaction)?.ok_or(StoreError::StaleFence)?;
+    if current.resource != fence.resource
+        || current.owner != fence.owner
+        || current.epoch != fence.epoch
+    {
+        return Err(StoreError::StaleFence);
+    }
+    if current.expires_at_ms <= now_ms {
+        return Err(StoreError::FenceExpired);
+    }
+    Ok(())
+}
+
+pub(super) fn check_exact_fence_transaction(
+    transaction: &Transaction<'_>,
+    fence: &Fence,
+    now_ms: u64,
+) -> Result<(), StoreError> {
+    check_fence_transaction(transaction, fence, now_ms)?;
+    if query_fence(transaction)?.as_ref() != Some(fence) {
+        return Err(StoreError::StaleFence);
+    }
+    Ok(())
+}
+
 pub(super) fn acquire_fence_transaction(
     transaction: &Transaction<'_>,
     request: FenceAcquisition<'_>,

--- a/zeroshot-rust/src/daemon_listener.rs
+++ b/zeroshot-rust/src/daemon_listener.rs
@@ -32,32 +32,10 @@ use crate::daemon_discovery::{
 };
 use crate::{NativeBackendFactory, binding_for_route};
 
-#[derive(Clone, Copy, Debug)]
-pub struct ListenerConfig {
-    pub startup_lock_timeout: Duration,
-    pub liveness_timeout: Duration,
-    pub handshake_timeout: Duration,
-    pub drain_timeout: Duration,
-    pub shutdown_timeout: Duration,
-    pub max_active_connections: usize,
-    pub max_pending_handshakes: usize,
-    pub max_liveness_connections: usize,
-}
-
-impl Default for ListenerConfig {
-    fn default() -> Self {
-        Self {
-            startup_lock_timeout: Duration::from_secs(1),
-            liveness_timeout: Duration::from_millis(500),
-            handshake_timeout: Duration::from_secs(2),
-            drain_timeout: Duration::from_millis(250),
-            shutdown_timeout: Duration::from_secs(1),
-            max_active_connections: 64,
-            max_pending_handshakes: 64,
-            max_liveness_connections: 8,
-        }
-    }
-}
+mod config;
+mod liveness;
+pub use config::ListenerConfig;
+pub use liveness::probe_liveness;
 
 #[derive(Debug, Error)]
 pub enum DaemonListenerError {
@@ -153,50 +131,12 @@ impl DaemonListener {
             rotate_away_from(&mut credentials.capability, &previous_capability);
             rotate_away_from(&mut credentials.daemon_nonce, &previous_nonce);
         }
-        let locator = DaemonLocator {
-            endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
-            cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
-            daemon_protocol: DAEMON_PROTOCOL.to_owned(),
-            profile_digest: credentials.profile_digest.clone(),
-            daemon_nonce: credentials.daemon_nonce.clone(),
-            capability: credentials.capability.clone(),
-        };
+        let locator = locator_for(address, &credentials);
 
-        let shutdown = Arc::new(Notify::new());
-        let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
-        let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
-        let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
-        let host = AcceptLoop {
-            acceptor: tcp,
-            factory: Arc::new(factory),
-            credentials,
-            shutdown: Arc::clone(&shutdown),
-            pending_handshake_permits: Arc::clone(&pending_handshake_permits),
-            liveness_connection_permits: Arc::clone(&liveness_connection_permits),
-            active_session_permits: Arc::clone(&active_session_permits),
-            config,
-        };
+        let host = AcceptLoop::new(tcp, Arc::new(factory), credentials, config);
         replace_locator_locked(&profile, &locator)?;
         drop(guard);
-        let accept_task = tokio::spawn(run_owned_accept_loop(
-            host,
-            profile.clone(),
-            locator.clone(),
-        ));
-
-        Ok(Self {
-            profile,
-            locator,
-            shutdown,
-            accept_task: Some(accept_task),
-            shutdown_timeout: config.shutdown_timeout,
-            pending_handshake_limit: config.max_pending_handshakes,
-            pending_handshake_permits,
-            liveness_connection_limit: config.max_liveness_connections,
-            liveness_connection_permits,
-            active_session_limit: config.max_active_connections,
-            active_session_permits,
-        })
+        Ok(spawn_listener_owner(host, profile, locator))
     }
 
     #[must_use]
@@ -267,105 +207,6 @@ impl Drop for DaemonListener {
     }
 }
 
-pub async fn probe_liveness(locator: &DaemonLocator, deadline: Duration) -> LivenessOutcome {
-    timeout(deadline, probe_liveness_inner(locator))
-        .await
-        .unwrap_or(LivenessOutcome::Indeterminate)
-}
-
-async fn probe_liveness_inner(locator: &DaemonLocator) -> LivenessOutcome {
-    if locator.cluster_protocol != CLUSTER_PROTOCOL || locator.daemon_protocol != DAEMON_PROTOCOL {
-        return LivenessOutcome::DefinitelyStale;
-    }
-    let mut request = match locator.endpoint.as_str().into_client_request() {
-        Ok(request) => request,
-        Err(_) => return LivenessOutcome::DefinitelyStale,
-    };
-    let Some(address) = loopback_address(&request) else {
-        return LivenessOutcome::DefinitelyStale;
-    };
-    let expectation = match DaemonCredentials::from_locator(locator)
-        .prepare_request(&mut request, ConnectionPurpose::Liveness)
-    {
-        Ok(expectation) => expectation,
-        Err(_) => return LivenessOutcome::Indeterminate,
-    };
-    let stream = match TcpStream::connect(address).await {
-        Ok(stream) => stream,
-        Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
-            return LivenessOutcome::DefinitelyStale;
-        }
-        Err(_) => return LivenessOutcome::Indeterminate,
-    };
-    let (mut websocket, response) = match tokio_tungstenite::client_async(request, stream).await {
-        Ok(connected) => connected,
-        Err(WebSocketError::Http(_)) => return LivenessOutcome::DefinitelyStale,
-        Err(_) => return LivenessOutcome::Indeterminate,
-    };
-    if !expectation.verify(&response) {
-        return LivenessOutcome::DefinitelyStale;
-    }
-    let initialize = serde_json::json!({
-        "jsonrpc": JSON_RPC_VERSION,
-        "id": "daemon-liveness",
-        "method": "initialize",
-        "params": { "protocolVersion": PROTOCOL_VERSION }
-    });
-    if websocket
-        .send(Message::Text(initialize.to_string().into()))
-        .await
-        .is_err()
-    {
-        return LivenessOutcome::Indeterminate;
-    }
-    while let Some(message) = websocket.next().await {
-        let message = match message {
-            Ok(message) => message,
-            Err(_) => return LivenessOutcome::Indeterminate,
-        };
-        let Message::Text(text) = message else {
-            if message.is_close() {
-                return LivenessOutcome::Indeterminate;
-            }
-            continue;
-        };
-        let response: Value = match serde_json::from_str(text.as_ref()) {
-            Ok(response) => response,
-            Err(_) => return LivenessOutcome::DefinitelyStale,
-        };
-        return classify_liveness_response(&response);
-    }
-    LivenessOutcome::Indeterminate
-}
-
-fn classify_liveness_response(response: &Value) -> LivenessOutcome {
-    let Some(object) = response.as_object() else {
-        return LivenessOutcome::DefinitelyStale;
-    };
-    if object.len() != 3
-        || object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION)
-        || object.get("id").and_then(Value::as_str) != Some("daemon-liveness")
-    {
-        return LivenessOutcome::DefinitelyStale;
-    }
-    if object.contains_key("error") && !object.contains_key("result") {
-        return LivenessOutcome::Indeterminate;
-    }
-    let Some(raw_result) = object.get("result") else {
-        return LivenessOutcome::DefinitelyStale;
-    };
-    let Ok(result) = serde_json::from_value::<InitializeResult>(raw_result.clone()) else {
-        return LivenessOutcome::DefinitelyStale;
-    };
-    if result.validate_protocol_version().is_ok()
-        && serde_json::to_value(result).ok().as_ref() == Some(raw_result)
-    {
-        LivenessOutcome::Alive
-    } else {
-        LivenessOutcome::DefinitelyStale
-    }
-}
-
 fn identity_for_profile(profile_digest: &str) -> ConnectionIdentity {
     ConnectionIdentity::new(ConnectionIdentityConfig {
         principal: PrincipalId::new(profile_digest),
@@ -381,23 +222,6 @@ fn rotate_away_from(value: &mut String, previous: &str) {
         let replacement = if value.starts_with('0') { "1" } else { "0" };
         value.replace_range(..1, replacement);
     }
-}
-
-fn loopback_address(
-    request: &tokio_tungstenite::tungstenite::handshake::client::Request,
-) -> Option<SocketAddr> {
-    let uri = request.uri();
-    if uri.scheme_str() != Some("ws")
-        || uri.path() != DAEMON_ROUTE
-        || uri.query().is_some()
-        || uri.host() != Some("127.0.0.1")
-    {
-        return None;
-    }
-    Some(SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::LOCALHOST),
-        uri.port_u16()?,
-    ))
 }
 
 trait ConnectionAcceptor: Send + Sync + 'static {
@@ -419,6 +243,71 @@ struct AcceptLoop<A, F> {
     pending_handshake_permits: Arc<Semaphore>,
     liveness_connection_permits: Arc<Semaphore>,
     active_session_permits: Arc<Semaphore>,
+}
+
+impl<A, F> AcceptLoop<A, F> {
+    fn new(
+        acceptor: A,
+        factory: Arc<F>,
+        credentials: DaemonCredentials,
+        config: ListenerConfig,
+    ) -> Self {
+        Self {
+            acceptor,
+            factory,
+            credentials,
+            shutdown: Arc::new(Notify::new()),
+            pending_handshake_permits: Arc::new(Semaphore::new(config.max_pending_handshakes)),
+            liveness_connection_permits: Arc::new(Semaphore::new(config.max_liveness_connections)),
+            active_session_permits: Arc::new(Semaphore::new(config.max_active_connections)),
+            config,
+        }
+    }
+}
+
+fn locator_for(address: SocketAddr, credentials: &DaemonCredentials) -> DaemonLocator {
+    DaemonLocator {
+        endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
+        cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
+        daemon_protocol: DAEMON_PROTOCOL.to_owned(),
+        profile_digest: credentials.profile_digest.clone(),
+        daemon_nonce: credentials.daemon_nonce.clone(),
+        capability: credentials.capability.clone(),
+    }
+}
+
+fn spawn_listener_owner<A, F>(
+    host: AcceptLoop<A, F>,
+    profile: NativeProfile,
+    locator: DaemonLocator,
+) -> DaemonListener
+where
+    A: ConnectionAcceptor,
+    F: NativeBackendFactory + Send + Sync + 'static,
+{
+    let config = host.config;
+    let shutdown = Arc::clone(&host.shutdown);
+    let pending_handshake_permits = Arc::clone(&host.pending_handshake_permits);
+    let liveness_connection_permits = Arc::clone(&host.liveness_connection_permits);
+    let active_session_permits = Arc::clone(&host.active_session_permits);
+    let accept_task = tokio::spawn(run_owned_accept_loop(
+        host,
+        profile.clone(),
+        locator.clone(),
+    ));
+    DaemonListener {
+        profile,
+        locator,
+        shutdown,
+        accept_task: Some(accept_task),
+        shutdown_timeout: config.shutdown_timeout,
+        pending_handshake_limit: config.max_pending_handshakes,
+        pending_handshake_permits,
+        liveness_connection_limit: config.max_liveness_connections,
+        liveness_connection_permits,
+        active_session_limit: config.max_active_connections,
+        active_session_permits,
+    }
 }
 
 async fn run_owned_accept_loop<A, F>(
@@ -590,148 +479,4 @@ where
 }
 
 #[cfg(test)]
-mod accept_loop_tests {
-    use std::fs;
-    use std::path::PathBuf;
-
-    use super::*;
-    use crate::ProductionNativeBackendFactory;
-    use crate::daemon_discovery::{random_hex, read_locator, replace_locator};
-
-    #[derive(Clone, Copy)]
-    enum FailureMode {
-        Error,
-        Panic,
-    }
-
-    struct FailingAcceptor {
-        _listener: TcpListener,
-        mode: FailureMode,
-    }
-
-    impl ConnectionAcceptor for FailingAcceptor {
-        fn accept(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send {
-            let mode = self.mode;
-            async move {
-                match mode {
-                    FailureMode::Error => Err(io::Error::other("controlled accept failure")),
-                    FailureMode::Panic => panic!("controlled accept loop panic"),
-                }
-            }
-        }
-    }
-
-    struct TestProfile {
-        profile: NativeProfile,
-        root: PathBuf,
-    }
-
-    impl Drop for TestProfile {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.root);
-        }
-    }
-
-    async fn failing_owner(
-        mode: FailureMode,
-        label: &str,
-    ) -> (DaemonListener, TestProfile, SocketAddr) {
-        let root = std::env::temp_dir().join(format!(
-            "zeroshot-accept-{label}-{}-{}",
-            std::process::id(),
-            random_hex().expect("temporary profile suffix")
-        ));
-        let profile = NativeProfile::new(&root, format!("native-profile:{label}"));
-        let tcp = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
-            .await
-            .expect("bind controlled acceptor");
-        let address = tcp.local_addr().expect("controlled acceptor address");
-        let credentials =
-            DaemonCredentials::generate(profile.digest().to_owned()).expect("credentials");
-        let locator = DaemonLocator {
-            endpoint: format!("ws://{address}{DAEMON_ROUTE}"),
-            cluster_protocol: CLUSTER_PROTOCOL.to_owned(),
-            daemon_protocol: DAEMON_PROTOCOL.to_owned(),
-            profile_digest: credentials.profile_digest.clone(),
-            daemon_nonce: credentials.daemon_nonce.clone(),
-            capability: credentials.capability.clone(),
-        };
-        replace_locator(&profile, &locator).expect("publish controlled locator");
-        let config = ListenerConfig::default();
-        let shutdown = Arc::new(Notify::new());
-        let pending_handshake_permits = Arc::new(Semaphore::new(config.max_pending_handshakes));
-        let liveness_connection_permits = Arc::new(Semaphore::new(config.max_liveness_connections));
-        let active_session_permits = Arc::new(Semaphore::new(config.max_active_connections));
-        let host = AcceptLoop {
-            acceptor: FailingAcceptor {
-                _listener: tcp,
-                mode,
-            },
-            factory: Arc::new(ProductionNativeBackendFactory),
-            credentials,
-            shutdown: Arc::clone(&shutdown),
-            config,
-            pending_handshake_permits: Arc::clone(&pending_handshake_permits),
-            liveness_connection_permits: Arc::clone(&liveness_connection_permits),
-            active_session_permits: Arc::clone(&active_session_permits),
-        };
-        let accept_task = tokio::spawn(run_owned_accept_loop(
-            host,
-            profile.clone(),
-            locator.clone(),
-        ));
-        let owner = DaemonListener {
-            profile: profile.clone(),
-            locator,
-            shutdown,
-            accept_task: Some(accept_task),
-            shutdown_timeout: config.shutdown_timeout,
-            pending_handshake_limit: config.max_pending_handshakes,
-            pending_handshake_permits,
-            liveness_connection_limit: config.max_liveness_connections,
-            liveness_connection_permits,
-            active_session_limit: config.max_active_connections,
-            active_session_permits,
-        };
-        (owner, TestProfile { profile, root }, address)
-    }
-
-    async fn assert_failure_cleanup_before_shutdown(mode: FailureMode, label: &str) {
-        let (owner, profile, address) = failing_owner(mode, label).await;
-        timeout(Duration::from_millis(500), async {
-            loop {
-                let locator_removed = read_locator(&profile.profile)
-                    .expect("automatic failure cleanup state")
-                    .is_none();
-                let socket_released = match TcpListener::bind(address).await {
-                    Ok(rebound) => {
-                        drop(rebound);
-                        true
-                    }
-                    Err(error) if error.kind() == io::ErrorKind::AddrInUse => false,
-                    Err(error) => panic!("unexpected rebind failure: {error}"),
-                };
-                if locator_removed && socket_released {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("owned accept failure released locator and socket");
-        assert!(matches!(
-            owner.shutdown().await,
-            Err(DaemonListenerError::Task)
-        ));
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn accept_error_cleans_owner_before_shutdown_and_remains_task_failure() {
-        assert_failure_cleanup_before_shutdown(FailureMode::Error, "accept-error").await;
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn accept_loop_panic_cleans_owner_before_shutdown_and_remains_task_failure() {
-        assert_failure_cleanup_before_shutdown(FailureMode::Panic, "accept-panic").await;
-    }
-}
+mod accept_loop_tests;

--- a/zeroshot-rust/src/daemon_listener/accept_loop_tests.rs
+++ b/zeroshot-rust/src/daemon_listener/accept_loop_tests.rs
@@ -1,0 +1,147 @@
+use std::fs;
+use std::path::PathBuf;
+
+use super::*;
+use crate::daemon_discovery::{random_hex, read_locator, replace_locator};
+
+#[derive(Clone, Copy)]
+struct UnusedFactory;
+
+#[derive(Clone, Copy)]
+struct UnusedBackend;
+
+impl crate::NativeBackendFactory for UnusedFactory {
+    type Backend = UnusedBackend;
+
+    fn create(&self) -> Self::Backend {
+        UnusedBackend
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::ClusterBackend for UnusedBackend {
+    async fn initialize(
+        &self,
+        _context: &crate::ConnectionContext,
+        _params: openengine_cluster_protocol::InitializeParams,
+    ) -> Result<
+        openengine_cluster_protocol::InitializeResult,
+        openengine_cluster_server::BackendError,
+    > {
+        panic!("controlled failing accept loop must not create a backend")
+    }
+
+    async fn get(
+        &self,
+        _context: &crate::ConnectionContext,
+        _params: openengine_cluster_protocol::GetParams,
+    ) -> Result<openengine_cluster_protocol::GetResult, openengine_cluster_server::BackendError>
+    {
+        panic!("controlled failing accept loop must not create a backend")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FailureMode {
+    Error,
+    Panic,
+}
+
+struct FailingAcceptor {
+    _listener: TcpListener,
+    mode: FailureMode,
+}
+
+impl ConnectionAcceptor for FailingAcceptor {
+    fn accept(&self) -> impl Future<Output = io::Result<(TcpStream, SocketAddr)>> + Send {
+        let mode = self.mode;
+        async move {
+            match mode {
+                FailureMode::Error => Err(io::Error::other("controlled accept failure")),
+                FailureMode::Panic => panic!("controlled accept loop panic"),
+            }
+        }
+    }
+}
+
+struct TestProfile {
+    profile: NativeProfile,
+    root: PathBuf,
+}
+
+impl Drop for TestProfile {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+async fn failing_owner(
+    mode: FailureMode,
+    label: &str,
+) -> (DaemonListener, TestProfile, SocketAddr) {
+    let root = std::env::temp_dir().join(format!(
+        "zeroshot-accept-{label}-{}-{}",
+        std::process::id(),
+        random_hex().expect("temporary profile suffix")
+    ));
+    let profile = NativeProfile::new(&root, format!("native-profile:{label}"));
+    let tcp = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .await
+        .expect("bind controlled acceptor");
+    let address = tcp.local_addr().expect("controlled acceptor address");
+    let credentials =
+        DaemonCredentials::generate(profile.digest().to_owned()).expect("credentials");
+    let locator = locator_for(address, &credentials);
+    replace_locator(&profile, &locator).expect("publish controlled locator");
+    let config = ListenerConfig::default();
+    let host = AcceptLoop::new(
+        FailingAcceptor {
+            _listener: tcp,
+            mode,
+        },
+        Arc::new(UnusedFactory),
+        credentials,
+        config,
+    );
+    let owner = spawn_listener_owner(host, profile.clone(), locator);
+    (owner, TestProfile { profile, root }, address)
+}
+
+async fn assert_failure_cleanup_before_shutdown(mode: FailureMode, label: &str) {
+    let (owner, profile, address) = failing_owner(mode, label).await;
+    timeout(Duration::from_millis(500), async {
+        loop {
+            let locator_removed = read_locator(&profile.profile)
+                .expect("automatic failure cleanup state")
+                .is_none();
+            let socket_released = match TcpListener::bind(address).await {
+                Ok(rebound) => {
+                    drop(rebound);
+                    true
+                }
+                Err(error) if error.kind() == io::ErrorKind::AddrInUse => false,
+                Err(error) => panic!("unexpected rebind failure: {error}"),
+            };
+            if locator_removed && socket_released {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("owned accept failure released locator and socket");
+    assert!(matches!(
+        owner.shutdown().await,
+        Err(DaemonListenerError::Task)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn accept_error_cleans_owner_before_shutdown_and_remains_task_failure() {
+    assert_failure_cleanup_before_shutdown(FailureMode::Error, "accept-error").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn accept_loop_panic_cleans_owner_before_shutdown_and_remains_task_failure() {
+    assert_failure_cleanup_before_shutdown(FailureMode::Panic, "accept-panic").await;
+}

--- a/zeroshot-rust/src/daemon_listener/config.rs
+++ b/zeroshot-rust/src/daemon_listener/config.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ListenerConfig {
+    pub startup_lock_timeout: Duration,
+    pub liveness_timeout: Duration,
+    pub handshake_timeout: Duration,
+    pub drain_timeout: Duration,
+    pub shutdown_timeout: Duration,
+    pub max_active_connections: usize,
+    pub max_pending_handshakes: usize,
+    pub max_liveness_connections: usize,
+}
+
+impl Default for ListenerConfig {
+    fn default() -> Self {
+        Self {
+            startup_lock_timeout: Duration::from_secs(1),
+            liveness_timeout: Duration::from_millis(500),
+            handshake_timeout: Duration::from_secs(2),
+            drain_timeout: Duration::from_millis(250),
+            shutdown_timeout: Duration::from_secs(1),
+            max_active_connections: 64,
+            max_pending_handshakes: 64,
+            max_liveness_connections: 8,
+        }
+    }
+}

--- a/zeroshot-rust/src/daemon_listener/liveness.rs
+++ b/zeroshot-rust/src/daemon_listener/liveness.rs
@@ -1,0 +1,153 @@
+use super::*;
+use crate::daemon_auth::ServerProofExpectation;
+
+struct PreparedProbe {
+    request: tokio_tungstenite::tungstenite::http::Request<()>,
+    address: SocketAddr,
+    expectation: ServerProofExpectation,
+}
+
+pub async fn probe_liveness(locator: &DaemonLocator, deadline: Duration) -> LivenessOutcome {
+    timeout(deadline, probe_liveness_inner(locator))
+        .await
+        .unwrap_or(LivenessOutcome::Indeterminate)
+}
+
+async fn probe_liveness_inner(locator: &DaemonLocator) -> LivenessOutcome {
+    execute_probe(locator)
+        .await
+        .unwrap_or_else(std::convert::identity)
+}
+
+async fn execute_probe(locator: &DaemonLocator) -> Result<LivenessOutcome, LivenessOutcome> {
+    let prepared = prepare_probe(locator)?;
+    let websocket = open_probe(prepared).await?;
+    Ok(exchange_initialize(websocket).await)
+}
+
+fn prepare_probe(locator: &DaemonLocator) -> Result<PreparedProbe, LivenessOutcome> {
+    if locator.cluster_protocol != CLUSTER_PROTOCOL || locator.daemon_protocol != DAEMON_PROTOCOL {
+        return Err(LivenessOutcome::DefinitelyStale);
+    }
+    let mut request = match locator.endpoint.as_str().into_client_request() {
+        Ok(request) => request,
+        Err(_) => return Err(LivenessOutcome::DefinitelyStale),
+    };
+    let Some(address) = loopback_address(&request) else {
+        return Err(LivenessOutcome::DefinitelyStale);
+    };
+    let expectation = match DaemonCredentials::from_locator(locator)
+        .prepare_request(&mut request, ConnectionPurpose::Liveness)
+    {
+        Ok(expectation) => expectation,
+        Err(_) => return Err(LivenessOutcome::Indeterminate),
+    };
+    Ok(PreparedProbe {
+        request,
+        address,
+        expectation,
+    })
+}
+
+async fn open_probe(
+    prepared: PreparedProbe,
+) -> Result<tokio_tungstenite::WebSocketStream<TcpStream>, LivenessOutcome> {
+    let stream = match TcpStream::connect(prepared.address).await {
+        Ok(stream) => stream,
+        Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
+            return Err(LivenessOutcome::DefinitelyStale);
+        }
+        Err(_) => return Err(LivenessOutcome::Indeterminate),
+    };
+    let (websocket, response) =
+        match tokio_tungstenite::client_async(prepared.request, stream).await {
+            Ok(connected) => connected,
+            Err(WebSocketError::Http(_)) => return Err(LivenessOutcome::DefinitelyStale),
+            Err(_) => return Err(LivenessOutcome::Indeterminate),
+        };
+    if !prepared.expectation.verify(&response) {
+        return Err(LivenessOutcome::DefinitelyStale);
+    }
+    Ok(websocket)
+}
+
+async fn exchange_initialize(
+    mut websocket: tokio_tungstenite::WebSocketStream<TcpStream>,
+) -> LivenessOutcome {
+    let initialize = serde_json::json!({
+        "jsonrpc": JSON_RPC_VERSION,
+        "id": "daemon-liveness",
+        "method": "initialize",
+        "params": { "protocolVersion": PROTOCOL_VERSION }
+    });
+    if websocket
+        .send(Message::Text(initialize.to_string().into()))
+        .await
+        .is_err()
+    {
+        return LivenessOutcome::Indeterminate;
+    }
+    while let Some(message) = websocket.next().await {
+        let message = match message {
+            Ok(message) => message,
+            Err(_) => return LivenessOutcome::Indeterminate,
+        };
+        let Message::Text(text) = message else {
+            if message.is_close() {
+                return LivenessOutcome::Indeterminate;
+            }
+            continue;
+        };
+        let response: Value = match serde_json::from_str(text.as_ref()) {
+            Ok(response) => response,
+            Err(_) => return LivenessOutcome::DefinitelyStale,
+        };
+        return classify_liveness_response(&response);
+    }
+    LivenessOutcome::Indeterminate
+}
+
+fn classify_liveness_response(response: &Value) -> LivenessOutcome {
+    let Some(object) = response.as_object() else {
+        return LivenessOutcome::DefinitelyStale;
+    };
+    if object.len() != 3
+        || object.get("jsonrpc").and_then(Value::as_str) != Some(JSON_RPC_VERSION)
+        || object.get("id").and_then(Value::as_str) != Some("daemon-liveness")
+    {
+        return LivenessOutcome::DefinitelyStale;
+    }
+    if object.contains_key("error") && !object.contains_key("result") {
+        return LivenessOutcome::Indeterminate;
+    }
+    let Some(raw_result) = object.get("result") else {
+        return LivenessOutcome::DefinitelyStale;
+    };
+    let Ok(result) = serde_json::from_value::<InitializeResult>(raw_result.clone()) else {
+        return LivenessOutcome::DefinitelyStale;
+    };
+    if result.validate_protocol_version().is_ok()
+        && serde_json::to_value(result).ok().as_ref() == Some(raw_result)
+    {
+        LivenessOutcome::Alive
+    } else {
+        LivenessOutcome::DefinitelyStale
+    }
+}
+
+fn loopback_address(
+    request: &tokio_tungstenite::tungstenite::handshake::client::Request,
+) -> Option<SocketAddr> {
+    let uri = request.uri();
+    if uri.scheme_str() != Some("ws")
+        || uri.path() != DAEMON_ROUTE
+        || uri.query().is_some()
+        || uri.host() != Some("127.0.0.1")
+    {
+        return None;
+    }
+    Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        uri.port_u16()?,
+    ))
+}

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -10,6 +10,7 @@ pub mod execution;
 pub mod full_v1_reducer;
 pub mod hosted_oecp;
 pub mod issue_provider;
+mod native_admission;
 pub mod native_credentials;
 pub mod native_settings;
 pub mod product_errors;
@@ -22,46 +23,16 @@ pub mod worker_bindings;
 pub mod worker_catalog;
 pub mod workspace_lease;
 
-use async_trait::async_trait;
-use openengine_cluster_protocol::{
-    ClusterStatus, GetParams, GetResult, InitializeParams, InitializeResult, ServerCapabilities,
-};
 use openengine_cluster_server::identity::{
     ConnectionBinding, ConnectionIdentity, StaticConnectionIdentityResolver, SystemConnectionTime,
 };
-use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext, Dispatcher};
+use openengine_cluster_server::{ClusterBackend, ConnectionContext, Dispatcher};
 
 pub mod fault;
 pub mod observability;
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct NativeBackend;
-
-#[async_trait]
-impl ClusterBackend for NativeBackend {
-    async fn initialize(
-        &self,
-        _context: &ConnectionContext,
-        _params: InitializeParams,
-    ) -> Result<InitializeResult, BackendError> {
-        Ok(InitializeResult::new(
-            ServerCapabilities::default(),
-            ClusterStatus::empty(),
-        ))
-    }
-
-    async fn get(
-        &self,
-        _context: &ConnectionContext,
-        _params: GetParams,
-    ) -> Result<GetResult, BackendError> {
-        Ok(GetResult {
-            spec: None,
-            status: ClusterStatus::empty(),
-            at_cursor: None,
-        })
-    }
-}
+pub use native_admission::{
+    NativeAdmissionOpenError, NativeBackend, NATIVE_FENCE_RENEW_INTERVAL_MS, NATIVE_FENCE_TTL_MS,
+};
 
 pub trait NativeBackendFactory {
     type Backend: ClusterBackend;
@@ -69,15 +40,9 @@ pub trait NativeBackendFactory {
     fn create(&self) -> Self::Backend;
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct ProductionNativeBackendFactory;
-
-impl NativeBackendFactory for ProductionNativeBackendFactory {
-    type Backend = NativeBackend;
-
-    fn create(&self) -> Self::Backend {
-        NativeBackend
-    }
+#[derive(Clone)]
+pub struct ProductionNativeBackendFactory {
+    backend: NativeBackend,
 }
 
 #[must_use]

--- a/zeroshot-rust/src/main.rs
+++ b/zeroshot-rust/src/main.rs
@@ -1,1 +1,146 @@
-fn main() {}
+use std::path::PathBuf;
+
+use openengine_cluster_server::identity::{
+    BindingAttributes, ConnectionIdentity, ConnectionIdentityConfig, PrincipalId, TenantId,
+};
+use openengine_cluster_server::stdio::serve_stdio;
+use thiserror::Error;
+use tokio::sync::watch;
+
+use zeroshot_engine::cluster_ledger::{LedgerError, OwnerId, ResourceId};
+use zeroshot_engine::{
+    binding_for_route, NativeAdmissionOpenError, ProductionNativeBackendFactory,
+    NATIVE_FENCE_RENEW_INTERVAL_MS, NATIVE_FENCE_TTL_MS,
+};
+
+#[derive(Debug, Error)]
+enum ProcessError {
+    #[error(
+        "usage: zeroshot-rust serve-stdio --state-dir <absolute-directory> --cluster-id <bounded-id>"
+    )]
+    Usage,
+    #[error("state directory must be an absolute path")]
+    RelativeStateDirectory,
+    #[error("process identity randomness is unavailable")]
+    Randomness,
+    #[error(transparent)]
+    Admission(#[from] NativeAdmissionOpenError),
+    #[error("native cluster transport failed: {0}")]
+    Transport(#[from] std::io::Error),
+    #[error("native cluster lease failed: {0}")]
+    Lease(#[from] LedgerError),
+    #[error("native cluster lease renewal task failed")]
+    RenewalTask,
+}
+
+struct ServeArgs {
+    state_dir: PathBuf,
+    cluster_id: ResourceId,
+}
+
+fn parse_args() -> Result<ServeArgs, ProcessError> {
+    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+    let [command, state_flag, state_dir, cluster_flag, cluster_id] = args.as_slice() else {
+        return Err(ProcessError::Usage);
+    };
+    if command != "serve-stdio" || state_flag != "--state-dir" || cluster_flag != "--cluster-id" {
+        return Err(ProcessError::Usage);
+    }
+    let state_dir = PathBuf::from(state_dir);
+    if !state_dir.is_absolute() {
+        return Err(ProcessError::RelativeStateDirectory);
+    }
+    let cluster_id = cluster_id.to_str().ok_or(ProcessError::Usage)?;
+    let cluster_id = ResourceId::new(cluster_id).map_err(|_| ProcessError::Usage)?;
+    Ok(ServeArgs {
+        state_dir,
+        cluster_id,
+    })
+}
+
+fn process_owner() -> Result<OwnerId, ProcessError> {
+    let mut random = [0_u8; 16];
+    getrandom::fill(&mut random).map_err(|_| ProcessError::Randomness)?;
+    let mut suffix = String::with_capacity(random.len() * 2);
+    for byte in random {
+        use std::fmt::Write as _;
+        write!(&mut suffix, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    OwnerId::new(format!("process-{}-{suffix}", std::process::id()))
+        .map_err(|_| ProcessError::Randomness)
+}
+
+async fn run() -> Result<(), ProcessError> {
+    let args = parse_args()?;
+    let factory =
+        ProductionNativeBackendFactory::open(&args.state_dir, args.cluster_id, process_owner()?)
+            .await?;
+
+    let renewal_factory = factory.clone();
+    let renewal_ledger = factory.ledger().clone();
+    let (stop_renewal, mut renewal_stop) = watch::channel(false);
+    let mut renewal_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                changed = renewal_stop.changed() => {
+                    if changed.is_err() || *renewal_stop.borrow() {
+                        return Ok(());
+                    }
+                }
+                () = tokio::time::sleep(std::time::Duration::from_millis(
+                    NATIVE_FENCE_RENEW_INTERVAL_MS,
+                )) => {
+                    if let Err(error) = renewal_ledger.renew_fence(NATIVE_FENCE_TTL_MS).await {
+                        renewal_factory.mark_lease_lost();
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    });
+
+    let identity = ConnectionIdentity::new(ConnectionIdentityConfig {
+        principal: PrincipalId::new("local-native"),
+        tenant: TenantId::new("local-native"),
+        issued_at_ms: None,
+        expires_at_ms: u64::MAX,
+        binding_attributes: BindingAttributes::default(),
+    });
+    let binding = binding_for_route(&factory, identity);
+    let server = serve_stdio(binding);
+    tokio::pin!(server);
+    tokio::select! {
+        server_result = &mut server => {
+            let _ = stop_renewal.send(true);
+            match renewal_task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    factory.mark_lease_lost();
+                    return Err(error.into());
+                }
+                Err(_) => {
+                    factory.mark_lease_lost();
+                    return Err(ProcessError::RenewalTask);
+                }
+            }
+            factory.ledger().release_fence().await?;
+            server_result?;
+            Ok(())
+        }
+        renewal_result = &mut renewal_task => {
+            factory.mark_lease_lost();
+            match renewal_result {
+                Ok(Err(error)) => Err(error.into()),
+                Ok(Ok(())) | Err(_) => Err(ProcessError::RenewalTask),
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("zeroshot-rust: {error}");
+        std::process::exit(1);
+    }
+}

--- a/zeroshot-rust/src/native_admission.rs
+++ b/zeroshot-rust/src/native_admission.rs
@@ -1,0 +1,394 @@
+//! Direct production composition for one admission-only native cluster.
+
+use std::num::NonZeroU64;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    canonical_value_bytes, ApplyParams, ApplyResult, GetParams, GetResult, InitializeParams,
+    InitializeResult, PlanParams, PlanResult, WorkerDescriptor, WorkerRef, INTERNAL_ERROR_CODE,
+};
+use openengine_cluster_server::admission::AdmissionCoordinator;
+use openengine_cluster_server::graph_verifier::ProductionGraphVerifier;
+use openengine_cluster_server::worker_registry::{WorkerRegistry, WorkerRegistryError};
+use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::cluster_ledger::adapters::{AdmissionRecordContext, ClusterLedgerAdapters};
+use crate::cluster_ledger::record::CanonicalDigest;
+use crate::cluster_ledger::store::sqlite::SqliteLedgerStore;
+use crate::cluster_ledger::store::{LedgerClock, StoreError, SystemLedgerClock};
+use crate::cluster_ledger::{ClusterLedger, LedgerError, LedgerErrorKind, OwnerId, ResourceId};
+use crate::{NativeBackendFactory, ProductionNativeBackendFactory};
+
+pub const NATIVE_FENCE_TTL_MS: u64 = 2_000;
+pub const NATIVE_FENCE_RENEW_INTERVAL_MS: u64 = 500;
+const NATIVE_RUN_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeCatalogSnapshot<'a> {
+    version: u8,
+    workers: &'a [WorkerDescriptor],
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeProfileSnapshot<'a> {
+    descriptors: &'a [WorkerDescriptor],
+}
+
+#[derive(Clone, Debug)]
+struct NativeAdmissionRegistry {
+    descriptors: Arc<[WorkerDescriptor]>,
+    catalog_digest: CanonicalDigest,
+    profile_digest: CanonicalDigest,
+}
+
+impl NativeAdmissionRegistry {
+    fn empty() -> Self {
+        let descriptors: Arc<[WorkerDescriptor]> = Arc::from([]);
+        let catalog = canonical_value_bytes(
+            &serde_json::to_value(NativeCatalogSnapshot {
+                version: 1,
+                workers: &descriptors,
+            })
+            .expect("native catalog snapshot must serialize"),
+        )
+        .expect("native catalog snapshot must canonicalize");
+        let profile = canonical_value_bytes(
+            &serde_json::to_value(NativeProfileSnapshot {
+                descriptors: &descriptors,
+            })
+            .expect("native profile snapshot must serialize"),
+        )
+        .expect("native profile snapshot must canonicalize");
+        Self {
+            descriptors,
+            catalog_digest: CanonicalDigest::of(&catalog),
+            profile_digest: CanonicalDigest::of(&profile),
+        }
+    }
+
+    fn matches(&self, admission: &crate::cluster_ledger::replay::AdmissionState) -> bool {
+        admission.catalog_digest == self.catalog_digest
+            && admission.profile_digest == self.profile_digest
+    }
+}
+
+#[async_trait]
+impl WorkerRegistry for NativeAdmissionRegistry {
+    async fn resolve(&self, worker: &WorkerRef) -> Result<WorkerDescriptor, WorkerRegistryError> {
+        self.descriptors
+            .iter()
+            .find(|descriptor| descriptor.worker == *worker)
+            .cloned()
+            .ok_or_else(|| WorkerRegistryError::NotFound {
+                worker: worker.clone(),
+            })
+    }
+}
+
+type NativeAdmissionCoordinator =
+    AdmissionCoordinator<ProductionGraphVerifier<NativeAdmissionRegistry>, ClusterLedgerAdapters>;
+
+#[derive(Clone)]
+pub struct NativeBackend {
+    admission: NativeAdmissionCoordinator,
+    ledger: ClusterLedger,
+    lease_healthy: Arc<AtomicBool>,
+}
+
+impl NativeBackend {
+    fn new(
+        admission: NativeAdmissionCoordinator,
+        ledger: ClusterLedger,
+        lease_healthy: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            admission,
+            ledger,
+            lease_healthy,
+        }
+    }
+
+    async fn require_lease(&self) -> Result<(), BackendError> {
+        if self.lease_healthy.load(Ordering::Acquire) && self.ledger.check_fence().await.is_ok() {
+            return Ok(());
+        }
+        self.mark_lease_lost();
+        Err(BackendError::new(
+            INTERNAL_ERROR_CODE,
+            "native cluster lease is unavailable",
+        ))
+    }
+
+    fn mark_lease_lost(&self) {
+        self.lease_healthy.store(false, Ordering::Release);
+    }
+}
+
+#[async_trait]
+impl ClusterBackend for NativeBackend {
+    async fn initialize(
+        &self,
+        context: &ConnectionContext,
+        params: InitializeParams,
+    ) -> Result<InitializeResult, BackendError> {
+        self.require_lease().await?;
+        let result = self.admission.initialize_admission(context, params).await;
+        self.require_lease().await?;
+        result
+    }
+
+    async fn plan(
+        &self,
+        context: &ConnectionContext,
+        params: PlanParams,
+    ) -> Result<PlanResult, BackendError> {
+        self.require_lease().await?;
+        let result = self.admission.plan_admission(context, params).await;
+        self.require_lease().await?;
+        result
+    }
+
+    async fn apply(
+        &self,
+        context: &ConnectionContext,
+        params: ApplyParams,
+    ) -> Result<ApplyResult, BackendError> {
+        self.require_lease().await?;
+        let result = self.admission.apply_admission(context, params).await;
+        self.require_lease().await?;
+        result
+    }
+
+    async fn get(
+        &self,
+        context: &ConnectionContext,
+        params: GetParams,
+    ) -> Result<GetResult, BackendError> {
+        self.require_lease().await?;
+        let result = self.admission.get_admission(context, params).await;
+        self.require_lease().await?;
+        result
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum NativeAdmissionOpenError {
+    #[error("native admission storage failed: {0}")]
+    Store(#[from] StoreError),
+    #[error("native admission ledger failed: {0}")]
+    Ledger(#[from] LedgerError),
+    #[error("native admission identity does not match durable state")]
+    CompositionMismatch,
+}
+
+async fn create_or_reopen_raced_resource(
+    store: Arc<dyn crate::cluster_ledger::LedgerStore>,
+    resource: ResourceId,
+    owner: OwnerId,
+) -> Result<ClusterLedger, LedgerError> {
+    match ClusterLedger::create(
+        Arc::clone(&store),
+        resource.clone(),
+        owner.clone(),
+        NATIVE_FENCE_TTL_MS,
+    )
+    .await
+    {
+        Ok(ledger) => Ok(ledger),
+        Err(error)
+            if matches!(
+                error.kind(),
+                LedgerErrorKind::Storage(StoreError::ResourceExists)
+            ) =>
+        {
+            ClusterLedger::open(store, resource, owner, NATIVE_FENCE_TTL_MS).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn open_or_create_ledger(
+    store: Arc<dyn crate::cluster_ledger::LedgerStore>,
+    resource: ResourceId,
+    owner: OwnerId,
+) -> Result<ClusterLedger, LedgerError> {
+    match ClusterLedger::open(
+        Arc::clone(&store),
+        resource.clone(),
+        owner.clone(),
+        NATIVE_FENCE_TTL_MS,
+    )
+    .await
+    {
+        Ok(ledger) => Ok(ledger),
+        Err(error)
+            if matches!(
+                error.kind(),
+                LedgerErrorKind::Storage(StoreError::ResourceNotFound)
+            ) =>
+        {
+            create_or_reopen_raced_resource(store, resource, owner).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+impl ProductionNativeBackendFactory {
+    pub async fn open(
+        state_dir: &Path,
+        resource: ResourceId,
+        owner: OwnerId,
+    ) -> Result<Self, NativeAdmissionOpenError> {
+        let clock: Arc<dyn LedgerClock> = Arc::new(SystemLedgerClock);
+        Self::open_with_clock(state_dir, resource, owner, clock).await
+    }
+
+    async fn open_with_clock(
+        state_dir: &Path,
+        resource: ResourceId,
+        owner: OwnerId,
+        clock: Arc<dyn LedgerClock>,
+    ) -> Result<Self, NativeAdmissionOpenError> {
+        let store = Arc::new(SqliteLedgerStore::with_clock(
+            state_dir,
+            Arc::clone(&clock),
+        )?);
+        let store_port: Arc<dyn crate::cluster_ledger::LedgerStore> = store;
+        let ledger = open_or_create_ledger(store_port, resource, owner).await?;
+
+        let registry = NativeAdmissionRegistry::empty();
+        let recovered = ledger.state().await?;
+        if recovered
+            .admission
+            .as_ref()
+            .is_some_and(|admission| !registry.matches(admission))
+        {
+            return Err(NativeAdmissionOpenError::CompositionMismatch);
+        }
+        let admission_context = AdmissionRecordContext::new(
+            registry.catalog_digest,
+            registry.profile_digest,
+            clock,
+            NonZeroU64::new(NATIVE_RUN_TIMEOUT_MS).expect("native run timeout must be non-zero"),
+        );
+        let adapters = ClusterLedgerAdapters::new(ledger.clone(), admission_context);
+        let coordinator =
+            AdmissionCoordinator::new(ProductionGraphVerifier::new(registry), adapters);
+        let lease_healthy = Arc::new(AtomicBool::new(true));
+        Ok(Self {
+            backend: NativeBackend::new(coordinator, ledger, lease_healthy),
+        })
+    }
+
+    #[must_use]
+    pub fn ledger(&self) -> &ClusterLedger {
+        &self.backend.ledger
+    }
+
+    pub fn mark_lease_lost(&self) {
+        self.backend.mark_lease_lost();
+    }
+}
+
+impl NativeBackendFactory for ProductionNativeBackendFactory {
+    type Backend = NativeBackend;
+
+    fn create(&self) -> Self::Backend {
+        self.backend.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster_ledger::store::fake::ManualLedgerClock;
+    use openengine_cluster_protocol::{Generation, GraphSpec, IdempotencyKey};
+    use serde_json::{json, Value};
+
+    #[tokio::test]
+    async fn direct_composition_reads_its_committed_snapshot() {
+        let root =
+            std::env::temp_dir().join(format!("zeroshot-native-direct-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let factory = ProductionNativeBackendFactory::open(
+            &root,
+            ResourceId::new("direct").unwrap(),
+            OwnerId::new("direct-owner").unwrap(),
+        )
+        .await
+        .unwrap();
+        let backend = factory.create();
+        let graph: GraphSpec = serde_json::from_value(json!({
+            "profile": "openengine.graph.full/v1",
+            "initialInput": {"kind": "null"},
+            "policy": {"policy": "policy.default@1", "default": "deny"},
+            "root": {"kind": "succeed", "name": "done", "output": {"kind": "null"}, "bindings": []}
+        }))
+        .unwrap();
+        backend
+            .apply(
+                &ConnectionContext::default(),
+                ApplyParams {
+                    graph,
+                    input: Some(Value::Null),
+                    dry_run: false,
+                    if_generation: Some(Generation::new(0).unwrap()),
+                    idempotency_key: Some(IdempotencyKey::new("direct-apply").unwrap()),
+                },
+            )
+            .await
+            .unwrap();
+        let result = backend
+            .get(&ConnectionContext::default(), GetParams::default())
+            .await;
+        assert!(result.is_ok(), "{result:?}");
+        factory.ledger().release_fence().await.unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn pure_plan_fails_closed_after_the_authoritative_fence_expires() {
+        let root = std::env::temp_dir().join(format!(
+            "zeroshot-native-expired-plan-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let clock = Arc::new(ManualLedgerClock::new(1_000));
+        let ledger_clock: Arc<dyn LedgerClock> = clock.clone();
+        let factory = ProductionNativeBackendFactory::open_with_clock(
+            &root,
+            ResourceId::new("expired-plan").unwrap(),
+            OwnerId::new("expired-plan-owner").unwrap(),
+            ledger_clock,
+        )
+        .await
+        .unwrap();
+        let backend = factory.create();
+        clock.advance(NATIVE_FENCE_TTL_MS).unwrap();
+        let graph: GraphSpec = serde_json::from_value(json!({
+            "profile": "openengine.graph.full/v1",
+            "initialInput": {"kind": "null"},
+            "policy": {"policy": "policy.default@1", "default": "deny"},
+            "root": {"kind": "succeed", "name": "done", "output": {"kind": "null"}, "bindings": []}
+        }))
+        .unwrap();
+
+        assert!(
+            backend
+                .plan(&ConnectionContext::default(), PlanParams { graph })
+                .await
+                .is_err()
+        );
+
+        drop(backend);
+        drop(factory);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/zeroshot-rust/tests/architecture.rs
+++ b/zeroshot-rust/tests/architecture.rs
@@ -83,7 +83,6 @@ fn product_dependencies_stay_inside_native_contract_and_backend_boundaries() {
         );
     }
     for prohibited in [
-        "openengine-cluster-client",
         "openengine-cluster-testkit",
         "postgres",
         "sqlx",
@@ -96,11 +95,19 @@ fn product_dependencies_stay_inside_native_contract_and_backend_boundaries() {
             "prohibited native dependency: {prohibited}"
         );
     }
+    assert!(
+        !dependencies.contains(&("openengine-cluster-client".to_owned(), "normal".to_owned())),
+        "cluster client is test-only and must not enter the native runtime"
+    );
+    assert!(
+        dependencies.contains(&("openengine-cluster-client".to_owned(), "dev".to_owned())),
+        "the process proof must use the real Rust cluster client"
+    );
 }
 
 #[test]
 fn runtime_reuses_the_protocol_backend_and_production_dispatcher() {
-    let runtime = runtime_source();
+    let runtime = rust_sources(&["src/lib.rs", "src/main.rs", "src/native_admission.rs"]);
     for required in [
         "openengine_cluster_protocol",
         "ClusterBackend",
@@ -142,7 +149,6 @@ fn runtime_does_not_copy_protocol_or_server_types() {
 fn runtime_has_no_alternate_runtime_seams() {
     let runtime = runtime_source();
     for forbidden_code in [
-        "std::process",
         "Command::new",
         "pub mod transport",
         "pub mod client",
@@ -174,9 +180,7 @@ fn runtime_has_no_future_product_concerns() {
         "fallback",
         "benchmark",
         "selector",
-        "transport",
         "persistence",
-        "verifier",
     ] {
         assert!(
             !words.contains(forbidden_word),
@@ -225,14 +229,14 @@ fn product_errors_are_one_private_projection_without_command_or_daemon_host_beha
 }
 
 #[test]
-fn manifest_has_no_client_testkit_or_node_dependencies() {
+fn manifest_keeps_the_cluster_client_dev_only_and_excludes_testkit_or_node() {
     let manifest = read(&product_root().join("Cargo.toml"));
-    for forbidden_dependency in [
-        "openengine-cluster-client",
-        "openengine-cluster-testkit",
-        "node",
-        "npm",
-    ] {
+    let (runtime, dev) = manifest
+        .split_once("[dev-dependencies]")
+        .expect("native manifest must declare dev dependencies");
+    assert!(!runtime.contains("openengine-cluster-client"));
+    assert!(dev.contains("openengine_cluster_client.workspace = true"));
+    for forbidden_dependency in ["openengine-cluster-testkit", "node", "npm"] {
         assert!(
             !manifest.contains(forbidden_dependency),
             "forbidden product dependency: {forbidden_dependency}"
@@ -284,6 +288,7 @@ fn product_modules_require_issue_authorization() {
             "cluster_ledger.rs",
             "daemon_auth.rs",
             "daemon_discovery.rs",
+            "daemon_listener",
             "daemon_listener.rs",
             "execution",
             "execution.rs",
@@ -297,6 +302,7 @@ fn product_modules_require_issue_authorization() {
             "main.rs",
             "native_credentials",
             "native_credentials.rs",
+            "native_admission.rs",
             "native_settings",
             "native_settings.rs",
             "observability.rs",

--- a/zeroshot-rust/tests/artifact_storage_architecture.rs
+++ b/zeroshot-rust/tests/artifact_storage_architecture.rs
@@ -58,12 +58,15 @@ fn artifact_storage_stays_product_private_and_receipts_stay_byte_free() {
     }
 
     let lib = read(&product.join("src/lib.rs"));
+    let native_admission = read(&product.join("src/native_admission.rs"));
     assert!(
-        lib.contains("pub struct NativeBackend;"),
-        "NativeBackend must remain uninjected until composition issue #693"
+        native_admission.contains("pub struct NativeBackend"),
+        "NativeBackend must own the direct admission composition"
     );
     assert!(!lib.contains("ArtifactStore>"));
     assert!(!lib.contains("artifact_store:"));
+    assert!(!native_admission.contains("ArtifactStore>"));
+    assert!(!native_admission.contains("artifact_store:"));
 
     let lifecycle_and_backend = format!(
         "{}\n{}\n{}",

--- a/zeroshot-rust/tests/backend_boundary.rs
+++ b/zeroshot-rust/tests/backend_boundary.rs
@@ -1,120 +1,14 @@
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
     ClusterStatus, Cursor, GetParams, GetResult, InitializeParams, InitializeResult,
-    ServerCapabilities, APPLICATION_ERROR, INVALID_PHASE, PROTOCOL_VERSION,
+    ServerCapabilities,
 };
 use openengine_cluster_server::identity::{
     BindingAttributes, ConnectionIdentity, ConnectionIdentityConfig, PrincipalId, TenantId,
 };
 use openengine_cluster_server::{BackendError, ClusterBackend, ConnectionContext};
 use serde_json::{json, Value};
-use zeroshot_engine::{dispatcher_for_route, NativeBackendFactory, ProductionNativeBackendFactory};
-
-fn graph() -> Value {
-    json!({
-        "profile": "openengine.graph.single-worker/v1",
-        "initialInput": {"kind": "null"},
-        "policy": {"policy": "policy.default@1", "default": "deny"},
-        "root": {
-            "kind": "step",
-            "name": "worker",
-            "worker": "legacy.zeroshot.ship@1",
-            "input": {"kind": "null"},
-            "output": {"kind": "null"},
-            "inputBindings": [],
-            "writeBindings": [],
-            "timeoutMs": 1,
-            "attempts": 1
-        }
-    })
-}
-
-async fn dispatch(method: &str, params: Value) -> Value {
-    let dispatcher = dispatcher_for_route(
-        &ProductionNativeBackendFactory,
-        ConnectionContext::default(),
-    );
-    let response = dispatcher
-        .dispatch(
-            &json!({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).to_string(),
-        )
-        .await;
-    serde_json::from_str(&response).expect("dispatcher response must be JSON")
-}
-
-fn empty_status() -> Value {
-    json!({
-        "phase": "empty",
-        "observedGeneration": null,
-        "currentRunId": null,
-        "atCursor": null
-    })
-}
-
-#[tokio::test]
-async fn production_dispatcher_returns_canonical_empty_initialize_and_get() {
-    let initialize = dispatch("initialize", json!({"protocolVersion": PROTOCOL_VERSION})).await;
-    assert_eq!(
-        initialize["result"],
-        json!({
-            "protocolVersion": PROTOCOL_VERSION,
-            "capabilities": { "graphProfiles": [], "logs": false, "agentAttach": false },
-            "status": empty_status()
-        })
-    );
-    assert_eq!(
-        initialize["result"]["capabilities"],
-        json!({ "graphProfiles": [], "logs": false, "agentAttach": false })
-    );
-
-    let get = dispatch("get", json!({"atCursor": null})).await;
-    assert_eq!(
-        get["result"],
-        json!({"spec": null, "status": empty_status(), "atCursor": null})
-    );
-}
-
-#[tokio::test]
-async fn valid_unsupported_operations_reach_backend_defaults() {
-    let requests = [
-        ("plan", json!({"graph": graph()})),
-        (
-            "apply",
-            json!({
-                "graph": graph(),
-                "input": null,
-                "dryRun": false,
-                "idempotencyKey": "apply-1"
-            }),
-        ),
-        (
-            "update",
-            json!({
-                "suspended": true,
-                "ifGeneration": 1,
-                "idempotencyKey": "update-1"
-            }),
-        ),
-        (
-            "stop",
-            json!({
-                "mode": "drain",
-                "ifGeneration": 1,
-                "idempotencyKey": "stop-1"
-            }),
-        ),
-    ];
-
-    for (method, params) in requests {
-        let response = dispatch(method, params).await;
-        assert_eq!(response["error"]["code"], APPLICATION_ERROR, "{method}");
-        assert_eq!(
-            response["error"]["data"]["code"], INVALID_PHASE,
-            "{method} must reach the backend default"
-        );
-        assert!(response.get("result").is_none(), "{method}");
-    }
-}
+use zeroshot_engine::{dispatcher_for_route, NativeBackendFactory};
 
 struct FakeFactory;
 

--- a/zeroshot-rust/tests/cluster_ledger_replay/protocol.rs
+++ b/zeroshot-rust/tests/cluster_ledger_replay/protocol.rs
@@ -1,12 +1,23 @@
 use super::races::assert_protocol_store_adapters;
 use super::snapshot_race_store::race_ledger;
 use super::*;
+use std::num::NonZeroU64;
+use zeroshot_engine::cluster_ledger::adapters::AdmissionRecordContext;
+
+fn admission_context() -> AdmissionRecordContext {
+    AdmissionRecordContext::new(
+        CanonicalDigest::of(b"test-catalog"),
+        CanonicalDigest::of(b"test-profile"),
+        Arc::new(ManualLedgerClock::new(1_000)),
+        NonZeroU64::new(10_000).unwrap(),
+    )
+}
 
 #[tokio::test]
 async fn protocol_adapters_fold_control_and_lifecycle_from_one_empty_prefix() {
     assert_protocol_store_adapters::<ClusterLedgerAdapters>();
     let (_, ledger) = ledger("adapter-prefix").await;
-    let adapters = ClusterLedgerAdapters::new(ledger);
+    let adapters = ClusterLedgerAdapters::new(ledger, admission_context());
     let (admission, lifecycle) = adapters.read_aggregate().await.unwrap();
     assert_eq!(
         admission.control.phase,
@@ -19,11 +30,54 @@ async fn protocol_adapters_fold_control_and_lifecycle_from_one_empty_prefix() {
 #[tokio::test]
 async fn protocol_admission_adapter_commits_control_seed_and_receipt_atomically() {
     let (store, ledger) = race_ledger("adapter-admission").await;
-    let adapters = ClusterLedgerAdapters::new(ledger);
+    let adapters = ClusterLedgerAdapters::new(ledger, admission_context());
     let proposal = admission_proposal();
     let (changed, generation) = exercise_initial_commits(&adapters, proposal).await;
     assert_running_aggregate(&adapters).await;
     exercise_changed_commit(&store, &adapters, changed, generation).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_admission_adapter_reconciles_a_position_race_as_generation_conflict() {
+    let (store, ledger) = race_ledger("adapter-generation-race").await;
+    let adapters = ClusterLedgerAdapters::new(ledger, admission_context());
+    let first = admission_proposal();
+    let mut second = first.clone();
+    second.idempotency_key =
+        openengine_cluster_protocol::IdempotencyKey::new("adapter-apply-second").unwrap();
+    second.fingerprint = openengine_cluster_protocol::admission_fingerprint(
+        "apply",
+        &serde_json::json!({"fixture": "adapter-second"}),
+    )
+    .unwrap();
+    store.arm();
+
+    let first_adapters = adapters.clone();
+    let first = tokio::spawn(async move {
+        first_adapters
+            .commit(first, &CancellationSignal::default())
+            .await
+    });
+    let second_adapters = adapters.clone();
+    let second = tokio::spawn(async move {
+        second_adapters
+            .commit(second, &CancellationSignal::default())
+            .await
+    });
+    let outcomes = [first.await.unwrap(), second.await.unwrap()];
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(
+                outcome,
+                Err(openengine_cluster_server::admission::StoreError::GenerationConflict {
+                    current: Some(current)
+                }) if current.get() == 1
+            ))
+            .count(),
+        1
+    );
 }
 
 fn fixture<T: serde::de::DeserializeOwned>(relative: &str) -> T {
@@ -116,7 +170,7 @@ async fn assert_running_aggregate(adapters: &ClusterLedgerAdapters) {
     );
     assert!(admission.control.spec.is_some());
     assert!(admission.control.compiled_ir.is_some());
-    assert_eq!(admission.seed.as_ref().unwrap().cursor.as_str(), "ledger:2");
+    assert_eq!(admission.seed.as_ref().unwrap().cursor.as_str(), "ledger:4");
     assert_eq!(
         admission.control.cursor.as_ref().unwrap().as_str(),
         "ledger:4"

--- a/zeroshot-rust/tests/cluster_ledger_replay/snapshot_race_store.rs
+++ b/zeroshot-rust/tests/cluster_ledger_replay/snapshot_race_store.rs
@@ -70,6 +70,10 @@ impl LedgerStore for SnapshotRaceStore {
         self.inner.renew_fence(fence, ttl_ms).await
     }
 
+    async fn release_fence(&self, fence: &Fence) -> Result<(), StoreError> {
+        self.inner.release_fence(fence).await
+    }
+
     async fn check_fence(&self, fence: &Fence) -> Result<(), StoreError> {
         self.inner.check_fence(fence).await
     }

--- a/zeroshot-rust/tests/ledger_store_contract.rs
+++ b/zeroshot-rust/tests/ledger_store_contract.rs
@@ -66,3 +66,95 @@ async fn fence_expiry_takeover_and_stale_owner_rejection_are_deterministic() {
         std::fs::remove_dir_all(root).unwrap();
     }
 }
+
+#[tokio::test]
+async fn exact_release_preserves_epoch_and_rejects_stale_renew_or_release() {
+    for sqlite in [false, true] {
+        let clock = ManualLedgerClock::new(20);
+        let root = temp_root("release-fence");
+        let store: Arc<dyn LedgerStore> = if sqlite {
+            Arc::new(SqliteLedgerStore::with_clock(&root, clock.clone()).unwrap())
+        } else {
+            Arc::new(FakeLedgerStore::new(clock.clone()))
+        };
+        let resource = resource(if sqlite {
+            "sqlite-release-fence"
+        } else {
+            "fake-release-fence"
+        });
+        store.create(&resource).await.unwrap();
+        let first = store
+            .acquire_fence(&resource, &owner("first"), 50)
+            .await
+            .unwrap();
+        store.release_fence(&first).await.unwrap();
+
+        let second = store
+            .acquire_fence(&resource, &owner("second"), 50)
+            .await
+            .unwrap();
+        assert_eq!(second.epoch, first.epoch + 1);
+        assert!(matches!(
+            store.renew_fence(&first, 50).await,
+            Err(StoreError::StaleFence)
+        ));
+        assert!(matches!(
+            store.release_fence(&first).await,
+            Err(StoreError::StaleFence)
+        ));
+
+        drop(store);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}
+
+#[tokio::test]
+async fn renewal_keeps_in_flight_same_epoch_operations_valid_but_release_exact() {
+    for sqlite in [false, true] {
+        let clock = ManualLedgerClock::new(30);
+        let root = temp_root("renewed-fence-operation");
+        let store: Arc<dyn LedgerStore> = if sqlite {
+            Arc::new(SqliteLedgerStore::with_clock(&root, clock.clone()).unwrap())
+        } else {
+            Arc::new(FakeLedgerStore::new(clock.clone()))
+        };
+        let resource = resource(if sqlite {
+            "sqlite-renewed-operation"
+        } else {
+            "fake-renewed-operation"
+        });
+        store.create(&resource).await.unwrap();
+        let acquired = store
+            .acquire_fence(&resource, &owner("owner"), 50)
+            .await
+            .unwrap();
+        let renewed = store.renew_fence(&acquired, 100).await.unwrap();
+
+        store.check_fence(&acquired).await.unwrap();
+        store
+            .compare_and_append(
+                &resource,
+                &acquired,
+                zeroshot_engine::cluster_ledger::store::Position::ZERO,
+                ledger_contract::one_record_batch(
+                    &resource,
+                    ledger_contract::OneRecordSpec {
+                        sequence: 1,
+                        previous_hash: [0; 32],
+                        payload: ledger_contract::cleanup_payload(b"renewed-operation"),
+                        receipt_key: "renewed-operation",
+                    },
+                ),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            store.release_fence(&acquired).await,
+            Err(StoreError::StaleFence)
+        ));
+        store.release_fence(&renewed).await.unwrap();
+
+        drop(store);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/zeroshot-rust/tests/legacy_ledger_store_compatibility.rs
+++ b/zeroshot-rust/tests/legacy_ledger_store_compatibility.rs
@@ -58,6 +58,10 @@ impl LedgerStore for LegacyStore {
         LedgerStore::renew_fence(&self.inner, fence, ttl_ms).await
     }
 
+    async fn release_fence(&self, fence: &Fence) -> Result<(), StoreError> {
+        LedgerStore::release_fence(&self.inner, fence).await
+    }
+
     async fn check_fence(&self, fence: &Fence) -> Result<(), StoreError> {
         LedgerStore::check_fence(&self.inner, fence).await
     }

--- a/zeroshot-rust/tests/native_admission_concurrency.rs
+++ b/zeroshot-rust/tests/native_admission_concurrency.rs
@@ -1,0 +1,166 @@
+#[path = "support/native_process.rs"]
+mod native_process;
+
+use native_process::{spawn, TempState};
+use openengine_cluster_client::ClientError;
+use openengine_cluster_protocol::{
+    ApplyParams, Generation, GraphSpec, IdempotencyKey, GENERATION_CONFLICT, IDEMPOTENCY_REUSE,
+};
+use serde_json::{json, Value};
+
+fn graph(name: &str) -> GraphSpec {
+    serde_json::from_value(json!({
+        "profile": "openengine.graph.full/v1",
+        "initialInput": {"kind": "null"},
+        "policy": {"policy": "policy.default@1", "default": "deny"},
+        "root": {
+            "kind": "succeed",
+            "name": name,
+            "output": {"kind": "null"},
+            "bindings": []
+        }
+    }))
+    .unwrap()
+}
+
+fn apply(name: &str, key: &str) -> ApplyParams {
+    ApplyParams {
+        graph: graph(name),
+        input: Some(Value::Null),
+        dry_run: false,
+        if_generation: Some(Generation::new(0).unwrap()),
+        idempotency_key: Some(IdempotencyKey::new(key).unwrap()),
+    }
+}
+
+fn upsert(name: &str, key: &str) -> ApplyParams {
+    ApplyParams {
+        if_generation: None,
+        ..apply(name, key)
+    }
+}
+
+fn code(error: &ClientError) -> Option<&str> {
+    let ClientError::Rpc(error) = error else {
+        return None;
+    };
+    error.data.as_ref().map(|data| data.code.as_str())
+}
+
+async fn assert_distinct_generation_race() {
+    let distinct_state = TempState::new("concurrency-distinct");
+    let (distinct_process, distinct_client) = spawn(distinct_state.path(), "distinct");
+    distinct_client.initialize().await.unwrap();
+    let (first, second) = tokio::join!(
+        distinct_client.apply(apply("first", "key-first")),
+        distinct_client.apply(apply("second", "key-second")),
+    );
+    let outcomes = [first, second];
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter_map(|outcome| outcome.as_ref().err())
+            .filter(|error| code(error) == Some(GENERATION_CONFLICT))
+            .count(),
+        1
+    );
+    drop(distinct_client);
+    distinct_process.join_success().await;
+}
+
+async fn assert_identical_key_race() {
+    let identical_state = TempState::new("concurrency-identical");
+    let (identical_process, identical_client) = spawn(identical_state.path(), "identical");
+    identical_client.initialize().await.unwrap();
+    let request = apply("same", "same-key");
+    let (first, second) = tokio::join!(
+        identical_client.apply(request.clone()),
+        identical_client.apply(request),
+    );
+    let first = first.unwrap();
+    let second = second.unwrap();
+    assert_ne!(first.deduped, second.deduped);
+    assert_eq!(first.generation, second.generation);
+    assert_eq!(first.run_id, second.run_id);
+    drop(identical_client);
+    identical_process.join_success().await;
+}
+
+async fn assert_conflicting_reuse_race() {
+    let reuse_state = TempState::new("concurrency-reuse");
+    let (reuse_process, reuse_client) = spawn(reuse_state.path(), "reuse");
+    reuse_client.initialize().await.unwrap();
+    let (first, second) = tokio::join!(
+        reuse_client.apply(apply("left", "reused-key")),
+        reuse_client.apply(apply("right", "reused-key")),
+    );
+    let outcomes = [first, second];
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter_map(|outcome| outcome.as_ref().err())
+            .filter(|error| code(error) == Some(IDEMPOTENCY_REUSE))
+            .count(),
+        1
+    );
+    drop(reuse_client);
+    reuse_process.join_success().await;
+}
+
+async fn assert_omitted_generation_upsert_race() {
+    let upsert_state = TempState::new("concurrency-upsert");
+    let (upsert_process, upsert_client) = spawn(upsert_state.path(), "upsert");
+    upsert_client.initialize().await.unwrap();
+    let (first, second) = tokio::join!(
+        upsert_client.apply(upsert("first", "upsert-first")),
+        upsert_client.apply(upsert("second", "upsert-second")),
+    );
+    let mut generations = [
+        first.unwrap().generation.unwrap().get(),
+        second.unwrap().generation.unwrap().get(),
+    ];
+    generations.sort_unstable();
+    assert_eq!(generations, [1, 2]);
+    drop(upsert_client);
+    upsert_process.join_success().await;
+}
+
+async fn assert_unchanged_distinct_key_race() {
+    let unchanged_state = TempState::new("concurrency-unchanged");
+    let (mut unchanged_process, unchanged_client) = spawn(unchanged_state.path(), "unchanged");
+    unchanged_client.initialize().await.unwrap();
+    let seeded = unchanged_client
+        .apply(apply("same", "unchanged-seed"))
+        .await
+        .unwrap();
+    let unchanged = |key: &str| ApplyParams {
+        graph: graph("same"),
+        input: None,
+        dry_run: false,
+        if_generation: Some(Generation::new(1).unwrap()),
+        idempotency_key: Some(IdempotencyKey::new(key).unwrap()),
+    };
+    let (first, second) = tokio::join!(
+        unchanged_client.apply(unchanged("unchanged-first")),
+        unchanged_client.apply(unchanged("unchanged-second")),
+    );
+    for result in [first.unwrap(), second.unwrap()] {
+        assert!(!result.deduped);
+        assert_eq!(result.generation, seeded.generation);
+        assert_eq!(result.run_id, seeded.run_id);
+    }
+    unchanged_process.kill().await;
+    drop(unchanged_client);
+    let _ = unchanged_process.join_failure().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn process_admission_races_have_exact_domain_outcomes() {
+    assert_distinct_generation_race().await;
+    assert_identical_key_race().await;
+    assert_conflicting_reuse_race().await;
+    assert_omitted_generation_upsert_race().await;
+    assert_unchanged_distinct_key_race().await;
+}

--- a/zeroshot-rust/tests/native_admission_process.rs
+++ b/zeroshot-rust/tests/native_admission_process.rs
@@ -1,0 +1,319 @@
+#[path = "support/native_process.rs"]
+mod native_process;
+
+use std::sync::Arc;
+
+use native_process::{spawn, NativeClient, TempState};
+use openengine_cluster_client::{ClientError, ClusterClient};
+use openengine_cluster_protocol::{
+    canonical_value_bytes, ApplyParams, Generation, GetParams, GetResult, GraphSpec,
+    IdempotencyKey, PlanParams, Phase, GENERATION_CONFLICT, GRAPH_INVALID, IDEMPOTENCY_REUSE,
+};
+use serde_json::{json, Value};
+use tokio::time::{sleep, Duration};
+use zeroshot_engine::cluster_ledger::record::CanonicalDigest;
+use zeroshot_engine::cluster_ledger::replay::replay;
+use zeroshot_engine::cluster_ledger::store::sqlite::{database_path, SqliteLedgerStore};
+use zeroshot_engine::cluster_ledger::store::LedgerStore;
+use zeroshot_engine::cluster_ledger::ResourceId;
+use zeroshot_engine::NATIVE_FENCE_TTL_MS;
+
+fn succeed_graph(name: &str) -> GraphSpec {
+    serde_json::from_value(json!({
+        "profile": "openengine.graph.full/v1",
+        "initialInput": {"kind": "null"},
+        "policy": {"policy": "policy.default@1", "default": "deny"},
+        "root": {
+            "kind": "succeed",
+            "name": name,
+            "output": {"kind": "null"},
+            "bindings": []
+        }
+    }))
+    .unwrap()
+}
+
+fn unresolved_worker_graph() -> GraphSpec {
+    serde_json::from_value(json!({
+        "profile": "openengine.graph.full/v1",
+        "initialInput": {"kind": "null"},
+        "policy": {"policy": "policy.default@1", "default": "deny"},
+        "root": {
+            "kind": "step",
+            "name": "worker",
+            "worker": "worker.unavailable@1",
+            "input": {"kind": "null"},
+            "output": {"kind": "null"},
+            "inputBindings": [],
+            "writeBindings": [],
+            "timeoutMs": 1,
+            "attempts": 1
+        }
+    }))
+    .unwrap()
+}
+
+fn committed_apply(graph: GraphSpec, key: &str, generation: u64) -> ApplyParams {
+    ApplyParams {
+        graph,
+        input: Some(Value::Null),
+        dry_run: false,
+        if_generation: Some(Generation::new(generation).unwrap()),
+        idempotency_key: Some(IdempotencyKey::new(key).unwrap()),
+    }
+}
+
+fn rpc_domain_code(error: &ClientError) -> Option<&str> {
+    let ClientError::Rpc(error) = error else {
+        return None;
+    };
+    error.data.as_ref().map(|data| data.code.as_str())
+}
+
+async fn assert_empty_initialize<T>(client: &ClusterClient<T>)
+where
+    T: openengine_cluster_client::JsonRpcTransport,
+{
+    let initialized = client.initialize().await.unwrap();
+    assert!(initialized.capabilities.graph_profiles.values().is_empty());
+    assert!(!initialized.capabilities.logs);
+    assert!(!initialized.capabilities.agent_attach);
+    assert_eq!(initialized.status.phase, Phase::Empty);
+}
+
+async fn assert_precommit_behavior(client: &NativeClient, graph: &GraphSpec) {
+    let plan = client
+        .plan(PlanParams {
+            graph: graph.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(plan.ok);
+    let dry_run = client
+        .apply(ApplyParams {
+            graph: graph.clone(),
+            input: None,
+            dry_run: true,
+            if_generation: Some(Generation::new(0).unwrap()),
+            idempotency_key: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(dry_run.generation, None);
+
+    let invalid = unresolved_worker_graph();
+    assert!(
+        !client
+            .plan(PlanParams {
+                graph: invalid.clone(),
+            })
+            .await
+            .unwrap()
+            .ok
+    );
+    let invalid_error = client
+        .apply(committed_apply(invalid, "invalid-apply", 0))
+        .await
+        .unwrap_err();
+    assert_eq!(rpc_domain_code(&invalid_error), Some(GRAPH_INVALID));
+    assert_eq!(
+        client.get(GetParams::default()).await.unwrap().status.phase,
+        Phase::Empty
+    );
+}
+
+async fn commit_and_read(client: &NativeClient, graph: &GraphSpec) -> (ApplyParams, GetResult) {
+    let request = committed_apply(graph.clone(), "apply-1", 0);
+    let applied = client.apply(request.clone()).await.unwrap();
+    assert_eq!(applied.generation.map(Generation::get), Some(1));
+    assert_eq!(applied.phase, Phase::Running);
+    assert!(!applied.deduped);
+    assert_eq!(
+        client.get(GetParams::default()).await.unwrap().status.phase,
+        Phase::Running
+    );
+    let replayed = client.apply(request.clone()).await.unwrap();
+    assert!(replayed.deduped);
+    assert_eq!(replayed.generation, applied.generation);
+    assert_eq!(replayed.run_id, applied.run_id);
+
+    let reuse_error = client
+        .apply(committed_apply(succeed_graph("different"), "apply-1", 0))
+        .await
+        .unwrap_err();
+    assert_eq!(rpc_domain_code(&reuse_error), Some(IDEMPOTENCY_REUSE));
+    let stale_error = client
+        .apply(committed_apply(succeed_graph("next"), "apply-stale", 0))
+        .await
+        .unwrap_err();
+    assert_eq!(rpc_domain_code(&stale_error), Some(GENERATION_CONFLICT));
+
+    let before = client.get(GetParams::default()).await.unwrap();
+    assert_eq!(before.spec, Some(graph.clone()));
+    assert!(before.at_cursor.is_some());
+    println!(
+        "before restart: {}",
+        serde_json::to_string(&before).unwrap()
+    );
+    (request, before)
+}
+
+async fn assert_persisted_admission_facts(state: &TempState, graph: &GraphSpec) {
+    let resource = ResourceId::new("cluster-a").unwrap();
+    let store: Arc<dyn LedgerStore> = Arc::new(SqliteLedgerStore::new(state.path()).unwrap());
+    let snapshot = store.read_prefix(&resource, None).await.unwrap();
+    let replayed_state = replay(&snapshot, &resource).unwrap();
+    let admitted = replayed_state.admission.unwrap();
+    let canonical_policy =
+        canonical_value_bytes(&serde_json::to_value(&graph.policy).unwrap()).unwrap();
+    assert_eq!(
+        admitted.policy_digest,
+        CanonicalDigest::of(&canonical_policy)
+    );
+    assert_eq!(
+        admitted.catalog_digest,
+        CanonicalDigest::of(b"{\"version\":1,\"workers\":[]}")
+    );
+    assert_eq!(
+        admitted.profile_digest,
+        CanonicalDigest::of(b"{\"descriptors\":[]}")
+    );
+    assert_ne!(admitted.absolute_deadline_ms, u64::MAX);
+    assert_eq!(replayed_state.mutation_receipts.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn real_binary_client_sqlite_and_restart_preserve_durable_admission() {
+    let state = TempState::new("admission-restart");
+    let graph = succeed_graph("done");
+    let (process, client) = spawn(state.path(), "cluster-a");
+
+    assert_empty_initialize(&client).await;
+    sleep(Duration::from_millis(NATIVE_FENCE_TTL_MS * 2 + 500)).await;
+    assert_eq!(
+        client.get(GetParams::default()).await.unwrap().status.phase,
+        Phase::Empty
+    );
+
+    assert_precommit_behavior(&client, &graph).await;
+    let (request, before) = commit_and_read(&client, &graph).await;
+
+    let (overlap, overlap_client) = spawn(state.path(), "cluster-a");
+    assert!(overlap_client.initialize().await.is_err());
+    drop(overlap_client);
+    let overlap_diagnostics = overlap.join_failure().await;
+    assert!(overlap_diagnostics.to_ascii_lowercase().contains("fence"));
+
+    drop(client);
+    process.join_success().await;
+
+    let (restart, restart_client) = spawn(state.path(), "cluster-a");
+    let initialized = restart_client.initialize().await.unwrap();
+    assert!(initialized.capabilities.graph_profiles.values().is_empty());
+    assert_eq!(initialized.status.phase, Phase::Running);
+    let after = restart_client.get(GetParams::default()).await.unwrap();
+    println!("after restart: {}", serde_json::to_string(&after).unwrap());
+    assert_eq!(after, before);
+    let restarted_replay = restart_client.apply(request).await.unwrap();
+    assert!(restarted_replay.deduped);
+    drop(restart_client);
+    restart.join_success().await;
+
+    assert_persisted_admission_facts(&state, &graph).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn crash_takeover_waits_for_ttl_but_clean_shutdown_does_not() {
+    let state = TempState::new("admission-crash");
+    let graph = succeed_graph("crash-preserved");
+    let request = committed_apply(graph, "crash-apply", 0);
+    let (mut crashed, client) = spawn(state.path(), "cluster-crash");
+    assert_empty_initialize(&client).await;
+    let applied = client.apply(request.clone()).await.unwrap();
+    let before = client.get(GetParams::default()).await.unwrap();
+    crashed.kill().await;
+    drop(client);
+    let _ = crashed.join_failure().await;
+
+    let (early, early_client) = spawn(state.path(), "cluster-crash");
+    assert!(early_client.initialize().await.is_err());
+    drop(early_client);
+    assert!(
+        early
+            .join_failure()
+            .await
+            .to_ascii_lowercase()
+            .contains("fence")
+    );
+
+    sleep(Duration::from_millis(NATIVE_FENCE_TTL_MS + 500)).await;
+    let (recovered, recovered_client) = spawn(state.path(), "cluster-crash");
+    let initialized = recovered_client.initialize().await.unwrap();
+    assert_eq!(initialized.status.phase, Phase::Running);
+    assert_eq!(
+        recovered_client.get(GetParams::default()).await.unwrap(),
+        before
+    );
+    let replayed = recovered_client.apply(request).await.unwrap();
+    assert!(replayed.deduped);
+    assert_eq!(replayed.generation, applied.generation);
+    assert_eq!(replayed.run_id, applied.run_id);
+    drop(recovered_client);
+    recovered.join_success().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn corrupt_history_and_renewal_loss_end_the_process_before_further_service() {
+    let corrupt_state = TempState::new("admission-corrupt");
+    let graph = succeed_graph("done");
+    let (seed, seed_client) = spawn(corrupt_state.path(), "cluster-corrupt");
+    assert_empty_initialize(&seed_client).await;
+    seed_client
+        .apply(committed_apply(graph, "seed", 0))
+        .await
+        .unwrap();
+    drop(seed_client);
+    seed.join_success().await;
+
+    let corrupt_resource = ResourceId::new("cluster-corrupt").unwrap();
+    let connection =
+        rusqlite::Connection::open(database_path(corrupt_state.path(), &corrupt_resource)).unwrap();
+    connection
+        .execute(
+            "UPDATE records SET record_hash = zeroblob(32) WHERE sequence = 1",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+    let (corrupt, corrupt_client) = spawn(corrupt_state.path(), "cluster-corrupt");
+    assert!(corrupt_client.initialize().await.is_err());
+    drop(corrupt_client);
+    assert!(corrupt.join_failure().await.contains("ledger"));
+
+    let lease_state = TempState::new("admission-lease-loss");
+    let (lost, lost_client) = spawn(lease_state.path(), "cluster-lease");
+    assert_empty_initialize(&lost_client).await;
+    sleep(Duration::from_millis(1_100)).await;
+    assert_eq!(
+        lost_client
+            .get(GetParams::default())
+            .await
+            .unwrap()
+            .status
+            .phase,
+        Phase::Empty
+    );
+    let lease_resource = ResourceId::new("cluster-lease").unwrap();
+    let connection =
+        rusqlite::Connection::open(database_path(lease_state.path(), &lease_resource)).unwrap();
+    connection
+        .execute(
+            "UPDATE fence SET owner_id = 'forced-owner', epoch = epoch + 1 WHERE singleton = 1",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+    let diagnostics = lost.join_failure().await;
+    assert!(diagnostics.contains("lease failed"));
+    assert!(lost_client.get(GetParams::default()).await.is_err());
+}

--- a/zeroshot-rust/tests/native_daemon_architecture.rs
+++ b/zeroshot-rust/tests/native_daemon_architecture.rs
@@ -21,6 +21,7 @@ fn native_daemon_modules_stay_on_the_discovery_auth_and_loopback_host_boundary()
         "src/daemon_auth.rs",
         "src/daemon_discovery.rs",
         "src/daemon_listener.rs",
+        "src/daemon_listener",
     ]);
     for required in [
         "authorize_request",

--- a/zeroshot-rust/tests/support/native_process.rs
+++ b/zeroshot-rust/tests/support/native_process.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use openengine_cluster_client::{ClusterClient, NdjsonTransport};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::{timeout, Duration};
+
+static NEXT_STATE_ROOT: AtomicU64 = AtomicU64::new(1);
+
+pub type NativeClient = ClusterClient<NdjsonTransport<ChildStdout, ChildStdin>>;
+
+pub struct TempState {
+    root: PathBuf,
+}
+
+impl TempState {
+    pub fn new(label: &str) -> Self {
+        let sequence = NEXT_STATE_ROOT.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "zeroshot-native-{label}-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        Self { root }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TempState {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+pub struct NativeProcess {
+    child: Child,
+}
+
+pub fn spawn(state_dir: &Path, cluster_id: &str) -> (NativeProcess, NativeClient) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_zeroshot-rust"))
+        .args([
+            "serve-stdio",
+            "--state-dir",
+            state_dir
+                .to_str()
+                .expect("temporary state path must be UTF-8"),
+            "--cluster-id",
+            cluster_id,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .unwrap();
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    (
+        NativeProcess { child },
+        ClusterClient::new(NdjsonTransport::new(stdout, stdin)),
+    )
+}
+
+impl NativeProcess {
+    pub async fn kill(&mut self) {
+        self.child.kill().await.unwrap();
+    }
+
+    pub async fn join_success(self) {
+        let output = timeout(Duration::from_secs(5), self.child.wait_with_output())
+            .await
+            .expect("native process must exit after EOF")
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "native process failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "successful native process wrote diagnostics: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    pub async fn join_failure(self) -> String {
+        let output = timeout(Duration::from_secs(5), self.child.wait_with_output())
+            .await
+            .expect("failed native process must exit promptly")
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "native process unexpectedly succeeded"
+        );
+        String::from_utf8(output.stderr).expect("native diagnostics must be UTF-8")
+    }
+}


### PR DESCRIPTION
## What changed

- compose a real admission-only native backend behind `zeroshot-rust serve-stdio`
- persist one cluster in SQLite with fenced ownership, clean release, and crash takeover
- exercise initialize, plan, apply, get, idempotency races, corruption, and restart through the real Rust client and binary
- keep watch, execution, providers, Node composition, and broader v1 certification deferred

## Why

This is the first bounded runnable Rust v2 increment. It turns the native executable from an empty stub into a durable admission process without introducing a second lifecycle authority.

## Validation

- `npm run opcore:check`
- `npm run protocol:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- focused native admission process, concurrency, ledger-store, server, architecture, and npm-shim suites
- full Node suite: 2827 passing, 18 pending

The full Rust workspace run exposed an unrelated timing assertion in the existing local-CAS recovery suite; the complete local-CAS binary and the specific test pass when rerun directly. No local-CAS source is changed here.

Closes #697