### PR TITLE
fix: emit terminal event for operation failures

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1847,16 +1847,31 @@ class Orchestrator {
             },
           },
         });
+        const boundary = this._clusterRunBoundaries.get(clusterId);
+        const complete = messageBus.query({
+          cluster_id: clusterId,
+          topic: 'CLUSTER_COMPLETE',
+          limit: 1,
+          ...(boundary === null || boundary === undefined ? {} : { afterId: boundary }),
+        })[0];
+        const failed = this._findCurrentRunClusterFailure(messageBus, clusterId);
+        if (!complete && !failed) {
+          messageBus.publish({
+            cluster_id: clusterId,
+            topic: 'CLUSTER_FAILED',
+            sender: 'orchestrator',
+            content: {
+              text: `Operation chain failed: ${err.message}`,
+              data: { reason: 'cluster_operations_failed' },
+            },
+          });
+        }
 
         this._log(`\n${'='.repeat(80)}`);
         this._log(`❌ CLUSTER_OPERATIONS FAILED - STOPPING CLUSTER`);
         this._log(`${'='.repeat(80)}`);
         this._log(`Error: ${err.message}`);
         this._log(`${'='.repeat(80)}\n`);
-
-        this.stop(clusterId).catch((stopErr) => {
-          console.error(`Failed to stop cluster after operation failure:`, stopErr.message);
-        });
       });
     });
   }

--- a/tests/integration/orchestrator-flow.test.js
+++ b/tests/integration/orchestrator-flow.test.js
@@ -1117,10 +1117,10 @@ function defineClusterOperationsFailureTests() {
      * Test for the bug where CLUSTER_OPERATIONS failure didn't stop the cluster.
      *
      * Root cause (fixed): When CLUSTER_OPERATIONS failed (e.g., agent model > maxModel),
-     * the .catch() handler published CLUSTER_OPERATIONS_FAILED but never called stop().
-     * The cluster remained running with no working agents.
+     * the .catch() handler published a nonterminal CLUSTER_OPERATIONS_FAILED event and
+     * stopped directly, leaving foreground result writers without a terminal event.
      *
-     * Fix: Added this.stop(clusterId) in the catch handler after publishing the failure message.
+     * Fix: Publish one CLUSTER_FAILED event and let the terminal subscription stop the cluster.
      */
     it('should stop cluster when CLUSTER_OPERATIONS fails due to model validation', async function () {
       await runClusterOperationsModelFailureTest();
@@ -1204,6 +1204,11 @@ async function runClusterOperationsModelFailureTest() {
       failedMessages[0].content.text.includes('Operation chain failed'),
       'Failure message: should indicate operation failure'
     );
+    assert.strictEqual(
+      cluster.messageBus.query({ cluster_id: clusterId, topic: 'CLUSTER_FAILED' }).length,
+      1,
+      'CLUSTER_FAILED: should contain exactly one terminal event'
+    );
 
     // Verify the cluster state is stopped (not running)
     const finalStatus = orchestrator.getStatus(clusterId);
@@ -1268,6 +1273,12 @@ async function runClusterOperationsValidationFailureTest() {
 
   // Wait for cluster to stop
   await waitForClusterState(orchestrator, clusterId, 'stopped', 10000);
+
+  assert.strictEqual(
+    cluster.messageBus.query({ cluster_id: clusterId, topic: 'CLUSTER_FAILED' }).length,
+    1,
+    'CLUSTER_FAILED: should contain exactly one terminal event'
+  );
 
   // Verify the cluster stopped due to the operation failure
   const finalStatus = orchestrator.getStatus(clusterId);


### PR DESCRIPTION
## Summary

- emit one current-run CLUSTER_FAILED event when a cluster operation chain fails
- let the existing terminal subscription own cluster shutdown
- cover both operation-validation failure paths with exact-one-terminal assertions

## Root cause

CLUSTER_OPERATIONS failures emitted only the nonterminal CLUSTER_OPERATIONS_FAILED diagnostic before stopping directly. Foreground result writers therefore saw no authoritative terminal event and rejected the retained result.

## Validation

- focused integration tests: 2 passing
- full test suite: 2,901 passing, 18 pending
- typecheck and lint (no errors)
- Opcore and Opcore Zero clean
- independent review: approved with no P0-P3 findings