### PR TITLE
fix(delivery): support custom pull request bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zero
 | Hosted capsule image                  | `docker/zeroshot-oecp/`, `scripts/hosted-oecp-image.js`                                                                          |
 | Docker mounts/env                     | `lib/docker-config.js`                                                                                                           |
 | Container lifecycle                   | `src/isolation-manager.js`                                                                                                       |
+| Pull-request body templates           | `src/pr-body-template.js`, `src/agents/git-pusher-template.js`                                                                   |
 | Settings                              | `lib/settings.js`                                                                                                                |
 | Legacy settings property selection    | `src/repo-settings-access.ts`                                                                                                    |
 | Cluster wire/domain types             | `crates/openengine-cluster-protocol/`                                                                                            |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ zeroshot run <input>             # issue, URL, markdown file, or inline text
 zeroshot run 123 --docker        # container isolation
 zeroshot run 123 --pr            # worktree + pull request
 zeroshot run 123 --ship          # worktree + PR + merge after approval
+zeroshot run 123 --pr --pr-body $'## Summary\n\nCustom text\n\n{{issue_reference}}'
 zeroshot run 123 -d              # background run
 
 zeroshot list                    # tasks and clusters (--json)
@@ -119,6 +120,11 @@ zeroshot providers               # provider availability and defaults
 zeroshot settings                # effective settings
 zeroshot agents list             # available agents
 ```
+
+`--pr-body` supplies a deterministic pull-request body for `--pr` and `--ship` runs. The
+template supports `{{issue_number}}`, `{{issue_title}}`, and `{{issue_reference}}`; all three
+expand to empty text for tasks without an issue, so manual runs never emit `Closes #unknown`.
+The unrendered template is retained for detached and resumed runs.
 
 </details>
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -107,6 +107,8 @@ const {
   runLegacyUpdateIfRequested,
 } = require('./lib/update-checker');
 const { checkBinDirOnPath, printPathWarning } = require('../lib/path-check');
+const { quoteShellArgument } = require('../lib/git-remote-utils');
+const { renderPullRequestBody, resolveIssueContext } = require('../src/pr-body-template');
 const { StatusFooter, AGENT_STATE, ACTIVE_STATES } = require('../src/status-footer');
 const { EVENT_COPY, formatMergeStatus } = require('./event-copy');
 
