### PR TITLE
fix: exercise valid Rust release smoke

### DIFF
--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -849,13 +849,7 @@ function run() {
   }
   if (command === 'smoke') {
     const binaryPath = path.resolve(argument('binary'));
-    const result = childProcess.spawnSync(binaryPath, [], { stdio: 'inherit' });
-    if (result.error) throw result.error;
-    if (result.signal || result.status !== 0) {
-      throw new Error(
-        `RUST_BINARY_SMOKE_FAILED: status=${result.status} signal=${result.signal || 'none'}`
-      );
-    }
+    smokeExecutable(binaryPath, 'RUST_BINARY_SMOKE_FAILED');
     process.stdout.write(`Rust release executable exited 0: ${binaryPath}\n`);
     return;
   }
@@ -871,13 +865,7 @@ function run() {
         declaration.executable
       );
       fs.writeFileSync(binaryPath, executable, { mode: 0o755 });
-      const result = childProcess.spawnSync(binaryPath, [], { stdio: 'inherit' });
-      if (result.error) throw result.error;
-      if (result.signal || result.status !== 0) {
-        throw new Error(
-          `RUST_ARCHIVE_SMOKE_FAILED: status=${result.status} signal=${result.signal || 'none'}`
-        );
-      }
+      smokeExecutable(binaryPath, 'RUST_ARCHIVE_SMOKE_FAILED');
     } finally {
       fs.rmSync(directory, { recursive: true, force: true });
     }
@@ -903,6 +891,26 @@ function run() {
   );
 }
 
+const SMOKE_GREETING = Buffer.from('zeroshot release smoke\n');
+
+function smokeExecutable(binaryPath, failureCode) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-rust-executable-smoke-'));
+  try {
+    fs.writeFileSync(path.join(directory, 'greeting.txt'), SMOKE_GREETING);
+    const result = childProcess.spawnSync(binaryPath, ['--native-validate-greeting'], {
+      cwd: directory,
+      input: SMOKE_GREETING,
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+    if (result.error) throw result.error;
+    if (result.signal || result.status !== 0) {
+      throw new Error(`${failureCode}: status=${result.status} signal=${result.signal || 'none'}`);
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
 if (require.main === module) {
   try {
     run();
@@ -926,6 +934,7 @@ module.exports = {
   packageTarget,
   parseChecksumManifest,
   sha256,
+  smokeExecutable,
   targetForHost,
   stageVersion,
   targets,

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -89,6 +89,32 @@ describe('Rust product distribution', function () {
   });
 });
 
+describe('Rust release executable smoke', function () {
+  it('uses the valid greeting-validator protocol', function () {
+    if (process.platform === 'win32') this.skip();
+    const directory = temporaryDirectory();
+    const binaryPath = path.join(directory, 'fixture-binary');
+    fs.writeFileSync(
+      binaryPath,
+      `#!/bin/sh
+[ "$1" = "--native-validate-greeting" ] || exit 2
+cat > actual-stdin
+cat > expected <<'EOF'
+zeroshot release smoke
+EOF
+cmp -s actual-stdin expected || exit 3
+cmp -s greeting.txt expected || exit 4
+`,
+      { mode: 0o755 }
+    );
+    try {
+      distribution.smokeExecutable(binaryPath, 'RUST_BINARY_SMOKE_FAILED');
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
 function registerVersionCouplingTests() {
   it('fails a release version mismatch with the named error and both versions', function () {
     const cargoToml = '[package]\nname = "zeroshot-rust"\nversion = "1.2.2"\n';


### PR DESCRIPTION
Summary: exercise the existing native greeting-validator protocol for both raw and extracted release executables, preserving the native entrypoint contract. Root cause: Release run 31615491026 failed all five targets because the smoke invoked the intentionally no-args-invalid native stdio entrypoint. Validation: real optimized binary and archive passed; full test suite, lint, typecheck, release workflow guard, Opcore and Opcore Zero passed; independent review approved with no P0-P3 findings.