### PR TITLE
docs: correct conductor validator counts to match the router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1045,12 +1045,18 @@ iteration start for the executing agent. Acceptable values: `cluster_start`, `la
 
 Classifies tasks on Complexity x TaskType, routes to parameterized templates.
 
-| Complexity | Description            | Validators |
-| ---------- | ---------------------- | ---------- |
-| TRIVIAL    | 1 file, mechanical     | 0          |
-| SIMPLE     | 1 concern              | 1          |
-| STANDARD   | Multi-file             | 3          |
-| CRITICAL   | Auth/payments/security | 5          |
+| Complexity | Description            | Validators           |
+| ---------- | ---------------------- | -------------------- |
+| TRIVIAL    | 1 file, mechanical     | 0                    |
+| SIMPLE     | 1 concern              | 1                    |
+| STANDARD   | Multi-file             | 2, inline            |
+| CRITICAL   | Auth/payments/security | 4, across two stages |
+
+Counts come from `getValidatorCount()` in `src/config-router.ts`. CRITICAL returns
+`validator_count: 0`, which skips the inline validators and activates the `meta-coordinator`:
+`quick-validation` then `heavy-validation`, 2 each.
+
+`UNCERTAIN` exists only in the junior conductor's schema and means escalate, not a workload.
 
 | TaskType | Action                |
 | -------- | --------------------- |
@@ -1058,7 +1064,8 @@ Classifies tasks on Complexity x TaskType, routes to parameterized templates.
 | TASK     | Implement new feature |
 | DEBUG    | Fix broken code       |
 
-Base templates: `single-worker`, `worker-validator`, `debug-workflow`, `full-workflow`.
+Base templates: `single-worker`, `worker-validator`, `debug-workflow`, `full-workflow`, plus
+`quick-validation` and `heavy-validation` for the CRITICAL two-stage pipeline.
 An exact whole-value `{{param}}` placeholder preserves the parameter's JSON type; placeholders
 embedded in surrounding text stringify their values. Keep numeric workflow controls typed through
 dynamic template loading.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,12 +188,18 @@ helpers.hasConsensus(topic, since);
 
 Classifies tasks on **Complexity × TaskType**, routes to parameterized templates.
 
-| Complexity | Description            | Validators |
-| ---------- | ---------------------- | ---------- |
-| TRIVIAL    | 1 file, mechanical     | 0          |
-| SIMPLE     | 1 concern              | 1          |
-| STANDARD   | Multi-file             | 3          |
-| CRITICAL   | Auth/payments/security | 5          |
+| Complexity | Description            | Validators           |
+| ---------- | ---------------------- | -------------------- |
+| TRIVIAL    | 1 file, mechanical     | 0                    |
+| SIMPLE     | 1 concern              | 1                    |
+| STANDARD   | Multi-file             | 2, inline            |
+| CRITICAL   | Auth/payments/security | 4, across two stages |
+
+Counts come from `getValidatorCount()` in `src/config-router.ts`. CRITICAL returns
+`validator_count: 0`, which skips the inline validators and activates the `meta-coordinator`:
+`quick-validation` then `heavy-validation`, 2 each.
+
+`UNCERTAIN` exists only in the junior conductor's schema and means escalate, not a workload.
 
 | TaskType | Action                |
 | -------- | --------------------- |
@@ -201,7 +207,8 @@ Classifies tasks on **Complexity × TaskType**, routes to parameterized template
 | TASK     | Implement new feature |
 | DEBUG    | Fix broken code       |
 
-**Base templates:** `single-worker`, `worker-validator`, `debug-workflow`, `full-workflow`
+**Base templates:** `single-worker`, `worker-validator`, `debug-workflow`, `full-workflow`, plus
+`quick-validation` and `heavy-validation` for the CRITICAL two-stage pipeline
 
 ## Isolation Modes
 

--- a/cluster-templates/conductor-bootstrap.json
+++ b/cluster-templates/conductor-bootstrap.json
@@ -1,6 +1,6 @@
 {
   "name": "Two-Tier Conductor (Complexity × TaskType)",
-  "description": "Cost-optimized conductor: level1 junior for 2D classification (complexity + taskType), level2 senior for UNCERTAIN tasks. Routes to appropriate cluster config via helpers.getConfig().",
+  "description": "Cost-optimized conductor: level2 junior for 2D classification (complexity + taskType), level3 senior for UNCERTAIN tasks. Routes to appropriate cluster config via helpers.getConfig().",
   "agents": [
     {
       "id": "junior-conductor",


### PR DESCRIPTION
The validator table in `CLAUDE.md` and `AGENTS.md` says STANDARD gets 3 validators and CRITICAL gets 5. Neither number is real.

`getValidatorCount()` in `src/config-router.ts:85-93` returns 2 for STANDARD and 0 for CRITICAL. The conductor prompts in `cluster-templates/conductor-bootstrap.json` already quote 2 and 4. So the router and the prompts agree with each other, and the two reference docs disagree with both.

Where the numbers come from:

- STANDARD sets `validator_count: 2`, which activates `validator-requirements` (`>= 1 && < 4`) and `validator-code` (`>= 2 && < 4`) in `full-workflow.json`.
- CRITICAL sets `validator_count: 0`, which is a signal rather than a count: it activates the `meta-coordinator` (`complexity == 'CRITICAL' && validator_count == 0`), which loads `quick-validation` and then `heavy-validation`, 2 validators each, so 4 in two stages.

Also corrects the `conductor-bootstrap.json` description, which said level1 junior / level2 senior where the agents are `modelLevel: level2` and `level3`.

Docs only, no behaviour change. Lifted from #863, which is otherwise stale against the README rewrite in #945.

## One thing this doesn't fix

`validator-security` and `validator-tester` in `full-workflow.json` are both gated on `validator_count == 3`, and the router never emits 3. They can only ever run through the CRITICAL sub-clusters, never inline. That's either a dead condition or an off-by-one against the `>= 2 && < 4` gate above it; leaving it alone here since it's a behaviour question, not a docs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeBinMzJJjDvW2fPSAu14S