### PR TITLE
feat(zeroshot-rust): run one foreground native agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,8 @@ a configurable provider/model/driver surface, general worker registration, sched
 watch, retry, session reuse, or broader lifecycle authority. Secret material crosses only the
 non-cloneable, redacted final-spawn input after child environment clearing; it never enters generic
 runtime commands, debug output, graph/ledger state, or artifacts.
+Foreground lease stores are cluster-scoped; the workspace directory lock and durable marker own
+cross-cluster exclusion.
 Issue and source registries and identifiers remain independent; neither is a worker/model provider.
 Mutating source calls carry an exclusively borrowed, non-serializable verified-workspace capability;
 their serializable intent and closed operation-specific receipts contain only canonical workspace,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Graph verifier facade                 | `crates/openengine-cluster-server/src/graph_verifier.rs`                                                                         |
 | Graph verifier analysis               | `crates/openengine-cluster-server/src/graph_verifier/`                                                                           |
 | Native product construction           | `zeroshot-rust/`                                                                                                                 |
+| Native foreground agent               | `zeroshot-rust/src/native_execution/agent/`, `zeroshot-rust/src/native_execution/program/foreground.rs`                          |
 | Native admission composition          | `zeroshot-rust/src/native_admission.rs`, `zeroshot-rust/src/main.rs`                                                             |
 | Native release targets                | `distribution/zeroshot-rust-targets.json`                                                                                        |
 | Native npm binary shim                | `npm/zeroshot-rust/`                                                                                                             |
@@ -260,8 +261,13 @@ filesystem store, and must preserve ref-first release plus synchronized blob-the
 The narrow native stdio entrypoint composes one SQLite ledger resource and only
 initialize/plan/apply/get. It advertises no graph profile, renews one process-owned fence while
 serving, and on graceful EOF stops renewal before exact conditional fence release. It may execute
-only the fixed private deterministic checkpoint; it must not acquire provider/general-worker,
-scheduler, daemon-loop, watch, or broader lifecycle authority.
+only the fixed private deterministic checkpoint and the fixed attempts-1 foreground Codex program.
+The latter owns one canonical borrowed workspace, one startup credential snapshot, one private
+Codex process driver, one fixed greeting validator, and one product-local CAS. It must not acquire
+a configurable provider/model/driver surface, general worker registration, scheduler, daemon-loop,
+watch, retry, session reuse, or broader lifecycle authority. Secret material crosses only the
+non-cloneable, redacted final-spawn input after child environment clearing; it never enters generic
+runtime commands, debug output, graph/ledger state, or artifacts.
 Issue and source registries and identifiers remain independent; neither is a worker/model provider.
 Mutating source calls carry an exclusively borrowed, non-serializable verified-workspace capability;
 their serializable intent and closed operation-specific receipts contain only canonical workspace,
@@ -406,10 +412,13 @@ the reducer.
 Reducer dispatch and terminal appends require opaque authorizations bound to the exact graph/input/
 history digests, decision fields, and ledger position/hash that produced them; only a newly committed
 dispatch receipt authorizes a physical effect. The native production backend additionally permits
-one private exact `seq(step, succeed)` deterministic process proof while advertising no graph
-profile. It validates and settles that process synchronously, exposes the protocol-owned optional
-`GetResult.terminalResult`, refuses an active dispatch on reopen, and runs bounded settled-prefix
-terminal recovery only after fence renewal starts.
+one private exact `seq(step, succeed)` deterministic process proof and one exact foreground Codex
+program whose authored error choice closes declared worker failures. It advertises no graph profile.
+The same coordinator validates and settles both programs synchronously, exposes the protocol-owned
+optional `GetResult.terminalResult`, refuses an active dispatch on reopen, and runs bounded
+settled-prefix terminal recovery only after fence renewal starts. The foreground program publishes
+only trusted-validator output to its cluster-scoped local CAS; terminal reopen revalidates that
+exact `ArtifactRef` and its bytes before service.
 Graph syntax, payload subtyping, compiled IR, diagnostics, and artifact receipt Rust types remain
 authoritative protocol contracts. `ProductionGraphVerifier` is the one reusable production
 semantic verifier for `openengine.graph.full/v1`; it resolves workers through `WorkerRegistry` and