@@ -2012,9 +2014,25 @@ function buildContextSummary({
   return contextSummary;
 }
 
-function buildCompletionPrompt({ contextSummary, taskText, issueNumber, issueTitle }) {
-  const mergeGoal = 'CREATE PR AND MERGE IT';
-  const mergeStep = `
+function buildDefaultFinishPrBody({ taskText, issueNumber, issueTitle }) {
+  const issueReference = renderPullRequestBody(undefined, { issueNumber, issueTitle });
+  return [
+    issueReference,
+    issueReference ? '' : null,
+    '## Summary',
+    `${String(taskText || 'Unknown task').slice(0, 200)}...`,
+    '',
+    '## Changes',
+    '- Implementation complete',
+    '- All validations addressed',
+    '',
+    '🤖 Generated with zeroshot finish',
+  ]
+    .filter((line) => line !== null)
+    .join('\n');
+}
+
+const FINISH_MERGE_STEP = `
 8. MERGE THE PR - THIS IS MANDATORY:
    \`\`\`bash
    gh pr merge --merge --auto
@@ -2029,7 +2047,29 @@ function buildCompletionPrompt({ contextSummary, taskText, issueNumber, issueTit
 
    REPEAT UNTIL MERGED. DO NOT GIVE UP.`;
 
-  return `# YOUR MISSION: ${mergeGoal}
+function buildFinishCommandArguments({ taskText, issueNumber, issueTitle, prBody }) {
+  const issueContext = resolveIssueContext({ issueNumber, issueTitle });
+  const resolvedTitle = issueContext.issueTitle;
+  const resolvedBody =
+    typeof prBody === 'string'
+      ? renderPullRequestBody(prBody, { issueNumber, issueTitle: resolvedTitle })
+      : buildDefaultFinishPrBody({ taskText, issueNumber, issueTitle: resolvedTitle });
+  return {
+    commitMessage: quoteShellArgument(resolvedTitle || 'feat: implement task'),
+    branch: quoteShellArgument(
+      issueContext.issueNumber !== 'unknown'
+        ? `issue-${issueContext.issueNumber}`
+        : 'feature/implementation'
+    ),
+    prTitle: quoteShellArgument(resolvedTitle),
+    prBody: quoteShellArgument(resolvedBody),
+  };
+}
+
+function buildCompletionPrompt({ contextSummary, taskText, issueNumber, issueTitle, prBody }) {
+  const args = buildFinishCommandArguments({ taskText, issueNumber, issueTitle, prBody });
+
+  return `# YOUR MISSION: CREATE PR AND MERGE IT
 
 ${contextSummary}
 
@@ -2050,12 +2090,12 @@ You are the FINISHER. Your ONLY job is to take this cluster's work and push it a
 2. COMMIT ALL CHANGES - Stage and commit everything:
    \`\`\`bash
    git add .
-   git commit -m "${issueTitle || 'feat: implement task'}"
+   git commit -m ${args.commitMessage}
    \`\`\`
 
 3. CREATE BRANCH - Use issue number if available:
    \`\`\`bash
-   ${issueNumber ? `git checkout -b issue-${issueNumber}` : 'git checkout -b feature/implementation'}
+   git checkout -b ${args.branch}
    \`\`\`
 
 4. PUSH TO REMOTE:
@@ -2065,16 +2105,7 @@ You are the FINISHER. Your ONLY job is to take this cluster's work and push it a
 
 5. CREATE PULL REQUEST:
    \`\`\`bash
-   gh pr create --title "${issueTitle || 'Implementation'}" --body "Closes #${issueNumber || 'N/A'}
-
-## Summary
-${taskText.slice(0, 200)}...
-
-## Changes
-- Implementation complete
-- All validations addressed
-
-🤖 Generated with zeroshot finish"
+   gh pr create --title ${args.prTitle} --body ${args.prBody}
    \`\`\`
 
 6. GET PR URL:
@@ -2083,7 +2114,7 @@ ${taskText.slice(0, 200)}...
    \`\`\`
 
 7. OUTPUT THE PR URL - Print it clearly so user can see it
-${mergeStep}
+${FINISH_MERGE_STEP}
 
 ## RULES
 
@@ -2707,6 +2738,10 @@ program
     'Full automation: worktree isolation + PR + auto-merge (use --docker for Docker)'
   )
   .option('--pr-base <branch>', 'Target branch for PRs (default: repo default branch)')
+  .option(
+    '--pr-body <template>',
+    'PR body template; supports {{issue_number}}, {{issue_title}}, and {{issue_reference}}'
+  )
   .option('--merge-queue', 'Use GitHub merge queue instead of direct merge')
   .option(
     '--close-issue <mode>',
@@ -3714,6 +3749,10 @@ program
   .helpGroup('Control:')
   .description('Take existing cluster and create completion-focused task (creates PR and merges)')
   .option('-y, --yes', 'Skip confirmation if cluster is running')
+  .option(
+    '--pr-body <template>',
+    'PR body template; supports {{issue_number}}, {{issue_title}}, and {{issue_reference}}'
+  )
   .action(async (id, options) => {
     try {
       const orchestrator = await getOrchestrator();
@@ -3732,6 +3771,7 @@ program
         taskText: context.taskText,
         issueNumber: context.issueNumber,
         issueTitle: context.issueTitle,
+        prBody: options.prBody ?? cluster.prOptions?.prBody,
       });
       printCompletionPromptPreview(completionPrompt);
 
@@ -6190,6 +6230,9 @@ module.exports = {
   isStartupUpdateEligible,
   handleNoArgumentInvocation,
   shouldRunInitialSetup,
+  extractFinishContext,
+  buildDefaultFinishPrBody,
+  buildCompletionPrompt,
   resolveRunMode,
   killRunningClusters,
 };

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -277,6 +277,7 @@ return hasSufficientEvidence;`;
 const { readRepoSettings } = require('../../lib/repo-settings');
 const { normalizeGitRemoteName, quoteShellArgument } = require('../../lib/git-remote-utils');
 const { resolveRequiredQualityGates } = require('../quality-gates');
+const { renderPullRequestBody, resolveIssueContext } = require('../pr-body-template');
 
 function getSafeBranchName(value) {
   if (typeof value !== 'string') {
@@ -314,35 +315,6 @@ function normalizeCloseIssueMode(value) {
   return null;
 }
 
-function normalizeIssueNumber(value) {
-  const candidate = typeof value === 'number' ? String(value) : value;
-  if (typeof candidate !== 'string') return 'unknown';
-  const trimmed = candidate.trim();
-  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) ? trimmed : 'unknown';
-}
-
-function normalizeIssueTitle(value) {
-  if (typeof value !== 'string' || value.trim() === '') return 'Implementation';
-  const normalized = [...value]
-    .map((character) => {
-      const codePoint = character.codePointAt(0);
-      return codePoint < 0x20 || codePoint === 0x7f ? ' ' : character;
-    })
-    .join('')
-    .trim();
-  return normalized || 'Implementation';
-}
-
-function resolveIssueContext(options) {
-  const issueNumber = normalizeIssueNumber(options.issueNumber);
-  const issueTitle = normalizeIssueTitle(options.issueTitle);
-  const issueReference =
-    options.includeIssueReference === false || issueNumber === 'unknown'
-      ? ''
-      : `Closes #${issueNumber}`;
-  return { issueNumber, issueTitle, issueReference };
-}
-
 /**
  * Resolve GitHub configuration from CLI options and repo settings.
  * Priority: CLI options > repo settings (.zeroshot/settings.json) > defaults
@@ -355,6 +327,7 @@ function resolveIssueContext(options) {
  * @param {string|number} [options.issueNumber] - Typed issue identifier for prompt commands
  * @param {string} [options.issueTitle] - Typed issue title for prompt commands
  * @param {boolean} [options.includeIssueReference] - Include the closing reference in PR text
+ * @param {string} [options.prBody] - Literal PR body template with supported issue tokens
  * @returns {Object} Resolved configuration
  */
 function resolveGitHubConfig(options = {}) {
@@ -385,14 +358,21 @@ function resolveGitHubConfig(options = {}) {
     options.autoMerge === true ||
     (options.autoMerge !== false && parseBool(repoGithub.autoMerge) === true);
 
+  const issueContext = resolveIssueContext(options);
+
   return {
     prBase,
     useMergeQueue,
     closeIssueMode,
     autoMerge,
     gitRemote,
-    issueContext: resolveIssueContext(options),
+    issueContext,
+    prBody: renderPullRequestBody(options.prBody, options),
   };
+}
+
+function resolvedPrBody(config, issueContext) {
+  return typeof config.prBody === 'string' ? config.prBody : issueContext.issueReference;
 }
 
 /**
@@ -406,13 +386,15 @@ function getPlatformConfig(platform, config = {}) {
   const { prBase, useMergeQueue, closeIssueMode, autoMerge, gitRemote } = config;
   const issueContext = config.issueContext || resolveIssueContext({});
   const issueTitleArgument = quoteShellArgument(`feat: ${issueContext.issueTitle}`);
-  const issueReferenceArgument = quoteShellArgument(issueContext.issueReference);
+  const prBodyArgument = quoteShellArgument(resolvedPrBody(config, issueContext));
 
   const PLATFORM_CONFIGS = {
     github: {
       prName: 'PR',
       prNameLower: 'pull request',
-      createCmd: `gh pr create${prBase ? ` --base ${prBase}` : ''} --title ${issueTitleArgument} --body ${issueReferenceArgument}`,
+      createCmd:
+        `gh pr create${prBase ? ` --base ${prBase}` : ''} ` +
+        `--title ${issueTitleArgument} --body ${prBodyArgument}`,
       mergeCmd: useMergeQueue
         ? `PR_ID="$(timeout 30 gh pr view --json id --jq .id)"
 gh api graphql -f query='mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){mergeQueueEntry{state}}}' -f id="$PR_ID"
@@ -434,7 +416,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
     gitlab: {
       prName: 'MR',
       prNameLower: 'merge request',
-      createCmd: `glab mr create --title ${issueTitleArgument} --description ${issueReferenceArgument}`,
+      createCmd: `glab mr create --title ${issueTitleArgument} --description ${prBodyArgument}`,
       mergeCmd: 'glab mr merge --auto-merge',
       mergeFallbackCmd: 'glab mr merge',
       prUrlExample: 'https://gitlab.com/owner/repo/-/merge_requests/123',
@@ -447,7 +429,7 @@ for i in $(seq 1 90); do if timeout 30 gh pr view --json mergedAt --jq .mergedAt
     'azure-devops': {
       prName: 'PR',
       prNameLower: 'pull request',
-      createCmd: `az repos pr create --title ${issueTitleArgument} --description ${issueReferenceArgument}`,
+      createCmd: `az repos pr create --title ${issueTitleArgument} --description ${prBodyArgument}`,
       mergeCmd: 'az repos pr update --id <PR_ID> --auto-complete true',
       mergeFallbackCmd: 'az repos pr update --id <PR_ID> --status completed',
       prUrlExample: 'https://dev.azure.com/org/project/_git/repo/pullrequest/123',
@@ -803,6 +785,7 @@ If blocked before creating a ${prName}, output:
  * @param {string|number} [options.issueNumber] - Typed issue identifier for prompt commands
  * @param {string} [options.issueTitle] - Typed issue title for prompt commands
  * @param {boolean} [options.includeIssueReference] - Include the closing reference in PR text
+ * @param {string} [options.prBody] - Literal PR body template with supported issue tokens
  * @param {Array} [options.requiredQualityGates] - Required handoff quality gates
  * @param {boolean} [options.autoMerge] - Merge the PR (--ship). False stops after PR creation (--pr).
  * @returns {Object} Agent configuration object

--- a/src/legacy-lib/detached-startup.ts
+++ b/src/legacy-lib/detached-startup.ts
@@ -26,6 +26,7 @@ interface RunOptions extends Record<string, unknown> {
   mergeQueue?: unknown;
   pr?: unknown;
   prBase?: unknown;
+  prBody?: unknown;
   ship?: unknown;
   worktree?: unknown;
 }
@@ -236,9 +237,10 @@ async function registerDetachedSetupCluster({
       setupStartedAt: Date.now(),
       setupStage: 'starting',
       autoPr: plan.delivery !== 'none',
-      prOptions: runOptions.prBase
+      prOptions: plan.delivery !== 'none'
         ? {
             prBase: runOptions.prBase,
+            prBody: typeof runOptions.prBody === 'string' ? runOptions.prBody : null,
             mergeQueue: runOptions.mergeQueue || false,
             closeIssue: runOptions.closeIssue || null,
             autoMerge: plan.autoMerge,

--- a/src/legacy-lib/start-cluster-environment.ts
+++ b/src/legacy-lib/start-cluster-environment.ts
@@ -10,6 +10,7 @@ interface RunOptions extends Record<string, unknown> {
   mount?: readonly string[] | null;
   noIsolation?: unknown;
   prBase?: unknown;
+  prBody?: unknown;
 }
 
 interface MountSpec {

--- a/src/legacy-lib/start-cluster-run-options.ts
+++ b/src/legacy-lib/start-cluster-run-options.ts
@@ -28,6 +28,7 @@ interface RunOptions extends Record<string, unknown> {
   noMounts?: unknown;
   pr?: unknown;
   prBase?: unknown;
+  prBody?: unknown;
   preparedWorktree?: unknown;
   requiredQualityGates?: unknown;
   ship?: unknown;
@@ -201,6 +202,7 @@ function buildStartOptionsFromPlan({
     containerHome: optionalValue(options.containerHome),
     forceProvider: optionalValue(forceProvider),
     prBase: environment ? resolvePrBase(options) : optionalValue(options.prBase),
+    prBody: typeof options.prBody === 'string' ? options.prBody : undefined,
     mergeQueue: environment ? resolveMergeQueue(options) : optionalValue(options.mergeQueue),
     closeIssue: environment ? resolveCloseIssue(options) : optionalValue(options.closeIssue),
     ship: plan.delivery === 'ship',

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -262,6 +262,7 @@ function buildPrOptions(options, requiredQualityGates) {
     prBase: options.prBase || null,
     mergeQueue: options.mergeQueue || false,
     closeIssue: options.closeIssue || null,
+    prBody: typeof options.prBody === 'string' ? options.prBody : null,
     gitRemote: options.gitRemote || null,
     autoMerge,
     ...(requiredQualityGates.length > 0 ? { requiredQualityGates } : {}),
@@ -2038,6 +2039,7 @@ class Orchestrator {
       prBase: options.prBase,
       mergeQueue: options.mergeQueue,
       closeIssue: options.closeIssue,
+      prBody: options.prBody,
       requiredQualityGates: options.requiredQualityGates,
       autoMerge: resolveRunPlan(options).autoMerge,
       gitRemote: gitContext?.remote || options.gitRemote,
@@ -4217,7 +4219,7 @@ Continue from where you left off. Review your previous output to understand what
 
       // Get issue context from ledger
       const issueMsg = cluster.messageBus.ledger.findLast({ topic: 'ISSUE_OPENED' });
-      const issueNumber = issueMsg?.content?.data?.number || 'unknown';
+      const issueNumber = issueMsg?.content?.data?.issue_number || 'unknown';
       const issueTitle = issueMsg?.content?.data?.title || 'Implementation';
 
       // Generate the final prompt in one typed assembly pass. Issue values are

--- a/src/pr-body-template.js
+++ b/src/pr-body-template.js
@@ -1,0 +1,71 @@
+const MAX_PR_BODY_LENGTH = 65536;
+
+function normalizeIssueNumber(value) {
+  const candidate = typeof value === 'number' ? String(value) : value;
+  if (typeof candidate !== 'string') return 'unknown';
+  const trimmed = candidate.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed) ? trimmed : 'unknown';
+}
+
+function normalizeIssueTitle(value) {
+  if (typeof value !== 'string' || value.trim() === '') return 'Implementation';
+  const normalized = [...value]
+    .map((character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint < 0x20 || codePoint === 0x7f ? ' ' : character;
+    })
+    .join('')
+    .trim();
+  return normalized || 'Implementation';
+}
+
+function resolveIssueContext(options = {}) {
+  const issueNumber = normalizeIssueNumber(options.issueNumber);
+  const issueTitle = normalizeIssueTitle(options.issueTitle);
+  const issueReference =
+    options.includeIssueReference === false || issueNumber === 'unknown'
+      ? ''
+      : `Closes #${issueNumber}`;
+  return { issueNumber, issueTitle, issueReference };
+}
+
+function normalizePrBodyTemplate(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') throw new TypeError('PR body template must be a string');
+  if (value.includes('\0')) throw new TypeError('PR body template must not contain NUL bytes');
+  if (value.length > MAX_PR_BODY_LENGTH) {
+    throw new TypeError(`PR body template must not exceed ${MAX_PR_BODY_LENGTH} characters`);
+  }
+  return value;
+}
+
+/**
+ * Render a bounded PR body. Missing issue metadata expands to empty text so
+ * manual tasks never leak internal sentinel values into pull requests.
+ */
+function renderPullRequestBody(template, options = {}) {
+  const issueContext = resolveIssueContext(options);
+  const normalizedTemplate = normalizePrBodyTemplate(template);
+  if (normalizedTemplate === null) return issueContext.issueReference;
+
+  const hasIssue = issueContext.issueNumber !== 'unknown';
+  const substitutions = {
+    '{{issue_number}}': hasIssue ? issueContext.issueNumber : '',
+    '{{issue_title}}': hasIssue ? issueContext.issueTitle : '',
+    '{{issue_reference}}': hasIssue ? issueContext.issueReference : '',
+  };
+  let rendered = normalizedTemplate;
+  for (const [token, replacement] of Object.entries(substitutions)) {
+    rendered = rendered.replaceAll(token, replacement);
+  }
+  if (rendered.length > MAX_PR_BODY_LENGTH) {
+    throw new TypeError(`Rendered PR body must not exceed ${MAX_PR_BODY_LENGTH} characters`);
+  }
+  return rendered;
+}
+
+module.exports = {
+  MAX_PR_BODY_LENGTH,
+  renderPullRequestBody,
+  resolveIssueContext,
+};

--- a/tests/git-pusher-pr-mode.test.js
+++ b/tests/git-pusher-pr-mode.test.js
@@ -217,6 +217,13 @@ describe('git-pusher --pr vs --ship (autoMerge)', function () {
     assert.strictEqual(prOptions.gitRemote, 'upstream');
   });
 
+  it('buildPrOptions persists the unrendered PR body template for resume', function () {
+    const prBody = '## Summary\n\n{{issue_title}}\n\n{{issue_reference}}';
+    const prOptions = Orchestrator.buildPrOptions({ pr: true, prBody }, []);
+
+    assert.strictEqual(prOptions.prBody, prBody);
+  });
+
   it('resolveRunPlan is the single source for the autoMerge decision', function () {
     assert.strictEqual(Orchestrator.resolveRunPlan({ ship: true }).autoMerge, true);
     assert.strictEqual(Orchestrator.resolveRunPlan({ pr: true }).autoMerge, false);

--- a/tests/pr-body-integration.test.js
+++ b/tests/pr-body-integration.test.js
@@ -1,0 +1,244 @@
+const assert = require('node:assert').strict;
+const { execFileSync: runFile } = require('node:child_process');
+const filesystem = require('node:fs');
+const { tmpdir } = require('node:os');
+const nodePath = require('node:path');
+
+const { buildCompletionPrompt, buildDefaultFinishPrBody } = require('../cli/index');
+const { getPlatformConfig, resolveGitHubConfig } = require('../src/agents/git-pusher-template');
+const Orchestrator = require('../src/orchestrator');
+
+function installArgumentRecorder(binDir, command, rowMode = false) {
+  const executable = nodePath.join(binDir, command);
+  const body = rowMode
+    ? `const fs = require('node:fs');
+const rows = fs.existsSync(process.env.ZEROSHOT_ARGUMENT_LOG)
+  ? JSON.parse(fs.readFileSync(process.env.ZEROSHOT_ARGUMENT_LOG, 'utf8'))
+  : [];
+rows.push([${JSON.stringify(command)}, ...process.argv.slice(2)]);
+fs.writeFileSync(process.env.ZEROSHOT_ARGUMENT_LOG, JSON.stringify(rows));`
+    : "require('node:fs').writeFileSync(process.env.ZEROSHOT_ARGUMENT_LOG, JSON.stringify(process.argv.slice(2)));";
+  filesystem.writeFileSync(executable, `#!/usr/bin/env node\n${body}\n`, 'utf8');
+  filesystem.chmodSync(executable, 0o755);
+}
+
+function commandStartingWith(prompt, prefix) {
+  return prompt
+    .split('\n')
+    .map((line) => line.trimStart())
+    .find((line) => line.startsWith(prefix));
+}
+
+function prCreateCommand(prompt) {
+  const marker = '   gh pr create ';
+  const start = prompt.indexOf(marker);
+  assert.notStrictEqual(start, -1, 'PR creation command missing');
+  const end = prompt.indexOf('\n   ```', start);
+  assert.notStrictEqual(end, -1, 'PR creation command fence missing');
+  return prompt.slice(start, end).trimStart();
+}
+
+describe('git-pusher PR body command quoting', function () {
+  it('preserves a custom body as one literal argument', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const cwd = filesystem.mkdtempSync(nodePath.join(tmpdir(), 'zeroshot-pr-body-'));
+    const binDir = nodePath.join(cwd, 'bin');
+    const argumentLog = nodePath.join(cwd, 'arguments.json');
+    const injectedFile = nodePath.join(cwd, 'PWNED');
+    const template = [
+      '## Summary',
+      "literal ' quote",
+      `$(touch ${injectedFile})`,
+      `\`touch ${injectedFile}\``,
+      '{{issue_title}}',
+      '{{issue_reference}}',
+    ].join('\n');
+    const expected = template
+      .replaceAll('{{issue_title}}', "Handle the user's input")
+      .replaceAll('{{issue_reference}}', 'Closes #448');
+
+    try {
+      filesystem.mkdirSync(binDir);
+      installArgumentRecorder(binDir, 'gh');
+      const resolved = resolveGitHubConfig({
+        cwd,
+        prBody: template,
+        issueNumber: 448,
+        issueTitle: "Handle the user's input",
+      });
+      runFile('/bin/sh', ['-c', getPlatformConfig('github', resolved).createCmd], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          ZEROSHOT_ARGUMENT_LOG: argumentLog,
+        },
+      });
+
+      const args = JSON.parse(filesystem.readFileSync(argumentLog, 'utf8'));
+      assert.strictEqual(args[args.indexOf('--body') + 1], expected);
+      assert.strictEqual(filesystem.existsSync(injectedFile), false);
+    } finally {
+      filesystem.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('PR body persistence across completion-agent injection', function () {
+  it('builds the same custom body for a fresh run and a resumed run', async function () {
+    const cwd = filesystem.mkdtempSync(nodePath.join(tmpdir(), 'zeroshot-pr-body-resume-'));
+    runFile('git', ['init'], { cwd, stdio: 'ignore' });
+    runFile('git', ['remote', 'add', 'origin', 'https://github.com/acme/widgets.git'], {
+      cwd,
+      stdio: 'ignore',
+    });
+    const orchestrator = new Orchestrator({
+      quiet: true,
+      skipLoad: true,
+      storageDir: nodePath.join(cwd, 'storage'),
+    });
+    const prBody = '## Issue {{issue_number}}\n\n{{issue_title}}\n\n{{issue_reference}}';
+    const inputData = { number: 448, title: 'Resume-safe body' };
+
+    try {
+      const freshConfig = { agents: [{ id: 'completion-detector' }] };
+      orchestrator._applyAutoPrConfig(freshConfig, inputData, {
+        autoPr: true,
+        autoMerge: false,
+        cwd,
+        prBody,
+        requiredQualityGates: [],
+      });
+      const freshAgent = freshConfig.agents.find((agent) => agent.id === 'git-pusher');
+
+      let resumedAgent = null;
+      orchestrator._opAddAgents = (_cluster, operation) => {
+        resumedAgent = operation.agents[0];
+      };
+      await orchestrator._injectCompletionAgent(
+        {
+          agents: [],
+          autoPr: true,
+          cwd,
+          gitPlatform: 'github',
+          prOptions: Orchestrator.buildPrOptions({ pr: true, autoMerge: false, cwd, prBody }, []),
+          messageBus: {
+            ledger: {
+              findLast: () => ({
+                content: { data: { issue_number: inputData.number, title: inputData.title } },
+              }),
+            },
+          },
+        },
+        {}
+      );
+
+      assert.ok(freshAgent);
+      assert.ok(resumedAgent);
+      assert.strictEqual(resumedAgent.prompt, freshAgent.prompt);
+      assert.match(resumedAgent.prompt, /## Issue 448/);
+      assert.match(resumedAgent.prompt, /Closes #448/);
+    } finally {
+      orchestrator.close();
+      filesystem.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('zeroshot finish PR body assembly', function () {
+  it('omits invalid issue references and shell-quotes hostile values', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const cwd = filesystem.mkdtempSync(nodePath.join(tmpdir(), 'zeroshot-finish-body-'));
+    const binDir = nodePath.join(cwd, 'bin');
+    const argumentLog = nodePath.join(cwd, 'arguments.json');
+    const injectedFile = nodePath.join(cwd, 'PWNED');
+    const issueTitle = `fix: safe'; touch ${injectedFile}; echo '`;
+    const taskText = `Do the work; $(touch ${injectedFile})`;
+    const bodyTemplate = [
+      '## Review',
+      `$(touch ${injectedFile})`,
+      '{{issue_title}}',
+      '{{issue_reference}}',
+    ].join('\n');
+    const expectedBody = bodyTemplate
+      .replaceAll('{{issue_title}}', issueTitle)
+      .replaceAll('{{issue_reference}}', 'Closes #1011');
+
+    try {
+      filesystem.mkdirSync(binDir);
+      installArgumentRecorder(binDir, 'git', true);
+      installArgumentRecorder(binDir, 'gh', true);
+      const prompt = buildCompletionPrompt({
+        contextSummary: taskText,
+        taskText,
+        issueNumber: 1011,
+        issueTitle,
+        prBody: bodyTemplate,
+      });
+      const commands = [
+        commandStartingWith(prompt, 'git commit -m '),
+        commandStartingWith(prompt, 'git checkout -b '),
+        prCreateCommand(prompt),
+      ];
+      assert.ok(commands.every(Boolean));
+      for (const command of commands) {
+        runFile('/bin/sh', ['-c', command], {
+          cwd,
+          env: {
+            ...process.env,
+            PATH: `${binDir}:${process.env.PATH}`,
+            ZEROSHOT_ARGUMENT_LOG: argumentLog,
+          },
+        });
+      }
+
+      const rows = JSON.parse(filesystem.readFileSync(argumentLog, 'utf8'));
+      const commitArgs = rows.find(
+        ([command, subcommand]) => command === 'git' && subcommand === 'commit'
+      );
+      const prArgs = rows.find(([command]) => command === 'gh');
+      assert.ok(commitArgs.includes(issueTitle));
+      assert.strictEqual(prArgs[prArgs.indexOf('--body') + 1], expectedBody);
+      assert.strictEqual(filesystem.existsSync(injectedFile), false);
+      assert.doesNotMatch(buildDefaultFinishPrBody({ taskText }), /Closes #(unknown|N\/A)/);
+    } finally {
+      filesystem.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps hostile task text literal in the default body', function () {
+    if (process.platform === 'win32') this.skip();
+
+    const cwd = filesystem.mkdtempSync(nodePath.join(tmpdir(), 'zeroshot-finish-default-'));
+    const binDir = nodePath.join(cwd, 'bin');
+    const argumentLog = nodePath.join(cwd, 'arguments.json');
+    const injectedFile = nodePath.join(cwd, 'PWNED');
+    const taskText = `$(touch ${injectedFile}) and \`touch ${injectedFile}\``;
+
+    try {
+      filesystem.mkdirSync(binDir);
+      installArgumentRecorder(binDir, 'gh', true);
+      const prompt = buildCompletionPrompt({
+        contextSummary: taskText,
+        taskText,
+        issueTitle: 'Manual task',
+      });
+      runFile('/bin/sh', ['-c', prCreateCommand(prompt)], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          ZEROSHOT_ARGUMENT_LOG: argumentLog,
+        },
+      });
+
+      const [args] = JSON.parse(filesystem.readFileSync(argumentLog, 'utf8'));
+      assert.ok(args[args.indexOf('--body') + 1].includes(taskText));
+      assert.strictEqual(filesystem.existsSync(injectedFile), false);
+    } finally {
+      filesystem.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/pr-body-template.test.js
+++ b/tests/pr-body-template.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert').strict;
+
+const {
+  generateGitPusherAgent,
+  getPlatformConfig,
+  resolveGitHubConfig,
+} = require('../src/agents/git-pusher-template');
+const { MAX_PR_BODY_LENGTH, renderPullRequestBody } = require('../src/pr-body-template');
+
+describe('git-pusher PR body rendering', function () {
+  it('uses the issue reference by default and emits an empty body for manual tasks', function () {
+    const issueAgent = generateGitPusherAgent('github', {
+      issueNumber: 448,
+      issueTitle: 'Body support',
+    });
+    const manualAgent = generateGitPusherAgent('github', {
+      issueTitle: 'Manual task',
+    });
+
+    assert.match(issueAgent.prompt, /--body 'Closes #448'/);
+    assert.match(manualAgent.prompt, /--body ''/);
+    assert.doesNotMatch(manualAgent.prompt, /Closes #(unknown|N\/A)/);
+  });
+
+  it('expands all issue tokens to empty text when issue metadata is absent', function () {
+    assert.strictEqual(
+      renderPullRequestBody('{{issue_number}}|{{issue_title}}|{{issue_reference}}', {
+        issueTitle: 'Manual task',
+      }),
+      '||'
+    );
+  });
+
+  it('rejects NUL bytes and overlong source or rendered bodies', function () {
+    assert.throws(() => renderPullRequestBody('bad\0body'), /NUL/);
+    assert.throws(
+      () => renderPullRequestBody('x'.repeat(MAX_PR_BODY_LENGTH + 1)),
+      /must not exceed/
+    );
+    assert.throws(
+      () =>
+        renderPullRequestBody('{{issue_title}}'.repeat(4000), {
+          issueNumber: 1,
+          issueTitle: 'x'.repeat(20),
+        }),
+      /Rendered PR body must not exceed/
+    );
+  });
+});
+
+describe('git-pusher PR body platform commands', function () {
+  it('uses the same safely quoted body for every supported platform', function () {
+    const template = "Line one\nline ' two\n{{issue_reference}}";
+    const resolved = resolveGitHubConfig({
+      prBody: template,
+      issueNumber: 'ABC-12',
+      issueTitle: 'Cross-platform body',
+    });
+
+    for (const platform of ['github', 'gitlab', 'azure-devops']) {
+      const command = getPlatformConfig(platform, resolved).createCmd;
+      assert.ok(command.includes(`Line one\nline '`), `${platform} must retain multiline body`);
+      assert.ok(command.includes('Closes #ABC-12'), `${platform} must render the issue reference`);
+    }
+  });
+});

--- a/tests/unit/cli-help.test.js
+++ b/tests/unit/cli-help.test.js
@@ -72,6 +72,7 @@ describe('curated CLI help', function () {
       assert.ok(index > previousIndex, `missing or out-of-order run option group ${heading}`);
       previousIndex = index;
     }
+    assert.match(runHelp.stdout, /--pr-body <template>/);
 
     const rootHelp = runCli(['--help']);
     assert.strictEqual(rootHelp.status, 0, rootHelp.stderr);
@@ -232,6 +233,7 @@ describe('CLI completion snapshots', function () {
       '--pr',
       '--ship',
       '--pr-base',
+      '--pr-body',
       '--merge-queue',
       '--close-issue',
       '--provider',

--- a/tests/unit/cli-pr-base-env.test.js
+++ b/tests/unit/cli-pr-base-env.test.js
@@ -56,6 +56,7 @@ describe('CLI PR config env fallback', function () {
       prBase: 'dev',
       mergeQueue: true,
       closeIssue: 'always',
+      prBody: 'Issue {{issue_number}}',
     });
 
     const result = buildStartOptions({ clusterId: 'test', options: {}, settings: {} });
@@ -63,6 +64,7 @@ describe('CLI PR config env fallback', function () {
     assert.strictEqual(result.prBase, 'dev');
     assert.strictEqual(result.mergeQueue, true);
     assert.strictEqual(result.closeIssue, 'always');
+    assert.strictEqual(result.prBody, 'Issue {{issue_number}}');
   });
 
   it('prefers explicit options over ZEROSHOT_RUN_OPTIONS', function () {

--- a/tests/unit/detached-startup.test.js
+++ b/tests/unit/detached-startup.test.js
@@ -92,7 +92,7 @@ describe('detached-startup helpers', function () {
       pid: 12345,
       storageDir,
       logPath: path.join(storageDir, 'setup-cluster-daemon.log'),
-      runOptions: { pr: true, prBase: 'dev' },
+      runOptions: { pr: true, prBase: 'dev', prBody: 'Issue {{issue_number}}' },
       cwd: '/repo',
     });
 
@@ -100,6 +100,7 @@ describe('detached-startup helpers', function () {
     assert.strictEqual(clusters['setup-cluster'].state, 'setup');
     assert.strictEqual(clusters['setup-cluster'].pid, 12345);
     assert.strictEqual(clusters['setup-cluster'].prOptions.prBase, 'dev');
+    assert.strictEqual(clusters['setup-cluster'].prOptions.prBody, 'Issue {{issue_number}}');
     assert.strictEqual(isClusterRegistered('setup-cluster', storageDir), true);
   });
 


### PR DESCRIPTION
Fixes #1011.

## Summary
- add `--pr-body <template>` for run and finish, with deterministic issue tokens
- persist the unrendered body through detached and resumed runs
- correct resumed issue-number lookup and suppress unknown/N/A references
- shell-quote custom bodies and legacy finish metadata across GitHub, GitLab, and Azure DevOps

## Validation
- 63 focused tests pass
- lint passes with repository baseline warnings only
- full TypeScript typecheck passes
- introduced-change Opcore validation passes
- Opcore Zero reports no introduced cycles, duplicates, interface findings, or documentation requirements

A local full-suite attempt was stopped after the shared tmpfs filled and cascaded into ENOSPC failures; required GitHub CI is the authoritative clean full-suite run.