### PR TITLE
docs(hosted): guide private remote runs

### DIFF
--- a/private/hosted-cli-candidate/README.md
+++ b/private/hosted-cli-candidate/README.md
@@ -1,0 +1,214 @@
+# Remote runs with the private Zeroshot candidate
+
+This guide applies only to the unpublished private candidate. The public Zeroshot package does not
+contain these commands, this guide, or the accompanying examples.
+
+A remote run has four inputs:
+
+- A **target** names the remote Zeroshot service and holds your authenticated session.
+- A **runtime config** selects the model API, Zeroshot harness, model, credentials, and normal
+  Zeroshot settings.
+- The supplied **graph** is the candidate's fixed delivery contract. The **input** contains the work
+  request.
+- A **delivery mode** decides whether Zeroshot opens a pull request (`--pr`) or also requests its
+  merge (`--ship`). Every remote run requires one of these modes.
+
+## Prerequisites
+
+- Node.js 22 or newer and npm.
+- A target URL and account, plus an operating-system credential store that the target login can use.
+- A GitHub repository and token that can clone it, push a branch, and open pull requests. `--ship`
+  also needs permission to merge or enable auto-merge.
+- The provider credential and routing variables referenced by the runtime config you choose.
+
+The commands below use GitHub CLI to obtain a token, so `gh` must already be authenticated. You may
+instead export a suitable `GH_TOKEN` or `GITHUB_TOKEN` yourself.
+
+## First run
+
+Install the candidate tarball supplied by your operator, copy its examples into a durable working
+directory, and confirm that its commands are present:
+
+```bash
+npm install --global /absolute/path/to/the-open-engine-zeroshot-private-hosted-candidate.tgz
+private_candidate_root="$(npm root --global)/@the-open-engine/zeroshot-private-hosted-candidate/lib/private-hosted-cli"
+test -f "$private_candidate_root/examples/graph.json"
+mkdir zeroshot-remote-run
+cp -R "$private_candidate_root/examples" zeroshot-remote-run/
+cd zeroshot-remote-run
+zeroshot target --help
+```
+
+Keep this directory after setup: Zeroshot rereads the selected runtime file for every run.
+
+Register and authenticate a target:
+
+```bash
+zeroshot target add team --url https://target.example
+zeroshot target login team
+```
+
+Choose a runtime config from `examples/`, export the local variables referenced by that file, and
+bind it to a GitHub repository:
+
+```bash
+export GH_TOKEN="$(gh auth token)"
+export OPENAI_API_KEY=...
+zeroshot target setup team \
+  --repository your-org/your-repository \
+  --base main \
+  --runtime-config examples/runtime-openai-codex.json
+```
+
+`--base` may be a branch or an exact lowercase 40-character commit. When it is an exact commit,
+also pass `--target-branch` to name the branch that receives the pull request. If `--base` is
+omitted, Zeroshot resolves the repository's default branch for each submission.
+
+Start a run with Zeroshot's built-in coordinator by omitting `--config`:
+
+```bash
+zeroshot run \
+  --target team \
+  --graph examples/graph.json \
+  --input examples/input.json \
+  --ship
+```
+
+Keep `examples/graph.json` unchanged. The included input asks the run to make a real repository
+change; replace only its prompt with your own work before submitting it to a repository you care
+about. `examples/cluster.json` is independent and is used only when you want a custom agent
+topology.
+
+`--pr` commits the change, pushes a delivery branch, and opens a pull request. `--ship` additionally
+requests an allowed merge or enables auto-merge. It succeeds only after the target reports that the
+pull request is merged or that GitHub accepted auto-merge. Checks, approvals, conflicts, branch
+protection, or insufficient token permissions can prevent shipping; inspect the retained pull
+request to resolve those repository conditions.
+
+## Runtime config
+
+The runtime config is ordinary JSON with these fields:
+
+| Field          | Required | Meaning                                                                                                   |
+| -------------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `provider`     | yes      | Stable label for the model API, such as `openai` or `openrouter`.                                         |
+| `harness`      | no       | Agent program Zeroshot uses to call the API, such as `claude`, `codex`, or `omp`. Defaults to `provider`. |
+| `model`        | no       | Model selector understood by the chosen harness.                                                          |
+| `environment`  | no       | Environment values supplied to the harness.                                                               |
+| `files`        | no       | Text files materialized for the harness.                                                                  |
+| `settings`     | no       | Normal Zeroshot settings used by the cluster.                                                             |
+| `command`      | no       | Custom command invoked through the registered harness name.                                               |
+| `setupCommand` | no       | Bounded setup command run before the harness is checked and started.                                      |
+
+Environment values may be inline strings or local environment references:
+
+```json
+{
+  "environment": {
+    "OPENAI_API_KEY": { "from": "OPENAI_API_KEY" },
+    "PROVIDER_REGION": "eu-west-1"
+  }
+}
+```
+
+File values may likewise be inline text or references to local regular files. Relative source
+paths are resolved from the runtime config's directory:
+
+```json
+{
+  "files": {
+    ".config/provider.json": { "from": "provider.json" }
+  }
+}
+```
+
+Target setup stores the runtime config's absolute path. Zeroshot reads it again at submission time
+and resolves references then, so rotated local credentials apply without repeating setup. Do not
+put GitHub delivery credentials in `environment`; use `GH_TOKEN` or `GITHUB_TOKEN` in the shell
+that starts the run.
+
+The example directory contains complete configurations for OpenRouter with the Claude harness,
+OpenAI with the Codex harness, and Azure OpenAI with the OMP harness. The Azure OMP configuration
+expects these local variables:
+
+```bash
+export AZURE_OPENAI_API_KEY=...
+export AZURE_OPENAI_API_VERSION=...
+export AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com/openai/v1
+export AZURE_OPENAI_DEPLOYMENT_NAME_MAP='{"gpt-5.1":"your-deployment"}'
+```
+
+Treat each runtime example as one atomic starting point. To change the model without changing its
+harness, update the top-level `model` and every model entry under
+`settings.providerSettings.<harness>.levelOverrides`. The top-level `harness` selects the agent
+program; keep `settings.defaultProvider` aligned with it so the settings remain internally
+consistent. When changing the model API, also update its `provider` label, environment routing, and
+harness-specific authentication settings together.
+
+## Coordinator and custom clusters
+
+Keep the supplied graph unchanged. Omit `--config` to use Zeroshot's built-in coordinator. To
+control the agent topology, pass a declarative Zeroshot cluster config:
+
+```bash
+zeroshot run \
+  --target team \
+  --graph examples/graph.json \
+  --input examples/input.json \
+  --config examples/cluster.json \
+  --ship
+```
+
+Remote custom configs accept normal declarative agent, trigger, prompt, model-level, and completion
+hook data. They reject executable scripts, config loaders, task executors, and system-command hooks.
+Provider, harness, model, credentials, and shared settings belong in the runtime config rather than
+the cluster file.
+
+## Following and recovery
+
+Runs follow their output by default. `--detach` returns after submission. Pressing Ctrl+C while
+following detaches without cancelling the remote work.
+
+Immediately before sending the submission request, the CLI prints `Submission key: <uuid>`. After
+acceptance it prints `Run <run-intent-id> submitted` and the exact `zeroshot attach` resume command.
+Save this output when you detach.
+
+```bash
+zeroshot attach <run-intent-id> --target team
+zeroshot target status team <run-intent-id>
+zeroshot target cancel team <run-intent-id>
+zeroshot list --target team
+```
+
+If submission ended without a definite response, the error includes the submission key that was
+printed before the request. The key is an idempotency key, not a lookup: retry only when the fully
+resolved request is unchanged. That means the graph, input, custom cluster, runtime file and its
+referenced environment values and files, GitHub token, size, delivery mode, and resolved repository
+revision must all match the first request. A changed request with the same key is rejected rather
+than creating a second run.
+
+For a recoverable run, configure an exact commit base and keep all referenced inputs unchanged
+until submission is confirmed. Then repeat the exact run with the canonical UUID as
+`--submission-key`. If you cannot guarantee an identical request, do not resubmit with that key;
+ask the target operator to determine whether the original request was accepted.
+
+```bash
+zeroshot run \
+  --target team \
+  --graph examples/graph.json \
+  --input examples/input.json \
+  --ship \
+  --submission-key 019fd17d-d9a7-4ef7-8a62-4e46f907c8ec
+```
+
+## Current command boundary
+
+- Remote runs accept explicit JSON graph and input files; general text or issue positionals remain
+  local-only.
+- The remote graph is the included single-worker delivery graph with one attempt; keep it unchanged.
+- Remote delivery always uses `--pr` or `--ship`; there is no delivery-free remote run.
+- `logs --target`, the `ls` alias with `--target`, and cross-target listing are not available.
+- A target can reject a harness, model, size, or runtime command that it does not provide.
+
+Use `zeroshot run --help`, `zeroshot target --help`, and
+`zeroshot target setup --help` for the concise command reference.