--- a/zeroshot-rust/src/execution/process.rs
+++ b/zeroshot-rust/src/execution/process.rs
@@ -9,6 +9,8 @@ mod session_runtime;
 mod spawn_recovery;
 
 use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::atomic::{compiler_fence, Ordering};
 
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -48,6 +50,61 @@ pub struct ProcessCommand {
     pub workspace: WorkspaceCapability,
     pub stdin: ProcessInput,
     pub deadline: Instant,
+}
+
+/// One consumed environment value for a process launch. The value is never cloneable or
+/// included in command debug output and is zeroed when the launch attempt has consumed it.
+pub(crate) struct ProcessSecretEnvironment {
+    name: &'static str,
+    value: Vec<u8>,
+}
+
+impl ProcessSecretEnvironment {
+    pub(crate) fn single(name: &'static str, value: &[u8]) -> Result<Self, ProcessRunnerError> {
+        if name.is_empty()
+            || value.is_empty()
+            || name.as_bytes().contains(&0)
+            || value.contains(&0)
+            || std::str::from_utf8(value).is_err()
+            || name.len().saturating_add(value.len()) > MAX_PROCESS_ENV_BYTES
+        {
+            return Err(ProcessRunnerError::InvalidCommand(
+                "secret process environment is invalid".to_owned(),
+            ));
+        }
+        Ok(Self {
+            name,
+            value: value.to_vec(),
+        })
+    }
+
+    fn apply(&self, command: &mut tokio::process::Command) {
+        let value = std::str::from_utf8(&self.value)
+            .expect("validated secret process environment is UTF-8");
+        command.env(self.name, value);
+    }
+}
+
+impl fmt::Debug for ProcessSecretEnvironment {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessSecretEnvironment")
+            .field("name", &self.name)
+            .field("value", &"[redacted]")
+            .finish()
+    }
+}
+
+impl Drop for ProcessSecretEnvironment {
+    fn drop(&mut self) {
+        for byte in &mut self.value {
+            // SAFETY: `byte` is a valid mutable pointer into the exclusively owned value.
+            unsafe {
+                std::ptr::write_volatile(byte, 0);
+            }
+        }
+        compiler_fence(Ordering::SeqCst);
+    }
 }
 
 impl ProcessCommand {
@@ -164,8 +221,28 @@ impl LocalProcessRunner {
         command: ProcessCommand,
         cancellation: DriverCancellation,
     ) -> Result<ProcessRunOutput, ProcessRunnerError> {
+        self.run_inner(command, None, cancellation).await
+    }
+
+    pub(crate) async fn run_with_secrets(
+        &self,
+        command: ProcessCommand,
+        secrets: ProcessSecretEnvironment,
+        cancellation: DriverCancellation,
+    ) -> Result<ProcessRunOutput, ProcessRunnerError> {
+        self.run_inner(command, Some(secrets), cancellation).await
+    }
+
+    async fn run_inner(
+        &self,
+        command: ProcessCommand,
+        secrets: Option<ProcessSecretEnvironment>,
+        cancellation: DriverCancellation,
+    ) -> Result<ProcessRunOutput, ProcessRunnerError> {
         command.validate()?;
-        let (process_tree, mut child) = launch_contained_child(&command, self.containment).await?;
+        let launched = launch_contained_child(&command, secrets.as_ref(), self.containment).await;
+        drop(secrets);
+        let (process_tree, mut child) = launched?;
         let mut event_rx = spawn_process_io(&mut child, command.stdin.into_inner());
         let state = drive_run(
             &process_tree,
@@ -295,12 +372,13 @@ fn inspect_process_tree(
 }
 async fn launch_contained_child(
     command: &ProcessCommand,
+    secrets: Option<&ProcessSecretEnvironment>,
     containment: ProcessContainment,
 ) -> Result<(platform::ProcessTreeHandle, tokio::process::Child), ProcessRunnerError> {
     let process_tree_registration = register_process_tree_for(containment).map_err(|_| {
         ProcessRunnerError::Launch("process containment registration failed".to_owned())
     })?;
-    let mut child = build_child_command(
+    let mut child_command = build_child_command(
         ChildCommandSpec {
             program: &command.program,
             argv: &command.argv,
@@ -308,9 +386,13 @@ async fn launch_contained_child(
             workspace: &command.workspace,
         },
         containment,
-    )
-    .spawn()
-    .map_err(|error| ProcessRunnerError::Launch(error.to_string()))?;
+    );
+    if let Some(secrets) = secrets {
+        secrets.apply(&mut child_command);
+    }
+    let mut child = child_command
+        .spawn()
+        .map_err(|error| ProcessRunnerError::Launch(error.to_string()))?;
     match capture_process_tree(process_tree_registration, &mut child) {
         Ok(process_tree) => Ok((process_tree, child)),
         Err(_) => {
@@ -396,3 +478,16 @@ async fn apply_termination(
 }
 
 pub use platform::ProcessCleanupEvidence;
+
+#[cfg(test)]
+mod secret_environment_tests {
+    use super::ProcessSecretEnvironment;
+
+    #[test]
+    fn debug_output_redacts_secret_material() {
+        let secret = ProcessSecretEnvironment::single("TOKEN", b"sensitive-value").unwrap();
+        let debug = format!("{secret:?}");
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains("sensitive-value"));
+    }
+}

--- a/zeroshot-rust/src/full_v1_reducer.rs
+++ b/zeroshot-rust/src/full_v1_reducer.rs
@@ -1,10 +1,6 @@
-//! Pure reduction of verifier-produced full-v1 graphs.
-//!
-//! This module deliberately accepts [`VerifiedGraph`], the result of
-//! [`ProductionGraphVerifier`](openengine_cluster_server::graph_verifier::ProductionGraphVerifier),
-//! rather than graph syntax or a directly constructed compiled value. All shape, type,
-//! binding, guard-domain, and bound proofs remain owned by that verifier. Reduction only applies
-//! those already-proven operations to durable values in authored order.
+//! Pure reduction of verifier-produced full-v1 graphs. It accepts [`VerifiedGraph`] rather than
+//! graph syntax or directly constructed IR; `ProductionGraphVerifier` owns shape, type, binding,
+//! guard-domain, and bound proofs while reduction applies proven operations in authored order.
 //! Reducer-issued mutation authorizations are opaque. Each binds a decision to the verified graph,
 //! canonical input, durable history, and exact snapshot, all revalidated before commit.
 //!
@@ -481,6 +477,10 @@ enum Status {
 }
 
 impl Status {
+    fn continuing(position: Position) -> Self {
+        Self::Continue { position }
+    }
+
     fn position(&self) -> Position {
         match self {
             Self::Pending => Position::MAX,
@@ -795,8 +795,7 @@ impl<'a> Engine<'a> {
             if mode == EvalMode::Probe || cutoff != Position::MAX {
                 return Ok(Status::Pending);
             }
-            let previous = matching.last().copied();
-            let node_instance = if let Some(previous) = previous {
+            let node_instance = if let Some(previous) = matching.last().copied() {
                 previous.node_instance
             } else {
                 let allocated = NodeInstanceId::new(self.next_node_instance)
@@ -837,7 +836,7 @@ impl<'a> Engine<'a> {
         if *position > cutoff {
             return Ok(Status::Pending);
         }
-        match outcome {
+        let promoted_bindings = match outcome {
             WorkerOutcome::Error { code, .. } => {
                 self.set_control(
                     context,
@@ -849,6 +848,7 @@ impl<'a> Engine<'a> {
                         map_indices,
                     },
                 );
+                &[]
             }
             WorkerOutcome::Verified { output, .. } if !verifier => {
                 apply_writes(
@@ -862,6 +862,7 @@ impl<'a> Engine<'a> {
                         map_indices,
                     },
                 )?;
+                write_bindings
             }
             WorkerOutcome::Verifier {
                 output,
@@ -892,11 +893,12 @@ impl<'a> Engine<'a> {
                         map_indices,
                     },
                 )?;
+                write_bindings
             }
             _ => return Err(ReducerError::InconsistentHistory),
-        }
-        if mode == EvalMode::Decide && !write_bindings.is_empty() {
-            let values = write_bindings
+        };
+        if mode == EvalMode::Decide && !promoted_bindings.is_empty() {
+            let values = promoted_bindings
                 .iter()
                 .map(|binding| {
                     Ok(PromotedValue {
@@ -912,9 +914,7 @@ impl<'a> Engine<'a> {
             });
         }
         self.continue_decision(name, mode);
-        Ok(Status::Continue {
-            position: *position,
-        })
+        Ok(Status::continuing(*position))
     }
 
     fn eval_choice(

--- a/zeroshot-rust/src/lib.rs
+++ b/zeroshot-rust/src/lib.rs
@@ -31,8 +31,9 @@ use openengine_cluster_server::{ClusterBackend, ConnectionContext, Dispatcher};
 pub mod fault;
 pub mod observability;
 pub use native_admission::{
-    run_deterministic_worker, NativeAdmissionOpenError, NativeBackend,
-    NATIVE_FENCE_RENEW_INTERVAL_MS, NATIVE_FENCE_TTL_MS, NATIVE_WORKER_MODE,
+    native_foreground_graph, run_deterministic_worker, run_greeting_validator,
+    NativeAdmissionOpenError, NativeBackend, NATIVE_FENCE_RENEW_INTERVAL_MS, NATIVE_FENCE_TTL_MS,
+    NATIVE_VALIDATOR_MODE, NATIVE_WORKER_MODE,
 };
 
 pub trait NativeBackendFactory {

--- a/zeroshot-rust/src/main.rs
+++ b/zeroshot-rust/src/main.rs
@@ -9,19 +9,19 @@ use tokio::sync::watch;
 
 use zeroshot_engine::cluster_ledger::{LedgerError, OwnerId, ResourceId};
 use zeroshot_engine::{
-    binding_for_route, run_deterministic_worker, NativeAdmissionOpenError,
+    binding_for_route, run_deterministic_worker, run_greeting_validator, NativeAdmissionOpenError,
     ProductionNativeBackendFactory, NATIVE_FENCE_RENEW_INTERVAL_MS, NATIVE_FENCE_TTL_MS,
-    NATIVE_WORKER_MODE,
+    NATIVE_VALIDATOR_MODE, NATIVE_WORKER_MODE,
 };
 
 #[derive(Debug, Error)]
 enum ProcessError {
-    #[error(
-        "usage: zeroshot-rust serve-stdio --state-dir <absolute-directory> --cluster-id <bounded-id>"
-    )]
+    #[error("invalid arguments for the native stdio entrypoint")]
     Usage,
     #[error("state directory must be an absolute path")]
     RelativeStateDirectory,
+    #[error("workspace must be a canonical absolute directory")]
+    InvalidWorkspace,
     #[error("process identity randomness is unavailable")]
     Randomness,
     #[error(transparent)]
@@ -32,22 +32,29 @@ enum ProcessError {
     Lease(#[from] LedgerError),
     #[error("native cluster lease renewal task failed")]
     RenewalTask,
+    #[error("native validation failed")]
+    Validation,
 }
 
 struct ServeArgs {
     state_dir: PathBuf,
     cluster_id: ResourceId,
+    workspace: PathBuf,
 }
 
 enum ProcessMode {
     Serve(ServeArgs),
     DeterministicWorker { effect_id: String },
+    GreetingValidator,
 }
 
 fn parse_args() -> Result<ProcessMode, ProcessError> {
     let args = std::env::args_os().skip(1).collect::<Vec<_>>();
     if let Some(effect_id) = parse_worker_args(&args)? {
         return Ok(ProcessMode::DeterministicWorker { effect_id });
+    }
+    if args.as_slice() == [NATIVE_VALIDATOR_MODE] {
+        return Ok(ProcessMode::GreetingValidator);
     }
     parse_serve_args(&args).map(ProcessMode::Serve)
 }
@@ -71,22 +78,65 @@ fn parse_worker_args(args: &[std::ffi::OsString]) -> Result<Option<String>, Proc
 }
 
 fn parse_serve_args(args: &[std::ffi::OsString]) -> Result<ServeArgs, ProcessError> {
-    let [command, state_flag, state_dir, cluster_flag, cluster_id] = args else {
-        return Err(ProcessError::Usage);
-    };
-    if command != "serve-stdio" || state_flag != "--state-dir" || cluster_flag != "--cluster-id" {
-        return Err(ProcessError::Usage);
-    }
+    let (state_dir, cluster_id, workspace) = serve_values(args)?;
     let state_dir = PathBuf::from(state_dir);
     if !state_dir.is_absolute() {
         return Err(ProcessError::RelativeStateDirectory);
     }
     let cluster_id = cluster_id.to_str().ok_or(ProcessError::Usage)?;
     let cluster_id = ResourceId::new(cluster_id).map_err(|_| ProcessError::Usage)?;
+    let workspace = canonical_workspace(workspace)?;
     Ok(ServeArgs {
         state_dir,
         cluster_id,
+        workspace,
     })
+}
+
+fn serve_values(
+    args: &[std::ffi::OsString],
+) -> Result<(&std::ffi::OsStr, &std::ffi::OsStr, &std::ffi::OsStr), ProcessError> {
+    let [
+        command,
+        state_flag,
+        state_dir,
+        cluster_flag,
+        cluster_id,
+        workspace_flag,
+        workspace,
+    ] = args
+    else {
+        return Err(ProcessError::Usage);
+    };
+    let actual = (
+        command.as_os_str(),
+        state_flag.as_os_str(),
+        cluster_flag.as_os_str(),
+        workspace_flag.as_os_str(),
+    );
+    let expected = (
+        std::ffi::OsStr::new("serve-stdio"),
+        std::ffi::OsStr::new("--state-dir"),
+        std::ffi::OsStr::new("--cluster-id"),
+        std::ffi::OsStr::new("--workspace"),
+    );
+    if actual != expected {
+        return Err(ProcessError::Usage);
+    }
+    Ok((state_dir, cluster_id, workspace))
+}
+
+fn canonical_workspace(workspace: &std::ffi::OsStr) -> Result<PathBuf, ProcessError> {
+    let supplied_workspace = PathBuf::from(workspace);
+    if !supplied_workspace.is_absolute() {
+        return Err(ProcessError::InvalidWorkspace);
+    }
+    let workspace =
+        std::fs::canonicalize(&supplied_workspace).map_err(|_| ProcessError::InvalidWorkspace)?;
+    if workspace != supplied_workspace {
+        return Err(ProcessError::InvalidWorkspace);
+    }
+    Ok(workspace)
 }
 
 fn process_owner() -> Result<OwnerId, ProcessError> {
@@ -108,13 +158,20 @@ async fn run() -> Result<(), ProcessError> {
             run_deterministic_worker(&effect_id)?;
             Ok(())
         }
+        ProcessMode::GreetingValidator => {
+            run_greeting_validator().map_err(|_| ProcessError::Validation)
+        }
     }
 }
 
 async fn serve(args: ServeArgs) -> Result<(), ProcessError> {
-    let factory =
-        ProductionNativeBackendFactory::open(&args.state_dir, args.cluster_id, process_owner()?)
-            .await?;
+    let factory = ProductionNativeBackendFactory::open(
+        &args.state_dir,
+        args.cluster_id,
+        process_owner()?,
+        &args.workspace,
+    )
+    .await?;
 
     let renewal_factory = factory.clone();
     let renewal_ledger = factory.ledger().clone();

--- a/zeroshot-rust/src/native_admission.rs
+++ b/zeroshot-rust/src/native_admission.rs
@@ -1,13 +1,11 @@
 //! Direct production composition for one narrow native cluster.
 
-#[path = "native_execution/agent/validator.rs"]
-mod native_agent_protocol;
 #[path = "native_execution.rs"]
 mod native_execution;
 #[path = "native_worker_protocol.rs"]
 mod native_worker_protocol;
 #[doc(hidden)]
-pub use native_agent_protocol::{run_greeting_validator, VALIDATOR_MODE as NATIVE_VALIDATOR_MODE};
+pub use native_execution::{run_greeting_validator, NATIVE_VALIDATOR_MODE};
 #[doc(hidden)]
 pub use native_worker_protocol::{run_deterministic_worker, WORKER_MODE as NATIVE_WORKER_MODE};
 

--- a/zeroshot-rust/src/native_admission.rs
+++ b/zeroshot-rust/src/native_admission.rs
@@ -1,9 +1,13 @@
 //! Direct production composition for one narrow native cluster.
 
+#[path = "native_execution/agent/validator.rs"]
+mod native_agent_protocol;
 #[path = "native_execution.rs"]
 mod native_execution;
 #[path = "native_worker_protocol.rs"]
 mod native_worker_protocol;
+#[doc(hidden)]
+pub use native_agent_protocol::{run_greeting_validator, VALIDATOR_MODE as NATIVE_VALIDATOR_MODE};
 #[doc(hidden)]
 pub use native_worker_protocol::{run_deterministic_worker, WORKER_MODE as NATIVE_WORKER_MODE};
 
@@ -28,14 +32,21 @@ use crate::cluster_ledger::store::sqlite::SqliteLedgerStore;
 use crate::cluster_ledger::store::{LedgerClock, StoreError, SystemLedgerClock};
 use crate::cluster_ledger::{ClusterLedger, LedgerError, LedgerErrorKind, OwnerId, ResourceId};
 use self::native_execution::{
-    is_worker_free_graph, NativeExecutionCoordinator, NativeExecutionError, NativeExecutionProcess,
-    NativeExecutionRegistry, NativeGraphVerifier,
+    is_deterministic_graph, is_worker_free_graph, NativeExecutionCoordinator, NativeExecutionError,
+    NativeExecutionProcess, NativeExecutionRegistry, NativeGraphVerifier,
 };
 use crate::{NativeBackendFactory, ProductionNativeBackendFactory};
 
 pub const NATIVE_FENCE_TTL_MS: u64 = 2_000;
 pub const NATIVE_FENCE_RENEW_INTERVAL_MS: u64 = 500;
 const NATIVE_RUN_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+
+/// Returns the one graph accepted by the private foreground-agent profile.
+#[doc(hidden)]
+#[must_use]
+pub fn native_foreground_graph() -> GraphSpec {
+    native_execution::foreground_graph()
+}
 
 type NativeAdmissionCoordinator = AdmissionCoordinator<NativeGraphVerifier, ClusterLedgerAdapters>;
 
@@ -176,18 +187,25 @@ async fn validate_predecessor_state(
     let Some(admission) = state.admission.as_ref() else {
         return Ok(true);
     };
-    let (catalog, profile) = NativeExecutionRegistry::predecessor_digests();
-    if admission.catalog_digest != catalog || admission.profile_digest != profile {
-        return Ok(false);
-    }
-    let (graph, compiled, graph_bytes) = reverify_predecessor(admission, verifier).await?;
-    if !is_worker_free_graph(&graph) {
-        return Ok(false);
-    }
-    let Some(verified_input) = state.verified_inputs.get(&admission.run) else {
+    let allows_deterministic = NativeExecutionRegistry::predecessor_digests()
+        .into_iter()
+        .find_map(|(catalog, profile, allows_deterministic)| {
+            (admission.catalog_digest == catalog && admission.profile_digest == profile)
+                .then_some(allows_deterministic)
+        });
+    let Some(allows_deterministic) = allows_deterministic else {
         return Ok(false);
     };
-    Ok([
+    let (graph, compiled, graph_bytes) = reverify_predecessor(admission, verifier)
+        .await
+        .map_err(|_| NativeAdmissionOpenError::Execution)?;
+    if !is_worker_free_graph(&graph) && !(allows_deterministic && is_deterministic_graph(&graph)) {
+        return Err(NativeAdmissionOpenError::Execution);
+    }
+    let Some(verified_input) = state.verified_inputs.get(&admission.run) else {
+        return Err(NativeAdmissionOpenError::Execution);
+    };
+    if [
         compiled == admission.canonical_compiled_ir,
         graph_bytes == admission.canonical_graph,
         CanonicalDigest::of(&graph_bytes) == admission.graph_digest,
@@ -195,7 +213,12 @@ async fn validate_predecessor_state(
         CanonicalDigest::of(&verified_input.canonical_bytes) == admission.input_digest,
     ]
     .into_iter()
-    .all(|matches| matches))
+    .all(|matches| matches)
+    {
+        Ok(true)
+    } else {
+        Err(NativeAdmissionOpenError::Execution)
+    }
 }
 
 async fn reverify_predecessor(
@@ -271,27 +294,48 @@ async fn open_or_create_ledger(
     }
 }
 
+struct NativeOpenConfig<'a> {
+    state_dir: &'a Path,
+    resource: ResourceId,
+    owner: OwnerId,
+    workspace: &'a Path,
+    clock: Arc<dyn LedgerClock>,
+}
+
 impl ProductionNativeBackendFactory {
     pub async fn open(
         state_dir: &Path,
         resource: ResourceId,
         owner: OwnerId,
+        workspace: &Path,
     ) -> Result<Self, NativeAdmissionOpenError> {
         let clock: Arc<dyn LedgerClock> = Arc::new(SystemLedgerClock);
-        Self::open_with_clock(state_dir, resource, owner, clock).await
+        Self::open_with_clock(NativeOpenConfig {
+            state_dir,
+            resource,
+            owner,
+            workspace,
+            clock,
+        })
+        .await
     }
 
     async fn open_with_clock(
-        state_dir: &Path,
-        resource: ResourceId,
-        owner: OwnerId,
-        clock: Arc<dyn LedgerClock>,
+        config: NativeOpenConfig<'_>,
     ) -> Result<Self, NativeAdmissionOpenError> {
+        let NativeOpenConfig {
+            state_dir,
+            resource,
+            owner,
+            workspace,
+            clock,
+        } = config;
         let store = Arc::new(SqliteLedgerStore::with_clock(
             state_dir,
             Arc::clone(&clock),
         )?);
         let store_port: Arc<dyn crate::cluster_ledger::LedgerStore> = store;
+        let native_resource = resource.clone();
         let ledger = open_or_create_ledger(store_port, resource, owner).await?;
 
         let registry = NativeExecutionRegistry::production();
@@ -317,10 +361,16 @@ impl ProductionNativeBackendFactory {
             verifier,
             registry,
             NativeExecutionProcess {
+                resource: native_resource,
                 state_dir: state_dir.to_path_buf(),
+                workspace: workspace.to_path_buf(),
                 executable,
+                path_snapshot: std::env::var_os("PATH"),
+                api_key_snapshot: std::env::var_os("OPENAI_API_KEY")
+                    .and_then(|value| value.into_string().ok()),
             },
-        );
+        )
+        .map_err(|_| NativeAdmissionOpenError::Execution)?;
         execution
             .validate_open_state()
             .await
@@ -372,14 +422,16 @@ mod tests {
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join(".git")).unwrap();
         let clock = Arc::new(ManualLedgerClock::new(1_000));
         let ledger_clock: Arc<dyn LedgerClock> = clock.clone();
-        let factory = ProductionNativeBackendFactory::open_with_clock(
-            &root,
-            ResourceId::new("expired-plan").unwrap(),
-            OwnerId::new("expired-plan-owner").unwrap(),
-            ledger_clock,
-        )
+        let factory = ProductionNativeBackendFactory::open_with_clock(NativeOpenConfig {
+            state_dir: &root,
+            resource: ResourceId::new("expired-plan").unwrap(),
+            owner: OwnerId::new("expired-plan-owner").unwrap(),
+            workspace: &root,
+            clock: ledger_clock,
+        })
         .await
         .unwrap();
         let backend = factory.create();

--- a/zeroshot-rust/src/native_credentials/resolver.rs
+++ b/zeroshot-rust/src/native_credentials/resolver.rs
@@ -127,6 +127,21 @@ impl<'a> NativeCredentialResolver<'a> {
         Ok(set)
     }
 
+    /// Product-private narrow acquisition for a catalog-declared requirement that does not use
+    /// the general admission manifest composition. Material remains borrowed for the callback
+    /// and the temporary lease is released immediately afterward.
+    pub(crate) fn with_requirement_material<R>(
+        &self,
+        requirement: &CredentialRequirementName,
+        budget: &AcquisitionBudget<'_>,
+        use_material: impl FnOnce(&[u8]) -> R,
+    ) -> Result<R, CredentialFault> {
+        self.validate_budget(requirement, budget)?;
+        let lease = self.resolve_one(requirement, budget)?;
+        super::CredentialCapability::from_lease(&lease, self.clock, self.observations)
+            .with_material(use_material)
+    }
+
     fn fault(
         &self,
         kind: CredentialFaultKind,

--- a/zeroshot-rust/src/native_execution.rs
+++ b/zeroshot-rust/src/native_execution.rs
@@ -7,6 +7,10 @@ use openengine_cluster_server::admission::GraphVerifier;
 use serde_json::Value;
 use thiserror::Error;
 
+#[path = "native_execution/agent.rs"]
+mod agent;
+#[path = "native_execution/command.rs"]
+mod command;
 #[path = "native_execution/process.rs"]
 mod process;
 #[path = "native_execution/program.rs"]
@@ -14,30 +18,26 @@ mod program;
 #[path = "native_execution/validation.rs"]
 mod validation;
 
-pub(crate) use process::NativeExecutionProcess;
-pub(crate) use program::{is_worker_free_graph, NativeExecutionRegistry, NativeGraphVerifier};
-use program::is_deterministic_graph;
+pub(crate) use program::{
+    foreground_graph, is_deterministic_graph, is_worker_free_graph, NativeExecutionRegistry,
+    NativeGraphVerifier,
+};
+use agent::{AgentWorkspaceAuthority, AgentWorkspacePreparation};
+use process::NativeExecutionRuntime;
+use program::{classify_graph, NativeProgram};
 
 use crate::cluster_ledger::record::CanonicalDigest;
-use crate::cluster_ledger::store::IdempotencyId;
 use crate::cluster_ledger::{ClusterLedger, LedgerError, ReplayState};
-use crate::execution::local::LocalExecutionRuntime;
-use crate::execution::{
-    BuiltinWorkerId, BuiltinWorkerRef, CatalogDigest, DispatchFence, ExecutionCommand,
-    ExecutionCommandSpec, ExecutionInput, ExecutionRuntime, ExecutionTargetRef, ProfileDigest,
-    RecoveryRef, RegistryDigest, SessionScope, WorkspaceAccessMode, WorkspaceAccessRef,
-};
 use crate::full_v1_reducer::{
     durable_executions_from_replay, Decision, FullV1Reducer, Reduction, ReductionInput,
 };
-use crate::native_admission::native_worker_protocol::{digest_hex, WORKER_REF};
 
 #[derive(Clone)]
 pub(crate) struct NativeExecutionCoordinator {
     ledger: ClusterLedger,
     verifier: Arc<NativeGraphVerifier>,
     registry: NativeExecutionRegistry,
-    runtime: LocalExecutionRuntime,
+    runtime: NativeExecutionRuntime,
     turn: Arc<tokio::sync::Mutex<()>>,
 }
 
@@ -49,8 +49,26 @@ pub(crate) enum NativeExecutionError {
     Verification,
     #[error("native execution contract construction failed")]
     Contract,
+    #[error("native execution preflight failed")]
+    Preflight,
     #[error("native execution ledger failed: {0}")]
     Ledger(#[from] LedgerError),
+}
+
+pub(crate) struct NativeExecutionProcess {
+    pub(crate) resource: crate::cluster_ledger::ResourceId,
+    pub(crate) state_dir: std::path::PathBuf,
+    pub(crate) workspace: std::path::PathBuf,
+    pub(crate) executable: std::path::PathBuf,
+    pub(crate) path_snapshot: Option<std::ffi::OsString>,
+    pub(crate) api_key_snapshot: Option<String>,
+}
+
+struct CommittedDispatch {
+    allocation: crate::cluster_ledger::DispatchAllocation,
+    worker: WorkerRef,
+    input: Value,
+    workspace: Option<AgentWorkspaceAuthority>,
 }
 
 impl NativeExecutionCoordinator {
@@ -59,14 +77,14 @@ impl NativeExecutionCoordinator {
         verifier: Arc<NativeGraphVerifier>,
         registry: NativeExecutionRegistry,
         process: NativeExecutionProcess,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, NativeExecutionError> {
+        Ok(Self {
             ledger,
             verifier,
             registry,
-            runtime: process::runtime(process),
+            runtime: process::runtime(process)?,
             turn: Arc::new(tokio::sync::Mutex::new(())),
-        }
+        })
     }
 
     pub(crate) async fn validate_open_state(&self) -> Result<(), NativeExecutionError> {
@@ -112,7 +130,10 @@ impl NativeExecutionCoordinator {
         };
         let graph: GraphSpec = serde_json::from_slice(&admission.canonical_graph)
             .map_err(|_| NativeExecutionError::InvalidState)?;
-        if !is_deterministic_graph(&graph) {
+        if !matches!(
+            classify_graph(&graph),
+            Some(NativeProgram::Deterministic | NativeProgram::ForegroundAgent)
+        ) {
             return Ok(None);
         }
         Ok(Some((state, graph)))
@@ -137,28 +158,122 @@ impl NativeExecutionCoordinator {
         graph: &GraphSpec,
         reduction: &Reduction,
     ) -> Result<Option<TerminalResult>, NativeExecutionError> {
+        let Some(mut dispatch) = self.commit_new_dispatch(reduction).await? else {
+            return Ok(None);
+        };
+        if let Some(outcome) = self.prepare_dispatch(state, &mut dispatch).await? {
+            let outcome = validation::canonical_outcome(&self.registry, &dispatch.worker, outcome)?;
+            return self
+                .settle_and_terminalize(graph, dispatch.allocation, outcome)
+                .await
+                .map(Some);
+        }
+        self.run_committed_dispatch(state, graph, dispatch).await
+    }
+
+    async fn commit_new_dispatch(
+        &self,
+        reduction: &Reduction,
+    ) -> Result<Option<CommittedDispatch>, NativeExecutionError> {
         let (execution, worker, input) = one_dispatch(reduction)?;
+        self.runtime.preflight(worker.as_str(), &input).await?;
         let authorization = reduction
             .dispatch_authorization(execution)
             .ok_or(NativeExecutionError::InvalidState)?;
         let committed = self
             .ledger
-            .dispatch_reduction(dispatch_key(reduction.run, execution)?, authorization)
+            .dispatch_reduction(
+                command::dispatch_key(reduction.run, execution)?,
+                authorization,
+            )
             .await?;
         if committed.replayed {
             return Ok(None);
         }
-        if worker.as_str() != WORKER_REF {
+        Ok(Some(CommittedDispatch {
+            allocation: committed.value,
+            worker,
+            input,
+            workspace: None,
+        }))
+    }
+
+    async fn prepare_dispatch(
+        &self,
+        state: &ReplayState,
+        dispatch: &mut CommittedDispatch,
+    ) -> Result<Option<openengine_cluster_protocol::WorkerOutcome>, NativeExecutionError> {
+        let prepared = self
+            .runtime
+            .prepare_workspace(
+                dispatch.worker.as_str(),
+                &state.resource,
+                &dispatch.allocation,
+            )
+            .await?;
+        match prepared {
+            Some(AgentWorkspacePreparation::Closed(outcome)) => Ok(Some(outcome)),
+            Some(AgentWorkspacePreparation::Ready(authority)) => {
+                dispatch.workspace = Some(authority);
+                Ok(None)
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn run_committed_dispatch(
+        &self,
+        state: &ReplayState,
+        graph: &GraphSpec,
+        mut dispatch: CommittedDispatch,
+    ) -> Result<Option<TerminalResult>, NativeExecutionError> {
+        let command = match command::build(
+            command::CommandRequest {
+                state,
+                allocation: dispatch.allocation.clone(),
+                input: dispatch.input,
+                worker: &dispatch.worker,
+            },
+            &self.registry,
+        ) {
+            Ok(command) => command,
+            Err(error) => {
+                finish_workspace(dispatch.workspace.take()).await?;
+                return Err(error);
+            }
+        };
+        let observation = self.runtime.dispatch(command).await;
+        if !matches!(
+            observation,
+            crate::execution::DispatchObservation::Completed { .. }
+        ) {
+            quarantine(dispatch.workspace.take());
             return Err(NativeExecutionError::InvalidState);
         }
-        let allocation = committed.value;
-        let command = self.command(state, allocation.clone(), input)?;
-        let observation = self.runtime.dispatch(command).await;
-        let outcome_bytes =
-            validation::validate_observation(&self.registry, &allocation, observation)?;
-        self.settle_and_terminalize(graph, allocation, outcome_bytes)
+        let outcome_bytes = match validation::validate_observation(
+            &self.registry,
+            &dispatch.worker,
+            &dispatch.allocation,
+            observation,
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                quarantine(dispatch.workspace.take());
+                return Err(error);
+            }
+        };
+        let terminal = match self
+            .settle_and_terminalize(graph, dispatch.allocation, outcome_bytes)
             .await
-            .map(Some)
+        {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                quarantine(dispatch.workspace.take());
+                return Err(error);
+            }
+        };
+        finish_workspace(dispatch.workspace.take()).await?;
+        Ok(Some(terminal))
     }
 
     async fn settle_and_terminalize(
@@ -171,7 +286,7 @@ impl NativeExecutionCoordinator {
         let settled = self
             .ledger
             .settle(
-                settlement_key(allocation.run, allocation.execution)?,
+                command::settlement_key(allocation.run, allocation.execution)?,
                 outcome_digest.as_bytes(),
                 allocation.execution,
                 outcome_digest,
@@ -196,7 +311,7 @@ impl NativeExecutionCoordinator {
             .terminal_authorization()
             .ok_or(NativeExecutionError::InvalidState)?;
         self.ledger
-            .terminalize_reduction(terminal_key(reduction.run)?, authorization)
+            .terminalize_reduction(command::terminal_key(reduction.run)?, authorization)
             .await?;
         Ok(())
     }
@@ -221,16 +336,17 @@ impl NativeExecutionCoordinator {
             .ok_or(NativeExecutionError::InvalidState)?;
         let graph: GraphSpec = serde_json::from_slice(&admission.canonical_graph)
             .map_err(|_| NativeExecutionError::InvalidState)?;
-        if !is_deterministic_graph(&graph) {
-            return Err(NativeExecutionError::InvalidState);
-        }
+        let reverify_artifact = terminal_program(&graph)?;
         let reduction = self.reduce(state, &graph).await?;
         let terminal = reduction
             .terminal
             .ok_or(NativeExecutionError::InvalidState)?;
-        let bytes = canonical_terminal_bytes(&terminal)?;
+        let bytes = validation::canonical_terminal_bytes(&terminal)?;
         if state.terminal_outcome != Some(CanonicalDigest::of(&bytes)) {
             return Err(NativeExecutionError::InvalidState);
+        }
+        if reverify_artifact {
+            self.runtime.reverify_agent_terminal(&terminal).await?;
         }
         Ok(terminal)
     }
@@ -282,35 +398,37 @@ impl NativeExecutionCoordinator {
         }
         Ok(verified)
     }
+}
 
-    fn command(
-        &self,
-        state: &ReplayState,
-        allocation: crate::cluster_ledger::DispatchAllocation,
-        input: Value,
-    ) -> Result<ExecutionCommand, NativeExecutionError> {
-        let admission = admission(state)?;
-        let (dispatch_fence, recovery_ref) = command_control_refs(&allocation)?;
-        let (catalog_digest, profile_digest, registry_digest) =
-            command_digests(admission, &self.registry)?;
-        ExecutionCommand::new(ExecutionCommandSpec {
-            cluster: state.resource.clone(),
-            run: allocation.run,
-            node_instance: allocation.node_instance,
-            execution: allocation.execution,
-            dispatch_fence,
-            recovery_ref,
-            target: command_target()?,
-            catalog_digest,
-            profile_digest,
-            registry_digest,
-            workspace: command_workspace(state)?,
-            input: command_input(input)?,
-            session_scope: SessionScope::Execution,
-            execution_deadline_ms: admission.absolute_deadline_ms,
-            session_deadline_ms: admission.absolute_deadline_ms,
-        })
-        .map_err(|_| NativeExecutionError::Contract)
+async fn finish_workspace(
+    authority: Option<AgentWorkspaceAuthority>,
+) -> Result<(), NativeExecutionError> {
+    let Some(authority) = authority else {
+        return Ok(());
+    };
+    match authority.finish_effect().await {
+        Ok(authority) => {
+            drop(authority);
+            Ok(())
+        }
+        Err(authority) => {
+            authority.quarantine();
+            Err(NativeExecutionError::InvalidState)
+        }
+    }
+}
+
+fn quarantine(authority: Option<AgentWorkspaceAuthority>) {
+    if let Some(authority) = authority {
+        authority.quarantine();
+    }
+}
+
+fn terminal_program(graph: &GraphSpec) -> Result<bool, NativeExecutionError> {
+    match classify_graph(graph) {
+        Some(NativeProgram::Deterministic) => Ok(false),
+        Some(NativeProgram::ForegroundAgent) => Ok(true),
+        Some(NativeProgram::WorkerFree) | None => Err(NativeExecutionError::InvalidState),
     }
 }
 
@@ -340,52 +458,6 @@ fn verified_initial_input(
         .map_err(|_| NativeExecutionError::InvalidState)
 }
 
-fn command_control_refs(
-    allocation: &crate::cluster_ledger::DispatchAllocation,
-) -> Result<(DispatchFence, RecoveryRef), NativeExecutionError> {
-    let fence = DispatchFence::new(allocation.execution.get())
-        .map_err(|_| NativeExecutionError::Contract)?;
-    let recovery = RecoveryRef::new(format!(
-        "native-run-{}-execution-{}",
-        allocation.run.get(),
-        allocation.execution.get()
-    ))
-    .map_err(|_| NativeExecutionError::Contract)?;
-    Ok((fence, recovery))
-}
-
-fn command_target() -> Result<ExecutionTargetRef, NativeExecutionError> {
-    let worker =
-        BuiltinWorkerId::new("native.deterministic").map_err(|_| NativeExecutionError::Contract)?;
-    let target = BuiltinWorkerRef::new(worker, 1).map_err(|_| NativeExecutionError::Contract)?;
-    Ok(ExecutionTargetRef::Builtin(target))
-}
-
-fn command_digests(
-    admission: &crate::cluster_ledger::replay::AdmissionState,
-    registry: &NativeExecutionRegistry,
-) -> Result<(CatalogDigest, ProfileDigest, RegistryDigest), NativeExecutionError> {
-    let catalog = CatalogDigest::new(digest_hex(admission.catalog_digest))
-        .map_err(|_| NativeExecutionError::Contract)?;
-    let profile = ProfileDigest::new(digest_hex(admission.profile_digest))
-        .map_err(|_| NativeExecutionError::Contract)?;
-    let registry = RegistryDigest::new(digest_hex(registry.catalog_digest()))
-        .map_err(|_| NativeExecutionError::Contract)?;
-    Ok((catalog, profile, registry))
-}
-
-fn command_workspace(state: &ReplayState) -> Result<WorkspaceAccessRef, NativeExecutionError> {
-    WorkspaceAccessRef::new(state.resource.clone(), WorkspaceAccessMode::Exclusive)
-        .map_err(|_| NativeExecutionError::Contract)
-}
-
-fn command_input(input: Value) -> Result<ExecutionInput, NativeExecutionError> {
-    let canonical =
-        canonical_value_bytes(&input).map_err(|_| NativeExecutionError::InvalidState)?;
-    let inline = String::from_utf8(canonical).map_err(|_| NativeExecutionError::InvalidState)?;
-    ExecutionInput::inline(inline).map_err(|_| NativeExecutionError::Contract)
-}
-
 fn one_dispatch(
     reduction: &Reduction,
 ) -> Result<(crate::cluster_ledger::ExecutionId, WorkerRef, Value), NativeExecutionError> {
@@ -408,38 +480,4 @@ fn one_dispatch(
         return Err(NativeExecutionError::InvalidState);
     }
     Ok(dispatch)
-}
-
-fn canonical_terminal_bytes(value: &TerminalResult) -> Result<Vec<u8>, NativeExecutionError> {
-    canonical_value_bytes(
-        &serde_json::to_value(value).map_err(|_| NativeExecutionError::InvalidState)?,
-    )
-    .map_err(|_| NativeExecutionError::InvalidState)
-}
-
-fn dispatch_key(
-    run: crate::cluster_ledger::RunSequence,
-    execution: crate::cluster_ledger::ExecutionId,
-) -> Result<IdempotencyId, NativeExecutionError> {
-    IdempotencyId::new(format!("native-dispatch-{}-{}", run.get(), execution.get()))
-        .map_err(|_| NativeExecutionError::Contract)
-}
-
-fn settlement_key(
-    run: crate::cluster_ledger::RunSequence,
-    execution: crate::cluster_ledger::ExecutionId,
-) -> Result<IdempotencyId, NativeExecutionError> {
-    IdempotencyId::new(format!(
-        "native-settlement-{}-{}",
-        run.get(),
-        execution.get()
-    ))
-    .map_err(|_| NativeExecutionError::Contract)
-}
-
-fn terminal_key(
-    run: crate::cluster_ledger::RunSequence,
-) -> Result<IdempotencyId, NativeExecutionError> {
-    IdempotencyId::new(format!("native-terminal-{}", run.get()))
-        .map_err(|_| NativeExecutionError::Contract)
 }

--- a/zeroshot-rust/src/native_execution.rs
+++ b/zeroshot-rust/src/native_execution.rs
@@ -22,9 +22,11 @@ pub(crate) use program::{
     foreground_graph, is_deterministic_graph, is_worker_free_graph, NativeExecutionRegistry,
     NativeGraphVerifier,
 };
-use agent::{AgentWorkspaceAuthority, AgentWorkspacePreparation};
+#[doc(hidden)]
+pub use agent::validator::{run_greeting_validator, VALIDATOR_MODE as NATIVE_VALIDATOR_MODE};
+use agent::{AgentWorkspaceAuthority, AgentWorkspaceCandidate, AgentWorkspacePreparation};
 use process::NativeExecutionRuntime;
-use program::{classify_graph, NativeProgram};
+use program::{classify_graph, NativeProgram, AGENT_WORKER_REF};
 
 use crate::cluster_ledger::record::CanonicalDigest;
 use crate::cluster_ledger::{ClusterLedger, LedgerError, ReplayState};
@@ -68,6 +70,7 @@ struct CommittedDispatch {
     allocation: crate::cluster_ledger::DispatchAllocation,
     worker: WorkerRef,
     input: Value,
+    workspace_candidate: Option<AgentWorkspaceCandidate>,
     workspace: Option<AgentWorkspaceAuthority>,
 }
 
@@ -176,7 +179,7 @@ impl NativeExecutionCoordinator {
         reduction: &Reduction,
     ) -> Result<Option<CommittedDispatch>, NativeExecutionError> {
         let (execution, worker, input) = one_dispatch(reduction)?;
-        self.runtime.preflight(worker.as_str(), &input).await?;
+        let workspace_candidate = self.runtime.preflight(worker.as_str(), &input).await?;
         let authorization = reduction
             .dispatch_authorization(execution)
             .ok_or(NativeExecutionError::InvalidState)?;
@@ -194,6 +197,7 @@ impl NativeExecutionCoordinator {
             allocation: committed.value,
             worker,
             input,
+            workspace_candidate,
             workspace: None,
         }))
     }
@@ -203,21 +207,21 @@ impl NativeExecutionCoordinator {
         state: &ReplayState,
         dispatch: &mut CommittedDispatch,
     ) -> Result<Option<openengine_cluster_protocol::WorkerOutcome>, NativeExecutionError> {
+        let candidate = match dispatch.workspace_candidate.take() {
+            Some(candidate) if dispatch.worker.as_str() == AGENT_WORKER_REF => candidate,
+            None if dispatch.worker.as_str() != AGENT_WORKER_REF => return Ok(None),
+            Some(_) | None => return Err(NativeExecutionError::InvalidState),
+        };
         let prepared = self
             .runtime
-            .prepare_workspace(
-                dispatch.worker.as_str(),
-                &state.resource,
-                &dispatch.allocation,
-            )
-            .await?;
+            .prepare_workspace(&state.resource, &dispatch.allocation, candidate)
+            .await;
         match prepared {
-            Some(AgentWorkspacePreparation::Closed(outcome)) => Ok(Some(outcome)),
-            Some(AgentWorkspacePreparation::Ready(authority)) => {
+            AgentWorkspacePreparation::Closed(outcome) => Ok(Some(outcome)),
+            AgentWorkspacePreparation::Ready(authority) => {
                 dispatch.workspace = Some(authority);
                 Ok(None)
             }
-            None => Ok(None),
         }
     }
 

--- a/zeroshot-rust/src/native_execution/agent.rs
+++ b/zeroshot-rust/src/native_execution/agent.rs
@@ -38,7 +38,8 @@ pub(super) struct NativeAgent {
 
 impl NativeAgent {
     pub(super) fn new(process: &NativeExecutionProcess) -> Result<Self, ()> {
-        let workspace = NativeAgentWorkspace::open(&process.state_dir, &process.workspace)?;
+        let workspace =
+            NativeAgentWorkspace::open(&process.state_dir, &process.resource, &process.workspace)?;
         let artifacts = AgentArtifactStore::open(&process.state_dir, &process.resource)?;
         let driver = Arc::new(NativeCodexDriver::new(
             workspace.root(),

--- a/zeroshot-rust/src/native_execution/agent.rs
+++ b/zeroshot-rust/src/native_execution/agent.rs
@@ -1,0 +1,81 @@
+//! Private composition for the one fixed foreground Codex execution.
+
+#[path = "agent/artifact.rs"]
+mod artifact;
+#[path = "agent/codex.rs"]
+mod codex;
+#[path = "agent/protocol.rs"]
+mod protocol;
+#[path = "agent/workspace.rs"]
+mod workspace;
+
+use std::sync::Arc;
+
+use openengine_cluster_protocol::{TerminalResult, WorkerErrorCode, WorkerOutcome};
+use serde_json::Value;
+
+use crate::cluster_ledger::{DispatchAllocation, ResourceId};
+use crate::execution::driver::BuiltinWorkerDriver;
+
+use artifact::AgentArtifactStore;
+use codex::NativeCodexDriver;
+pub(super) use protocol::{AgentDispatchInput, AgentTerminalOutput};
+pub(super) use workspace::{AgentWorkspaceAuthority, AgentWorkspacePreparation};
+use workspace::NativeAgentWorkspace;
+
+use super::NativeExecutionProcess;
+
+#[derive(Clone)]
+pub(super) struct NativeAgent {
+    driver: Arc<NativeCodexDriver>,
+    workspace: NativeAgentWorkspace,
+    artifacts: AgentArtifactStore,
+}
+
+impl NativeAgent {
+    pub(super) fn new(process: &NativeExecutionProcess) -> Result<Self, ()> {
+        let workspace = NativeAgentWorkspace::open(&process.state_dir, &process.workspace)?;
+        let artifacts = AgentArtifactStore::open(&process.state_dir, &process.resource)?;
+        let driver = Arc::new(NativeCodexDriver::new(
+            workspace.root(),
+            process,
+            artifacts.clone(),
+        )?);
+        Ok(Self {
+            driver,
+            workspace,
+            artifacts,
+        })
+    }
+
+    pub(super) fn driver(&self) -> Arc<dyn BuiltinWorkerDriver> {
+        self.driver.clone()
+    }
+
+    pub(super) async fn preflight(&self, input: &Value) -> Result<(), ()> {
+        protocol::AgentUserInput::parse(input)?;
+        self.workspace.preflight()?;
+        self.driver.preflight().await
+    }
+
+    pub(super) async fn prepare_workspace(
+        &self,
+        cluster: &ResourceId,
+        allocation: &DispatchAllocation,
+    ) -> AgentWorkspacePreparation {
+        self.workspace.prepare(cluster, allocation).await
+    }
+
+    pub(super) async fn reverify_terminal(&self, terminal: &TerminalResult) -> Result<(), ()> {
+        let TerminalResult::Succeeded { output } = terminal else {
+            return Ok(());
+        };
+        let output: AgentTerminalOutput = serde_json::from_value(output.clone()).map_err(|_| ())?;
+        output.validate()?;
+        self.artifacts.reverify(&output.validation_artifact).await
+    }
+}
+
+pub(super) fn closed_error(code: WorkerErrorCode) -> WorkerOutcome {
+    WorkerOutcome::declared_failure(code)
+}

--- a/zeroshot-rust/src/native_execution/agent.rs
+++ b/zeroshot-rust/src/native_execution/agent.rs
@@ -6,6 +6,8 @@ mod artifact;
 mod codex;
 #[path = "agent/protocol.rs"]
 mod protocol;
+#[path = "agent/validator.rs"]
+pub(super) mod validator;
 #[path = "agent/workspace.rs"]
 mod workspace;
 
@@ -20,7 +22,9 @@ use crate::execution::driver::BuiltinWorkerDriver;
 use artifact::AgentArtifactStore;
 use codex::NativeCodexDriver;
 pub(super) use protocol::{AgentDispatchInput, AgentTerminalOutput};
-pub(super) use workspace::{AgentWorkspaceAuthority, AgentWorkspacePreparation};
+pub(super) use workspace::{
+    AgentWorkspaceAuthority, AgentWorkspaceCandidate, AgentWorkspacePreparation,
+};
 use workspace::NativeAgentWorkspace;
 
 use super::NativeExecutionProcess;
@@ -52,18 +56,20 @@ impl NativeAgent {
         self.driver.clone()
     }
 
-    pub(super) async fn preflight(&self, input: &Value) -> Result<(), ()> {
+    pub(super) async fn preflight(&self, input: &Value) -> Result<AgentWorkspaceCandidate, ()> {
         protocol::AgentUserInput::parse(input)?;
-        self.workspace.preflight()?;
-        self.driver.preflight().await
+        let candidate = self.workspace.preflight()?;
+        self.driver.preflight().await?;
+        Ok(candidate)
     }
 
     pub(super) async fn prepare_workspace(
         &self,
         cluster: &ResourceId,
         allocation: &DispatchAllocation,
+        candidate: AgentWorkspaceCandidate,
     ) -> AgentWorkspacePreparation {
-        self.workspace.prepare(cluster, allocation).await
+        self.workspace.prepare(cluster, allocation, candidate).await
     }
 
     pub(super) async fn reverify_terminal(&self, terminal: &TerminalResult) -> Result<(), ()> {

--- a/zeroshot-rust/src/native_execution/agent/artifact.rs
+++ b/zeroshot-rust/src/native_execution/agent/artifact.rs
@@ -1,0 +1,124 @@
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+
+use openengine_cluster_protocol::{
+    ArtifactLineage, ArtifactProducer, ArtifactRef, ByteLength, Generation, MediaType, NodeName,
+    PositiveInteger, RedactionClass, RunId, Sha256Digest, TypeId, WorkerOutcome, WorkerRef,
+};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+
+use crate::artifact_store::local_cas::LocalCasArtifactStore;
+use crate::artifact_store::{ArtifactIntent, ArtifactStore};
+use crate::cluster_ledger::ResourceId;
+use crate::execution::driver::DriverRequest;
+
+use super::super::program::AGENT_WORKER_REF;
+use super::protocol::{
+    validate_validation_output, AgentDispatchInput, AgentTerminalOutput, VALIDATION_TYPE_ID,
+};
+
+#[derive(Clone)]
+pub(super) struct AgentArtifactStore {
+    store: Arc<LocalCasArtifactStore>,
+}
+
+pub(super) struct ValidatedAgentOutput {
+    pub(super) summary: String,
+    pub(super) validation: Vec<u8>,
+}
+
+impl AgentArtifactStore {
+    pub(super) fn open(state_dir: &Path, resource: &ResourceId) -> Result<Self, ()> {
+        let store = LocalCasArtifactStore::new(
+            state_dir.join(format!("artifacts-{}", resource_storage_id(resource))),
+        )
+        .map_err(|_| ())?;
+        Ok(Self {
+            store: Arc::new(store),
+        })
+    }
+
+    pub(super) async fn publish(
+        &self,
+        request: &DriverRequest,
+        input: &AgentDispatchInput,
+        output: ValidatedAgentOutput,
+    ) -> Result<WorkerOutcome, ()> {
+        let intent = artifact_intent(request, input.generation, &output.validation)?;
+        let staged = self
+            .store
+            .stage(intent, Box::new(Cursor::new(output.validation)))
+            .await
+            .map_err(|_| ())?;
+        let artifact = match self.store.publish(&staged).await {
+            Ok(artifact) => artifact,
+            Err(_) => {
+                let _ = self.store.discard(&staged).await;
+                return Err(());
+            }
+        };
+        let output = AgentTerminalOutput {
+            summary: output.summary,
+            validation_artifact: artifact.clone(),
+        };
+        output.validate()?;
+        let output = serde_json::to_value(output).map_err(|_| ())?;
+        Ok(WorkerOutcome::Verified {
+            output,
+            artifacts: vec![artifact],
+        })
+    }
+
+    pub(super) async fn reverify(&self, expected: &ArtifactRef) -> Result<(), ()> {
+        let inspected = self
+            .store
+            .inspect(&expected.artifact_id)
+            .await
+            .map_err(|_| ())?
+            .ok_or(())?;
+        if inspected != *expected {
+            return Err(());
+        }
+        let mut stream = self
+            .store
+            .open(&expected.artifact_id)
+            .await
+            .map_err(|_| ())?;
+        let mut bytes = Vec::new();
+        stream.read_to_end(&mut bytes).await.map_err(|_| ())?;
+        validate_validation_output(&bytes)
+    }
+}
+
+fn artifact_intent(
+    request: &DriverRequest,
+    generation: u64,
+    bytes: &[u8],
+) -> Result<ArtifactIntent, ()> {
+    Ok(ArtifactIntent {
+        expected_sha256: Sha256Digest::new(format!("{:x}", Sha256::digest(bytes)))
+            .map_err(|_| ())?,
+        expected_byte_length: ByteLength::new(bytes.len() as u64).map_err(|_| ())?,
+        media_type: MediaType::new("application/json").map_err(|_| ())?,
+        type_id: TypeId::new(VALIDATION_TYPE_ID).map_err(|_| ())?,
+        producer: ArtifactProducer {
+            node: NodeName::new("codex").map_err(|_| ())?,
+            worker: WorkerRef::new(AGENT_WORKER_REF).map_err(|_| ())?,
+        },
+        lineage: ArtifactLineage {
+            generation: Generation::new(generation).map_err(|_| ())?,
+            run_id: RunId::new(format!("run:{}", request.control.run().get())),
+            attempt: PositiveInteger::new(1).map_err(|_| ())?,
+        },
+        redaction: RedactionClass::Internal,
+    })
+}
+
+fn resource_storage_id(resource: &ResourceId) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"zeroshot.native-agent-artifacts/v1\0");
+    digest.update(resource.as_str().as_bytes());
+    format!("{:x}", digest.finalize())
+}

--- a/zeroshot-rust/src/native_execution/agent/codex.rs
+++ b/zeroshot-rust/src/native_execution/agent/codex.rs
@@ -1,0 +1,397 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{canonical_value_bytes, WorkerErrorCode, WorkerOutcome};
+use tokio::sync::watch;
+use tokio::time::{Duration, Instant};
+
+use crate::execution::driver::{
+    BuiltinWorkerDriver, DriverCancellation, DriverCompletion, DriverRequest, DriverStartOutcome,
+    WorkspaceCapability,
+};
+use crate::execution::process::{
+    LocalProcessRunner, ProcessCommand, ProcessInput, ProcessLaunchEvidence, ProcessRunOutput,
+    ProcessRunnerError, ProcessSecretEnvironment,
+};
+use crate::execution::{CompletionEvidence, ExecutionCandidate, ExecutionResult, WorkspaceAccessMode};
+use crate::native_admission::native_agent_protocol::VALIDATOR_MODE;
+use crate::native_credentials::{
+    AcquisitionBudget, CancellationSignal, CredentialClock, CredentialRequirementName,
+    CredentialSourceKind, CredentialSourcePolicy, CredentialSourceRef, CredentialSourceRegistry,
+    EnvSnapshotCredentialSource, NativeCredentialResolver,
+};
+use crate::observability::NoopObservationSink;
+use crate::worker_catalog::{worker_catalog, DriverFamily, ProbeStrategy};
+
+use super::artifact::{AgentArtifactStore, ValidatedAgentOutput};
+use super::protocol::{parse_codex_output, validate_validation_output, AgentDispatchInput};
+use super::super::program::NATIVE_AGENT_PROCESS_TIMEOUT_MS;
+use super::super::NativeExecutionProcess;
+
+const OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+static CREDENTIAL_CLOCK: SystemCredentialClock = SystemCredentialClock;
+static CREDENTIAL_OBSERVATIONS: NoopObservationSink = NoopObservationSink;
+static NEVER_CANCELLED: NeverCancelled = NeverCancelled;
+
+pub(super) struct NativeCodexDriver {
+    runner: LocalProcessRunner,
+    codex_executable: Option<PathBuf>,
+    base_arguments: Vec<String>,
+    validator_executable: PathBuf,
+    workspace: PathBuf,
+    artifacts: AgentArtifactStore,
+    requirement: CredentialRequirementName,
+    credentials: NativeCredentialResolver<'static>,
+}
+
+impl NativeCodexDriver {
+    pub(super) fn new(
+        workspace: &Path,
+        process: &NativeExecutionProcess,
+        artifacts: AgentArtifactStore,
+    ) -> Result<Self, ()> {
+        let (codex_executable, base_arguments, requirement) =
+            canonical_codex_configuration(process.path_snapshot.clone())?;
+        let credentials =
+            credential_resolver(requirement.clone(), process.api_key_snapshot.clone())?;
+        Ok(Self {
+            runner: LocalProcessRunner::new(),
+            codex_executable,
+            base_arguments,
+            validator_executable: process.executable.clone(),
+            workspace: workspace.to_path_buf(),
+            artifacts,
+            requirement,
+            credentials,
+        })
+    }
+
+    pub(super) async fn preflight(&self) -> Result<(), ()> {
+        drop(self.acquire_secret()?);
+        let executable = self.codex_executable.as_ref().ok_or(())?;
+        let version = self
+            .run_probe(executable, vec!["--version".to_owned()])
+            .await?;
+        if version.is_empty() {
+            return Err(());
+        }
+        let mut help_args = self.base_arguments.clone();
+        help_args.push("--help".to_owned());
+        let help =
+            String::from_utf8(self.run_probe(executable, help_args).await?).map_err(|_| ())?;
+        for flag in [
+            "--json",
+            "--sandbox",
+            "--config",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--strict-config",
+        ] {
+            if !help.contains(flag) {
+                return Err(());
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_probe(&self, executable: &Path, argv: Vec<String>) -> Result<Vec<u8>, ()> {
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let output = self
+            .runner
+            .run(
+                ProcessCommand {
+                    program: executable.to_str().ok_or(())?.to_owned(),
+                    argv,
+                    environment: BTreeMap::new(),
+                    workspace: WorkspaceCapability {
+                        current_dir: self.workspace.clone(),
+                        mode: WorkspaceAccessMode::ReadOnly,
+                    },
+                    stdin: ProcessInput::empty(),
+                    deadline: Instant::now() + Duration::from_secs(10),
+                },
+                DriverCancellation::new(cancel_rx),
+            )
+            .await
+            .map_err(|_| ())?;
+        if output.exit_code != Some(0)
+            || output.cancelled
+            || output.timed_out
+            || !output.cleanup.proves_tree_empty()
+            || output.post_launch_error.is_some()
+        {
+            return Err(());
+        }
+        let mut bytes = output.stdout;
+        bytes.extend_from_slice(&output.stderr);
+        Ok(bytes)
+    }
+
+    fn acquire_secret(&self) -> Result<ProcessSecretEnvironment, ()> {
+        let now = CREDENTIAL_CLOCK.now_ms();
+        let budget = AcquisitionBudget::new(
+            now.saturating_add(NATIVE_AGENT_PROCESS_TIMEOUT_MS),
+            NATIVE_AGENT_PROCESS_TIMEOUT_MS,
+            &NEVER_CANCELLED,
+        );
+        self.credentials
+            .with_requirement_material(&self.requirement, &budget, |material| {
+                ProcessSecretEnvironment::single(OPENAI_API_KEY, material)
+            })
+            .map_err(|_| ())?
+            .map_err(|_| ())
+    }
+
+    fn codex_command(&self, input: &AgentDispatchInput) -> Option<ProcessCommand> {
+        let executable = self.codex_executable.as_ref()?.to_str()?.to_owned();
+        let mut argv = self.base_arguments.clone();
+        argv.extend([
+            "--json".to_owned(),
+            "--sandbox".to_owned(),
+            "workspace-write".to_owned(),
+            "--config".to_owned(),
+            "approval_policy=\"never\"".to_owned(),
+            "--ephemeral".to_owned(),
+            "--ignore-user-config".to_owned(),
+            "--ignore-rules".to_owned(),
+            "--strict-config".to_owned(),
+            "--config".to_owned(),
+            "web_search=\"disabled\"".to_owned(),
+            "-".to_owned(),
+        ]);
+        Some(ProcessCommand {
+            program: executable,
+            argv,
+            environment: BTreeMap::new(),
+            workspace: WorkspaceCapability {
+                current_dir: self.workspace.clone(),
+                mode: WorkspaceAccessMode::Exclusive,
+            },
+            stdin: ProcessInput::new(input.provider_prompt().into_bytes()).ok()?,
+            deadline: Instant::now() + Duration::from_millis(NATIVE_AGENT_PROCESS_TIMEOUT_MS),
+        })
+    }
+
+    async fn validate_greeting(
+        &self,
+        input: &AgentDispatchInput,
+        cancellation: DriverCancellation,
+    ) -> Result<Vec<u8>, AgentRunFailure> {
+        let Some(program) = self.validator_executable.to_str().map(str::to_owned) else {
+            return Err(AgentRunFailure::Closed(WorkerErrorCode::Crash));
+        };
+        let stdin = match ProcessInput::new(input.expected_greeting.as_bytes().to_vec()) {
+            Ok(stdin) => stdin,
+            Err(_) => return Err(AgentRunFailure::Closed(WorkerErrorCode::Malformed)),
+        };
+        let output = self
+            .runner
+            .run(
+                ProcessCommand {
+                    program,
+                    argv: vec![VALIDATOR_MODE.to_owned()],
+                    environment: BTreeMap::new(),
+                    workspace: WorkspaceCapability {
+                        current_dir: self.workspace.clone(),
+                        mode: WorkspaceAccessMode::ReadOnly,
+                    },
+                    stdin,
+                    deadline: Instant::now() + Duration::from_secs(10),
+                },
+                cancellation,
+            )
+            .await;
+        let output = cleaned_process(output)?;
+        if output.exit_code != Some(0)
+            || !output.stderr.is_empty()
+            || validate_validation_output(&output.stdout).is_err()
+        {
+            return Err(AgentRunFailure::Closed(WorkerErrorCode::Refusal));
+        }
+        Ok(output.stdout)
+    }
+
+    async fn run_request(
+        &self,
+        request: &DriverRequest,
+        cancellation: DriverCancellation,
+    ) -> Result<WorkerOutcome, AgentRunFailure> {
+        let input = AgentDispatchInput::from_execution_input(request.input.clone())
+            .map_err(|()| AgentRunFailure::Closed(WorkerErrorCode::Malformed))?;
+        let secrets = self
+            .acquire_secret()
+            .map_err(|()| AgentRunFailure::Closed(WorkerErrorCode::Refusal))?;
+        let command = self
+            .codex_command(&input)
+            .ok_or(AgentRunFailure::Closed(WorkerErrorCode::Crash))?;
+        let provider = self
+            .runner
+            .run_with_secrets(command, secrets, cancellation.clone())
+            .await;
+        let summary = classify_provider(provider)?;
+        let validation = self.validate_greeting(&input, cancellation).await?;
+        self.artifacts
+            .publish(
+                request,
+                &input,
+                ValidatedAgentOutput {
+                    summary,
+                    validation,
+                },
+            )
+            .await
+            .map_err(|()| AgentRunFailure::Closed(WorkerErrorCode::Crash))
+    }
+}
+
+#[async_trait]
+impl BuiltinWorkerDriver for NativeCodexDriver {
+    async fn start(
+        &self,
+        request: DriverRequest,
+        cancellation: DriverCancellation,
+    ) -> DriverStartOutcome {
+        match self.run_request(&request, cancellation).await {
+            Ok(outcome) => completed_outcome(outcome),
+            Err(AgentRunFailure::Closed(code)) => completed_error(code),
+            Err(AgentRunFailure::Uncertain) => indeterminate(),
+        }
+    }
+}
+
+enum AgentRunFailure {
+    Closed(WorkerErrorCode),
+    Uncertain,
+}
+
+fn cleaned_process(
+    result: Result<ProcessRunOutput, ProcessRunnerError>,
+) -> Result<ProcessRunOutput, AgentRunFailure> {
+    let output = match result {
+        Err(error) if error.launch_evidence() == ProcessLaunchEvidence::DefinitelyNotStarted => {
+            return Err(AgentRunFailure::Closed(WorkerErrorCode::Crash));
+        }
+        Err(_) => return Err(AgentRunFailure::Uncertain),
+        Ok(output) => output,
+    };
+    if !output.cleanup.proves_tree_empty() || output.post_launch_error.is_some() {
+        return Err(AgentRunFailure::Uncertain);
+    }
+    if output.timed_out || output.cancelled {
+        return Err(AgentRunFailure::Closed(WorkerErrorCode::Timeout));
+    }
+    Ok(output)
+}
+
+fn classify_provider(
+    result: Result<ProcessRunOutput, ProcessRunnerError>,
+) -> Result<String, AgentRunFailure> {
+    let output = cleaned_process(result)?;
+    if output.exit_code != Some(0) || !output.stderr.is_empty() {
+        return Err(AgentRunFailure::Closed(WorkerErrorCode::Crash));
+    }
+    parse_codex_output(&output.stdout)
+        .map_err(|()| AgentRunFailure::Closed(WorkerErrorCode::Malformed))
+}
+
+fn credential_resolver(
+    requirement: CredentialRequirementName,
+    api_key: Option<String>,
+) -> Result<NativeCredentialResolver<'static>, ()> {
+    let source = CredentialSourceRef::new(CredentialSourceKind::Environment, OPENAI_API_KEY)
+        .map_err(|_| ())?;
+    let policy = CredentialSourcePolicy::new(BTreeMap::from([(requirement, vec![source])]))
+        .map_err(|_| ())?;
+    let snapshot = api_key
+        .map(|value| BTreeMap::from([(OPENAI_API_KEY.to_owned(), value)]))
+        .unwrap_or_default();
+    let registry = CredentialSourceRegistry::new()
+        .register(Arc::new(EnvSnapshotCredentialSource::new(snapshot)))
+        .map_err(|_| ())?;
+    Ok(NativeCredentialResolver::new(
+        policy,
+        registry,
+        &CREDENTIAL_CLOCK,
+        &CREDENTIAL_OBSERVATIONS,
+    ))
+}
+
+fn canonical_codex_configuration(
+    path_snapshot: Option<std::ffi::OsString>,
+) -> Result<(Option<PathBuf>, Vec<String>, CredentialRequirementName), ()> {
+    let descriptor = worker_catalog().resolve("codex").ok_or(())?;
+    if descriptor.driver_family() != DriverFamily::CliProcess
+        || descriptor.credential_requirements().len() != 1
+    {
+        return Err(());
+    }
+    let metadata = descriptor.executable().ok_or(())?;
+    if metadata.probe() != ProbeStrategy::Version {
+        return Err(());
+    }
+    let executable = resolve_executable(metadata.name().as_str(), path_snapshot.as_deref());
+    let arguments = metadata
+        .arguments()
+        .iter()
+        .map(|argument| argument.as_str().to_owned())
+        .collect();
+    Ok((
+        executable,
+        arguments,
+        descriptor.credential_requirements()[0].clone(),
+    ))
+}
+
+fn resolve_executable(name: &str, path: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    std::env::split_paths(path?)
+        .map(|directory| directory.join(name))
+        .find(|candidate| candidate.is_file())
+        .and_then(|candidate| std::fs::canonicalize(candidate).ok())
+}
+
+fn completed_error(code: WorkerErrorCode) -> DriverStartOutcome {
+    completed_outcome(WorkerOutcome::declared_failure(code))
+}
+
+fn completed_outcome(outcome: WorkerOutcome) -> DriverStartOutcome {
+    let value = serde_json::to_value(outcome).expect("closed worker outcome must serialize");
+    let bytes = canonical_value_bytes(&value).expect("closed worker outcome must canonicalize");
+    let candidate = ExecutionCandidate::new(
+        String::from_utf8(bytes).expect("canonical worker outcome must be UTF-8"),
+    )
+    .expect("closed worker outcome fits execution candidate bounds");
+    let result = ExecutionResult::new(candidate, CompletionEvidence::Success, None)
+        .expect("closed worker completion is valid");
+    DriverStartOutcome::Completed {
+        completion: DriverCompletion::success(result),
+    }
+}
+
+fn indeterminate() -> DriverStartOutcome {
+    DriverStartOutcome::Indeterminate { fault: None }
+}
+
+struct SystemCredentialClock;
+
+impl CredentialClock for SystemCredentialClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
+}
+
+struct NeverCancelled;
+
+impl CancellationSignal for NeverCancelled {
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+}

--- a/zeroshot-rust/src/native_execution/agent/codex.rs
+++ b/zeroshot-rust/src/native_execution/agent/codex.rs
@@ -17,7 +17,6 @@ use crate::execution::process::{
     ProcessRunnerError, ProcessSecretEnvironment,
 };
 use crate::execution::{CompletionEvidence, ExecutionCandidate, ExecutionResult, WorkspaceAccessMode};
-use crate::native_admission::native_agent_protocol::VALIDATOR_MODE;
 use crate::native_credentials::{
     AcquisitionBudget, CancellationSignal, CredentialClock, CredentialRequirementName,
     CredentialSourceKind, CredentialSourcePolicy, CredentialSourceRef, CredentialSourceRegistry,
@@ -28,6 +27,7 @@ use crate::worker_catalog::{worker_catalog, DriverFamily, ProbeStrategy};
 
 use super::artifact::{AgentArtifactStore, ValidatedAgentOutput};
 use super::protocol::{parse_codex_output, validate_validation_output, AgentDispatchInput};
+use super::validator::VALIDATOR_MODE;
 use super::super::program::NATIVE_AGENT_PROCESS_TIMEOUT_MS;
 use super::super::NativeExecutionProcess;
 

--- a/zeroshot-rust/src/native_execution/agent/protocol.rs
+++ b/zeroshot-rust/src/native_execution/agent/protocol.rs
@@ -3,9 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::execution::ExecutionInput;
-use crate::native_admission::native_agent_protocol::MAX_EXPECTED_GREETING_BYTES;
-
 use super::super::program::AGENT_WORKER_REF;
+use super::validator::MAX_EXPECTED_GREETING_BYTES;
 
 pub(super) const VALIDATION_TYPE_ID: &str = "native.agent.validation@1";
 const MAX_PROMPT_BYTES: usize = 16 * 1024;

--- a/zeroshot-rust/src/native_execution/agent/protocol.rs
+++ b/zeroshot-rust/src/native_execution/agent/protocol.rs
@@ -1,0 +1,210 @@
+use openengine_cluster_protocol::{canonical_value_bytes, ArtifactRef, Generation, RedactionClass};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::execution::ExecutionInput;
+use crate::native_admission::native_agent_protocol::MAX_EXPECTED_GREETING_BYTES;
+
+use super::super::program::AGENT_WORKER_REF;
+
+pub(super) const VALIDATION_TYPE_ID: &str = "native.agent.validation@1";
+const MAX_PROMPT_BYTES: usize = 16 * 1024;
+const MAX_SUMMARY_BYTES: usize = 4 * 1024;
+const MAX_CODEX_EVENTS: usize = 4096;
+const MAX_CODEX_EVENT_BYTES: usize = 64 * 1024;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct AgentUserInput {
+    prompt: String,
+    expected_greeting: String,
+}
+
+impl AgentUserInput {
+    pub(super) fn parse(value: &Value) -> Result<Self, ()> {
+        let input: Self = serde_json::from_value(value.clone()).map_err(|_| ())?;
+        validate_bounded_text(&input.prompt, MAX_PROMPT_BYTES)?;
+        validate_bounded_text(&input.expected_greeting, MAX_EXPECTED_GREETING_BYTES)?;
+        Ok(input)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentDispatchInput {
+    pub(super) generation: u64,
+    prompt: String,
+    pub(super) expected_greeting: String,
+}
+
+impl AgentDispatchInput {
+    pub(crate) fn new(generation: u64, input: Value) -> Result<Self, ()> {
+        let input = AgentUserInput::parse(&input)?;
+        Generation::new(generation).map_err(|_| ())?;
+        Ok(Self {
+            generation,
+            prompt: input.prompt,
+            expected_greeting: input.expected_greeting,
+        })
+    }
+
+    pub(super) fn from_execution_input(input: ExecutionInput) -> Result<Self, ()> {
+        let ExecutionInput::Inline(input) = input else {
+            return Err(());
+        };
+        let value: Self = serde_json::from_str(input.as_str()).map_err(|_| ())?;
+        validate_bounded_text(&value.prompt, MAX_PROMPT_BYTES)?;
+        validate_bounded_text(&value.expected_greeting, MAX_EXPECTED_GREETING_BYTES)?;
+        Generation::new(value.generation).map_err(|_| ())?;
+        Ok(value)
+    }
+
+    pub(super) fn provider_prompt(&self) -> String {
+        let greeting = serde_json::to_string(&self.expected_greeting)
+            .expect("bounded greeting must serialize");
+        format!(
+            concat!(
+                "{}\n\nModify only this workspace. Write the JSON string value {greeting} ",
+                "as the exact UTF-8 contents of greeting.txt. Finish with exactly one JSON ",
+                "object {{\"summary\":\"a short bounded summary\"}} and no Markdown."
+            ),
+            self.prompt,
+            greeting = greeting
+        )
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentTerminalOutput {
+    pub(crate) summary: String,
+    pub(crate) validation_artifact: ArtifactRef,
+}
+
+impl AgentTerminalOutput {
+    pub(crate) fn validate(&self) -> Result<(), ()> {
+        validate_bounded_text(&self.summary, MAX_SUMMARY_BYTES)?;
+        if self.validation_artifact.type_id.as_str() != VALIDATION_TYPE_ID
+            || self.validation_artifact.media_type.as_str() != "application/json"
+            || self.validation_artifact.redaction != RedactionClass::Internal
+            || self.validation_artifact.producer.worker.as_str() != AGENT_WORKER_REF
+        {
+            return Err(());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentFinalMessage {
+    summary: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ValidationOutput {
+    path: String,
+    sha256: String,
+    status: String,
+}
+
+#[derive(Default)]
+struct CodexTranscript {
+    final_message: Option<String>,
+    turn_completed: bool,
+}
+
+pub(super) fn parse_codex_output(bytes: &[u8]) -> Result<String, ()> {
+    let text = std::str::from_utf8(bytes).map_err(|_| ())?;
+    let mut transcript = CodexTranscript::default();
+    for (index, line) in text.lines().filter(|line| !line.is_empty()).enumerate() {
+        if index >= MAX_CODEX_EVENTS || line.len() > MAX_CODEX_EVENT_BYTES {
+            return Err(());
+        }
+        parse_codex_event(line, &mut transcript)?;
+    }
+    if !transcript.turn_completed {
+        return Err(());
+    }
+    let final_message = transcript.final_message.ok_or(())?;
+    let parsed: AgentFinalMessage = serde_json::from_str(&final_message).map_err(|_| ())?;
+    validate_bounded_text(&parsed.summary, MAX_SUMMARY_BYTES)?;
+    Ok(parsed.summary)
+}
+
+fn parse_codex_event(line: &str, transcript: &mut CodexTranscript) -> Result<(), ()> {
+    let event: Value = serde_json::from_str(line).map_err(|_| ())?;
+    let object = event.as_object().ok_or(())?;
+    match object.get("type").and_then(Value::as_str).ok_or(())? {
+        "thread.started" | "turn.started" => Ok(()),
+        "turn.completed" => {
+            transcript.turn_completed = true;
+            Ok(())
+        }
+        "turn.failed" | "error" => Err(()),
+        "item.started" | "item.created" | "item.completed" => parse_codex_item(object, transcript),
+        _ => Err(()),
+    }
+}
+
+fn parse_codex_item(
+    event: &serde_json::Map<String, Value>,
+    transcript: &mut CodexTranscript,
+) -> Result<(), ()> {
+    let item = event.get("item").and_then(Value::as_object).ok_or(())?;
+    match item.get("type").and_then(Value::as_str).ok_or(())? {
+        "agent_message" => {
+            if let Some(text) = item.get("text").and_then(Value::as_str) {
+                transcript.final_message = Some(text.to_owned());
+            }
+            Ok(())
+        }
+        "message" if item.get("role").and_then(Value::as_str) == Some("assistant") => {
+            transcript.final_message = assistant_message_text(item)?;
+            Ok(())
+        }
+        "reasoning" | "command_execution" | "function_call" | "function_call_output" => Ok(()),
+        _ => Err(()),
+    }
+}
+
+fn assistant_message_text(item: &serde_json::Map<String, Value>) -> Result<Option<String>, ()> {
+    let content = item.get("content").and_then(Value::as_array).ok_or(())?;
+    let mut output = String::new();
+    for entry in content {
+        let entry = entry.as_object().ok_or(())?;
+        if entry.get("type").and_then(Value::as_str) == Some("text") {
+            output.push_str(entry.get("text").and_then(Value::as_str).ok_or(())?);
+        }
+    }
+    Ok((!output.is_empty()).then_some(output))
+}
+
+pub(super) fn validate_validation_output(bytes: &[u8]) -> Result<(), ()> {
+    let output: ValidationOutput = serde_json::from_slice(bytes).map_err(|_| ())?;
+    if output.path != "greeting.txt"
+        || output.status != "passed"
+        || output.sha256.len() != 64
+        || !output
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(());
+    }
+    let canonical =
+        canonical_value_bytes(&serde_json::to_value(output).map_err(|_| ())?).map_err(|_| ())?;
+    if canonical != bytes {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn validate_bounded_text(value: &str, maximum: usize) -> Result<(), ()> {
+    if value.is_empty() || value.len() > maximum || value.contains('\0') {
+        Err(())
+    } else {
+        Ok(())
+    }
+}

--- a/zeroshot-rust/src/native_execution/agent/validator.rs
+++ b/zeroshot-rust/src/native_execution/agent/validator.rs
@@ -1,0 +1,41 @@
+//! Fixed process protocol for the foreground agent's trusted greeting validator.
+
+use std::io::{Read, Write};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+pub const VALIDATOR_MODE: &str = "--native-validate-greeting";
+pub const MAX_EXPECTED_GREETING_BYTES: usize = 4 * 1024;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ValidationOutput<'a> {
+    path: &'a str,
+    sha256: String,
+    status: &'a str,
+}
+
+pub fn run_greeting_validator() -> std::io::Result<()> {
+    let mut expected = Vec::new();
+    std::io::stdin()
+        .take((MAX_EXPECTED_GREETING_BYTES + 1) as u64)
+        .read_to_end(&mut expected)?;
+    if expected.is_empty() || expected.len() > MAX_EXPECTED_GREETING_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid expected greeting",
+        ));
+    }
+    let actual = std::fs::read("greeting.txt")?;
+    if actual != expected {
+        return Err(std::io::Error::other("greeting validation failed"));
+    }
+    let output = ValidationOutput {
+        path: "greeting.txt",
+        sha256: format!("{:x}", Sha256::digest(&actual)),
+        status: "passed",
+    };
+    let bytes = serde_json::to_vec(&output).map_err(std::io::Error::other)?;
+    std::io::stdout().write_all(&bytes)
+}

--- a/zeroshot-rust/src/native_execution/agent/workspace.rs
+++ b/zeroshot-rust/src/native_execution/agent/workspace.rs
@@ -1,0 +1,285 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use fs2::FileExt;
+use openengine_cluster_protocol::{canonical_value_bytes, WorkerErrorCode};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::cluster_ledger::{DispatchAllocation, OwnerId, ResourceId};
+use crate::execution::WorkspaceAccessMode;
+use crate::workspace_lease::{
+    BorrowedWorkspace, BorrowedWorkspaceAdapter, BorrowedWorkspaceFingerprintPort,
+    CanonicalWorkspaceRoot, FilesystemBorrowedWorkspaceFingerprint, PrepareWorkspaceRequest,
+    SqliteWorkspaceLeaseStore, WorkspaceFingerprint, WorkspaceIsolation, WorkspaceLeaseId,
+    WorkspaceLeaseKey, WorkspaceLeaseManager, WorkspaceLeaseOwnerRequest, WorkspaceLeaseState,
+    WorkspaceMode,
+};
+
+use super::closed_error;
+
+const QUARANTINE_MARKER: &str = "zeroshot-native-workspace-quarantine-v1";
+
+pub(crate) enum AgentWorkspacePreparation {
+    Ready(AgentWorkspaceAuthority),
+    Closed(openengine_cluster_protocol::WorkerOutcome),
+}
+
+pub(crate) struct AgentWorkspaceAuthority {
+    lock: Option<File>,
+    marker: std::path::PathBuf,
+    git_dir: std::path::PathBuf,
+    lease_manager: WorkspaceLeaseManager,
+    lease_owner: WorkspaceLeaseOwnerRequest,
+}
+
+impl AgentWorkspaceAuthority {
+    pub(crate) async fn finish_effect(self) -> Result<Self, Self> {
+        if self
+            .lease_manager
+            .cleanup(self.lease_owner.clone())
+            .await
+            .is_err()
+        {
+            return Err(self);
+        }
+        if remove_marker(&self.marker, &self.git_dir).is_err() {
+            return Err(self);
+        }
+        Ok(self)
+    }
+
+    pub(crate) fn quarantine(mut self) {
+        if let Some(lock) = self.lock.take() {
+            std::mem::forget(lock);
+        }
+    }
+}
+
+pub(super) struct NativeAgentWorkspace {
+    canonical_root: CanonicalWorkspaceRoot,
+    fingerprints: Arc<dyn BorrowedWorkspaceFingerprintPort>,
+    lease_manager: WorkspaceLeaseManager,
+}
+
+impl Clone for NativeAgentWorkspace {
+    fn clone(&self) -> Self {
+        Self {
+            canonical_root: self.canonical_root.clone(),
+            fingerprints: Arc::clone(&self.fingerprints),
+            lease_manager: self.lease_manager.clone(),
+        }
+    }
+}
+
+impl NativeAgentWorkspace {
+    pub(super) fn open(state_dir: &Path, workspace: &Path) -> Result<Self, ()> {
+        let canonical_root = canonical_workspace_root(workspace)?;
+        let fingerprints: Arc<dyn BorrowedWorkspaceFingerprintPort> =
+            Arc::new(FilesystemBorrowedWorkspaceFingerprint::default());
+        let lease_store = Arc::new(
+            SqliteWorkspaceLeaseStore::open(state_dir.join("workspace-leases.sqlite"))
+                .map_err(|_| ())?,
+        );
+        let lease_manager = WorkspaceLeaseManager::new(
+            lease_store,
+            Arc::new(BorrowedWorkspaceAdapter::new(Arc::clone(&fingerprints))),
+        );
+        Ok(Self {
+            canonical_root,
+            fingerprints,
+            lease_manager,
+        })
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        self.canonical_root.as_path()
+    }
+
+    pub(super) fn preflight(&self) -> Result<(), ()> {
+        let lock = lock_workspace(self.canonical_root.as_path())?;
+        require_no_marker(self.canonical_root.as_path())?;
+        self.fingerprints
+            .fingerprint(self.canonical_root.as_path())
+            .map_err(|_| ())?;
+        drop(lock);
+        Ok(())
+    }
+
+    pub(super) async fn prepare(
+        &self,
+        cluster: &ResourceId,
+        allocation: &DispatchAllocation,
+    ) -> AgentWorkspacePreparation {
+        let lock = match lock_workspace(self.canonical_root.as_path()) {
+            Ok(lock) => lock,
+            Err(()) => return closed_preparation(),
+        };
+        if require_no_marker(self.canonical_root.as_path()).is_err() {
+            return closed_preparation();
+        }
+        let fingerprint = match self.fingerprints.fingerprint(self.canonical_root.as_path()) {
+            Ok(fingerprint) => fingerprint,
+            Err(_) => return closed_preparation(),
+        };
+        let (request, owner) = match workspace_request(
+            cluster,
+            allocation,
+            self.canonical_root.clone(),
+            fingerprint,
+        ) {
+            Ok(requests) => requests,
+            Err(()) => return closed_preparation(),
+        };
+        let prepared = self.lease_manager.prepare(request).await;
+        let ready = prepared
+            .as_ref()
+            .is_ok_and(|record| record.state == WorkspaceLeaseState::Ready);
+        if !ready {
+            let _ = self.lease_manager.cleanup(owner).await;
+            return closed_preparation();
+        }
+        let git_dir = self.canonical_root.as_path().join(".git");
+        let marker = git_dir.join(QUARANTINE_MARKER);
+        if write_marker(&marker, &git_dir, cluster, allocation).is_err() {
+            let _ = remove_marker(&marker, &git_dir);
+            let _ = self.lease_manager.cleanup(owner).await;
+            return closed_preparation();
+        }
+        AgentWorkspacePreparation::Ready(AgentWorkspaceAuthority {
+            lock: Some(lock),
+            marker,
+            git_dir,
+            lease_manager: self.lease_manager.clone(),
+            lease_owner: owner,
+        })
+    }
+}
+
+fn closed_preparation() -> AgentWorkspacePreparation {
+    AgentWorkspacePreparation::Closed(closed_error(WorkerErrorCode::Refusal))
+}
+
+fn canonical_workspace_root(workspace: &Path) -> Result<CanonicalWorkspaceRoot, ()> {
+    let canonical = std::fs::canonicalize(workspace).map_err(|_| ())?;
+    if canonical != workspace || !canonical.join(".git").is_dir() {
+        return Err(());
+    }
+    CanonicalWorkspaceRoot::new(canonical.to_str().ok_or(())?).map_err(|_| ())
+}
+
+fn lock_workspace(root: &Path) -> Result<File, ()> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = root;
+        Err(())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        let file = options.open(root).map_err(|_| ())?;
+        file.try_lock_exclusive().map_err(|_| ())?;
+        if std::fs::canonicalize(root).map_err(|_| ())? != root {
+            return Err(());
+        }
+        Ok(file)
+    }
+}
+
+fn require_no_marker(root: &Path) -> Result<(), ()> {
+    let git_dir = root.join(".git");
+    let metadata = std::fs::symlink_metadata(&git_dir).map_err(|_| ())?;
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || git_dir.join(QUARANTINE_MARKER).exists()
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn workspace_request(
+    cluster: &ResourceId,
+    allocation: &DispatchAllocation,
+    canonical_root: CanonicalWorkspaceRoot,
+    fingerprint: WorkspaceFingerprint,
+) -> Result<(PrepareWorkspaceRequest, WorkspaceLeaseOwnerRequest), ()> {
+    let key = WorkspaceLeaseKey {
+        cluster: cluster.clone(),
+        run: allocation.run,
+        logical_key: ResourceId::new("native-agent-workspace").map_err(|_| ())?,
+        isolation: WorkspaceIsolation::Execution(allocation.execution),
+    };
+    let id = WorkspaceLeaseId::derive(&key);
+    let owner = workspace_owner(cluster, allocation)?;
+    Ok((
+        PrepareWorkspaceRequest {
+            key,
+            owner: owner.clone(),
+            access_mode: WorkspaceAccessMode::Exclusive,
+            mode: WorkspaceMode::Borrowed(BorrowedWorkspace {
+                canonical_root,
+                fingerprint,
+            }),
+        },
+        WorkspaceLeaseOwnerRequest { id, owner },
+    ))
+}
+
+fn workspace_owner(cluster: &ResourceId, allocation: &DispatchAllocation) -> Result<OwnerId, ()> {
+    let mut digest = Sha256::new();
+    digest.update(b"zeroshot.native-agent-workspace-owner/v1\0");
+    digest.update(cluster.as_str().as_bytes());
+    digest.update(allocation.run.get().to_be_bytes());
+    digest.update(allocation.execution.get().to_be_bytes());
+    OwnerId::new(format!("native-agent-{:x}", digest.finalize())).map_err(|_| ())
+}
+
+fn write_marker(
+    marker: &Path,
+    git_dir: &Path,
+    cluster: &ResourceId,
+    allocation: &DispatchAllocation,
+) -> Result<(), ()> {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Marker<'a> {
+        cluster: &'a str,
+        run: u64,
+        execution: u64,
+    }
+    #[cfg(unix)]
+    use std::os::unix::fs::OpenOptionsExt;
+    let bytes = canonical_value_bytes(
+        &serde_json::to_value(Marker {
+            cluster: cluster.as_str(),
+            run: allocation.run.get(),
+            execution: allocation.execution.get(),
+        })
+        .map_err(|_| ())?,
+    )
+    .map_err(|_| ())?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(marker).map_err(|_| ())?;
+    file.write_all(&bytes).map_err(|_| ())?;
+    file.sync_all().map_err(|_| ())?;
+    File::open(git_dir)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| ())
+}
+
+fn remove_marker(marker: &Path, git_dir: &Path) -> Result<(), ()> {
+    std::fs::remove_file(marker).map_err(|_| ())?;
+    File::open(git_dir)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| ())
+}

--- a/zeroshot-rust/src/native_execution/agent/workspace.rs
+++ b/zeroshot-rust/src/native_execution/agent/workspace.rs
@@ -80,13 +80,20 @@ impl Clone for NativeAgentWorkspace {
 }
 
 impl NativeAgentWorkspace {
-    pub(super) fn open(state_dir: &Path, workspace: &Path) -> Result<Self, ()> {
+    pub(super) fn open(
+        state_dir: &Path,
+        resource: &ResourceId,
+        workspace: &Path,
+    ) -> Result<Self, ()> {
         let canonical_root = canonical_workspace_root(workspace)?;
         let fingerprints: Arc<dyn BorrowedWorkspaceFingerprintPort> =
             Arc::new(FilesystemBorrowedWorkspaceFingerprint::default());
         let lease_store = Arc::new(
-            SqliteWorkspaceLeaseStore::open(state_dir.join("workspace-leases.sqlite"))
-                .map_err(|_| ())?,
+            SqliteWorkspaceLeaseStore::open(state_dir.join(format!(
+                "workspace-leases-{}.sqlite",
+                workspace_store_id(resource)
+            )))
+            .map_err(|_| ())?,
         );
         let lease_manager = WorkspaceLeaseManager::new(
             lease_store,
@@ -244,6 +251,13 @@ fn workspace_owner(cluster: &ResourceId, allocation: &DispatchAllocation) -> Res
     OwnerId::new(format!("native-agent-{:x}", digest.finalize())).map_err(|_| ())
 }
 
+fn workspace_store_id(resource: &ResourceId) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"zeroshot.native-agent-workspace-store/v1\0");
+    digest.update(resource.as_str().as_bytes());
+    format!("{:x}", digest.finalize())
+}
+
 fn write_marker(
     marker: &Path,
     git_dir: &Path,
@@ -307,12 +321,13 @@ mod tests {
         std::fs::create_dir_all(&state).unwrap();
         std::fs::create_dir_all(workspace.join(".git")).unwrap();
 
-        let authority = NativeAgentWorkspace::open(&state, &workspace).unwrap();
+        let resource = ResourceId::new("changed-after-preflight").unwrap();
+        let authority = NativeAgentWorkspace::open(&state, &resource, &workspace).unwrap();
         let candidate = authority.preflight().unwrap();
         std::fs::write(workspace.join("changed.txt"), b"changed").unwrap();
         let prepared = authority
             .prepare(
-                &ResourceId::new("changed-after-preflight").unwrap(),
+                &resource,
                 &DispatchAllocation {
                     run: RunSequence::new(1).unwrap(),
                     node_instance: NodeInstanceId::new(1).unwrap(),

--- a/zeroshot-rust/src/native_execution/agent/workspace.rs
+++ b/zeroshot-rust/src/native_execution/agent/workspace.rs
@@ -27,6 +27,11 @@ pub(crate) enum AgentWorkspacePreparation {
     Closed(openengine_cluster_protocol::WorkerOutcome),
 }
 
+/// The workspace state observed before the ledger grants effect authority.
+pub(crate) struct AgentWorkspaceCandidate {
+    fingerprint: WorkspaceFingerprint,
+}
+
 pub(crate) struct AgentWorkspaceAuthority {
     lock: Option<File>,
     marker: std::path::PathBuf,
@@ -98,20 +103,22 @@ impl NativeAgentWorkspace {
         self.canonical_root.as_path()
     }
 
-    pub(super) fn preflight(&self) -> Result<(), ()> {
+    pub(super) fn preflight(&self) -> Result<AgentWorkspaceCandidate, ()> {
         let lock = lock_workspace(self.canonical_root.as_path())?;
         require_no_marker(self.canonical_root.as_path())?;
-        self.fingerprints
+        let fingerprint = self
+            .fingerprints
             .fingerprint(self.canonical_root.as_path())
             .map_err(|_| ())?;
         drop(lock);
-        Ok(())
+        Ok(AgentWorkspaceCandidate { fingerprint })
     }
 
     pub(super) async fn prepare(
         &self,
         cluster: &ResourceId,
         allocation: &DispatchAllocation,
+        candidate: AgentWorkspaceCandidate,
     ) -> AgentWorkspacePreparation {
         let lock = match lock_workspace(self.canonical_root.as_path()) {
             Ok(lock) => lock,
@@ -120,15 +127,11 @@ impl NativeAgentWorkspace {
         if require_no_marker(self.canonical_root.as_path()).is_err() {
             return closed_preparation();
         }
-        let fingerprint = match self.fingerprints.fingerprint(self.canonical_root.as_path()) {
-            Ok(fingerprint) => fingerprint,
-            Err(_) => return closed_preparation(),
-        };
         let (request, owner) = match workspace_request(
             cluster,
             allocation,
             self.canonical_root.clone(),
-            fingerprint,
+            candidate.fingerprint,
         ) {
             Ok(requests) => requests,
             Err(()) => return closed_preparation(),
@@ -282,4 +285,46 @@ fn remove_marker(marker: &Path, git_dir: &Path) -> Result<(), ()> {
     File::open(git_dir)
         .and_then(|directory| directory.sync_all())
         .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster_ledger::{ExecutionId, NodeInstanceId, RunSequence};
+
+    #[tokio::test]
+    async fn prepare_rejects_workspace_changed_after_preflight() {
+        let suffix = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let state = std::env::temp_dir().join(format!("zeroshot-agent-state-{suffix}"));
+        let workspace = std::env::temp_dir().join(format!("zeroshot-agent-workspace-{suffix}"));
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::create_dir_all(workspace.join(".git")).unwrap();
+
+        let authority = NativeAgentWorkspace::open(&state, &workspace).unwrap();
+        let candidate = authority.preflight().unwrap();
+        std::fs::write(workspace.join("changed.txt"), b"changed").unwrap();
+        let prepared = authority
+            .prepare(
+                &ResourceId::new("changed-after-preflight").unwrap(),
+                &DispatchAllocation {
+                    run: RunSequence::new(1).unwrap(),
+                    node_instance: NodeInstanceId::new(1).unwrap(),
+                    execution: ExecutionId::new(1).unwrap(),
+                },
+                candidate,
+            )
+            .await;
+
+        assert!(matches!(prepared, AgentWorkspacePreparation::Closed(_)));
+        drop(authority);
+        let _ = std::fs::remove_dir_all(state);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
 }

--- a/zeroshot-rust/src/native_execution/command.rs
+++ b/zeroshot-rust/src/native_execution/command.rs
@@ -1,0 +1,139 @@
+use openengine_cluster_protocol::{canonical_value_bytes, WorkerRef};
+use serde_json::Value;
+
+use crate::cluster_ledger::store::IdempotencyId;
+use crate::cluster_ledger::{DispatchAllocation, ExecutionId, ReplayState, RunSequence};
+use crate::execution::{
+    BuiltinWorkerId, BuiltinWorkerRef, CatalogDigest, DispatchFence, ExecutionCommand,
+    ExecutionCommandSpec, ExecutionInput, ExecutionTargetRef, ProfileDigest, RecoveryRef,
+    RegistryDigest, SessionScope, WorkspaceAccessMode, WorkspaceAccessRef,
+};
+use crate::native_admission::native_worker_protocol::{digest_hex, WORKER_REF};
+
+use super::agent::AgentDispatchInput;
+use super::program::{NativeExecutionRegistry, AGENT_WORKER_REF};
+use super::{admission, NativeExecutionError};
+
+pub(super) fn dispatch_key(
+    run: RunSequence,
+    execution: ExecutionId,
+) -> Result<IdempotencyId, NativeExecutionError> {
+    IdempotencyId::new(format!("native-dispatch-{}-{}", run.get(), execution.get()))
+        .map_err(|_| NativeExecutionError::Contract)
+}
+
+pub(super) fn settlement_key(
+    run: RunSequence,
+    execution: ExecutionId,
+) -> Result<IdempotencyId, NativeExecutionError> {
+    IdempotencyId::new(format!(
+        "native-settlement-{}-{}",
+        run.get(),
+        execution.get()
+    ))
+    .map_err(|_| NativeExecutionError::Contract)
+}
+
+pub(super) fn terminal_key(run: RunSequence) -> Result<IdempotencyId, NativeExecutionError> {
+    IdempotencyId::new(format!("native-terminal-{}", run.get()))
+        .map_err(|_| NativeExecutionError::Contract)
+}
+
+pub(super) struct CommandRequest<'a> {
+    pub(super) state: &'a ReplayState,
+    pub(super) allocation: DispatchAllocation,
+    pub(super) input: Value,
+    pub(super) worker: &'a WorkerRef,
+}
+
+pub(super) fn build(
+    request: CommandRequest<'_>,
+    registry: &NativeExecutionRegistry,
+) -> Result<ExecutionCommand, NativeExecutionError> {
+    let CommandRequest {
+        state,
+        allocation,
+        input,
+        worker,
+    } = request;
+    let admission = admission(state)?;
+    let (dispatch_fence, recovery_ref) = control_refs(&allocation)?;
+    let (catalog_digest, profile_digest, registry_digest) = digests(admission, registry)?;
+    ExecutionCommand::new(ExecutionCommandSpec {
+        cluster: state.resource.clone(),
+        run: allocation.run,
+        node_instance: allocation.node_instance,
+        execution: allocation.execution,
+        dispatch_fence,
+        recovery_ref,
+        target: target(worker)?,
+        catalog_digest,
+        profile_digest,
+        registry_digest,
+        workspace: WorkspaceAccessRef::new(state.resource.clone(), WorkspaceAccessMode::Exclusive)
+            .map_err(|_| NativeExecutionError::Contract)?,
+        input: execution_input(input, admission.generation.get(), worker)?,
+        session_scope: SessionScope::Execution,
+        execution_deadline_ms: admission.absolute_deadline_ms,
+        session_deadline_ms: admission.absolute_deadline_ms,
+    })
+    .map_err(|_| NativeExecutionError::Contract)
+}
+
+fn control_refs(
+    allocation: &DispatchAllocation,
+) -> Result<(DispatchFence, RecoveryRef), NativeExecutionError> {
+    let fence = DispatchFence::new(allocation.execution.get())
+        .map_err(|_| NativeExecutionError::Contract)?;
+    let recovery = RecoveryRef::new(format!(
+        "native-run-{}-execution-{}",
+        allocation.run.get(),
+        allocation.execution.get()
+    ))
+    .map_err(|_| NativeExecutionError::Contract)?;
+    Ok((fence, recovery))
+}
+
+fn target(worker: &WorkerRef) -> Result<ExecutionTargetRef, NativeExecutionError> {
+    let worker = match worker.as_str() {
+        WORKER_REF => "native.deterministic",
+        AGENT_WORKER_REF => "native.agent.codex",
+        _ => return Err(NativeExecutionError::InvalidState),
+    };
+    let worker = BuiltinWorkerId::new(worker).map_err(|_| NativeExecutionError::Contract)?;
+    let target = BuiltinWorkerRef::new(worker, 1).map_err(|_| NativeExecutionError::Contract)?;
+    Ok(ExecutionTargetRef::Builtin(target))
+}
+
+fn digests(
+    admission: &crate::cluster_ledger::replay::AdmissionState,
+    registry: &NativeExecutionRegistry,
+) -> Result<(CatalogDigest, ProfileDigest, RegistryDigest), NativeExecutionError> {
+    let catalog = CatalogDigest::new(digest_hex(admission.catalog_digest))
+        .map_err(|_| NativeExecutionError::Contract)?;
+    let profile = ProfileDigest::new(digest_hex(admission.profile_digest))
+        .map_err(|_| NativeExecutionError::Contract)?;
+    let registry = RegistryDigest::new(digest_hex(registry.catalog_digest()))
+        .map_err(|_| NativeExecutionError::Contract)?;
+    Ok((catalog, profile, registry))
+}
+
+fn execution_input(
+    input: Value,
+    generation: u64,
+    worker: &WorkerRef,
+) -> Result<ExecutionInput, NativeExecutionError> {
+    let value = if worker.as_str() == AGENT_WORKER_REF {
+        serde_json::to_value(
+            AgentDispatchInput::new(generation, input)
+                .map_err(|()| NativeExecutionError::InvalidState)?,
+        )
+        .map_err(|_| NativeExecutionError::InvalidState)?
+    } else {
+        input
+    };
+    let canonical =
+        canonical_value_bytes(&value).map_err(|_| NativeExecutionError::InvalidState)?;
+    let inline = String::from_utf8(canonical).map_err(|_| NativeExecutionError::InvalidState)?;
+    ExecutionInput::inline(inline).map_err(|_| NativeExecutionError::Contract)
+}

--- a/zeroshot-rust/src/native_execution/process.rs
+++ b/zeroshot-rust/src/native_execution/process.rs
@@ -22,7 +22,7 @@ use crate::execution::{
 use crate::native_admission::native_worker_protocol::{effect_marker_id, WORKER_MODE};
 
 use super::program::NATIVE_PROCESS_TIMEOUT_MS;
-use super::agent::{AgentWorkspacePreparation, NativeAgent};
+use super::agent::{AgentWorkspaceCandidate, AgentWorkspacePreparation, NativeAgent};
 use super::program::AGENT_WORKER_REF;
 use super::{NativeExecutionError, NativeExecutionProcess};
 
@@ -37,28 +37,27 @@ impl NativeExecutionRuntime {
         &self,
         worker: &str,
         input: &serde_json::Value,
-    ) -> Result<(), NativeExecutionError> {
+    ) -> Result<Option<AgentWorkspaceCandidate>, NativeExecutionError> {
         if worker == AGENT_WORKER_REF {
-            self.agent
+            let candidate = self
+                .agent
                 .preflight(input)
                 .await
                 .map_err(|()| NativeExecutionError::Preflight)?;
+            return Ok(Some(candidate));
         }
-        Ok(())
+        Ok(None)
     }
 
     pub(super) async fn prepare_workspace(
         &self,
-        worker: &str,
         cluster: &crate::cluster_ledger::ResourceId,
         allocation: &crate::cluster_ledger::DispatchAllocation,
-    ) -> Result<Option<AgentWorkspacePreparation>, NativeExecutionError> {
-        if worker == AGENT_WORKER_REF {
-            return Ok(Some(
-                self.agent.prepare_workspace(cluster, allocation).await,
-            ));
-        }
-        Ok(None)
+        candidate: AgentWorkspaceCandidate,
+    ) -> AgentWorkspacePreparation {
+        self.agent
+            .prepare_workspace(cluster, allocation, candidate)
+            .await
     }
 
     pub(super) async fn dispatch(

--- a/zeroshot-rust/src/native_execution/process.rs
+++ b/zeroshot-rust/src/native_execution/process.rs
@@ -17,31 +17,90 @@ use crate::execution::process::{
 };
 use crate::execution::{
     CompletionEvidence, ExecutionCandidate, ExecutionCommand, ExecutionInput, ExecutionResult,
-    ExecutionTargetRef, WorkspaceAccessMode,
+    ExecutionRuntime, ExecutionTargetRef, WorkspaceAccessMode,
 };
 use crate::native_admission::native_worker_protocol::{effect_marker_id, WORKER_MODE};
 
 use super::program::NATIVE_PROCESS_TIMEOUT_MS;
+use super::agent::{AgentWorkspacePreparation, NativeAgent};
+use super::program::AGENT_WORKER_REF;
+use super::{NativeExecutionError, NativeExecutionProcess};
 
-pub(crate) struct NativeExecutionProcess {
-    pub(crate) state_dir: PathBuf,
-    pub(crate) executable: PathBuf,
+#[derive(Clone)]
+pub(super) struct NativeExecutionRuntime {
+    runtime: LocalExecutionRuntime,
+    agent: NativeAgent,
 }
 
-pub(super) fn runtime(process: NativeExecutionProcess) -> LocalExecutionRuntime {
-    let driver = Arc::new(NativeDeterministicDriver {
+impl NativeExecutionRuntime {
+    pub(super) async fn preflight(
+        &self,
+        worker: &str,
+        input: &serde_json::Value,
+    ) -> Result<(), NativeExecutionError> {
+        if worker == AGENT_WORKER_REF {
+            self.agent
+                .preflight(input)
+                .await
+                .map_err(|()| NativeExecutionError::Preflight)?;
+        }
+        Ok(())
+    }
+
+    pub(super) async fn prepare_workspace(
+        &self,
+        worker: &str,
+        cluster: &crate::cluster_ledger::ResourceId,
+        allocation: &crate::cluster_ledger::DispatchAllocation,
+    ) -> Result<Option<AgentWorkspacePreparation>, NativeExecutionError> {
+        if worker == AGENT_WORKER_REF {
+            return Ok(Some(
+                self.agent.prepare_workspace(cluster, allocation).await,
+            ));
+        }
+        Ok(None)
+    }
+
+    pub(super) async fn dispatch(
+        &self,
+        command: ExecutionCommand,
+    ) -> crate::execution::DispatchObservation {
+        self.runtime.dispatch(command).await
+    }
+
+    pub(super) async fn reverify_agent_terminal(
+        &self,
+        terminal: &openengine_cluster_protocol::TerminalResult,
+    ) -> Result<(), NativeExecutionError> {
+        self.agent
+            .reverify_terminal(terminal)
+            .await
+            .map_err(|()| NativeExecutionError::InvalidState)
+    }
+}
+
+pub(super) fn runtime(
+    process: NativeExecutionProcess,
+) -> Result<NativeExecutionRuntime, NativeExecutionError> {
+    let deterministic = Arc::new(NativeDeterministicDriver {
         runner: LocalProcessRunner::new(),
-        executable: process.executable,
+        executable: process.executable.clone(),
     });
-    LocalExecutionRuntime::new(Arc::new(NativeExecutionResolver {
-        driver,
+    let agent = NativeAgent::new(&process).map_err(|()| NativeExecutionError::Contract)?;
+    let runtime = LocalExecutionRuntime::new(Arc::new(NativeExecutionResolver {
+        deterministic,
+        agent: agent.driver(),
         state_dir: process.state_dir,
-    }))
+        workspace: process.workspace,
+    }));
+    Ok(NativeExecutionRuntime { runtime, agent })
 }
 
 struct NativeExecutionResolver {
-    driver: Arc<NativeDeterministicDriver>,
+    deterministic: Arc<NativeDeterministicDriver>,
+    agent: Arc<dyn BuiltinWorkerDriver>,
     state_dir: PathBuf,
+    workspace: PathBuf,
 }
 
 #[async_trait]
@@ -50,16 +109,24 @@ impl ExecutionSiteResolver for NativeExecutionResolver {
         let ExecutionTargetRef::Builtin(target) = command.target() else {
             return indeterminate_resolution();
         };
-        if target.builtin_id().as_str() != "native.deterministic" || target.version() != 1 {
+        if target.version() != 1 {
             return indeterminate_resolution();
         }
+        let (driver, workspace) = match target.builtin_id().as_str() {
+            "native.deterministic" => (
+                self.deterministic.clone() as Arc<dyn BuiltinWorkerDriver>,
+                self.state_dir.clone(),
+            ),
+            "native.agent.codex" => (self.agent.clone(), self.workspace.clone()),
+            _ => return indeterminate_resolution(),
+        };
         ExecutionSiteResolution::Resolved(Box::new(ResolvedExecutionSite::Builtin {
-            driver: self.driver.clone(),
+            driver,
             request: DriverRequest {
                 control: command.control(),
                 input: command.input().clone(),
                 workspace: WorkspaceCapability {
-                    current_dir: self.state_dir.clone(),
+                    current_dir: workspace,
                     mode: WorkspaceAccessMode::Exclusive,
                 },
                 credentials: Vec::new(),

--- a/zeroshot-rust/src/native_execution/program.rs
+++ b/zeroshot-rust/src/native_execution/program.rs
@@ -15,7 +15,19 @@ use crate::cluster_ledger::record::CanonicalDigest;
 use crate::cluster_ledger::ReplayState;
 use crate::native_admission::native_worker_protocol::WORKER_REF;
 
+#[path = "program/foreground.rs"]
+mod foreground;
+
 pub(super) const NATIVE_PROCESS_TIMEOUT_MS: u64 = 10_000;
+pub(super) const NATIVE_AGENT_PROCESS_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+pub(super) const AGENT_WORKER_REF: &str = "native.agent.codex@1";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeProgram {
+    WorkerFree,
+    Deterministic,
+    ForegroundAgent,
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,12 +51,23 @@ pub(crate) struct NativeExecutionRegistry {
 
 impl NativeExecutionRegistry {
     pub(crate) fn production() -> Self {
-        Self::from_descriptors(Arc::from([deterministic_descriptor()]))
+        Self::from_descriptors(Arc::from([
+            foreground::descriptor(),
+            deterministic_descriptor(),
+        ]))
     }
 
-    pub(crate) fn predecessor_digests() -> (CanonicalDigest, CanonicalDigest) {
+    pub(crate) fn predecessor_digests() -> Vec<(CanonicalDigest, CanonicalDigest, bool)> {
         let empty = Self::from_descriptors(Arc::from([]));
-        (empty.catalog_digest, empty.profile_digest)
+        let deterministic = Self::from_descriptors(Arc::from([deterministic_descriptor()]));
+        vec![
+            (empty.catalog_digest, empty.profile_digest, false),
+            (
+                deterministic.catalog_digest,
+                deterministic.profile_digest,
+                true,
+            ),
+        ]
     }
 
     fn from_descriptors(descriptors: Arc<[WorkerDescriptor]>) -> Self {
@@ -85,10 +108,10 @@ impl NativeExecutionRegistry {
         })
     }
 
-    pub(crate) fn descriptor(&self) -> &WorkerDescriptor {
+    pub(crate) fn descriptor(&self, worker: &str) -> Option<&WorkerDescriptor> {
         self.descriptors
-            .first()
-            .expect("production native registry has one descriptor")
+            .iter()
+            .find(|descriptor| descriptor.worker.as_str() == worker)
     }
 }
 
@@ -121,19 +144,36 @@ impl NativeGraphVerifier {
 impl GraphVerifier for NativeGraphVerifier {
     async fn verify(&self, graph: &GraphSpec) -> Result<VerifiedGraph, VerificationError> {
         let verified = self.inner.verify(graph).await?;
-        if !contains_executable(&graph.root) || is_deterministic_graph(graph) {
-            return Ok(verified);
+        match classify_graph(graph) {
+            Some(_) => Ok(verified),
+            None => Err(VerificationError::Rejected {
+                diagnostics: vec![GraphDiagnostic {
+                    severity: DiagnosticSeverity::Error,
+                    code: GraphDiagnosticCode::InvalidGraphShape,
+                    message: "native execution permits only the fixed foreground programs"
+                        .to_owned(),
+                    path: Vec::new(),
+                    related_nodes: Vec::new(),
+                }],
+            }),
         }
-        Err(VerificationError::Rejected {
-            diagnostics: vec![GraphDiagnostic {
-                severity: DiagnosticSeverity::Error,
-                code: GraphDiagnosticCode::InvalidGraphShape,
-                message: "native execution permits only the fixed one-step graph".to_owned(),
-                path: Vec::new(),
-                related_nodes: Vec::new(),
-            }],
-        })
     }
+}
+
+pub(crate) fn classify_graph(graph: &GraphSpec) -> Option<NativeProgram> {
+    if is_worker_free_graph(graph) {
+        Some(NativeProgram::WorkerFree)
+    } else if is_deterministic_graph(graph) {
+        Some(NativeProgram::Deterministic)
+    } else if *graph == foreground_graph() {
+        Some(NativeProgram::ForegroundAgent)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn foreground_graph() -> GraphSpec {
+    foreground::graph()
 }
 
 pub(crate) fn deterministic_graph() -> GraphSpec {

--- a/zeroshot-rust/src/native_execution/program/foreground.rs
+++ b/zeroshot-rust/src/native_execution/program/foreground.rs
@@ -1,0 +1,190 @@
+use openengine_cluster_protocol::{GraphSpec, WorkerDescriptor};
+use serde_json::json;
+
+use super::AGENT_WORKER_REF;
+
+pub(super) fn graph() -> GraphSpec {
+    serde_json::from_value(json!({
+        "profile": "openengine.graph.full/v1",
+        "initialInput": input_type(),
+        "policy": { "policy": "policy.default@1", "default": "deny" },
+        "root": {
+            "kind": "seq",
+            "name": "root",
+            "state": state_type(),
+            "children": [agent_step(), terminal_choice()],
+            "promotedStatePaths": []
+        }
+    }))
+    .expect("fixed native foreground agent graph must decode")
+}
+
+fn agent_step() -> serde_json::Value {
+    json!({
+        "kind": "step",
+        "name": "codex",
+        "worker": AGENT_WORKER_REF,
+        "input": input_type(),
+        "output": output_type(),
+        "inputBindings": [
+            {
+                "target": ["prompt"],
+                "value": { "source": "state", "path": ["prompt"] }
+            },
+            {
+                "target": ["expectedGreeting"],
+                "value": { "source": "state", "path": ["expectedGreeting"] }
+            }
+        ],
+        "writeBindings": [
+            {
+                "value": { "node": "codex", "channel": "out", "path": ["summary"] },
+                "target": ["summary"]
+            },
+            {
+                "value": {
+                    "node": "codex",
+                    "channel": "out",
+                    "path": ["validationArtifact"]
+                },
+                "target": ["validationArtifact"]
+            }
+        ],
+        "timeoutMs": 3_600_000,
+        "attempts": 1
+    })
+}
+
+fn terminal_choice() -> serde_json::Value {
+    json!({
+        "kind": "choice",
+        "name": "finish",
+        "state": state_type(),
+        "branches": [{
+            "when": {
+                "kind": "in",
+                "value": { "name": "codex", "source": "error", "field": null },
+                "labels": ["timeout", "crash", "malformed", "refusal"]
+            },
+            "node": { "kind": "fail", "name": "failed", "reason": "worker_failed" }
+        }],
+        "otherwise": {
+            "kind": "succeed",
+            "name": "done",
+            "output": output_type(),
+            "bindings": [
+                {
+                    "target": ["summary"],
+                    "value": { "source": "state", "path": ["summary"] }
+                },
+                {
+                    "target": ["validationArtifact"],
+                    "value": { "source": "state", "path": ["validationArtifact"] }
+                }
+            ]
+        },
+        "promotedStatePaths": []
+    })
+}
+
+pub(super) fn descriptor() -> WorkerDescriptor {
+    serde_json::from_value(json!({
+        "worker": AGENT_WORKER_REF,
+        "graphProfiles": ["openengine.graph.full/v1"],
+        "binding": {
+            "protocol": "builtin",
+            "version": "1",
+            "profile": "openengine.worker.builtin/v1"
+        },
+        "contract": {
+            "input": input_type(),
+            "output": output_type(),
+            "verifier": null,
+            "errors": ["timeout", "crash", "malformed", "refusal"]
+        },
+        "capabilityPolicy": {
+            "autonomy": "strict",
+            "permissionPolicy": "policy.default@1"
+        },
+        "artifactProfile": {
+            "allowedTypeIds": ["native.agent.validation@1"],
+            "allowedMediaTypes": ["application/json"],
+            "minimumRedaction": "internal"
+        },
+        "credentialRequirements": []
+    }))
+    .expect("fixed native foreground agent descriptor must decode")
+}
+
+fn input_type() -> serde_json::Value {
+    json!({
+        "kind": "record",
+        "fields": {
+            "prompt": { "type": { "kind": "string" }, "required": true },
+            "expectedGreeting": { "type": { "kind": "string" }, "required": true }
+        }
+    })
+}
+
+fn state_type() -> serde_json::Value {
+    json!({
+        "kind": "record",
+        "fields": {
+            "prompt": { "type": { "kind": "string" }, "required": true },
+            "expectedGreeting": { "type": { "kind": "string" }, "required": true },
+            "summary": { "type": { "kind": "string" }, "required": false },
+            "validationArtifact": { "type": artifact_type(), "required": false }
+        }
+    })
+}
+
+fn output_type() -> serde_json::Value {
+    json!({
+        "kind": "record",
+        "fields": {
+            "summary": { "type": { "kind": "string" }, "required": true },
+            "validationArtifact": { "type": artifact_type(), "required": true }
+        }
+    })
+}
+
+fn artifact_type() -> serde_json::Value {
+    json!({
+        "kind": "record",
+        "fields": {
+            "artifactId": { "type": { "kind": "string" }, "required": true },
+            "sha256": { "type": { "kind": "string" }, "required": true },
+            "byteLength": { "type": { "kind": "integer" }, "required": true },
+            "mediaType": { "type": { "kind": "string" }, "required": true },
+            "typeId": { "type": { "kind": "string" }, "required": true },
+            "producer": {
+                "type": {
+                    "kind": "record",
+                    "fields": {
+                        "node": { "type": { "kind": "string" }, "required": true },
+                        "worker": { "type": { "kind": "string" }, "required": true }
+                    }
+                },
+                "required": true
+            },
+            "lineage": {
+                "type": {
+                    "kind": "record",
+                    "fields": {
+                        "generation": { "type": { "kind": "integer" }, "required": true },
+                        "runId": { "type": { "kind": "string" }, "required": true },
+                        "attempt": { "type": { "kind": "integer" }, "required": true }
+                    }
+                },
+                "required": true
+            },
+            "redaction": {
+                "type": {
+                    "kind": "enum",
+                    "values": ["public", "internal", "confidential", "restricted"]
+                },
+                "required": true
+            }
+        }
+    })
+}

--- a/zeroshot-rust/src/native_execution/validation.rs
+++ b/zeroshot-rust/src/native_execution/validation.rs
@@ -1,15 +1,28 @@
-use openengine_cluster_protocol::{canonical_value_bytes, WorkerOutcome};
+use openengine_cluster_protocol::{
+    canonical_value_bytes, ArtifactRef, TerminalResult, WorkerDescriptor, WorkerOutcome, WorkerRef,
+};
 use serde_json::json;
 
 use crate::cluster_ledger::DispatchAllocation;
 use crate::execution::{CompletionEvidence, DispatchFence, DispatchObservation};
 
-use super::program::NativeExecutionRegistry;
+use super::program::{AGENT_WORKER_REF, NativeExecutionRegistry};
 use super::NativeExecutionError;
 use crate::native_admission::native_worker_protocol::OUTPUT_VALUE;
+use super::agent::AgentTerminalOutput;
+
+pub(super) fn canonical_terminal_bytes(
+    value: &TerminalResult,
+) -> Result<Vec<u8>, NativeExecutionError> {
+    canonical_value_bytes(
+        &serde_json::to_value(value).map_err(|_| NativeExecutionError::InvalidState)?,
+    )
+    .map_err(|_| NativeExecutionError::InvalidState)
+}
 
 pub(super) fn validate_observation(
     registry: &NativeExecutionRegistry,
+    worker: &WorkerRef,
     allocation: &DispatchAllocation,
     observation: DispatchObservation,
 ) -> Result<Vec<u8>, NativeExecutionError> {
@@ -27,29 +40,17 @@ pub(super) fn validate_observation(
     if !identity_matches || !matches!(result.evidence(), CompletionEvidence::Success) {
         return Err(NativeExecutionError::InvalidState);
     }
-    validate_candidate(registry, result.candidate().as_str().as_bytes())
+    validate_candidate(registry, worker, result.candidate().as_str().as_bytes())
 }
 
 fn validate_candidate(
     registry: &NativeExecutionRegistry,
+    worker: &WorkerRef,
     candidate: &[u8],
 ) -> Result<Vec<u8>, NativeExecutionError> {
     let outcome: WorkerOutcome =
         serde_json::from_slice(candidate).map_err(|_| NativeExecutionError::InvalidState)?;
-    let WorkerOutcome::Verified { output, artifacts } = &outcome else {
-        return Err(NativeExecutionError::InvalidState);
-    };
-    let valid = artifacts.is_empty()
-        && output == &json!({ "value": OUTPUT_VALUE })
-        && registry
-            .descriptor()
-            .contract
-            .output
-            .validate_value(output)
-            .is_ok();
-    if !valid {
-        return Err(NativeExecutionError::InvalidState);
-    }
+    validate_outcome(registry, worker, &outcome)?;
     let value = serde_json::to_value(&outcome).map_err(|_| NativeExecutionError::InvalidState)?;
     let canonical =
         canonical_value_bytes(&value).map_err(|_| NativeExecutionError::InvalidState)?;
@@ -57,6 +58,82 @@ fn validate_candidate(
         return Err(NativeExecutionError::InvalidState);
     }
     Ok(canonical)
+}
+
+pub(super) fn canonical_outcome(
+    registry: &NativeExecutionRegistry,
+    worker: &WorkerRef,
+    outcome: WorkerOutcome,
+) -> Result<Vec<u8>, NativeExecutionError> {
+    let value = serde_json::to_value(outcome).map_err(|_| NativeExecutionError::InvalidState)?;
+    let candidate =
+        canonical_value_bytes(&value).map_err(|_| NativeExecutionError::InvalidState)?;
+    validate_candidate(registry, worker, &candidate)
+}
+
+fn validate_outcome(
+    registry: &NativeExecutionRegistry,
+    worker: &WorkerRef,
+    outcome: &WorkerOutcome,
+) -> Result<(), NativeExecutionError> {
+    let descriptor = registry
+        .descriptor(worker.as_str())
+        .ok_or(NativeExecutionError::InvalidState)?;
+    match outcome {
+        WorkerOutcome::Error { code, .. } => descriptor
+            .contract
+            .errors
+            .contains(code)
+            .then_some(())
+            .ok_or(NativeExecutionError::InvalidState),
+        WorkerOutcome::Verified { output, artifacts } => {
+            validate_verified(descriptor, worker, output, artifacts)
+        }
+        _ => Err(NativeExecutionError::InvalidState),
+    }
+}
+
+fn validate_verified(
+    descriptor: &WorkerDescriptor,
+    worker: &WorkerRef,
+    output: &serde_json::Value,
+    artifacts: &[ArtifactRef],
+) -> Result<(), NativeExecutionError> {
+    descriptor
+        .contract
+        .output
+        .validate_value(output)
+        .map_err(|_| NativeExecutionError::InvalidState)?;
+    match worker.as_str() {
+        crate::native_admission::native_worker_protocol::WORKER_REF => {
+            validate_deterministic(output, artifacts)
+        }
+        AGENT_WORKER_REF => validate_agent(output, artifacts),
+        _ => Err(NativeExecutionError::InvalidState),
+    }
+}
+
+fn validate_deterministic(
+    output: &serde_json::Value,
+    artifacts: &[ArtifactRef],
+) -> Result<(), NativeExecutionError> {
+    (artifacts.is_empty() && output == &json!({ "value": OUTPUT_VALUE }))
+        .then_some(())
+        .ok_or(NativeExecutionError::InvalidState)
+}
+
+fn validate_agent(
+    output: &serde_json::Value,
+    artifacts: &[ArtifactRef],
+) -> Result<(), NativeExecutionError> {
+    let terminal: AgentTerminalOutput =
+        serde_json::from_value(output.clone()).map_err(|_| NativeExecutionError::InvalidState)?;
+    terminal
+        .validate()
+        .map_err(|()| NativeExecutionError::InvalidState)?;
+    (artifacts == [terminal.validation_artifact])
+        .then_some(())
+        .ok_or(NativeExecutionError::InvalidState)
 }
 
 #[cfg(test)]
@@ -71,6 +148,10 @@ mod tests {
 
     fn candidate(value: serde_json::Value) -> Vec<u8> {
         canonical_value_bytes(&value).unwrap()
+    }
+
+    fn worker() -> WorkerRef {
+        WorkerRef::new(crate::native_admission::native_worker_protocol::WORKER_REF).unwrap()
     }
 
     fn allocation() -> DispatchAllocation {
@@ -109,11 +190,12 @@ mod tests {
             artifacts: Vec::new(),
         })
         .unwrap();
-        assert!(validate_candidate(&registry, &candidate(valid)).is_ok());
-        assert!(validate_candidate(&registry, b"not-json").is_err());
+        assert!(validate_candidate(&registry, &worker(), &candidate(valid)).is_ok());
+        assert!(validate_candidate(&registry, &worker(), b"not-json").is_err());
         assert!(
             validate_candidate(
                 &registry,
+                &worker(),
                 br#"{ "status":"verified","output":{"value":42},"artifacts":[] }"#,
             )
             .is_err()
@@ -121,6 +203,7 @@ mod tests {
         assert!(
             validate_candidate(
                 &registry,
+                &worker(),
                 &candidate(json!({
                     "status": "verifier",
                     "output": { "value": 42 },
@@ -134,6 +217,7 @@ mod tests {
         assert!(
             validate_candidate(
                 &registry,
+                &worker(),
                 &candidate(json!({
                     "status": "verified",
                     "output": { "value": 42 },
@@ -164,6 +248,7 @@ mod tests {
         assert!(
             validate_observation(
                 &registry,
+                &worker(),
                 &allocation,
                 DispatchObservation::Running {
                     execution: allocation.execution,
@@ -175,6 +260,7 @@ mod tests {
         assert!(
             validate_observation(
                 &registry,
+                &worker(),
                 &allocation,
                 DispatchObservation::Completed {
                     execution: ExecutionId::new(2).unwrap(),
@@ -187,6 +273,7 @@ mod tests {
         assert!(
             validate_observation(
                 &registry,
+                &worker(),
                 &allocation,
                 DispatchObservation::Completed {
                     execution: allocation.execution,

--- a/zeroshot-rust/src/native_settings/profile.rs
+++ b/zeroshot-rust/src/native_settings/profile.rs
@@ -85,7 +85,7 @@ pub struct ProfileFile {
 }
 
 /// Validated, cycle-free named-profile set: no duplicate ids, no unknown `extends` targets, and
-/// every inheritance chain within [`MAX_PROFILE_INHERITANCE_DEPTH`].
+/// every inheritance chain within `MAX_PROFILE_INHERITANCE_DEPTH`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProfileRegistry(BTreeMap<ProfileId, Profile>);
 

--- a/zeroshot-rust/tests/full_v1_reducer_failures.rs
+++ b/zeroshot-rust/tests/full_v1_reducer_failures.rs
@@ -1,0 +1,141 @@
+use async_trait::async_trait;
+use openengine_cluster_protocol::{
+    GraphSpec, PositiveInteger, WorkerDescriptor, WorkerErrorCode, WorkerOutcome, WorkerRef,
+};
+use openengine_cluster_server::admission::{GraphVerifier, VerifiedGraph};
+use openengine_cluster_server::graph_verifier::ProductionGraphVerifier;
+use openengine_cluster_server::worker_registry::{WorkerRegistry, WorkerRegistryError};
+use serde_json::json;
+use zeroshot_engine::cluster_ledger::store::Position;
+use zeroshot_engine::cluster_ledger::{ExecutionId, NodeInstanceId, RunSequence, StructuralOccurrence};
+use zeroshot_engine::full_v1_reducer::{
+    DurableExecution, DurableExecutionState, FullV1Reducer, ReductionInput, TerminalProjection,
+};
+
+struct TestWorker;
+
+#[async_trait]
+impl WorkerRegistry for TestWorker {
+    async fn resolve(&self, worker: &WorkerRef) -> Result<WorkerDescriptor, WorkerRegistryError> {
+        serde_json::from_value(json!({
+            "worker": worker.as_str(),
+            "graphProfiles": ["openengine.graph.full/v1"],
+            "binding": {
+                "protocol": "acp",
+                "version": "1",
+                "profile": "openengine.worker.acp/v1"
+            },
+            "contract": {
+                "input": {"kind":"null"},
+                "output": {
+                    "kind":"record",
+                    "fields":{"value":{"type":{"kind":"integer"},"required":true}}
+                },
+                "verifier": null,
+                "errors": ["timeout", "crash", "malformed", "refusal"]
+            },
+            "capabilityPolicy": {
+                "autonomy": "strict",
+                "permissionPolicy": "policy.strict@1"
+            },
+            "artifactProfile": {
+                "allowedTypeIds": ["openengine.result@1"],
+                "allowedMediaTypes": ["application/json"],
+                "minimumRedaction": "internal"
+            },
+            "credentialRequirements": []
+        }))
+        .map_err(|_| WorkerRegistryError::NotFound {
+            worker: worker.clone(),
+        })
+    }
+}
+
+async fn verified_graph() -> VerifiedGraph {
+    let state = json!({
+        "kind":"record",
+        "fields":{"value":{"type":{"kind":"integer"},"required":false}}
+    });
+    let graph: GraphSpec = serde_json::from_value(json!({
+        "profile":"openengine.graph.full/v1",
+        "initialInput":state.clone(),
+        "policy":{"policy":"policy.test@1","default":"deny"},
+        "root":{
+            "kind":"seq", "name":"root", "state":state.clone(),
+            "children":[
+                {
+                    "kind":"step", "name":"work", "worker":"worker.test@1",
+                    "input":{"kind":"null"},
+                    "output":{
+                        "kind":"record",
+                        "fields":{"value":{"type":{"kind":"integer"},"required":true}}
+                    },
+                    "inputBindings":[],
+                    "writeBindings":[{
+                        "value":{"node":"work","channel":"out","path":["value"]},
+                        "target":["value"]
+                    }],
+                    "timeoutMs":1, "attempts":1
+                },
+                {
+                    "kind":"choice", "name":"route", "state":state,
+                    "branches":[{
+                        "when":{
+                            "kind":"in",
+                            "value":{"name":"work","source":"error","field":null},
+                            "labels":["crash"]
+                        },
+                        "node":{"kind":"fail","name":"failed","reason":"worker_failed"}
+                    }],
+                    "otherwise":{
+                        "kind":"succeed", "name":"done",
+                        "output":{"kind":"null"}, "bindings":[]
+                    },
+                    "promotedStatePaths":[]
+                }
+            ],
+            "promotedStatePaths":[]
+        }
+    }))
+    .unwrap();
+    ProductionGraphVerifier::new(TestWorker)
+        .verify(&graph)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn failed_step_does_not_promote_success_only_writes_before_error_routing() {
+    let execution = DurableExecution {
+        run: RunSequence::new(1).unwrap(),
+        dispatch_position: Position::new(2).unwrap(),
+        node_instance: NodeInstanceId::new(1).unwrap(),
+        execution: ExecutionId::new(1).unwrap(),
+        occurrence: StructuralOccurrence {
+            node: "work".parse().unwrap(),
+            map_indices: Vec::new(),
+        },
+        attempt: PositiveInteger::new(1).unwrap(),
+        input: serde_json::Value::Null,
+        state: DurableExecutionState::Settled {
+            position: Position::new(3).unwrap(),
+            outcome: WorkerOutcome::declared_failure(WorkerErrorCode::Crash),
+        },
+    };
+    let reduction = FullV1Reducer::new(&verified_graph().await)
+        .reduce(ReductionInput {
+            run: RunSequence::new(1).unwrap(),
+            snapshot: None,
+            initial_input: &json!({}),
+            executions: &[execution],
+            next_node_instance: 2,
+            next_execution: 2,
+        })
+        .unwrap();
+    assert_eq!(
+        reduction.terminal,
+        Some(TerminalProjection::Failed {
+            reason: "worker_failed".parse().unwrap()
+        })
+    );
+}

--- a/zeroshot-rust/tests/native_execution_corruption.rs
+++ b/zeroshot-rust/tests/native_execution_corruption.rs
@@ -18,7 +18,10 @@ async fn assert_startup_fails_without_effect(state: &TempState, cluster: &str) {
     assert!(client.initialize().await.is_err());
     drop(client);
     let diagnostics = process.join_failure().await;
-    assert!(diagnostics.contains("execution state is invalid"));
+    assert!(
+        diagnostics.contains("execution state is invalid"),
+        "unexpected native diagnostics: {diagnostics}"
+    );
     assert_eq!(effect_count(state), 0);
 }
 

--- a/zeroshot-rust/tests/native_foreground_agent_process.rs
+++ b/zeroshot-rust/tests/native_foreground_agent_process.rs
@@ -1,0 +1,385 @@
+#[path = "support/native_process.rs"]
+pub mod native_process;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use native_process::{rpc_domain_code, spawn_with_workspace, NativeClient, NativeProcess, TempState};
+use openengine_cluster_protocol::{
+    ApplyParams, ArtifactRef, Generation, GetParams, IdempotencyKey, Phase, PlanParams,
+    TerminalResult, GENERATION_CONFLICT, IDEMPOTENCY_REUSE,
+};
+use serde_json::json;
+use tokio::io::AsyncReadExt;
+use zeroshot_engine::artifact_store::local_cas::LocalCasArtifactStore;
+use zeroshot_engine::artifact_store::ArtifactStore;
+
+const API_KEY: &str = "test-native-openai-key";
+const GREETING: &str = "hello from native zeroshot\n";
+
+#[derive(Clone, Copy)]
+enum FakeMode {
+    Success,
+    Malformed,
+}
+
+struct ForegroundFixture {
+    state: TempState,
+    workspace: TempState,
+    counter: PathBuf,
+    environment: Vec<(String, String)>,
+}
+
+impl ForegroundFixture {
+    fn new(label: &str, mode: FakeMode) -> Self {
+        let state = TempState::new(label);
+        let workspace = prepare_workspace(&format!("{label}-workspace"));
+        let (bin, counter) = install_fake_codex(&state, workspace.path(), mode);
+        Self {
+            state,
+            workspace,
+            counter,
+            environment: environment(&bin),
+        }
+    }
+
+    fn spawn(&self, cluster: &str, include_credential: bool) -> (NativeProcess, NativeClient) {
+        let environment = self
+            .environment
+            .iter()
+            .filter(|(name, _)| include_credential || name != "OPENAI_API_KEY")
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        spawn_with_workspace(
+            self.state.path(),
+            cluster,
+            self.workspace.path(),
+            &environment,
+        )
+    }
+
+    fn invocation_count(&self) -> u64 {
+        invocation_count(&self.counter)
+    }
+}
+
+fn apply_request(key: &str) -> ApplyParams {
+    ApplyParams {
+        graph: zeroshot_engine::native_foreground_graph(),
+        input: Some(json!({
+            "prompt": "Make the requested deterministic greeting change.",
+            "expectedGreeting": GREETING
+        })),
+        dry_run: false,
+        if_generation: Some(Generation::new(0).unwrap()),
+        idempotency_key: Some(IdempotencyKey::new(key).unwrap()),
+    }
+}
+
+fn prepare_workspace(label: &str) -> TempState {
+    let workspace = TempState::new(label);
+    let status = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(workspace.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    workspace
+}
+
+fn install_fake_codex(state: &TempState, workspace: &Path, mode: FakeMode) -> (PathBuf, PathBuf) {
+    let bin = state.path().join("fake-bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let executable = bin.join("codex");
+    let counter = state.path().join("codex-invocations");
+    let expected_args = [
+        "exec",
+        "--json",
+        "--sandbox",
+        "workspace-write",
+        "--config",
+        "approval_policy=\"never\"",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--strict-config",
+        "--config",
+        "web_search=\"disabled\"",
+        "-",
+    ];
+    let emitted = match mode {
+        FakeMode::Success => concat!(
+            "print(json.dumps({'type':'thread.started','thread_id':'native-test'}))\n",
+            "print(json.dumps({'type':'item.completed','item':",
+            "{'type':'agent_message','text':'{\\\"summary\\\":\\\"greeting updated\\\"}'}}))\n",
+            "print(json.dumps({'type':'turn.completed','usage':",
+            "{'input_tokens':1,'output_tokens':1}}))\n"
+        ),
+        FakeMode::Malformed => "print(json.dumps({'type':'unknown.event'}))\n",
+    };
+    let script = format!(
+        concat!(
+            "#!/usr/bin/python3\n",
+            "import json, os, pathlib, sys\n\n",
+            "if sys.argv[1:] == ['--version']:\n",
+            "    print('codex-cli 0.147.0')\n",
+            "    raise SystemExit(0)\n",
+            "if sys.argv[1:] == ['exec', '--help']:\n",
+            "    print('--json --sandbox --config --ephemeral --ignore-user-config ",
+            "--ignore-rules --strict-config')\n",
+            "    raise SystemExit(0)\n",
+            "expected = {expected_args:?}\n",
+            "if sys.argv[1:] != expected:\n",
+            "    raise SystemExit(21)\n",
+            "if os.environ.get('OPENAI_API_KEY') != {API_KEY:?}:\n",
+            "    raise SystemExit(22)\n",
+            "if 'ZEROSHOT_SECRET_SENTINEL' in os.environ:\n",
+            "    raise SystemExit(23)\n",
+            "prompt = sys.stdin.read()\n",
+            "if 'Make the requested deterministic greeting change.' not in prompt ",
+            "or {GREETING:?}.strip() not in prompt:\n",
+            "    raise SystemExit(24)\n",
+            "counter = pathlib.Path({counter:?})\n",
+            "count = int(counter.read_text()) if counter.exists() else 0\n",
+            "counter.write_text(str(count + 1))\n",
+            "pathlib.Path({workspace:?}, 'greeting.txt').write_text({GREETING:?})\n",
+            "{emitted}"
+        ),
+        expected_args = expected_args,
+        API_KEY = API_KEY,
+        GREETING = GREETING,
+        counter = counter.to_str().unwrap(),
+        workspace = workspace.to_str().unwrap(),
+        emitted = emitted,
+    );
+    std::fs::write(&executable, script).unwrap();
+    let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&executable, permissions).unwrap();
+    (bin, counter)
+}
+
+fn environment(bin: &Path) -> Vec<(String, String)> {
+    let inherited = std::env::var("PATH").unwrap();
+    vec![
+        (
+            "PATH".to_owned(),
+            format!("{}:{inherited}", bin.to_str().unwrap()),
+        ),
+        ("OPENAI_API_KEY".to_owned(), API_KEY.to_owned()),
+        (
+            "ZEROSHOT_SECRET_SENTINEL".to_owned(),
+            "must-not-reach-provider".to_owned(),
+        ),
+    ]
+}
+
+fn invocation_count(counter: &Path) -> u64 {
+    std::fs::read_to_string(counter)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+fn terminal_artifact(terminal: &TerminalResult) -> ArtifactRef {
+    let TerminalResult::Succeeded { output } = terminal else {
+        panic!("expected successful terminal result: {terminal:?}");
+    };
+    serde_json::from_value(output["validationArtifact"].clone()).unwrap()
+}
+
+fn artifact_root(state: &TempState) -> PathBuf {
+    std::fs::read_dir(state.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("artifacts-"))
+        })
+        .unwrap()
+        .path()
+}
+
+fn artifact_blob(state: &TempState, artifact: &ArtifactRef) -> PathBuf {
+    let digest = artifact.sha256.as_str();
+    artifact_root(state)
+        .join("blobs/sha256")
+        .join(&digest[..2])
+        .join(digest)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn real_foreground_agent_validates_publishes_and_restarts_without_a_second_invocation() {
+    let fixture = ForegroundFixture::new("foreground-agent", FakeMode::Success);
+    let (process, client) = fixture.spawn("foreground-agent", true);
+    client.initialize().await.unwrap();
+    let plan = client
+        .plan(PlanParams {
+            graph: zeroshot_engine::native_foreground_graph(),
+        })
+        .await
+        .unwrap();
+    assert!(plan.ok, "{:#?}", plan.diagnostics);
+    let request = apply_request("foreground-once");
+    client.apply(request.clone()).await.unwrap();
+    let before = client.get(GetParams::default()).await.unwrap();
+    assert_eq!(before.status.phase, Phase::Finished);
+    let terminal = before.terminal_result.as_ref().unwrap();
+    let artifact = terminal_artifact(terminal);
+    assert_eq!(fixture.invocation_count(), 1);
+    assert_eq!(
+        std::fs::read_to_string(fixture.workspace.path().join("greeting.txt")).unwrap(),
+        GREETING
+    );
+    drop(client);
+    process.join_success().await;
+
+    let store = LocalCasArtifactStore::new(artifact_root(&fixture.state)).unwrap();
+    let mut bytes = Vec::new();
+    store
+        .open(&artifact.artifact_id)
+        .await
+        .unwrap()
+        .read_to_end(&mut bytes)
+        .await
+        .unwrap();
+    assert_eq!(artifact.byte_length.get(), bytes.len() as u64);
+    drop(store);
+
+    let (restart, restart_client) = fixture.spawn("foreground-agent", true);
+    let initialized = restart_client.initialize().await.unwrap();
+    assert_eq!(initialized.status.phase, Phase::Finished);
+    let after = restart_client.get(GetParams::default()).await.unwrap();
+    assert_eq!(after, before);
+    assert_eq!(
+        terminal_artifact(after.terminal_result.as_ref().unwrap()),
+        artifact
+    );
+    assert!(restart_client.apply(request).await.unwrap().deduped);
+    assert_eq!(fixture.invocation_count(), 1);
+    drop(restart_client);
+    restart.join_success().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn corrupt_validation_artifact_refuses_restart_without_relaunch() {
+    let fixture = ForegroundFixture::new("foreground-corrupt-artifact", FakeMode::Success);
+    let (process, client) = fixture.spawn("foreground-corrupt-artifact", true);
+    client.initialize().await.unwrap();
+    client
+        .apply(apply_request("corrupt-artifact"))
+        .await
+        .unwrap();
+    let result = client.get(GetParams::default()).await.unwrap();
+    let artifact = terminal_artifact(result.terminal_result.as_ref().unwrap());
+    drop(client);
+    process.join_success().await;
+
+    std::fs::write(artifact_blob(&fixture.state, &artifact), b"corrupt").unwrap();
+    let (restart, restart_client) = fixture.spawn("foreground-corrupt-artifact", true);
+    assert!(restart_client.initialize().await.is_err());
+    drop(restart_client);
+    assert!(
+        restart
+            .join_failure()
+            .await
+            .contains("execution state is invalid")
+    );
+    assert_eq!(fixture.invocation_count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn missing_credential_rejects_before_dispatch_or_provider_effect() {
+    let fixture = ForegroundFixture::new("foreground-missing-credential", FakeMode::Success);
+    let (process, client) = fixture.spawn("foreground-missing-credential", false);
+    client.initialize().await.unwrap();
+    assert!(
+        client
+            .apply(apply_request("missing-credential"))
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        client.get(GetParams::default()).await.unwrap().status.phase,
+        Phase::Running
+    );
+    assert_eq!(fixture.invocation_count(), 0);
+    assert!(!fixture.workspace.path().join("greeting.txt").exists());
+    drop(client);
+    process.join_success().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn malformed_provider_output_settles_failure_without_relaunch() {
+    let fixture = ForegroundFixture::new("foreground-malformed", FakeMode::Malformed);
+    let (process, client) = fixture.spawn("foreground-malformed", true);
+    client.initialize().await.unwrap();
+    client.apply(apply_request("malformed-once")).await.unwrap();
+    let result = client.get(GetParams::default()).await.unwrap();
+    assert_eq!(result.status.phase, Phase::Finished);
+    assert!(matches!(
+        result.terminal_result,
+        Some(TerminalResult::Failed { .. })
+    ));
+    assert_eq!(fixture.invocation_count(), 1);
+    drop(client);
+    process.join_success().await;
+
+    let (restart, restart_client) = fixture.spawn("foreground-malformed", true);
+    restart_client.initialize().await.unwrap();
+    assert_eq!(
+        restart_client.get(GetParams::default()).await.unwrap(),
+        result
+    );
+    assert_eq!(fixture.invocation_count(), 1);
+    drop(restart_client);
+    restart.join_success().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_applies_share_one_provider_authority() {
+    let fixture = ForegroundFixture::new("foreground-concurrent", FakeMode::Success);
+    let (process, client) = fixture.spawn("foreground-concurrent", true);
+    client.initialize().await.unwrap();
+    let same = apply_request("same-key");
+    let (first, second) = tokio::join!(client.apply(same.clone()), client.apply(same));
+    assert_ne!(first.unwrap().deduped, second.unwrap().deduped);
+    assert_eq!(fixture.invocation_count(), 1);
+
+    let mut mismatched = apply_request("same-key");
+    mismatched.input = Some(json!({
+        "prompt": "A different prompt must not reuse the key.",
+        "expectedGreeting": GREETING
+    }));
+    let reuse = client.apply(mismatched).await.unwrap_err();
+    assert_eq!(rpc_domain_code(&reuse), Some(IDEMPOTENCY_REUSE));
+
+    let distinct = client
+        .apply(apply_request("distinct-key"))
+        .await
+        .unwrap_err();
+    assert_eq!(rpc_domain_code(&distinct), Some(GENERATION_CONFLICT));
+    assert_eq!(fixture.invocation_count(), 1);
+    drop(client);
+    process.join_success().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_distinct_keys_still_create_one_provider_effect() {
+    let fixture = ForegroundFixture::new("foreground-distinct-keys", FakeMode::Success);
+    let (process, client) = fixture.spawn("foreground-distinct-keys", true);
+    client.initialize().await.unwrap();
+
+    let (first, second) = tokio::join!(
+        client.apply(apply_request("first-key")),
+        client.apply(apply_request("second-key"))
+    );
+    assert_eq!(first.is_ok() as u8 + second.is_ok() as u8, 1);
+    let conflict = first.err().or_else(|| second.err()).unwrap();
+    assert_eq!(rpc_domain_code(&conflict), Some(GENERATION_CONFLICT));
+    assert_eq!(fixture.invocation_count(), 1);
+    drop(client);
+    process.join_success().await;
+}

--- a/zeroshot-rust/tests/support/native_process.rs
+++ b/zeroshot-rust/tests/support/native_process.rs
@@ -23,6 +23,7 @@ impl TempState {
             std::process::id()
         ));
         std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
         Self { root }
     }
 
@@ -42,6 +43,15 @@ pub struct NativeProcess {
 }
 
 pub fn spawn(state_dir: &Path, cluster_id: &str) -> (NativeProcess, NativeClient) {
+    spawn_with_workspace(state_dir, cluster_id, state_dir, &[])
+}
+
+pub fn spawn_with_workspace(
+    state_dir: &Path,
+    cluster_id: &str,
+    workspace: &Path,
+    environment: &[(&str, &str)],
+) -> (NativeProcess, NativeClient) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_zeroshot-rust"))
         .args([
             "serve-stdio",
@@ -51,7 +61,13 @@ pub fn spawn(state_dir: &Path, cluster_id: &str) -> (NativeProcess, NativeClient
                 .expect("temporary state path must be UTF-8"),
             "--cluster-id",
             cluster_id,
+            "--workspace",
+            workspace
+                .to_str()
+                .expect("temporary workspace path must be UTF-8"),
         ])
+        .env_remove("OPENAI_API_KEY")
+        .envs(environment.iter().copied())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Closes #986

## What changed

- Adds one fixed native foreground Codex program: one step, one attempt, and one authored terminal choice.
- Runs the existing process runtime with a canonical borrowed workspace, a durable execution-scoped lease, and a narrow secret-aware launch input.
- Validates the exact `greeting.txt` result, publishes/reverifies one product-local CAS artifact, and terminalizes through the existing reducer and ledger.
- Fails closed on uncertain execution by quarantining the workspace; restart never relaunches an active dispatch.
- Fixes the reducer so failed worker outcomes cannot promote success-only write bindings.

## Architecture boundary

This remains a private, fixed composition. It adds no provider/model registry, configurable worker surface, scheduler, daemon loop, watch path, or general lifecycle service. Program shape, process policy, credential use, workspace authority, output parsing, artifact proof, and settlement are separate modules with one-way orchestration from the coordinator.

## Validation

- `cargo test --workspace --quiet`
- `cargo clippy -p zeroshot-rust --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm test` — 2,896 passing, 18 pending
- `npm run typecheck`
- `npm run lint` — 0 errors (322 existing warnings)
- `npm run protocol:check`
- `npm run audit:production`
- `npm run opcore:graph:update`
- `npm run opcore:check` — no diagnostics

The process proof uses a deterministic fake Codex executable at the real process boundary; no paid live-provider invocation was run.