### PR TITLE
fix(ship): count staged validation approvals in the git-pusher handoff

### DIFF
--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -216,7 +216,14 @@ function assertRequiredQualityGatesPass(messages) {
 const requiredQualityGatesForHandoff = getRequiredQualityGates();
 if (validators.length === 0 && requiredQualityGatesForHandoff.length === 0) return true;
 
-const results = ledger.query({ topic: 'VALIDATION_RESULT', since: lastPush.timestamp });
+// A generated topology validates in stages, and every stage but the last
+// publishes STAGE_<n>_VALIDATION_RESULT rather than VALIDATION_RESULT. Counting
+// only the plain topic misses every earlier-stage validator, so
+// latestByValidator can never reach validators.length and the handoff never
+// fires: the work is built, approved by all of them, and then never shipped.
+const results = ledger
+  .query({ since: lastPush.timestamp })
+  .filter((msg) => typeof msg.topic === 'string' && /(?:^|_)VALIDATION_RESULT$/.test(msg.topic));
 if (results.length === 0) return false;
 
 const validatorIds = new Set(validators.map((v) => v.id));

--- a/src/agents/git-pusher-template.js
+++ b/src/agents/git-pusher-template.js
@@ -216,14 +216,19 @@ function assertRequiredQualityGatesPass(messages) {
 const requiredQualityGatesForHandoff = getRequiredQualityGates();
 if (validators.length === 0 && requiredQualityGatesForHandoff.length === 0) return true;
 
-// A generated topology validates in stages, and every stage but the last
-// publishes STAGE_<n>_VALIDATION_RESULT rather than VALIDATION_RESULT. Counting
-// only the plain topic misses every earlier-stage validator, so
-// latestByValidator can never reach validators.length and the handoff never
-// fires: the work is built, approved by all of them, and then never shipped.
+// A staged topology has every stage but the last publish
+// STAGE_<n>_VALIDATION_RESULT, so counting only the plain topic misses those
+// validators, latestByValidator never reaches validators.length, and the
+// handoff never fires: the work is built, approved by all of them, and never
+// shipped.
+//
+// Matched exactly, not by suffix. QUICK_VALIDATION_RESULT and
+// HEAVY_VALIDATION_RESULT are tiers of the same check, and letting a cheap
+// pre-check satisfy the ship gate would be worse than not shipping at all.
+const STAGED_VALIDATION_TOPIC = /^(?:STAGE_[0-9]+_)?VALIDATION_RESULT$/;
 const results = ledger
   .query({ since: lastPush.timestamp })
-  .filter((msg) => typeof msg.topic === 'string' && /(?:^|_)VALIDATION_RESULT$/.test(msg.topic));
+  .filter((msg) => typeof msg.topic === 'string' && STAGED_VALIDATION_TOPIC.test(msg.topic));
 if (results.length === 0) return false;
 
 const validatorIds = new Set(validators.map((v) => v.id));

--- a/tests/git-pusher-staged-validators.test.js
+++ b/tests/git-pusher-staged-validators.test.js
@@ -114,6 +114,25 @@ describe('git-pusher handoff across validation stages', function () {
     assert.strictEqual(ready, false, 'counting staged results must not weaken the gate');
   });
 
+  it('does not let a cheap pre-check tier satisfy the ship gate', function () {
+    // QUICK_ and HEAVY_VALIDATION_RESULT are tiers of the same check. Matching
+    // validation topics by suffix would count the quick pass as approval and
+    // ship on a pre-check, which is worse than not shipping.
+    for (const tier of ['QUICK_VALIDATION_RESULT', 'HEAVY_VALIDATION_RESULT']) {
+      const ready = evaluateTrigger({
+        cluster: makeCluster(VALIDATORS),
+        ledger: makeLedger([
+          IMPLEMENTATION_READY,
+          approval('toolchain-gate', tier, true),
+          approval('cancel-behaviour-audit', 'VALIDATION_RESULT', true),
+        ]),
+        agent: { id: 'git-pusher' },
+      });
+
+      assert.strictEqual(ready, false, tier + ' must not count as a validator approval');
+    }
+  });
+
   it('blocks when a validator has not reported at all', function () {
     const ready = evaluateTrigger({
       cluster: makeCluster(VALIDATORS),

--- a/tests/git-pusher-staged-validators.test.js
+++ b/tests/git-pusher-staged-validators.test.js
@@ -1,0 +1,129 @@
+/**
+ * Test: git-pusher must hand off for a STAGED topology, not just a flat one.
+ *
+ * HISTORY:
+ * - The handoff trigger queried only `VALIDATION_RESULT` and then required one
+ *   such message per validator: `latestByValidator.size < validators.length`.
+ * - A generated topology validates in stages, and every stage except the last
+ *   publishes `STAGE_<n>_VALIDATION_RESULT` instead. So an earlier-stage
+ *   validator never counted, the size check could never be satisfied, and
+ *   git-pusher stayed idle forever.
+ * - Observed for real: a two-stage cluster built the change, both validators
+ *   approved it, and nothing was ever committed or pushed. The work sat
+ *   uncommitted in the worktree while the run reported retries exhausted.
+ *
+ * The trigger's intent is "every validator approved". A staged validator's
+ * approval is in STAGE_<n>_VALIDATION_RESULT, so it has to count.
+ */
+
+const assert = require('assert');
+const vm = require('vm');
+
+const { SHARED_TRIGGER_SCRIPT } = require('../src/agents/git-pusher-template.js');
+
+/**
+ * Run the trigger the way the runtime does: it is stored as a script string and
+ * evaluated in a sandbox, so the test compiles it the same way rather than
+ * reimplementing the logic it is meant to cover.
+ */
+function evaluateTrigger({ cluster, ledger, agent }) {
+  const script = new vm.Script(`(function() { 'use strict'; ${SHARED_TRIGGER_SCRIPT} })()`);
+  return script.runInNewContext({ cluster, ledger, agent, require });
+}
+
+function makeLedger(messages) {
+  return {
+    findLast: ({ topic }) => [...messages].reverse().find((m) => m.topic === topic) || null,
+    query: ({ topic, since }) =>
+      messages.filter(
+        (m) => (topic ? m.topic === topic : true) && (since ? m.timestamp >= since : true)
+      ),
+  };
+}
+
+function makeCluster(validators) {
+  return {
+    getAgentsByRole: (role) => (role === 'validator' ? validators : []),
+    getAgent: () => null,
+  };
+}
+
+function approval(sender, topic, approved) {
+  return {
+    topic,
+    sender,
+    timestamp: sender === 'toolchain-gate' ? 200 : 300,
+    content: { data: { approved, disposition: approved ? 'approved' : 'rejected', errors: [] } },
+  };
+}
+
+const IMPLEMENTATION_READY = {
+  topic: 'IMPLEMENTATION_READY',
+  sender: 'cancel-implementer',
+  timestamp: 100,
+  content: { data: { completed: true } },
+};
+
+const VALIDATORS = [{ id: 'toolchain-gate' }, { id: 'cancel-behaviour-audit' }];
+
+describe('git-pusher handoff across validation stages', function () {
+  it('hands off when every validator publishes a plain VALIDATION_RESULT', function () {
+    const ready = evaluateTrigger({
+      cluster: makeCluster(VALIDATORS),
+      ledger: makeLedger([
+        IMPLEMENTATION_READY,
+        approval('toolchain-gate', 'VALIDATION_RESULT', true),
+        approval('cancel-behaviour-audit', 'VALIDATION_RESULT', true),
+      ]),
+      agent: { id: 'git-pusher' },
+    });
+
+    assert.strictEqual(ready, true, 'a flat topology must still hand off');
+  });
+
+  it('hands off when an earlier stage approved under STAGE_<n>_VALIDATION_RESULT', function () {
+    const ready = evaluateTrigger({
+      cluster: makeCluster(VALIDATORS),
+      ledger: makeLedger([
+        IMPLEMENTATION_READY,
+        // Stage 1 of a generated topology does not publish the plain topic.
+        approval('toolchain-gate', 'STAGE_1_VALIDATION_RESULT', true),
+        approval('cancel-behaviour-audit', 'VALIDATION_RESULT', true),
+      ]),
+      agent: { id: 'git-pusher' },
+    });
+
+    assert.strictEqual(
+      ready,
+      true,
+      'a stage-1 approval must count, or approved work is built and never shipped'
+    );
+  });
+
+  it('still blocks when a staged validator rejected', function () {
+    const ready = evaluateTrigger({
+      cluster: makeCluster(VALIDATORS),
+      ledger: makeLedger([
+        IMPLEMENTATION_READY,
+        approval('toolchain-gate', 'STAGE_1_VALIDATION_RESULT', false),
+        approval('cancel-behaviour-audit', 'VALIDATION_RESULT', true),
+      ]),
+      agent: { id: 'git-pusher' },
+    });
+
+    assert.strictEqual(ready, false, 'counting staged results must not weaken the gate');
+  });
+
+  it('blocks when a validator has not reported at all', function () {
+    const ready = evaluateTrigger({
+      cluster: makeCluster(VALIDATORS),
+      ledger: makeLedger([
+        IMPLEMENTATION_READY,
+        approval('cancel-behaviour-audit', 'VALIDATION_RESULT', true),
+      ]),
+      agent: { id: 'git-pusher' },
+    });
+
+    assert.strictEqual(ready, false, 'a silent validator is not an approving one');
+  });
+});


### PR DESCRIPTION
## Scope — read this first

**This is not a live bug on `main`.** Nothing on `main` publishes
`STAGE_<n>_VALIDATION_RESULT`, so the handoff cannot currently fail this way.
It is a forward-compatibility fix: it becomes a real bug the moment a topology
that validates in stages is used, which is exactly what
`eivind/topology-generator` produces.

I hit it there, not on main. Flagging that because the first version of this
description implied otherwise.

## The problem

`git-pusher` commits, pushes and opens the PR in ship mode, and only fires once
every validator has approved. It established that by counting `VALIDATION_RESULT`
messages:

```js
if (latestByValidator.size < validators.length) return false;
```

A staged topology publishes `STAGE_<n>_VALIDATION_RESULT` for every stage
except the last, so those validators never counted, the size check could never
be satisfied, and `git-pusher` stayed `idle` forever.

Observed on a real two-stage cluster, both approving:

```
STAGE_1_VALIDATION_RESULT  <- toolchain-gate           ← not counted
VALIDATION_RESULT          <- cancel-behaviour-audit   ← counted

latestByValidator.size = 1  <  validators.length = 2   →  no ship
```

The change was built, every validator approved it, and it was abandoned
uncommitted in the worktree while the run reported retries exhausted.

## The fix

Match `^(?:STAGE_[0-9]+_)?VALIDATION_RESULT$`.

Two deliberate details:

- **Exact, not suffix.** My first attempt used `/(?:^|_)VALIDATION_RESULT$/`,
  which also matches `QUICK_VALIDATION_RESULT` and `HEAVY_VALIDATION_RESULT` —
  both present in this repo as tiers of the same check. That would have let a
  cheap pre-check satisfy the ship gate, which is strictly worse than the bug:
  not shipping is recoverable, shipping unverified work is not.
- **`[0-9]` rather than `\d`.** `SHARED_TRIGGER_SCRIPT` is a template literal,
  so the backslash is consumed before the script is compiled — `\d` silently
  became `d` and the staged topic stopped matching at all.

## Verification

The test compiles the trigger through `vm` exactly as the runtime does, rather
than reimplementing its logic.

- against `main`: **4 passing, 1 failing**
- with this branch: **5 passing**

Covered: flat topology still hands off; a staged approval counts; a rejected
stage still blocks; a validator that never reported still blocks; and neither
QUICK nor HEAVY tier can satisfy the gate.

## Trade-off worth a reviewer's eye

The query drops its indexed `topic` filter and filters in JS instead, so it now
scans messages since the last `IMPLEMENTATION_READY` rather than hitting the
topic index. That window is the tail of a run, so it is bounded — but if you'd
rather keep the index, the alternative is two targeted queries, or having the
topology generator emit a terminal `VALIDATION_RESULT` per validator.