--- a/private/hosted-cli-candidate/build-candidate.js
+++ b/private/hosted-cli-candidate/build-candidate.js
@@ -8,7 +8,17 @@ const { spawnSync } = require('node:child_process');
 const { PRIVATE_MARKER } = require('./manifest');
 
 const ROOT = path.resolve(__dirname, '../..');
+const CANDIDATE_GUIDANCE_FILES = Object.freeze([
+  'README.md',
+  'examples/cluster.json',
+  'examples/graph.json',
+  'examples/input.json',
+  'examples/runtime-azure-openai-omp.json',
+  'examples/runtime-openai-codex.json',
+  'examples/runtime-openrouter-claude.json',
+]);
 const CANDIDATE_FILES = Object.freeze([
+  ...CANDIDATE_GUIDANCE_FILES,
   'manifest.js',
   'readers.js',
   'credentials.js',
@@ -25,6 +35,7 @@ const CANDIDATE_FILES = Object.freeze([
   'target-services.js',
   'register.js',
   'register-support.js',
+  'help-text.js',
 ]);
 const CANDIDATE_SUPPORT_FILES = Object.freeze([
   Object.freeze({
@@ -108,7 +119,9 @@ function writeCandidateFiles(stage) {
   const target = path.join(stage, 'lib/private-hosted-cli');
   fs.mkdirSync(target, { recursive: true });
   for (const file of CANDIDATE_FILES) {
-    fs.copyFileSync(path.join(__dirname, file), path.join(target, file));
+    const destination = path.join(target, file);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(__dirname, file), destination);
   }
   for (const file of CANDIDATE_SUPPORT_FILES) {
     fs.copyFileSync(path.join(ROOT, file.source), path.join(target, file.destination));
@@ -201,4 +214,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseArgs };
+module.exports = { CANDIDATE_GUIDANCE_FILES, parseArgs };

--- a/private/hosted-cli-candidate/default-run-intent-services.js
+++ b/private/hosted-cli-candidate/default-run-intent-services.js
@@ -34,7 +34,9 @@ function isDeterministicSubmissionError(error) {
 function submissionUncertain(submissionKey, cause) {
   return new Error(
     'RunIntent submission outcome is uncertain. Do not create a replacement. ' +
-      `Recover by rerunning the same command with --submission-key ${submissionKey}.`,
+      'Retry only if the graph, input, cluster config, runtime references, credentials, size, ' +
+      'delivery mode, and resolved repository revision are unchanged. ' +
+      `Then rerun with --submission-key ${submissionKey}; a changed payload is rejected.`,
     { cause }
   );
 }

--- a/private/hosted-cli-candidate/examples/cluster.json
+++ b/private/hosted-cli-candidate/examples/cluster.json
@@ -1,0 +1,18 @@
+{
+  "name": "Remote implementation cluster",
+  "agents": [
+    {
+      "id": "worker",
+      "role": "implementation",
+      "maxIterations": 30,
+      "prompt": "Complete the requested repository change and verify the result.",
+      "triggers": [{ "topic": "ISSUE_OPENED", "action": "execute_task" }],
+      "hooks": {
+        "onComplete": {
+          "action": "publish_message",
+          "config": { "topic": "CLUSTER_COMPLETE" }
+        }
+      }
+    }
+  ]
+}

--- a/private/hosted-cli-candidate/examples/graph.json
+++ b/private/hosted-cli-candidate/examples/graph.json
@@ -1,0 +1,197 @@
+{
+  "initialInput": {
+    "fields": {
+      "artifacts": {
+        "required": true,
+        "type": {
+          "items": {
+            "fields": {
+              "artifactId": { "required": true, "type": { "kind": "string" } },
+              "byteLength": { "required": true, "type": { "kind": "integer" } },
+              "lineage": {
+                "required": true,
+                "type": {
+                  "fields": {
+                    "attempt": { "required": true, "type": { "kind": "integer" } },
+                    "generation": { "required": true, "type": { "kind": "integer" } },
+                    "runId": { "required": true, "type": { "kind": "string" } }
+                  },
+                  "kind": "record"
+                }
+              },
+              "mediaType": { "required": true, "type": { "kind": "string" } },
+              "producer": {
+                "required": true,
+                "type": {
+                  "fields": {
+                    "node": { "required": true, "type": { "kind": "string" } },
+                    "worker": { "required": true, "type": { "kind": "string" } }
+                  },
+                  "kind": "record"
+                }
+              },
+              "redaction": {
+                "required": true,
+                "type": {
+                  "kind": "enum",
+                  "values": ["confidential", "internal", "public", "restricted"]
+                }
+              },
+              "sha256": { "required": true, "type": { "kind": "string" } },
+              "typeId": { "required": true, "type": { "kind": "string" } }
+            },
+            "kind": "record"
+          },
+          "kind": "array"
+        }
+      },
+      "isolationProfile": { "required": true, "type": { "kind": "string" } },
+      "issue": { "required": false, "type": { "kind": "string" } },
+      "modelLevel": {
+        "required": true,
+        "type": { "kind": "enum", "values": ["level1", "level2", "level3"] }
+      },
+      "prompt": { "required": false, "type": { "kind": "string" } },
+      "provider": { "required": true, "type": { "kind": "string" } },
+      "providerProfile": { "required": true, "type": { "kind": "string" } },
+      "repository": { "required": true, "type": { "kind": "string" } },
+      "source": {
+        "required": true,
+        "type": { "kind": "enum", "values": ["artifact", "issue", "prompt"] }
+      }
+    },
+    "kind": "record"
+  },
+  "policy": { "default": "deny", "policy": "policy.strict@1" },
+  "profile": "openengine.graph.single-worker/v1",
+  "root": {
+    "attempts": 1,
+    "input": {
+      "fields": {
+        "artifacts": {
+          "required": true,
+          "type": {
+            "items": {
+              "fields": {
+                "artifactId": { "required": true, "type": { "kind": "string" } },
+                "byteLength": { "required": true, "type": { "kind": "integer" } },
+                "lineage": {
+                  "required": true,
+                  "type": {
+                    "fields": {
+                      "attempt": { "required": true, "type": { "kind": "integer" } },
+                      "generation": { "required": true, "type": { "kind": "integer" } },
+                      "runId": { "required": true, "type": { "kind": "string" } }
+                    },
+                    "kind": "record"
+                  }
+                },
+                "mediaType": { "required": true, "type": { "kind": "string" } },
+                "producer": {
+                  "required": true,
+                  "type": {
+                    "fields": {
+                      "node": { "required": true, "type": { "kind": "string" } },
+                      "worker": { "required": true, "type": { "kind": "string" } }
+                    },
+                    "kind": "record"
+                  }
+                },
+                "redaction": {
+                  "required": true,
+                  "type": {
+                    "kind": "enum",
+                    "values": ["confidential", "internal", "public", "restricted"]
+                  }
+                },
+                "sha256": { "required": true, "type": { "kind": "string" } },
+                "typeId": { "required": true, "type": { "kind": "string" } }
+              },
+              "kind": "record"
+            },
+            "kind": "array"
+          }
+        },
+        "isolationProfile": { "required": true, "type": { "kind": "string" } },
+        "issue": { "required": false, "type": { "kind": "string" } },
+        "modelLevel": {
+          "required": true,
+          "type": { "kind": "enum", "values": ["level1", "level2", "level3"] }
+        },
+        "prompt": { "required": false, "type": { "kind": "string" } },
+        "provider": { "required": true, "type": { "kind": "string" } },
+        "providerProfile": { "required": true, "type": { "kind": "string" } },
+        "repository": { "required": true, "type": { "kind": "string" } },
+        "source": {
+          "required": true,
+          "type": { "kind": "enum", "values": ["artifact", "issue", "prompt"] }
+        }
+      },
+      "kind": "record"
+    },
+    "inputBindings": [],
+    "kind": "step",
+    "name": "worker",
+    "output": {
+      "fields": {
+        "artifacts": {
+          "required": true,
+          "type": {
+            "items": {
+              "fields": {
+                "artifactId": { "required": true, "type": { "kind": "string" } },
+                "byteLength": { "required": true, "type": { "kind": "integer" } },
+                "lineage": {
+                  "required": true,
+                  "type": {
+                    "fields": {
+                      "attempt": { "required": true, "type": { "kind": "integer" } },
+                      "generation": { "required": true, "type": { "kind": "integer" } },
+                      "runId": { "required": true, "type": { "kind": "string" } }
+                    },
+                    "kind": "record"
+                  }
+                },
+                "mediaType": { "required": true, "type": { "kind": "string" } },
+                "producer": {
+                  "required": true,
+                  "type": {
+                    "fields": {
+                      "node": { "required": true, "type": { "kind": "string" } },
+                      "worker": { "required": true, "type": { "kind": "string" } }
+                    },
+                    "kind": "record"
+                  }
+                },
+                "redaction": {
+                  "required": true,
+                  "type": {
+                    "kind": "enum",
+                    "values": ["confidential", "internal", "public", "restricted"]
+                  }
+                },
+                "sha256": { "required": true, "type": { "kind": "string" } },
+                "typeId": { "required": true, "type": { "kind": "string" } }
+              },
+              "kind": "record"
+            },
+            "kind": "array"
+          }
+        },
+        "branch": { "required": false, "type": { "kind": "string" } },
+        "headRevision": { "required": false, "type": { "kind": "string" } },
+        "pullRequestUrl": { "required": false, "type": { "kind": "string" } },
+        "repository": { "required": false, "type": { "kind": "string" } },
+        "status": {
+          "required": true,
+          "type": { "kind": "enum", "values": ["failed", "succeeded"] }
+        },
+        "summary": { "required": true, "type": { "kind": "string" } }
+      },
+      "kind": "record"
+    },
+    "timeoutMs": 3600000,
+    "worker": "legacy.zeroshot.ship@1",
+    "writeBindings": []
+  }
+}

--- a/private/hosted-cli-candidate/examples/input.json
+++ b/private/hosted-cli-candidate/examples/input.json
@@ -1,0 +1,5 @@
+{
+  "artifacts": [],
+  "prompt": "Create a file named hosted-run-proof.txt at the repository root containing a concise summary of the repository's purpose followed by one newline. Make no other changes. Perform the edit; do not merely describe it.",
+  "source": "prompt"
+}

--- a/private/hosted-cli-candidate/examples/runtime-azure-openai-omp.json
+++ b/private/hosted-cli-candidate/examples/runtime-azure-openai-omp.json
@@ -1,0 +1,38 @@
+{
+  "provider": "azure-openai",
+  "harness": "omp",
+  "model": "azure/gpt-5.1",
+  "environment": {
+    "AZURE_OPENAI_API_KEY": { "from": "AZURE_OPENAI_API_KEY" },
+    "AZURE_OPENAI_API_VERSION": { "from": "AZURE_OPENAI_API_VERSION" },
+    "AZURE_OPENAI_BASE_URL": { "from": "AZURE_OPENAI_BASE_URL" },
+    "AZURE_OPENAI_DEPLOYMENT_NAME_MAP": { "from": "AZURE_OPENAI_DEPLOYMENT_NAME_MAP" }
+  },
+  "files": {},
+  "settings": {
+    "defaultProvider": "omp",
+    "providerSettings": {
+      "omp": {
+        "transport": "sdk",
+        "minLevel": "level1",
+        "defaultLevel": "level1",
+        "maxLevel": "level1",
+        "levelOverrides": {
+          "level1": { "model": "azure/gpt-5.1", "reasoningEffort": "high" },
+          "level2": { "model": "azure/gpt-5.1", "reasoningEffort": "high" },
+          "level3": { "model": "azure/gpt-5.1", "reasoningEffort": "high" }
+        },
+        "modelsConfig": { "providers": {} },
+        "auth": {
+          "mode": "environment",
+          "credentials": {
+            "azure": { "env": "AZURE_OPENAI_API_KEY" }
+          }
+        },
+        "tools": ["read", "bash", "edit", "write", "grep", "glob"],
+        "nestedAgents": false,
+        "mcp": false
+      }
+    }
+  }
+}

--- a/private/hosted-cli-candidate/examples/runtime-openai-codex.json
+++ b/private/hosted-cli-candidate/examples/runtime-openai-codex.json
@@ -1,0 +1,22 @@
+{
+  "provider": "openai",
+  "harness": "codex",
+  "model": "gpt-5.4",
+  "environment": {
+    "OPENAI_API_KEY": { "from": "OPENAI_API_KEY" }
+  },
+  "files": {},
+  "settings": {
+    "defaultProvider": "codex",
+    "providerSettings": {
+      "codex": {
+        "minLevel": "level1",
+        "defaultLevel": "level1",
+        "maxLevel": "level1",
+        "levelOverrides": {
+          "level1": { "model": "gpt-5.4", "reasoningEffort": "medium" }
+        }
+      }
+    }
+  }
+}

--- a/private/hosted-cli-candidate/examples/runtime-openrouter-claude.json
+++ b/private/hosted-cli-candidate/examples/runtime-openrouter-claude.json
@@ -1,0 +1,24 @@
+{
+  "provider": "openrouter",
+  "harness": "claude",
+  "model": "claude-haiku-4-5",
+  "environment": {
+    "ANTHROPIC_API_KEY": "",
+    "ANTHROPIC_AUTH_TOKEN": { "from": "OPENROUTER_API_KEY" },
+    "ANTHROPIC_BASE_URL": "https://openrouter.ai/api"
+  },
+  "files": {},
+  "settings": {
+    "defaultProvider": "claude",
+    "providerSettings": {
+      "claude": {
+        "minLevel": "level1",
+        "defaultLevel": "level1",
+        "maxLevel": "level1",
+        "levelOverrides": {
+          "level1": { "model": "claude-haiku-4-5" }
+        }
+      }
+    }
+  }
+}

--- a/private/hosted-cli-candidate/help-text.js
+++ b/private/hosted-cli-candidate/help-text.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const TARGET_HELP = `
+Workflow:
+  1. zeroshot target add <name> --url <https-origin>
+  2. zeroshot target login <name>
+  3. zeroshot target setup <name> --repository <owner/name> --runtime-config <file>
+  4. zeroshot run --target <name> --graph <file> --input <file> --ship
+
+Run \`zeroshot target <command> --help\` for command details.
+`;
+const TARGET_SETUP_HELP = `
+Runtime configuration:
+  provider       Stable label for the model API used by the run.
+  harness        Agent program Zeroshot uses to call that API; defaults to provider.
+  model          Optional model selector understood by the harness.
+  environment    Inline values or {"from":"LOCAL_ENV_NAME"} references.
+  files          Inline text or {"from":"local/path"} references.
+  settings       Zeroshot settings supplied to the remote cluster.
+
+The runtime file is read for every run. Setup stores its path, not resolved secrets.
+`;
+const HOSTED_RUN_HELP = `
+Remote execution with --target:
+  --graph and --input are required explicit JSON files.
+  Keep the candidate graph unchanged; put the work request in the input.
+  --pr or --ship is required for Git delivery.
+  Omit --config to use Zeroshot's built-in coordinator.
+  Add --config <file> to use a declarative custom cluster.
+  Runs follow by default; --detach and Ctrl+C detach without cancelling.
+  --submission-key retries only an unchanged, fully resolved request.
+
+Examples:
+  zeroshot run --target team --graph graph.json --input input.json --ship
+  zeroshot run --target team --graph graph.json --input input.json --config cluster.json --ship
+`;
+
+module.exports = { HOSTED_RUN_HELP, TARGET_HELP, TARGET_SETUP_HELP };

--- a/private/hosted-cli-candidate/register.js
+++ b/private/hosted-cli-candidate/register.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { createDefaultServices } = require('./default-services');
+const { HOSTED_RUN_HELP, TARGET_HELP, TARGET_SETUP_HELP } = require('./help-text');
 const { COMMAND_MANIFEST } = require('./manifest');
 const {
   assertOnlyOptions,
@@ -27,7 +28,10 @@ const HOSTED_RUN_OPTIONS = new Set([
 ]);
 
 function registerTarget(program, service) {
-  const target = program.command('target').description('Manage named private hosted targets');
+  const target = program
+    .command('target')
+    .description('Manage named private hosted targets')
+    .addHelpText('after', TARGET_HELP);
   target
     .command('add <name>')
     .description('Register a named remote target')
@@ -47,14 +51,15 @@ function registerTarget(program, service) {
     .description('Revoke and remove a target')
     .option('--force', 'Remove even if remote revocation fails')
     .action((name, options) => failClosed(() => service().targetRemove(name, options)));
-  target
+  const setup = target
     .command('setup <name>')
     .description('Bind a repository and local hosted runtime configuration')
-    .requiredOption('--repository <owner/name>', 'Exact GitHub owner/name')
-    .option('--base <branch-or-sha>', 'Branch or exact lowercase 40-character commit')
-    .option('--target-branch <branch>', 'Delivery target required with an exact commit')
-    .requiredOption('--runtime-config <file>', 'Generic hosted runtime JSON')
+    .requiredOption('--repository <owner/name>', 'GitHub repository to clone and deliver to')
+    .option('--base <branch-or-sha>', 'Base branch or exact lowercase 40-character commit')
+    .option('--target-branch <branch>', 'Delivery branch required with an exact commit base')
+    .requiredOption('--runtime-config <file>', 'Zeroshot provider, harness, and model JSON')
     .action((name, options) => failClosed(() => service().targetSetup(name, options)));
+  setup.addHelpText('after', TARGET_SETUP_HELP);
   target
     .command('status <name> <intent-id>')
     .description('Inspect a private hosted run')
@@ -113,11 +118,16 @@ function registerHostedRun(program, service) {
   if (!positional) throw new Error('stable run argument is unavailable');
   positional.required = false;
   run
-    .option('--graph <file>', 'Explicit hosted GraphSpec JSON')
+    .option('--graph <file>', 'Candidate delivery GraphSpec JSON')
     .option('--input <file>', 'Explicit hosted JSON input')
     .option('--target <name>', 'Named private hosted target')
     .option('--size <size>', 'Advertised capsule size')
-    .option('--submission-key <uuid>', 'Retry-stable RunIntent submission key', canonicalUuid);
+    .option(
+      '--submission-key <uuid>',
+      'Idempotency key; retry payload must match exactly',
+      canonicalUuid
+    );
+  run.addHelpText('after', HOSTED_RUN_HELP);
   wrapExisting(run, ({ args, options, command, invokeLocal }) => {
     const inputArg = args[0];
     if (options.target === undefined) {

--- a/private/hosted-cli-candidate/runtime-config.js
+++ b/private/hosted-cli-candidate/runtime-config.js
@@ -36,7 +36,7 @@ const MAX_CONFIG_BYTES = 1024 * 1024;
 const MAX_FILE_BYTES = 512 * 1024;
 const RUNTIME_FIELDS = new Set([
   'provider',
-  'executable',
+  'harness',
   'model',
   'command',
   'setupCommand',
@@ -142,10 +142,10 @@ function normalizeRuntimeConfig(value) {
   if (unknown.length) throw new Error(`unknown runtime config field: ${unknown.join(', ')}`);
 
   const provider = boundedIdentifier(input.provider, 'runtime provider', 64);
-  const requestedExecutable =
-    boundedIdentifier(input.executable, 'runtime executable', 128, true) ?? provider;
+  const requestedHarness =
+    boundedIdentifier(input.harness, 'runtime harness', 128, true) ?? provider;
   const { getProviderRegistryEntry } = require('../../lib/agent-cli-provider');
-  const executable = getProviderRegistryEntry(requestedExecutable).id;
+  const harness = getProviderRegistryEntry(requestedHarness).id;
   const model = boundedString(input.model, 'runtime model', 512, true);
   const command = boundedString(input.command, 'runtime command', 4096, true);
   const setupCommand = boundedString(input.setupCommand, 'runtime setupCommand', 16 * 1024, true);
@@ -155,7 +155,7 @@ function normalizeRuntimeConfig(value) {
       : JSON.parse(JSON.stringify(record(input.settings, 'runtime settings')));
   return {
     provider,
-    executable,
+    harness,
     ...(model === undefined ? {} : { model }),
     ...(command === undefined ? {} : { command }),
     ...(setupCommand === undefined ? {} : { setupCommand }),
@@ -265,8 +265,10 @@ function withRuntimeFile(runtime, filename, contents) {
 
 function resolveHostedRuntime(targetRuntime, hostEnvironment = process.env) {
   const runtime = normalizeRuntimeConfig(targetRuntime);
+  const { harness, ...resolved } = runtime;
   return {
-    ...runtime,
+    ...resolved,
+    executable: harness,
     environment: resolveEnvironment(runtime.environment, hostEnvironment),
     files: resolveFiles(runtime.files),
   };

--- a/tests/private-hosted-cli/candidate-fixtures.js
+++ b/tests/private-hosted-cli/candidate-fixtures.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { resolveHostedRuntime } = require('../../private/hosted-cli-candidate/runtime-config');
 
 const BASE_REVISION = 'b'.repeat(40);
 const RUNTIME_CONFIG_PATH = path.join(__dirname, 'fixtures', 'runtime-config.json');
@@ -19,10 +20,7 @@ const RUNTIME_BUNDLE = Object.freeze({
     targetBranch: 'main',
     baseRevision: BASE_REVISION,
   },
-  runtime: {
-    ...RUNTIME_CONFIG,
-    environment: { ANTHROPIC_API_KEY: 'model-test-token' },
-  },
+  runtime: resolveHostedRuntime(RUNTIME_CONFIG, { LOCAL_MODEL_KEY: 'model-test-token' }),
 });
 const RUN_INTENT_ID = '019fd17e-71f3-7cf5-a57b-b8f1845c140c';
 const RUN_INTENT_NOW = '2026-08-05T10:00:00.000Z';

--- a/tests/private-hosted-cli/fixtures/runtime-config.json
+++ b/tests/private-hosted-cli/fixtures/runtime-config.json
@@ -1,6 +1,6 @@
 {
   "provider": "claude",
-  "executable": "claude",
+  "harness": "claude",
   "model": "claude-sonnet-4-5",
   "environment": {
     "ANTHROPIC_API_KEY": {

--- a/tests/private-hosted-cli/guidance.test.js
+++ b/tests/private-hosted-cli/guidance.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+const { getProviderRegistryEntry } = require('../../lib/agent-cli-provider');
+const { assertGraphSpec } = require('../../lib/cluster/index.cjs');
+const { validateConfig } = require('../../src/config-validator');
+const {
+  assertDeclarativeClusterConfig,
+} = require('../../private/hosted-cli-candidate/declarative-cluster');
+const { readHostedInputs } = require('../../private/hosted-cli-candidate/readers');
+const {
+  buildRunIntentExecution,
+} = require('../../private/hosted-cli-candidate/run-intent-execution');
+const { buildRunIntentEnvelope } = require('../../private/hosted-cli-candidate/run-intent-schema');
+const {
+  normalizeRuntimeConfig,
+  readRuntimeConfig,
+} = require('../../private/hosted-cli-candidate/runtime-config');
+
+const EXAMPLES = path.join(__dirname, '../../private/hosted-cli-candidate/examples');
+const RUNTIMES = Object.freeze({
+  'runtime-azure-openai-omp.json': 'omp',
+  'runtime-openai-codex.json': 'codex',
+  'runtime-openrouter-claude.json': 'claude',
+});
+
+test('runtime guidance uses the user-facing harness vocabulary', () => {
+  for (const [filename, expectedHarness] of Object.entries(RUNTIMES)) {
+    const fullPath = path.join(EXAMPLES, filename);
+    const source = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+    assert.equal(source.harness, expectedHarness);
+    assert.equal(Object.hasOwn(source, 'executable'), false);
+
+    const runtime = readRuntimeConfig(fullPath);
+    assert.equal(runtime.harness, expectedHarness);
+    const registry = getProviderRegistryEntry(runtime.harness);
+    const providerSettings = runtime.settings.providerSettings?.[registry.id] ?? {};
+    assert.equal(
+      registry.settingsValidator?.(providerSettings, { executionContext: 'docker' }) ?? null,
+      null
+    );
+  }
+});
+
+test('graph and input guidance passes production request validation', async () => {
+  const graphPath = path.join(EXAMPLES, 'graph.json');
+  const inputPath = path.join(EXAMPLES, 'input.json');
+  const { graph, input } = await readHostedInputs(graphPath, inputPath, assertGraphSpec);
+  const execution = buildRunIntentExecution({ graph, input });
+  assert.equal(buildRunIntentEnvelope(execution.graph, execution.input).input, execution.input);
+  assert.match(input.prompt, /Create a file/);
+  assert.equal(graph.root.timeoutMs, 3_600_000);
+});
+
+test('custom cluster guidance passes production configuration validation', () => {
+  const cluster = JSON.parse(fs.readFileSync(path.join(EXAMPLES, 'cluster.json'), 'utf8'));
+  assert.equal(assertDeclarativeClusterConfig(cluster), cluster);
+  assert.deepEqual(validateConfig(cluster), { valid: true, errors: [], warnings: [] });
+});
+
+test('runtime guidance rejects the internal executable vocabulary', () => {
+  assert.throws(
+    () => normalizeRuntimeConfig({ provider: 'claude', executable: 'claude' }),
+    /unknown runtime config field: executable/
+  );
+});

--- a/tests/private-hosted-cli/package-isolation.test.js
+++ b/tests/private-hosted-cli/package-isolation.test.js
@@ -7,10 +7,14 @@ const fs = require('node:fs');
 const os = require('node:os');
 const { describe, it } = require('node:test');
 const { COMMAND_MANIFEST, PRIVATE_MARKER } = require('../../private/hosted-cli-candidate/manifest');
-const { parseArgs } = require('../../private/hosted-cli-candidate/build-candidate');
+const {
+  CANDIDATE_GUIDANCE_FILES,
+  parseArgs,
+} = require('../../private/hosted-cli-candidate/build-candidate');
 
 const ROOT = path.resolve(__dirname, '../..');
-const CANDIDATE_PACKAGE_PATH = 'node_modules/@the-open-engine/zeroshot-private-hosted-candidate';
+const CANDIDATE_PACKAGE_PATH =
+  'lib/node_modules/@the-open-engine/zeroshot-private-hosted-candidate';
 
 function run(command, args, options = {}) {
   return spawnSync(command, args, {
@@ -32,6 +36,12 @@ function buildCandidate(output) {
   return JSON.parse(built.stdout);
 }
 
+function assertCandidateGuidance(root, label) {
+  for (const relative of CANDIDATE_GUIDANCE_FILES) {
+    assert.equal(fs.existsSync(path.join(root, relative)), true, `${label} omitted ${relative}`);
+  }
+}
+
 function assertCandidateOutput(candidate, output) {
   assert.deepEqual(candidate, {
     tarballPath: path.join(
@@ -45,6 +55,8 @@ function assertCandidateOutput(candidate, output) {
     fs.existsSync(path.join(candidate.stage, 'lib', 'private-hosted-cli', 'candidate-build.json')),
     false
   );
+  const guideRoot = path.join(candidate.stage, 'lib', 'private-hosted-cli');
+  assertCandidateGuidance(guideRoot, 'candidate');
 }
 
 function installCandidate(temporaryRoot, tarballPath) {
@@ -53,6 +65,7 @@ function installCandidate(temporaryRoot, tarballPath) {
     'npm',
     [
       'install',
+      '--global',
       '--no-audit',
       '--no-fund',
       '--no-package-lock',
@@ -76,7 +89,9 @@ function installCandidate(temporaryRoot, tarballPath) {
 }
 
 function assertCandidateLaunches(temporaryRoot, installation) {
-  const executable = path.join(installation, CANDIDATE_PACKAGE_PATH, 'cli', 'index.js');
+  const packageRoot = path.join(installation, CANDIDATE_PACKAGE_PATH);
+  const guideRoot = path.join(packageRoot, 'lib', 'private-hosted-cli');
+  const executable = path.join(packageRoot, 'cli', 'index.js');
   const launchOptions = {
     cwd: installation,
     env: {
@@ -95,6 +110,30 @@ function assertCandidateLaunches(temporaryRoot, installation) {
   const target = run(process.execPath, [executable, 'target', 'add', '--help'], launchOptions);
   assert.equal(target.status, 0, target.stderr || target.stdout);
   assert.match(target.stdout, /Register a named remote target/);
+
+  const targetRoot = run(process.execPath, [executable, 'target', '--help'], launchOptions);
+  assert.equal(targetRoot.status, 0, targetRoot.stderr || targetRoot.stdout);
+  assert.match(targetRoot.stdout, /Workflow:/);
+  assert.match(targetRoot.stdout, /target setup/);
+
+  const setup = run(process.execPath, [executable, 'target', 'setup', '--help'], launchOptions);
+  assert.equal(setup.status, 0, setup.stderr || setup.stdout);
+  assert.match(setup.stdout, /provider, harness, and model/);
+  assert.match(setup.stdout, /stores its path, not resolved secrets/);
+
+  const hostedRun = run(process.execPath, [executable, 'run', '--help'], launchOptions);
+  assert.equal(hostedRun.status, 0, hostedRun.stderr || hostedRun.stdout);
+  assert.match(hostedRun.stdout, /Omit --config to use Zeroshot's built-in coordinator/);
+  assert.match(hostedRun.stdout, /Ctrl\+C detach without cancelling/);
+  assert.match(hostedRun.stdout, /unchanged, fully resolved request/);
+
+  const workingDirectory = path.join(temporaryRoot, 'documented-working-directory');
+  fs.mkdirSync(workingDirectory);
+  fs.cpSync(path.join(guideRoot, 'examples'), path.join(workingDirectory, 'examples'), {
+    recursive: true,
+  });
+  assertCandidateGuidance(guideRoot, 'installed candidate');
+  assert.equal(fs.existsSync(path.join(workingDirectory, 'examples', 'cluster.json')), true);
 }
 
 function assertPackedCandidateBuildsInstallsAndLaunches() {

--- a/tests/private-hosted-cli/preflight-setup.test.js
+++ b/tests/private-hosted-cli/preflight-setup.test.js
@@ -80,7 +80,7 @@ it('stores references and resolves one provider-neutral runtime bundle per run',
   };
   const runtime = {
     provider: 'bedrock-runner',
-    executable: 'claude',
+    harness: 'claude',
     model: 'anthropic.claude-sonnet-4-5',
     environment: {
       AWS_ACCESS_KEY_ID: { from: 'LOCAL_AWS_ACCESS_KEY_ID' },
@@ -210,14 +210,18 @@ it('resolves omitted and named bases to one immutable submission revision', asyn
 
 it('validates generic runtime bounds and anchors mapped files to the config', () => {
   const runtime = (overrides) =>
-    normalizeRuntimeConfig({ provider: 'custom', executable: 'claude', ...overrides });
+    normalizeRuntimeConfig({ provider: 'custom', harness: 'claude', ...overrides });
   assert.equal(
-    normalizeRuntimeConfig({ provider: 'azure-openai', executable: 'gateway' }).executable,
+    normalizeRuntimeConfig({ provider: 'azure-openai', harness: 'gateway' }).harness,
     'gateway'
   );
   assert.throws(
-    () => normalizeRuntimeConfig({ provider: 'future-provider', executable: 'future-cli' }),
+    () => normalizeRuntimeConfig({ provider: 'future-provider', harness: 'future-cli' }),
     /Unknown provider/
+  );
+  assert.throws(
+    () => normalizeRuntimeConfig({ provider: 'claude', executable: 'claude' }),
+    /unknown runtime config field: executable/
   );
   for (const name of RESERVED_RUNTIME_NAMES) {
     assert.throws(() => runtime({ environment: { [name]: '/escape' } }), /reserved/);
@@ -233,7 +237,7 @@ it('validates generic runtime bounds and anchors mapped files to the config', ()
     configFile,
     JSON.stringify({
       provider: 'custom',
-      executable: 'claude',
+      harness: 'claude',
       files: { '.config/harness.json': { from: '../credentials/harness.json' } },
     })
   );

--- a/tests/private-hosted-cli/services-run-intent.test.js
+++ b/tests/private-hosted-cli/services-run-intent.test.js
@@ -185,6 +185,8 @@ function registerObservationTests() {
       captureLogs(() => h.services.remoteRun(detachedRunOptions(SUBMISSION_KEY))),
       (error) => {
         assert.match(error.message, new RegExp(`--submission-key ${SUBMISSION_KEY}`));
+        assert.match(error.message, /fully resolved|resolved repository revision/);
+        assert.match(error.message, /changed payload is rejected/);
         assert.doesNotMatch(error.message, /peer-secret-detail/);
         return true;
       }


### PR DESCRIPTION
## Summary

- add concise candidate-only target, setup, and remote-run CLI help
- include a private guide and complete hosted examples for built-in and custom coordinators
- use provider, harness, and model consistently at the user-facing runtime boundary
- package and validate the guide and examples without changing the public npm artifact
- make uncertain-submission retry requirements explicit and payload-safe

## Verification

- `npm run test:hosted` (59 private-candidate tests, 44 hosted-target tests)
- packed tarball global install, installed guide/example copy, and CLI launch
- `npm run check` (typecheck and lint; no errors)
- staged Opcore policy gate
- independent newcomer, information-boundary, and technical reviews

The candidate remains unpublished and private. Normal Zeroshot npm packing excludes the private candidate, guide, examples, and tests.
